### PR TITLE
Fix API endpoint 404 error for sign request

### DIFF
--- a/app/api/edl/[id]/sign/route.ts
+++ b/app/api/edl/[id]/sign/route.ts
@@ -4,7 +4,6 @@ export const runtime = 'nodejs';
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { getRateLimiterByUser, rateLimitPresets } from "@/lib/middleware/rate-limit";
-import { decode } from "base64-arraybuffer";
 import { generateSignatureProof } from "@/lib/services/signature-proof.service";
 import { extractClientIP } from "@/lib/utils/ip-address";
 import { 
@@ -317,7 +316,7 @@ export async function POST(
     
     const { error: uploadError } = await serviceClient.storage
       .from("documents")
-      .upload(fileName, decode(base64Data), {
+      .upload(fileName, Buffer.from(base64Data, 'base64'), {
         contentType: "image/png",
         upsert: true,
       });

--- a/app/api/signature/edl/[token]/sign/route.ts
+++ b/app/api/signature/edl/[token]/sign/route.ts
@@ -2,7 +2,6 @@ export const runtime = 'nodejs';
 
 import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
-import { decode } from "base64-arraybuffer";
 import { generateSignatureProof } from "@/lib/services/signature-proof.service";
 import { extractClientIP } from "@/lib/utils/ip-address";
 
@@ -49,7 +48,7 @@ export async function POST(
     
     const { error: uploadError } = await serviceClient.storage
       .from("documents")
-      .upload(fileName, decode(base64Data), {
+      .upload(fileName, Buffer.from(base64Data, 'base64'), {
         contentType: "image/png",
         upsert: true,
       });


### PR DESCRIPTION
The base64-arraybuffer package was imported but not installed in package.json, causing the /api/edl/[id]/sign endpoint to fail with a 404 error (module not found at runtime).

Replaced decode() from base64-arraybuffer with native Node.js Buffer.from(data, 'base64') which achieves the same result without requiring an external dependency.