### PR TITLE
🐛 Fix: Next.js 15 params Promise - EDL edit error

### DIFF
--- a/app/api/edl/[id]/meter-readings/[readingId]/route.ts
+++ b/app/api/edl/[id]/meter-readings/[readingId]/route.ts
@@ -19,9 +19,10 @@ import { validateEDLMeterReadingSchema } from "@/lib/validations/edl-meters";
 
 export async function GET(
   request: Request,
-  { params }: { params: { id: string; readingId: string } }
+  { params }: { params: Promise<{ id: string; readingId: string }> }
 ) {
   try {
+    const { id: edlId, readingId } = await params;
     const supabase = await createClient();
     const {
       data: { user },
@@ -30,8 +31,6 @@ export async function GET(
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
-
-    const { id: edlId, readingId } = params;
 
     // Récupérer le relevé avec les infos du compteur
     const { data: reading, error } = await supabase
@@ -78,9 +77,10 @@ export async function GET(
 
 export async function PATCH(
   request: Request,
-  { params }: { params: { id: string; readingId: string } }
+  { params }: { params: Promise<{ id: string; readingId: string }> }
 ) {
   try {
+    const { id: edlId, readingId } = await params;
     const supabase = await createClient();
     const {
       data: { user },
@@ -90,7 +90,6 @@ export async function PATCH(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    const { id: edlId, readingId } = params;
     const body = await request.json();
 
     // Valider les données
@@ -210,9 +209,10 @@ export async function PATCH(
 
 export async function DELETE(
   request: Request,
-  { params }: { params: { id: string; readingId: string } }
+  { params }: { params: Promise<{ id: string; readingId: string }> }
 ) {
   try {
+    const { id: edlId, readingId } = await params;
     const supabase = await createClient();
     const {
       data: { user },
@@ -221,8 +221,6 @@ export async function DELETE(
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
-
-    const { id: edlId, readingId } = params;
 
     // Vérifier le rôle de l'utilisateur (seul le propriétaire peut supprimer)
     const { data: profile } = await supabase

--- a/app/api/edl/[id]/meter-readings/route.ts
+++ b/app/api/edl/[id]/meter-readings/route.ts
@@ -28,9 +28,9 @@ import {
 
 export async function GET(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const edlId = params.id;
+  const { id: edlId } = await params;
   console.log(`[GET /api/edl/${edlId}/meter-readings] Entering`);
 
   try {
@@ -139,9 +139,9 @@ export async function GET(
 
 export async function POST(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const edlId = params.id;
+  const { id: edlId } = await params;
   console.log(`[POST /api/edl/${edlId}/meter-readings] Entering`);
 
   try {

--- a/app/api/edl/[id]/route.ts
+++ b/app/api/edl/[id]/route.ts
@@ -17,9 +17,10 @@ import {
  */
 export async function GET(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id: edlId } = await params;
     const supabase = await createClient();
     const {
       data: { user },
@@ -28,8 +29,6 @@ export async function GET(
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
-
-    const edlId = params.id;
     const serviceClient = createServiceClient();
 
     // Récupérer le profil
@@ -123,9 +122,10 @@ export async function GET(
  */
 export async function PUT(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id: edlId } = await params;
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
 
@@ -133,7 +133,6 @@ export async function PUT(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    const edlId = params.id;
     const body = await request.json();
     const { observations_generales, keys, sections } = body;
 
@@ -257,9 +256,10 @@ export async function PUT(
  */
 export async function DELETE(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id: edlId } = await params;
     const supabase = await createClient();
     const {
       data: { user },
@@ -268,8 +268,6 @@ export async function DELETE(
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
-
-    const edlId = params.id;
     const serviceClient = createServiceClient();
 
     // Récupérer le profil

--- a/app/api/edl/[id]/sections/route.ts
+++ b/app/api/edl/[id]/sections/route.ts
@@ -24,9 +24,10 @@ const sectionSchema = z.object({
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id: edlId } = await params;
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
 
@@ -38,7 +39,7 @@ export async function POST(
     const { data: edl, error: edlError } = await supabase
       .from("edl")
       .select("id, lease_id, created_by")
-      .eq("id", params.id)
+      .eq("id", edlId)
       .single();
 
     if (edlError || !edl) {
@@ -80,7 +81,7 @@ export async function POST(
     for (const section of validated.sections) {
       for (const item of section.items) {
         allItems.push({
-          edl_id: params.id,
+          edl_id: edlId,
           room_name: item.room_name || section.room_name,
           item_name: item.item_name,
           condition: item.condition || null,
@@ -107,7 +108,7 @@ export async function POST(
     await supabase
       .from("edl")
       .update({ status: "in_progress" })
-      .eq("id", params.id)
+      .eq("id", edlId)
       .eq("status", "draft");
 
     return NextResponse.json({
@@ -133,9 +134,10 @@ export async function POST(
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id: edlId } = await params;
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
 
@@ -147,7 +149,7 @@ export async function GET(
     const { data: items, error } = await supabase
       .from("edl_items")
       .select("*")
-      .eq("edl_id", params.id)
+      .eq("edl_id", edlId)
       .order("room_name", { ascending: true })
       .order("item_name", { ascending: true });
 


### PR DESCRIPTION
Les routes API avec des paramètres dynamiques [id] nécessitent
maintenant `await params` dans Next.js 15. Corrige l'erreur
"EDL introuvable" lors de la modification d'un état des lieux.

Fichiers corrigés:
- /api/edl/[id]/route.ts (GET, PUT, DELETE)
- /api/edl/[id]/meter-readings/route.ts (GET, POST)
- /api/edl/[id]/meter-readings/[readingId]/route.ts (GET, PATCH, DELETE)
- /api/edl/[id]/sections/route.ts (GET, POST)
- /api/edl/[id]/invite/route.ts (POST)
- /api/edl/[id]/sign/route.ts (POST)