### PR TITLE
fix(edl): améliorer la synchronisation des données des compteurs

### DIFF
--- a/features/edl/components/edl-preview.tsx
+++ b/features/edl/components/edl-preview.tsx
@@ -78,10 +78,12 @@ export function EDLPreview({
       locataires: edlData.locataires?.map((l) => l.nom_complet),
       nb_pieces: edlData.pieces?.length,
       // 🔧 FIX: Inclure les valeurs des relevés de compteurs pour forcer la regénération
-      compteurs: edlData.compteurs?.map((c) => ({
+      // Normaliser la valeur: supporte 'reading' (string) et 'reading_value' (number)
+      compteurs: edlData.compteurs?.map((c: any) => ({
         type: c.type,
         meter_number: c.meter_number,
-        reading: c.reading,
+        // Normaliser: utiliser reading_value si disponible, sinon reading
+        reading_value: c.reading_value !== undefined ? String(c.reading_value) : c.reading,
         unit: c.unit,
       })),
       scheduled_date: edlData.scheduled_date,
@@ -144,7 +146,11 @@ export function EDLPreview({
     if (!edlData.compteurs || edlData.compteurs.length === 0) {
       warnings.push("Aucun compteur enregistré pour ce logement");
     } else {
-      const unreadMeters = edlData.compteurs.filter(c => c.reading === "Non relevé" || !c.reading);
+      // 🔧 FIX: Vérifier les deux formats possibles (reading et reading_value)
+      const unreadMeters = edlData.compteurs.filter((c: any) => {
+        const readingVal = c.reading_value !== undefined ? String(c.reading_value) : c.reading;
+        return readingVal === "Non relevé" || readingVal === "null" || !readingVal;
+      });
       if (unreadMeters.length > 0) {
         warnings.push(`${unreadMeters.length} relevé(s) de compteur à saisir`);
       }


### PR DESCRIPTION
Corrections apportées:
- Hash de l'aperçu: utilise reading_value normalisé pour détecter les changements
- APIs preview/pdf: génération d'URLs signées pour les photos des compteurs
- APIs preview/pdf: vérification par ID uniquement (pas par type) pour éviter
  de masquer des compteurs multiples du même type
- Mapper edl-to-template: gestion améliorée des valeurs null/undefined avec
  affichage "À valider" si photo présente mais pas de valeur OCR
- Route meter-readings: ajout du flag needs_validation dans la réponse

Ces corrections résolvent les problèmes de déconnexion entre:
- Les données du formulaire et l'aperçu
- L'aperçu et le PDF final
- Les valeurs OCR nulles et l'affichage