### PR TITLE
fix(passkeys): Normalize APP_URL with protocol before URL parsing

### DIFF
--- a/app/api/auth/passkeys/authenticate/options/route.ts
+++ b/app/api/auth/passkeys/authenticate/options/route.ts
@@ -7,9 +7,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { generateAuthenticationOptions } from "@simplewebauthn/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
 
-const RP_ID = process.env.NEXT_PUBLIC_APP_URL
-  ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
-  : "localhost";
+// Normaliser l'URL avec protocole pour éviter "Invalid URL" avec new URL()
+const rawAppUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+const normalizedAppUrl = rawAppUrl.startsWith("http") ? rawAppUrl : `https://${rawAppUrl}`;
+const RP_ID = rawAppUrl ? new URL(normalizedAppUrl).hostname : "localhost";
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/auth/passkeys/authenticate/verify/route.ts
+++ b/app/api/auth/passkeys/authenticate/verify/route.ts
@@ -7,11 +7,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { verifyAuthenticationResponse } from "@simplewebauthn/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
 
-const RP_ID = process.env.NEXT_PUBLIC_APP_URL
-  ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
-  : "localhost";
-
-const ORIGIN = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+// Normaliser l'URL avec protocole pour éviter "Invalid URL" avec new URL()
+const rawAppUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+const normalizedAppUrl = rawAppUrl.startsWith("http") ? rawAppUrl : `https://${rawAppUrl}`;
+const RP_ID = rawAppUrl ? new URL(normalizedAppUrl).hostname : "localhost";
+const ORIGIN = normalizedAppUrl || "http://localhost:3000";
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/auth/passkeys/register/options/route.ts
+++ b/app/api/auth/passkeys/register/options/route.ts
@@ -8,9 +8,10 @@ import { generateRegistrationOptions } from "@simplewebauthn/server";
 import { createClient } from "@/lib/supabase/server";
 
 const RP_NAME = "Talok";
-const RP_ID = process.env.NEXT_PUBLIC_APP_URL
-  ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
-  : "localhost";
+// Normaliser l'URL avec protocole pour éviter "Invalid URL" avec new URL()
+const rawAppUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+const normalizedAppUrl = rawAppUrl.startsWith("http") ? rawAppUrl : `https://${rawAppUrl}`;
+const RP_ID = rawAppUrl ? new URL(normalizedAppUrl).hostname : "localhost";
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/auth/passkeys/register/verify/route.ts
+++ b/app/api/auth/passkeys/register/verify/route.ts
@@ -8,11 +8,11 @@ import { verifyRegistrationResponse } from "@simplewebauthn/server";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
 
-const RP_ID = process.env.NEXT_PUBLIC_APP_URL
-  ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
-  : "localhost";
-
-const ORIGIN = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+// Normaliser l'URL avec protocole pour éviter "Invalid URL" avec new URL()
+const rawAppUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+const normalizedAppUrl = rawAppUrl.startsWith("http") ? rawAppUrl : `https://${rawAppUrl}`;
+const RP_ID = rawAppUrl ? new URL(normalizedAppUrl).hostname : "localhost";
+const ORIGIN = normalizedAppUrl || "http://localhost:3000";
 
 export async function POST(request: NextRequest) {
   try {


### PR DESCRIPTION
The build was failing with "TypeError: Invalid URL" because NEXT_PUBLIC_APP_URL contained "talok.fr" without a protocol. Node's URL constructor requires a fully-qualified URL.

Added safeguard to prepend "https://" if the URL doesn't start with "http". This makes the code resilient to environment variables configured without the protocol prefix.

Affected files:
- authenticate/options/route.ts
- authenticate/verify/route.ts
- register/options/route.ts
- register/verify/route.ts