### PR TITLE
Improve inspection view button styling and accessibility

### DIFF
--- a/app/owner/inspections/InspectionsClient.tsx
+++ b/app/owner/inspections/InspectionsClient.tsx
@@ -193,9 +193,10 @@ export function InspectionsClient({ inspections }: Props) {
       className: "text-right",
       cell: (edl: Inspection) => (
         <div className="flex justify-end gap-2">
-          <Button size="sm" variant="ghost" asChild className="hover:bg-slate-100 h-8 w-8 p-0" title="Voir">
+          <Button size="sm" variant="outline" asChild className="hover:bg-blue-50 hover:border-blue-300 h-8 gap-1.5 px-2.5 text-blue-600 border-blue-200" title="Voir l'état des lieux">
             <Link href={`/owner/inspections/${edl.id}`}>
-              <Eye className="h-4 w-4 text-slate-600" />
+              <Eye className="h-4 w-4" />
+              <span className="text-xs font-medium">Voir</span>
             </Link>
           </Button>
 


### PR DESCRIPTION
## Summary
Enhanced the inspection view button in the inspections table with improved visual design, better accessibility, and clearer user intent.

## Key Changes
- **Button variant**: Changed from `ghost` to `outline` for better visual hierarchy
- **Color scheme**: Updated from slate to blue theme with custom hover states (`hover:bg-blue-50`, `hover:border-blue-300`)
- **Button content**: Added visible "Voir" text label alongside the eye icon for improved clarity
- **Spacing**: Adjusted padding and gap (`px-2.5`, `gap-1.5`) to accommodate the text label
- **Icon styling**: Removed explicit text color from icon, allowing it to inherit from parent button styling
- **Accessibility**: Updated button title from "Voir" to "Voir l'état des lieux" for more descriptive context

## Implementation Details
The button now displays as an outlined blue button with an eye icon and text label, making it more discoverable and clearer in intent compared to the previous ghost variant. The hover state provides visual feedback with a light blue background and blue border.

https://claude.ai/code/session_01VxhMDnvdmr33p3999Wf9NV