### PR TITLE
Add GET endpoint for inspection photos and improve accessibility

### DIFF
--- a/components/documents/DocumentUploadModal.tsx
+++ b/components/documents/DocumentUploadModal.tsx
@@ -122,7 +122,7 @@ export function DocumentUploadModal({ leaseId, propertyId }: DocumentUploadModal
           Ajouter un document
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Ajouter un document</DialogTitle>
         </DialogHeader>

--- a/components/documents/LeasePreview.tsx
+++ b/components/documents/LeasePreview.tsx
@@ -76,7 +76,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
                 <Maximize2 className="h-4 w-4" />
               </Button>
             </DialogTrigger>
-            <DialogContent className="max-w-[90vw] max-h-[90vh] p-0">
+            <DialogContent className="max-w-[90vw] max-h-[90vh] p-0" aria-describedby={undefined}>
               <DialogHeader className="p-4 border-b">
                 <DialogTitle>Contrat de location - Plein écran</DialogTitle>
               </DialogHeader>

--- a/components/documents/pdf-preview-modal.tsx
+++ b/components/documents/pdf-preview-modal.tsx
@@ -66,6 +66,7 @@ export function PDFPreviewModal({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
+        aria-describedby={undefined}
         className={cn(
           // Taille responsive : plein écran sur mobile, contrainte sur desktop
           "w-[calc(100%-1rem)] sm:w-[calc(100%-2rem)] max-w-5xl",

--- a/components/onboarding/welcome-modal.tsx
+++ b/components/onboarding/welcome-modal.tsx
@@ -19,7 +19,7 @@ import {
   Shield
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import type { UserRole } from "@/lib/types";
 
@@ -242,7 +242,8 @@ export function WelcomeModal({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent hideClose className="sm:max-w-2xl p-0 overflow-hidden border-0 bg-transparent shadow-none">
+      <DialogContent hideClose className="sm:max-w-2xl p-0 overflow-hidden border-0 bg-transparent shadow-none" aria-describedby={undefined}>
+        <DialogTitle className="sr-only">Bienvenue sur Talok</DialogTitle>
         <motion.div
           variants={containerVariants}
           initial="hidden"

--- a/components/owner/properties/PropertyHero.tsx
+++ b/components/owner/properties/PropertyHero.tsx
@@ -89,7 +89,7 @@ export function PropertyHero({ property, activeLease, onDelete, photos = [], pro
       
       {/* Lightbox / Gallery Modal */}
       <Dialog open={isGalleryOpen} onOpenChange={setIsGalleryOpen}>
-        <DialogContent className="max-w-5xl w-full h-[90vh] p-0 bg-black/95 border-none text-white overflow-hidden flex flex-col">
+        <DialogContent className="max-w-5xl w-full h-[90vh] p-0 bg-black/95 border-none text-white overflow-hidden flex flex-col" aria-describedby={undefined}>
           {/* DialogTitle requis pour l'accessibilité (screen readers) */}
           <DialogTitle className="sr-only">Galerie photos du bien</DialogTitle>
           

--- a/components/payments/ManualPaymentDialog.tsx
+++ b/components/payments/ManualPaymentDialog.tsx
@@ -195,7 +195,8 @@ export function ManualPaymentDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-lg md:max-w-xl overflow-hidden">
+      <DialogContent className="sm:max-w-lg md:max-w-xl overflow-hidden" aria-describedby={undefined}>
+        <DialogTitle className="sr-only">Enregistrer un paiement manuel</DialogTitle>
         <AnimatePresence mode="wait">
           {/* Step 1: Method Selection */}
           {step === "select" && (

--- a/components/portfolio/before-after-gallery.tsx
+++ b/components/portfolio/before-after-gallery.tsx
@@ -158,7 +158,7 @@ export function BeforeAfterGallery({ items, className }: BeforeAfterGalleryProps
       
       {/* Modal plein écran */}
       <Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
-        <DialogContent className="max-w-[95vw] max-h-[95vh] p-0">
+        <DialogContent className="max-w-[95vw] max-h-[95vh] p-0" aria-describedby={undefined}>
           <DialogTitle className="sr-only">{currentItem.title}</DialogTitle>
           <div className="relative w-full h-[85vh]">
             {currentItem.before_photo_url ? (

--- a/components/properties/property-comparison.tsx
+++ b/components/properties/property-comparison.tsx
@@ -321,7 +321,7 @@ function AddPropertyDialog({ availableProperties, selectedIds, onAdd }: AddPrope
           </div>
         </Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Sélectionner un bien à comparer</DialogTitle>
         </DialogHeader>

--- a/components/subscription/cancel-modal.tsx
+++ b/components/subscription/cancel-modal.tsx
@@ -139,7 +139,8 @@ export function CancelModal({ open, onClose, onSuccess }: CancelModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={resetAndClose}>
-      <DialogContent className="max-w-lg bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 border-slate-700/50">
+      <DialogContent className="max-w-lg bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 border-slate-700/50" aria-describedby={undefined}>
+        <DialogTitle className="sr-only">Résiliation d&apos;abonnement</DialogTitle>
         <AnimatePresence mode="wait">
           {/* Step 1: Raison */}
           {step === "reason" && (

--- a/components/ui/keyboard-shortcuts-help.tsx
+++ b/components/ui/keyboard-shortcuts-help.tsx
@@ -92,7 +92,7 @@ export function KeyboardShortcutsHelp({
           </Button>
         )}
       </DialogTrigger>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Keyboard className="h-5 w-5" />


### PR DESCRIPTION
## Summary
This PR adds a new GET endpoint for retrieving inspection photos and improves accessibility across multiple dialog components by adding proper ARIA attributes.

## Key Changes

### API Enhancement
- **New GET endpoint** (`/api/inspections/[iid]/photos`): Retrieves photos for a specific inspection with support for optional `item_id` filtering
  - Implements proper authentication and authorization checks (admin, owner, or lease signer access)
  - Generates signed URLs for secure photo access (1-hour expiration)
  - Includes comprehensive error handling and logging

### Accessibility Improvements
- Added `aria-describedby={undefined}` to multiple `DialogContent` components to suppress console warnings about missing descriptions
- Added `DialogTitle` with `sr-only` class to dialogs that were missing accessible titles:
  - `WelcomeModal`: "Bienvenue sur Talok"
  - `ManualPaymentDialog`: "Enregistrer un paiement manuel"
  - `CancelModal`: "Résiliation d'abonnement"
- Updated imports in `welcome-modal.tsx` to include `DialogTitle`

### Code Quality
- **Refactored document queries** in `use-documents.ts`:
  - Extracted common select clauses (`SELECT_WITH_PROPERTY`, `SELECT_WITH_PROPERTY_AND_TENANT`)
  - Introduced `queryDocumentsWithFallback()` helper to gracefully handle PostgREST foreign key relationship errors
  - Fallback mechanism: attempts queries with joins first, then retries without joins if 400 error occurs
  - Improved error handling and logging throughout document fetching logic
  - Applied fallback pattern to `useDocument()` hook as well

## Implementation Details
- The GET endpoint validates EDL access through multiple authorization paths (direct property ownership, lease signer status, admin role)
- Photo URLs are generated with 1-hour signed expiration for security
- Document query fallback handles cases where foreign key relationships may not be exposed in PostgREST
- All dialog accessibility improvements follow WCAG guidelines for screen reader compatibility

https://claude.ai/code/session_01W3XkF6tQ9r6Sisx3PnT1C9