### PR TITLE
fix(edl): résoudre le bug 'Profil non trouvé' lors de la signature EDL

### DIFF
--- a/app/api/signature/edl/[token]/sign/route.ts
+++ b/app/api/signature/edl/[token]/sign/route.ts
@@ -28,7 +28,8 @@ export async function POST(
       return NextResponse.json({ error: "Lien invalide ou expiré" }, { status: 404 });
     }
 
-    if (signatureEntry.signed_at) {
+    // Vérifier si déjà signé (on vérifie signature_image_path car c'est la preuve réelle)
+    if (signatureEntry.signature_image_path) {
       return NextResponse.json({ error: "Ce document a déjà été signé" }, { status: 400 });
     }
 

--- a/app/tenant/inspections/[id]/TenantEDLDetailClient.tsx
+++ b/app/tenant/inspections/[id]/TenantEDLDetailClient.tsx
@@ -125,13 +125,21 @@ export default function TenantEDLDetailClient({
       const response = await fetch(`/api/edl/${edl.id}/sign`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ signature: signatureData.data }),
+        body: JSON.stringify({
+          signature: signatureData.data,
+          metadata: signatureData.metadata
+        }),
       });
-      if (!response.ok) throw new Error("Erreur lors de la signature");
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Erreur lors de la signature");
+      }
+
       setIsSignModalOpen(false);
       router.refresh();
     } catch (error: unknown) {
-      alert(error.message);
+      alert(error instanceof Error ? error.message : "Erreur lors de la signature");
     } finally {
       setIsSigning(false);
     }


### PR DESCRIPTION
- Implémenter une stratégie multi-niveau pour trouver le profil:
  1. Recherche par user_id (cas standard)
  2. Recherche par email et liaison automatique au compte auth
  3. Recherche dans edl_signatures pour l'EDL concerné
  4. Création automatique d'un profil minimal en dernier recours
- Corriger la vérification 'déjà signé' pour utiliser signature_image_path
- Améliorer la gestion d'erreurs côté client avec messages explicites
- Inclure les metadata de signature dans l'appel API