### PR TITLE
fix: Resolve lease signing errors

### DIFF
--- a/app/api/leases/[id]/sign/route.ts
+++ b/app/api/leases/[id]/sign/route.ts
@@ -134,7 +134,7 @@ export async function POST(
       signatureType: "draw",
       signatureImage: signature_image,
       userAgent: request.headers.get("user-agent") || "Inconnu",
-      ipAddress: request.headers.get("x-forwarded-for") || "Inconnue",
+      ipAddress: (request.headers.get("x-forwarded-for") || "").split(",")[0].trim() || "0.0.0.0",
       screenSize: clientMetadata?.screenSize || "Non spécifié",
       touchDevice: clientMetadata?.touchDevice || false,
     });

--- a/next.config.js
+++ b/next.config.js
@@ -188,8 +188,10 @@ const nextConfig = {
             value: [
               "frame-ancestors 'self'",
               "default-src 'self' 'unsafe-inline' 'unsafe-eval'",
-              "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.googleapis.com https://api-adresse.data.gouv.fr https://nominatim.openstreetmap.org https://*.tile.openstreetmap.org",
-              "img-src 'self' blob: data: https://*.supabase.co https://*.googleapis.com https://images.unsplash.com https://*.tile.openstreetmap.org https://tile.openstreetmap.org https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org https://unpkg.com",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
+              "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+              "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.googleapis.com https://api-adresse.data.gouv.fr https://nominatim.openstreetmap.org https://*.tile.openstreetmap.org https://api.stripe.com",
+              "img-src 'self' blob: data: https://*.supabase.co https://*.googleapis.com https://images.unsplash.com https://*.tile.openstreetmap.org https://tile.openstreetmap.org https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org https://unpkg.com https://*.stripe.com",
               "font-src 'self' https://fonts.gstatic.com",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com",
             ].join("; "),


### PR DESCRIPTION
- Fix inet type error by extracting first IP from X-Forwarded-For header (was receiving "92.144.19.212, 100.27.6.12" instead of single IP)
- Add CSP rules for Stripe.js (script-src, frame-src, connect-src, img-src)