### PR TITLE
Fix Next.js build command in Netlify

### DIFF
--- a/app/api/charges/[id]/route.ts
+++ b/app/api/charges/[id]/route.ts
@@ -3,9 +3,8 @@ export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
-import { chargeSchema } from "@/lib/validations";
+import { chargeUpdateSchema } from "@/lib/validations";
 import { handleApiError } from "@/lib/helpers/api-error";
-import type { z } from "zod";
 
 export async function GET(request: Request, { params }: { params: { id: string } }) {
   try {
@@ -41,7 +40,7 @@ export async function PUT(request: Request, { params }: { params: { id: string }
     }
 
     const body = await request.json();
-    const validated = chargeSchema.partial().parse(body);
+    const validated = chargeUpdateSchema.parse(body);
 
     const { data: charge, error } = await supabase
       .from("charges")

--- a/lib/validations/index.ts
+++ b/lib/validations/index.ts
@@ -697,6 +697,9 @@ export const chargeSchema = z.object({
   eligible_pinel: z.boolean().optional(),
 });
 
+// Partial schema for charge updates (pre-computed to avoid runtime .partial() issues)
+export const chargeUpdateSchema = chargeSchema.partial();
+
 // Validation des tickets
 export const ticketSchema = z.object({
   property_id: z.string().uuid(),


### PR DESCRIPTION
The Netlify build was failing with "TypeError: r.partial is not a function" during page data collection for /api/charges/[id]. This was caused by calling .partial() at runtime on chargeSchema.

Solution: create a pre-computed chargeUpdateSchema at module level, following the same pattern used elsewhere in the codebase (addressUpdateSchema, dpeUpdateSchema, etc.).