### PR TITLE
fix(validation): ajouter le type de bail 'etudiant' aux validations

### DIFF
--- a/app/signature/[token]/SignatureFlow.tsx
+++ b/app/signature/[token]/SignatureFlow.tsx
@@ -94,6 +94,7 @@ const LEASE_TYPE_LABELS: Record<string, string> = {
   colocation: "Colocation",
   saisonnier: "Location saisonnière",
   mobilite: "Bail mobilité",
+  etudiant: "Bail étudiant",
 };
 
 export function SignatureFlow({ token, lease, tenantEmail, ownerName, propertyAddress }: SignatureFlowProps) {

--- a/lib/templates/edl/template.service.ts
+++ b/lib/templates/edl/template.service.ts
@@ -428,6 +428,8 @@ function formatBailType(type: string): string {
     colocation: "Colocation",
     saisonnier: "Location saisonnière",
     bail_mobilite: "Bail mobilité",
+    mobilite: "Bail mobilité",
+    etudiant: "Bail étudiant",
     commercial_3_6_9: "Bail commercial 3/6/9",
     professionnel: "Bail professionnel",
     contrat_parking: "Contrat de parking",

--- a/lib/validations/lease-financial.ts
+++ b/lib/validations/lease-financial.ts
@@ -13,7 +13,7 @@
 import { z } from "zod";
 
 // Types de bail supportés
-export const BAIL_TYPES = ["nu", "meuble", "colocation", "saisonnier", "mobilite"] as const;
+export const BAIL_TYPES = ["nu", "meuble", "colocation", "saisonnier", "mobilite", "etudiant"] as const;
 export type BailType = typeof BAIL_TYPES[number];
 
 /**
@@ -22,6 +22,7 @@ export type BailType = typeof BAIL_TYPES[number];
 export function getMaxDepotLegal(typeBail: BailType | string, loyerHC: number): number {
   switch (typeBail) {
     case "nu":
+    case "etudiant": // Bail étudiant = 1 mois max (meublé 9 mois)
       return loyerHC; // 1 mois max
     case "meuble":
     case "colocation":
@@ -40,7 +41,8 @@ export function getMaxDepotLegal(typeBail: BailType | string, loyerHC: number): 
  */
 export function getMaxDepotMois(typeBail: BailType | string): number {
   switch (typeBail) {
-    case "nu": return 1;
+    case "nu":
+    case "etudiant": return 1; // Bail étudiant = 1 mois max
     case "meuble":
     case "colocation":
     case "saisonnier": return 2;


### PR DESCRIPTION
Le bail étudiant (9 mois meublé) était présent en base de données mais
manquait dans les schémas de validation Zod et les labels UI, causant
des erreurs "Type de bail invalide" lors de la création/signature.

Corrections:
- lib/validations/lease-financial.ts: ajout 'etudiant' à BAIL_TYPES,
  getMaxDepotLegal() et getMaxDepotMois() (1 mois max dépôt)
- SignatureFlow.tsx: ajout 'Bail étudiant' à LEASE_TYPE_LABELS
- edl/template.service.ts: ajout 'etudiant' à formatBailType()