### PR TITLE
fix: ajouter les imports lucide-react manquants

### DIFF
--- a/app/owner/inspections/new/CreateInspectionWizard.tsx
+++ b/app/owner/inspections/new/CreateInspectionWizard.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
   Trash2,
   Key,
+  DoorOpen,
 } from "lucide-react";
 import {
   Card,

--- a/app/tenant/onboarding/payments/page.tsx
+++ b/app/tenant/onboarding/payments/page.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/use-toast";
 import { onboardingService } from "@/features/onboarding/services/onboarding.service";
 import { tenantPaymentSchema } from "@/lib/validations/onboarding";
-import { CreditCard, ArrowRight, Banknote, ShieldCheck, CheckCircle2 } from "lucide-react";
+import { CreditCard, ArrowRight, Banknote, ShieldCheck, CheckCircle2, Loader2 } from "lucide-react";
 import {
   Select,
   SelectContent,

--- a/app/tenant/payments/TenantPaymentsClient.tsx
+++ b/app/tenant/payments/TenantPaymentsClient.tsx
@@ -6,20 +6,21 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { formatCurrency, formatDateShort } from "@/lib/helpers/format";
-import { 
-  CreditCard, 
-  Receipt, 
-  Search, 
-  Download, 
-  ChevronRight, 
-  TrendingUp, 
+import {
+  CreditCard,
+  Receipt,
+  Search,
+  Download,
+  ChevronRight,
+  TrendingUp,
   AlertCircle,
   FileText,
   Filter,
   Euro,
   PartyPopper,
   Sparkles,
-  History
+  History,
+  CheckCircle2
 } from "lucide-react";
 import { PaymentCheckout } from "@/features/billing/components/payment-checkout";
 import { Input } from "@/components/ui/input";


### PR DESCRIPTION
- CreateInspectionWizard.tsx: import DoorOpen
- page.tsx (tenant/onboarding/payments): import Loader2
- TenantPaymentsClient.tsx: import CheckCircle2

Ces imports manquants causaient des erreurs react/jsx-no-undef
qui pourraient bloquer le build sur Netlify.