### PR TITLE
refactor(ux): Remove duplicate CTAs and standardize button labels

### DIFF
--- a/app/owner/dashboard/DashboardClient.tsx
+++ b/app/owner/dashboard/DashboardClient.tsx
@@ -332,24 +332,7 @@ export function DashboardClient({ dashboardData, profileCompletion }: DashboardC
               </motion.p>
             </div>
             
-            {hasProperties && (
-              <motion.div
-                initial={{ opacity: 0, scale: 0.8 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ delay: 0.5, type: "spring" }}
-              >
-                <Button
-                  asChild
-                  size="lg"
-                  className="bg-white text-slate-900 hover:bg-slate-100 shadow-lg border-0 font-semibold"
-                >
-                  <Link href={`${OWNER_ROUTES.properties.path}/new`}>
-                    <Plus className="mr-2 h-5 w-5" />
-                    Ajouter un bien
-                  </Link>
-                </Button>
-              </motion.div>
-            )}
+            {/* ✅ SOTA 2026: Bouton "Ajouter un bien" supprimé du header - déjà présent dans quick-links */}
           </div>
 
           {/* Quick Stats in Header */}

--- a/app/owner/inspections/[id]/InspectionDetailClient.tsx
+++ b/app/owner/inspections/[id]/InspectionDetailClient.tsx
@@ -474,7 +474,7 @@ export function InspectionDetailClient({ data }: Props) {
                 className="bg-blue-600 hover:bg-blue-700 shadow-sm"
               >
                 {isSigning ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <FileSignature className="h-4 w-4 mr-2" />}
-                Signer maintenant
+                Signer l'EDL
               </Button>
             )}
 

--- a/app/owner/leases/[id]/LeaseDetailsClient.tsx
+++ b/app/owner/leases/[id]/LeaseDetailsClient.tsx
@@ -332,7 +332,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
         title: "À votre tour de signer !",
         description: "Le locataire a signé. Signez pour valider le bail.",
         action: () => setShowSignatureModal(true),
-        actionLabel: "Signer maintenant",
+        actionLabel: "Signer le bail",
         color: "blue",
         urgent: true
       };

--- a/app/tenant/dashboard/DashboardClient.tsx
+++ b/app/tenant/dashboard/DashboardClient.tsx
@@ -336,19 +336,7 @@ export function DashboardClient() {
                     </Link>
                   </Button>
                 )}
-                {/* ✅ FIX: Vérifier que le locataire n'a pas déjà signé */}
-                {hasLeaseData && currentLease?.statut === 'pending_signature' && !hasSignedLease && (
-                  <Button 
-                    asChild 
-                    className="bg-white text-indigo-700 hover:bg-white/90 font-bold rounded-xl h-12 px-6 shadow-lg"
-                  >
-                    <Link href="/tenant/onboarding/sign" className="flex items-center gap-2">
-                      <PenTool className="h-4 w-4" />
-                      Signer mon bail
-                      <ArrowRight className="h-4 w-4" />
-                    </Link>
-                  </Button>
-                )}
+                {/* ✅ SOTA 2026: Bouton "Signer mon bail" supprimé ici car déjà présent dans pendingActions */}
                 {dashboard?.kyc_status !== 'verified' && (
                   <Button 
                     asChild 

--- a/app/tenant/inspections/page.tsx
+++ b/app/tenant/inspections/page.tsx
@@ -186,7 +186,7 @@ export default function TenantInspectionsPage() {
                           )}
                         >
                           <Link href={edl.needsMySignature ? `/signature-edl/${edl.invitation_token}` : `/tenant/inspections/${edl.id}`}>
-                            {edl.needsMySignature ? "Signer maintenant" : "Consulter"}
+                            {edl.needsMySignature ? "Signer l'EDL" : "Consulter"}
                             <ChevronRight className="ml-2 h-4 w-4" />
                           </Link>
                         </Button>


### PR DESCRIPTION
- Remove duplicate "Signer mon bail" button from tenant dashboard onboarding (already present in pendingActions)
- Remove duplicate "Ajouter un bien" button from owner dashboard header (already present in quick-links grid)
- Standardize button labels:
  - "Signer maintenant" → "Signer le bail" (for lease signing)
  - "Signer maintenant" → "Signer l'EDL" (for inspection signing)

This improves UX by reducing visual clutter and decision paralysis.