### PR TITLE
Simplify owner profile lookup by removing intermediate table query

### DIFF
--- a/app/owner/entities/actions.ts
+++ b/app/owner/entities/actions.ts
@@ -101,15 +101,9 @@ async function getAuthenticatedOwnerProfileId(): Promise<{
 
   if (!profile || profile.role !== "owner") return null;
 
-  const { data: ownerProfile } = await supabase
-    .from("owner_profiles")
-    .select("id")
-    .eq("profile_id", profile.id)
-    .single();
-
-  if (!ownerProfile) return null;
-
-  return { ownerProfileId: ownerProfile.id, profileId: profile.id };
+  // profile.id is the FK value for legal_entities.owner_profile_id
+  // (owner_profiles PK is profile_id, not id)
+  return { ownerProfileId: profile.id, profileId: profile.id };
 }
 
 // ============================================

--- a/app/owner/entities/new/page.tsx
+++ b/app/owner/entities/new/page.tsx
@@ -157,7 +157,7 @@ export default function NewEntityPage() {
     try {
       const supabase = createClient();
 
-      // Get owner_profile_id
+      // Get profile.id — which is the FK value for legal_entities.owner_profile_id
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error("Non authentifié");
 
@@ -168,16 +168,9 @@ export default function NewEntityPage() {
         .single();
       if (!profile) throw new Error("Profil non trouvé");
 
-      const { data: ownerProfile } = await supabase
-        .from("owner_profiles")
-        .select("id")
-        .eq("profile_id", profile.id)
-        .single();
-      if (!ownerProfile) throw new Error("Profil propriétaire non trouvé");
-
       // Map form data to DB
       const entityPayload = {
-        owner_profile_id: ownerProfile.id,
+        owner_profile_id: profile.id,
         entity_type: formData.entityType || "sci_ir",
         nom: formData.nom || `Entité de ${profile.id.slice(0, 8)}`,
         forme_juridique: formData.formeJuridique || null,

--- a/app/owner/entities/page.tsx
+++ b/app/owner/entities/page.tsx
@@ -25,25 +25,15 @@ export default async function EntitiesPage() {
 
   if (!profile || profile.role !== "owner") redirect("/auth/signin");
 
-  // Fetch owner_profile
-  const { data: ownerProfile } = await supabase
-    .from("owner_profiles")
-    .select("id")
-    .eq("profile_id", profile.id)
-    .single();
+  // Fetch entities — profile.id is the FK value for legal_entities.owner_profile_id
+  const { data } = await supabase
+    .from("legal_entities")
+    .select("*")
+    .eq("owner_profile_id", profile.id)
+    .eq("is_active", true)
+    .order("nom");
 
-  // Fetch entities
-  let entities: Record<string, unknown>[] = [];
-  if (ownerProfile?.id) {
-    const { data } = await supabase
-      .from("legal_entities")
-      .select("*")
-      .eq("owner_profile_id", ownerProfile.id)
-      .eq("is_active", true)
-      .order("nom");
-
-    entities = (data || []) as Record<string, unknown>[];
-  }
+  const entities: Record<string, unknown>[] = (data || []) as Record<string, unknown>[];
 
   return <EntitiesPageClient entities={entities} />;
 }

--- a/components/profile/profile-completion.tsx
+++ b/components/profile/profile-completion.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { useEntityStore } from "@/stores/useEntityStore";
 import type { ProfileFormData } from "@/lib/hooks/use-profile-form";
 
 interface ProfileCompletionProps {
@@ -12,7 +13,7 @@ interface WeightedField {
   weight: number;
 }
 
-function calculateCompletion(data: ProfileFormData): number {
+function calculateCompletion(data: ProfileFormData, entityCount: number): number {
   const fields: WeightedField[] = [
     // Required fields (weight 2)
     { filled: !!data.prenom.trim(), weight: 2 },
@@ -26,6 +27,11 @@ function calculateCompletion(data: ProfileFormData): number {
     { filled: !!data.adresse_facturation.trim(), weight: 1 },
   ];
 
+  // For "societe" owners, having at least one entity is a required criterion
+  if (data.owner_type === "societe") {
+    fields.push({ filled: entityCount > 0, weight: 2 });
+  }
+
   const totalWeight = fields.reduce((sum, f) => sum + f.weight, 0);
   const filledWeight = fields
     .filter((f) => f.filled)
@@ -35,7 +41,8 @@ function calculateCompletion(data: ProfileFormData): number {
 }
 
 export function ProfileCompletion({ data }: ProfileCompletionProps) {
-  const completion = calculateCompletion(data);
+  const { entities } = useEntityStore();
+  const completion = calculateCompletion(data, entities.length);
 
   return (
     <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
This PR removes unnecessary queries to the `owner_profiles` table by recognizing that `profile.id` directly serves as the foreign key value for `legal_entities.owner_profile_id`. The `owner_profiles` table's primary key is `profile_id` (not `id`), making the intermediate lookup redundant.

## Key Changes
- **app/owner/entities/actions.ts**: Removed `owner_profiles` query in `getAuthenticatedOwnerProfileId()` and directly return `profile.id` as the `ownerProfileId`
- **app/owner/entities/new/page.tsx**: Removed `owner_profiles` lookup when creating new entities; use `profile.id` directly for the `owner_profile_id` field
- **app/owner/entities/page.tsx**: Simplified entity fetching by querying `legal_entities` directly with `profile.id` instead of first fetching from `owner_profiles`
- **providers/EntityProvider.tsx**: Removed intermediate `owner_profiles` query; pass `profile.id` directly to `fetchEntities()`
- **components/profile/profile-completion.tsx**: Enhanced profile completion calculation to include entity count as a required criterion for "societe" owner type; now uses `useEntityStore` to access entity data

## Implementation Details
- The schema relationship is: `profiles.id` = `owner_profiles.profile_id` = `legal_entities.owner_profile_id`
- By eliminating the intermediate `owner_profiles` query, we reduce database calls and simplify the data flow
- Added clarifying comments throughout to document this relationship
- Profile completion now properly reflects that "societe" owners must have at least one legal entity to be considered complete

https://claude.ai/code/session_01X6wRuyDbeb9vA6CZ7oJpQT