### PR TITLE
Fix missing API endpoints returning 404 errors

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -59,15 +59,16 @@ export function middleware(request: NextRequest) {
     // L'app résoudra le branding via l'API /api/white-label/resolve
   }
 
-  // 1. Laisser passer les assets statiques, les webhooks et les routes publiques
+  // 1. Laisser passer les assets statiques, les routes API et les routes publiques
+  // IMPORTANT: Les routes /api/* gèrent leur propre authentification et retournent des erreurs JSON.
+  // Ne pas les rediriger vers /auth/signin car cela causerait des erreurs JSON parse côté client.
   if (
     pathname.startsWith("/_next") ||
     pathname.includes(".") ||
-    publicRoutes.some((route) => 
+    pathname.startsWith("/api/") ||
+    publicRoutes.some((route) =>
       route === "/" ? pathname === "/" : pathname.startsWith(route)
     ) ||
-    pathname.startsWith("/api/webhooks") ||
-    pathname.startsWith("/api/public") ||
     pathname.startsWith("/auth/callback")
   ) {
     return NextResponse.next();


### PR DESCRIPTION
The middleware was redirecting unauthenticated API requests to /auth/signin, causing clients to receive HTML instead of JSON error responses. This resulted in "SyntaxError: Unexpected token '<'" errors when parsing API responses.

Changed middleware to let all /api/* routes pass through without redirection. API routes handle their own authentication and return proper JSON error codes.