### PR TITLE
fix(api): prevent HTML responses in meter-readings API routes

### DIFF
--- a/app/api/edl/[id]/meter-readings/route.ts
+++ b/app/api/edl/[id]/meter-readings/route.ts
@@ -30,10 +30,23 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id: edlId } = await params;
-  console.log(`[GET /api/edl/${edlId}/meter-readings] Entering`);
+  let edlId: string;
 
   try {
+    // 🔧 FIX: await params INSIDE try-catch to prevent unhandled errors returning HTML
+    const resolvedParams = await params;
+    edlId = resolvedParams.id;
+
+    // Validate UUID format
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!edlId || !uuidRegex.test(edlId)) {
+      return NextResponse.json(
+        { error: "ID d'EDL invalide", code: "INVALID_EDL_ID" },
+        { status: 400 }
+      );
+    }
+
+    console.log(`[GET /api/edl/${edlId}/meter-readings] Entering`);
     const supabase = await createClient();
     const {
       data: { user },
@@ -141,10 +154,23 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id: edlId } = await params;
-  console.log(`[POST /api/edl/${edlId}/meter-readings] Entering`);
+  let edlId: string;
 
   try {
+    // 🔧 FIX: await params INSIDE try-catch to prevent unhandled errors returning HTML
+    const resolvedParams = await params;
+    edlId = resolvedParams.id;
+
+    // Validate UUID format
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!edlId || !uuidRegex.test(edlId)) {
+      return NextResponse.json(
+        { error: "ID d'EDL invalide", code: "INVALID_EDL_ID" },
+        { status: 400 }
+      );
+    }
+
+    console.log(`[POST /api/edl/${edlId}/meter-readings] Entering`);
     const supabase = await createClient();
     const {
       data: { user },

--- a/app/api/meters/[id]/readings/route.ts
+++ b/app/api/meters/[id]/readings/route.ts
@@ -17,10 +17,15 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id: meterId } = await params;
-  console.log(`[GET /api/meters/${meterId}/readings] Entering`);
+  let meterId: string;
 
   try {
+    // 🔧 FIX: await params INSIDE try-catch to prevent unhandled errors returning HTML
+    const resolvedParams = await params;
+    meterId = resolvedParams.id;
+
+    console.log(`[GET /api/meters/${meterId}/readings] Entering`);
+
     // Validate meter ID format
     const parseResult = uuidSchema.safeParse(meterId);
     if (!parseResult.success) {
@@ -151,11 +156,14 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  // Next.js 15: params is now a Promise
-  const { id: meterId } = await params;
-  console.log(`[POST /api/meters/${meterId}/readings] Entering`);
+  let meterId: string;
 
   try {
+    // 🔧 FIX: await params INSIDE try-catch to prevent unhandled errors returning HTML
+    const resolvedParams = await params;
+    meterId = resolvedParams.id;
+
+    console.log(`[POST /api/meters/${meterId}/readings] Entering`);
     const supabase = await createClient();
     const {
       data: { user },


### PR DESCRIPTION
Move `await params` inside try-catch blocks in API route handlers to
ensure all errors are properly caught and return JSON responses instead
of HTML error pages.

Routes fixed:
- /api/edl/[id]/meter-readings (GET, POST)
- /api/meters/[id]/readings (GET, POST)

Also added UUID validation for EDL IDs to return proper 400 errors
for invalid IDs instead of database errors.

This fixes the recurring 500 errors during EDL creation at the
"Enregistrement des compteurs" step where the server was returning
HTML <!DOCTYPE...> instead of JSON.

https://claude.ai/code/session_013ff2dgXUZARhcSfeW5zZs2