### PR TITLE
Refactor entity creation with server-side validation and adaptive stepper

### DIFF
--- a/app/owner/entities/new/page.tsx
+++ b/app/owner/entities/new/page.tsx
@@ -2,15 +2,22 @@
 
 /**
  * Page /owner/entities/new — Création d'une nouvelle entité juridique (stepper 5 étapes)
+ *
+ * Corrections apportées :
+ * - Validation stricte par étape (canProceed + validateStep avec erreurs inline)
+ * - Utilisation de la Server Action createEntity (validation Zod côté serveur)
+ * - Auto-remplissage forme juridique et régime fiscal depuis le type d'entité
+ * - Stepper adaptatif pour le type "particulier" (2 étapes au lieu de 5)
+ * - Sauvegarde email/téléphone/dateNaissance/qualité (données auparavant perdues)
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronLeft, ChevronRight, Check, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
-import { createClient } from "@/lib/supabase/client";
 import { useEntityStore } from "@/stores/useEntityStore";
+import { createEntity } from "@/app/owner/entities/actions";
 import { StepEntityType } from "@/components/entities/create/StepEntityType";
 import { StepLegalInfo } from "@/components/entities/create/StepLegalInfo";
 import { StepAddress } from "@/components/entities/create/StepAddress";
@@ -81,13 +88,43 @@ const INITIAL_DATA: EntityFormData = {
   banqueNom: "",
 };
 
-const STEPS = [
+const ALL_STEPS = [
   { id: 1, label: "Type" },
   { id: 2, label: "Légal" },
   { id: 3, label: "Adresse" },
   { id: 4, label: "Représentant" },
   { id: 5, label: "Bancaire" },
 ];
+
+const PARTICULIER_STEPS = [
+  { id: 1, label: "Type" },
+  { id: 5, label: "Bancaire" },
+];
+
+// Entity type → Forme juridique auto-mapping
+const ENTITY_TYPE_TO_FORME: Record<string, string> = {
+  sci_ir: "SCI",
+  sci_is: "SCI",
+  sarl: "SARL",
+  sarl_famille: "SARL",
+  sas: "SAS",
+  sasu: "SASU",
+  eurl: "EURL",
+  sa: "SA",
+  snc: "SNC",
+};
+
+// Régime fiscal constraints
+const FORCE_IS_TYPES = ["sci_is", "sas", "sasu", "sa"];
+
+function getDefaultRegimeFiscal(entityType: string): string {
+  if (FORCE_IS_TYPES.includes(entityType)) return "is";
+  return "ir";
+}
+
+export function isRegimeFiscalLocked(entityType: string): boolean {
+  return FORCE_IS_TYPES.includes(entityType);
+}
 
 // ============================================
 // PAGE
@@ -100,13 +137,129 @@ export default function NewEntityPage() {
 
   const [step, setStep] = useState(1);
   const [formData, setFormData] = useState<EntityFormData>(INITIAL_DATA);
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isParticulier = formData.entityType === "particulier";
+
+  // Visible steps adapt for "particulier"
+  const visibleSteps = useMemo(
+    () => (isParticulier ? PARTICULIER_STEPS : ALL_STEPS),
+    [isParticulier]
+  );
 
   const updateFormData = useCallback(
     (updates: Partial<EntityFormData>) => {
-      setFormData((prev) => ({ ...prev, ...updates }));
+      setFormData((prev) => {
+        const next = { ...prev, ...updates };
+
+        // Auto-fill forme juridique and régime fiscal when entity type changes
+        if (updates.entityType && updates.entityType !== prev.entityType) {
+          const forme = ENTITY_TYPE_TO_FORME[updates.entityType];
+          next.formeJuridique = forme || "";
+          next.regimeFiscal = getDefaultRegimeFiscal(updates.entityType);
+
+          // Auto-set nom for "particulier"
+          if (updates.entityType === "particulier" && !prev.nom) {
+            next.nom = "Patrimoine personnel";
+          }
+        }
+
+        return next;
+      });
+
+      // Clear errors for changed fields
+      const keys = Object.keys(updates);
+      if (keys.length > 0) {
+        setErrors((prev) => {
+          const next = { ...prev };
+          for (const key of keys) {
+            delete next[key];
+          }
+          return next;
+        });
+      }
     },
     []
+  );
+
+  // Validate a specific step — returns true if valid, sets errors otherwise
+  const validateStep = useCallback(
+    (stepNum: number): boolean => {
+      const newErrors: Record<string, string> = {};
+
+      switch (stepNum) {
+        case 1:
+          if (!formData.entityType) {
+            newErrors.entityType =
+              "Veuillez sélectionner un type de structure";
+          }
+          break;
+
+        case 2:
+          if (isParticulier) break;
+          if (!formData.nom.trim()) {
+            newErrors.nom = "La raison sociale est obligatoire";
+          }
+          if (!formData.formeJuridique) {
+            newErrors.formeJuridique = "La forme juridique est obligatoire";
+          }
+          if (formData.siret) {
+            const digits = formData.siret.replace(/\D/g, "");
+            if (digits.length > 0 && digits.length !== 14) {
+              newErrors.siret = "Le SIRET doit contenir 14 chiffres";
+            }
+          }
+          break;
+
+        case 3:
+          if (isParticulier) break;
+          if (!formData.adresseSiege.trim()) {
+            newErrors.adresseSiege = "L'adresse est obligatoire";
+          }
+          if (!formData.codePostalSiege) {
+            newErrors.codePostalSiege = "Le code postal est obligatoire";
+          } else if (!/^\d{5}$/.test(formData.codePostalSiege)) {
+            newErrors.codePostalSiege =
+              "Le code postal doit contenir 5 chiffres";
+          }
+          if (!formData.villeSiege.trim()) {
+            newErrors.villeSiege = "La ville est obligatoire";
+          }
+          if (
+            formData.emailEntite &&
+            !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.emailEntite)
+          ) {
+            newErrors.emailEntite = "Format d'email invalide";
+          }
+          break;
+
+        case 4:
+          if (formData.representantMode === "other") {
+            if (!formData.representantPrenom.trim()) {
+              newErrors.representantPrenom = "Le prénom est obligatoire";
+            }
+            if (!formData.representantNom.trim()) {
+              newErrors.representantNom = "Le nom est obligatoire";
+            }
+          }
+          break;
+
+        case 5:
+          if (formData.iban) {
+            const cleanIban = formData.iban.replace(/\s/g, "");
+            if (cleanIban.length < 15 || cleanIban.length > 34) {
+              newErrors.iban =
+                "L'IBAN doit contenir entre 15 et 34 caractères";
+            }
+          }
+          break;
+      }
+
+      setErrors(newErrors);
+      return Object.keys(newErrors).length === 0;
+    },
+    [formData, isParticulier]
   );
 
   const canProceed = useCallback((): boolean => {
@@ -114,25 +267,36 @@ export default function NewEntityPage() {
       case 1:
         return !!formData.entityType;
       case 2:
-        if (formData.entityType === "particulier") return true;
-        return !!(formData.nom && formData.formeJuridique);
+        if (isParticulier) return true;
+        return !!(formData.nom.trim() && formData.formeJuridique);
       case 3:
-        if (formData.entityType === "particulier") return true;
-        return !!(formData.adresseSiege && formData.codePostalSiege && formData.villeSiege);
+        if (isParticulier) return true;
+        return !!(
+          formData.adresseSiege.trim() &&
+          formData.codePostalSiege &&
+          formData.villeSiege.trim()
+        );
       case 4:
+        if (formData.representantMode === "other") {
+          return !!(
+            formData.representantPrenom.trim() &&
+            formData.representantNom.trim()
+          );
+        }
         return true;
       case 5:
         return true;
       default:
         return false;
     }
-  }, [step, formData]);
+  }, [step, formData, isParticulier]);
 
   const handleNext = () => {
+    if (!validateStep(step)) return;
+
     if (step < 5) {
-      // Skip step 2 for "particulier"
-      if (step === 1 && formData.entityType === "particulier") {
-        setStep(5); // Jump to bank details
+      if (step === 1 && isParticulier) {
+        setStep(5);
         return;
       }
       setStep((s) => s + 1);
@@ -140,8 +304,9 @@ export default function NewEntityPage() {
   };
 
   const handleBack = () => {
+    setErrors({});
     if (step > 1) {
-      if (step === 5 && formData.entityType === "particulier") {
+      if (step === 5 && isParticulier) {
         setStep(1);
         return;
       }
@@ -152,104 +317,81 @@ export default function NewEntityPage() {
   };
 
   const handleSubmit = async () => {
+    if (!validateStep(step)) return;
     setIsSubmitting(true);
 
     try {
-      const supabase = createClient();
+      const result = await createEntity({
+        entity_type: formData.entityType as Parameters<
+          typeof createEntity
+        >[0]["entity_type"],
+        nom: formData.nom || "Patrimoine personnel",
+        forme_juridique: formData.formeJuridique || undefined,
+        regime_fiscal:
+          (formData.regimeFiscal as "ir" | "is" | "ir_option_is" | "is_option_ir") ||
+          undefined,
+        siret: formData.siret.replace(/\s/g, "") || undefined,
+        capital_social: formData.capitalSocial
+          ? parseFloat(formData.capitalSocial)
+          : undefined,
+        date_creation: formData.dateCreation || undefined,
+        numero_tva: formData.numeroTva || undefined,
+        adresse_siege: formData.adresseSiege || undefined,
+        code_postal_siege: formData.codePostalSiege || undefined,
+        ville_siege: formData.villeSiege || undefined,
+        iban: formData.iban.replace(/\s/g, "") || undefined,
+        bic: formData.bic || undefined,
+        banque_nom: formData.banqueNom || undefined,
+        representant_mode: formData.representantMode,
+        representant_prenom: formData.representantPrenom || undefined,
+        representant_nom: formData.representantNom || undefined,
+        representant_qualite: formData.representantQualite || undefined,
+        representant_date_naissance:
+          formData.representantDateNaissance || undefined,
+        email_entite: formData.emailEntite || undefined,
+        telephone_entite: formData.telephoneEntite || undefined,
+      });
 
-      // Get profile.id — which is the FK value for legal_entities.owner_profile_id
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("Non authentifié");
-
-      const { data: profile } = await supabase
-        .from("profiles")
-        .select("id")
-        .eq("user_id", user.id)
-        .single();
-      if (!profile) throw new Error("Profil non trouvé");
-
-      // Map form data to DB
-      const entityPayload = {
-        owner_profile_id: profile.id,
-        entity_type: formData.entityType || "sci_ir",
-        nom: formData.nom || `Entité de ${profile.id.slice(0, 8)}`,
-        forme_juridique: formData.formeJuridique || null,
-        regime_fiscal: formData.regimeFiscal || "ir",
-        siret: formData.siret.replace(/\s/g, "") || null,
-        capital_social: formData.capitalSocial ? parseFloat(formData.capitalSocial) : null,
-        date_creation: formData.dateCreation || null,
-        numero_tva: formData.numeroTva || null,
-        adresse_siege: formData.adresseSiege || null,
-        code_postal_siege: formData.codePostalSiege || null,
-        ville_siege: formData.villeSiege || null,
-        iban: formData.iban.replace(/\s/g, "") || null,
-        bic: formData.bic || null,
-        banque_nom: formData.banqueNom || null,
-        is_active: true,
-      };
-
-      const { data: newEntity, error } = await supabase
-        .from("legal_entities")
-        .insert(entityPayload)
-        .select()
-        .single();
-
-      if (error) throw new Error(error.message);
-
-      // Create associate (representative)
-      if (formData.representantMode === "self") {
-        await supabase.from("entity_associates").insert({
-          legal_entity_id: (newEntity as Record<string, unknown>).id,
-          profile_id: profile.id,
-          nom: null,
-          prenom: null,
-          nombre_parts: 100,
-          pourcentage_capital: 100,
-          is_gerant: true,
-          is_current: true,
-          date_entree: new Date().toISOString().split("T")[0],
+      if (!result.success) {
+        toast({
+          title: "Erreur",
+          description: result.error,
+          variant: "destructive",
         });
-      } else if (formData.representantNom) {
-        await supabase.from("entity_associates").insert({
-          legal_entity_id: (newEntity as Record<string, unknown>).id,
-          nom: formData.representantNom,
-          prenom: formData.representantPrenom,
-          nombre_parts: 100,
-          pourcentage_capital: 100,
-          is_gerant: true,
-          is_current: true,
-          date_entree: new Date().toISOString().split("T")[0],
-        });
+        return;
       }
 
-      // Update store
+      const entityId = result.data?.id;
+
+      // Update client store
       addEntity({
-        id: (newEntity as Record<string, unknown>).id as string,
-        nom: entityPayload.nom,
-        entityType: entityPayload.entity_type,
-        legalForm: entityPayload.forme_juridique,
-        fiscalRegime: entityPayload.regime_fiscal,
-        siret: entityPayload.siret,
-        codePostalSiege: entityPayload.code_postal_siege,
-        villeSiege: entityPayload.ville_siege,
+        id: entityId!,
+        nom: formData.nom || "Patrimoine personnel",
+        entityType: formData.entityType,
+        legalForm: formData.formeJuridique || null,
+        fiscalRegime: formData.regimeFiscal || null,
+        siret: formData.siret.replace(/\s/g, "") || null,
+        codePostalSiege: formData.codePostalSiege || null,
+        villeSiege: formData.villeSiege || null,
         isDefault: false,
         isActive: true,
         couleur: null,
         propertyCount: 0,
         activeLeaseCount: 0,
-        hasIban: !!entityPayload.iban,
+        hasIban: !!formData.iban,
       });
 
       toast({
         title: "Entité créée",
-        description: `${entityPayload.nom} a été créée avec succès.`,
+        description: `${formData.nom || "Patrimoine personnel"} a été créée avec succès.`,
       });
 
-      router.push(`/owner/entities/${(newEntity as Record<string, unknown>).id}`);
+      router.push(`/owner/entities/${entityId}`);
     } catch (err) {
       toast({
         title: "Erreur",
-        description: err instanceof Error ? err.message : "Impossible de créer l'entité.",
+        description:
+          err instanceof Error ? err.message : "Impossible de créer l'entité.",
         variant: "destructive",
       });
     } finally {
@@ -274,42 +416,46 @@ export default function NewEntityPage() {
         </p>
       </div>
 
-      {/* Progress bar */}
+      {/* Progress bar — adapts for "particulier" (2 steps) */}
       <div className="flex items-center gap-2">
-        {STEPS.map((s) => (
-          <div key={s.id} className="flex items-center gap-2 flex-1">
-            <div
-              className={cn(
-                "h-8 w-8 rounded-full flex items-center justify-center text-sm font-medium shrink-0 transition-colors",
-                step > s.id
-                  ? "bg-primary text-primary-foreground"
-                  : step === s.id
-                    ? "bg-primary text-primary-foreground ring-4 ring-primary/20"
-                    : "bg-muted text-muted-foreground"
-              )}
-            >
-              {step > s.id ? <Check className="h-4 w-4" /> : s.id}
-            </div>
-            <span
-              className={cn(
-                "text-xs font-medium hidden sm:block",
-                step >= s.id
-                  ? "text-foreground"
-                  : "text-muted-foreground"
-              )}
-            >
-              {s.label}
-            </span>
-            {s.id < STEPS.length && (
+        {visibleSteps.map((s, index) => {
+          const isCompleted = step > s.id;
+          const isCurrent = step === s.id;
+          return (
+            <div key={s.id} className="flex items-center gap-2 flex-1">
               <div
                 className={cn(
-                  "flex-1 h-0.5 rounded-full",
-                  step > s.id ? "bg-primary" : "bg-muted"
+                  "h-8 w-8 rounded-full flex items-center justify-center text-sm font-medium shrink-0 transition-colors",
+                  isCompleted
+                    ? "bg-primary text-primary-foreground"
+                    : isCurrent
+                      ? "bg-primary text-primary-foreground ring-4 ring-primary/20"
+                      : "bg-muted text-muted-foreground"
                 )}
-              />
-            )}
-          </div>
-        ))}
+              >
+                {isCompleted ? <Check className="h-4 w-4" /> : index + 1}
+              </div>
+              <span
+                className={cn(
+                  "text-xs font-medium hidden sm:block",
+                  isCompleted || isCurrent
+                    ? "text-foreground"
+                    : "text-muted-foreground"
+                )}
+              >
+                {s.label}
+              </span>
+              {index < visibleSteps.length - 1 && (
+                <div
+                  className={cn(
+                    "flex-1 h-0.5 rounded-full",
+                    isCompleted ? "bg-primary" : "bg-muted"
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {/* Step content */}
@@ -321,16 +467,33 @@ export default function NewEntityPage() {
           />
         )}
         {step === 2 && (
-          <StepLegalInfo formData={formData} onChange={updateFormData} />
+          <StepLegalInfo
+            formData={formData}
+            onChange={updateFormData}
+            errors={errors}
+          />
         )}
         {step === 3 && (
-          <StepAddress formData={formData} onChange={updateFormData} />
+          <StepAddress
+            formData={formData}
+            onChange={updateFormData}
+            errors={errors}
+          />
         )}
         {step === 4 && (
-          <StepRepresentative formData={formData} onChange={updateFormData} />
+          <StepRepresentative
+            formData={formData}
+            onChange={updateFormData}
+            errors={errors}
+          />
         )}
         {step === 5 && (
-          <StepBankDetails formData={formData} onChange={updateFormData} />
+          <StepBankDetails
+            formData={formData}
+            onChange={updateFormData}
+            errors={errors}
+            showNomField={isParticulier}
+          />
         )}
       </div>
 
@@ -347,7 +510,7 @@ export default function NewEntityPage() {
             <ChevronRight className="h-4 w-4 ml-1" />
           </Button>
         ) : (
-          <Button onClick={handleSubmit} disabled={isSubmitting}>
+          <Button onClick={handleSubmit} disabled={isSubmitting || !canProceed()}>
             {isSubmitting ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/components/entities/create/StepAddress.tsx
+++ b/components/entities/create/StepAddress.tsx
@@ -8,9 +8,10 @@ import type { EntityFormData } from "@/app/owner/entities/new/page";
 interface StepAddressProps {
   formData: EntityFormData;
   onChange: (updates: Partial<EntityFormData>) => void;
+  errors?: Record<string, string>;
 }
 
-export function StepAddress({ formData, onChange }: StepAddressProps) {
+export function StepAddress({ formData, onChange, errors }: StepAddressProps) {
   const isDom = isDomTomPostalCode(formData.codePostalSiege);
   const tvaRate = getTvaRate(formData.codePostalSiege);
 
@@ -45,11 +46,14 @@ export function StepAddress({ formData, onChange }: StepAddressProps) {
           </Label>
           <textarea
             id="adresseSiege"
-            className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className={`flex min-h-[80px] w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${errors?.adresseSiege ? "border-destructive" : "border-input"}`}
             value={formData.adresseSiege}
             onChange={(e) => onChange({ adresseSiege: e.target.value })}
             placeholder="12 rue Victor Schoelcher"
           />
+          {errors?.adresseSiege && (
+            <p className="text-xs text-destructive">{errors.adresseSiege}</p>
+          )}
         </div>
 
         {/* Code postal */}
@@ -63,7 +67,11 @@ export function StepAddress({ formData, onChange }: StepAddressProps) {
             onChange={(e) => onChange({ codePostalSiege: e.target.value.replace(/\D/g, "").slice(0, 5) })}
             placeholder="97200"
             maxLength={5}
+            className={errors?.codePostalSiege ? "border-destructive" : ""}
           />
+          {errors?.codePostalSiege && (
+            <p className="text-xs text-destructive">{errors.codePostalSiege}</p>
+          )}
         </div>
 
         {/* Ville */}
@@ -76,7 +84,11 @@ export function StepAddress({ formData, onChange }: StepAddressProps) {
             value={formData.villeSiege}
             onChange={(e) => onChange({ villeSiege: e.target.value })}
             placeholder="Fort-de-France"
+            className={errors?.villeSiege ? "border-destructive" : ""}
           />
+          {errors?.villeSiege && (
+            <p className="text-xs text-destructive">{errors.villeSiege}</p>
+          )}
         </div>
 
         {/* Email entité */}
@@ -88,7 +100,11 @@ export function StepAddress({ formData, onChange }: StepAddressProps) {
             value={formData.emailEntite}
             onChange={(e) => onChange({ emailEntite: e.target.value })}
             placeholder="contact@atomgiste.fr"
+            className={errors?.emailEntite ? "border-destructive" : ""}
           />
+          {errors?.emailEntite && (
+            <p className="text-xs text-destructive">{errors.emailEntite}</p>
+          )}
         </div>
 
         {/* Téléphone */}

--- a/components/entities/create/StepBankDetails.tsx
+++ b/components/entities/create/StepBankDetails.tsx
@@ -7,9 +7,16 @@ import type { EntityFormData } from "@/app/owner/entities/new/page";
 interface StepBankDetailsProps {
   formData: EntityFormData;
   onChange: (updates: Partial<EntityFormData>) => void;
+  errors?: Record<string, string>;
+  showNomField?: boolean;
 }
 
-export function StepBankDetails({ formData, onChange }: StepBankDetailsProps) {
+export function StepBankDetails({
+  formData,
+  onChange,
+  errors,
+  showNomField,
+}: StepBankDetailsProps) {
   return (
     <div className="space-y-4">
       <div>
@@ -18,6 +25,24 @@ export function StepBankDetails({ formData, onChange }: StepBankDetailsProps) {
           Pour recevoir les loyers et configurer Stripe Connect
         </p>
       </div>
+
+      {/* Nom field for "particulier" type (skipped legal step) */}
+      {showNomField && (
+        <div className="space-y-2">
+          <Label htmlFor="nom-particulier">
+            Nom de l&apos;entité
+          </Label>
+          <Input
+            id="nom-particulier"
+            value={formData.nom}
+            onChange={(e) => onChange({ nom: e.target.value })}
+            placeholder="Patrimoine personnel"
+          />
+          <p className="text-xs text-muted-foreground">
+            Un nom pour identifier votre patrimoine en nom propre
+          </p>
+        </div>
+      )}
 
       <div className="grid gap-4 sm:grid-cols-2">
         {/* IBAN */}
@@ -33,11 +58,15 @@ export function StepBankDetails({ formData, onChange }: StepBankDetailsProps) {
               onChange({ iban: v });
             }}
             placeholder="FR76 XXXX XXXX XXXX XXXX XXXX XXX"
-            className="font-mono"
+            className={`font-mono ${errors?.iban ? "border-destructive" : ""}`}
           />
-          <p className="text-xs text-muted-foreground">
-            L&apos;IBAN sera utilisé pour les virements de loyers
-          </p>
+          {errors?.iban ? (
+            <p className="text-xs text-destructive">{errors.iban}</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              L&apos;IBAN sera utilisé pour les virements de loyers
+            </p>
+          )}
         </div>
 
         {/* BIC */}

--- a/components/entities/create/StepLegalInfo.tsx
+++ b/components/entities/create/StepLegalInfo.tsx
@@ -2,11 +2,13 @@
 
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { isRegimeFiscalLocked } from "@/app/owner/entities/new/page";
 import type { EntityFormData } from "@/app/owner/entities/new/page";
 
 interface StepLegalInfoProps {
   formData: EntityFormData;
   onChange: (updates: Partial<EntityFormData>) => void;
+  errors?: Record<string, string>;
 }
 
 const FORME_JURIDIQUE_OPTIONS = [
@@ -25,7 +27,9 @@ const REGIME_FISCAL_OPTIONS = [
   { value: "is", label: "Impôt sur les Sociétés (IS)" },
 ];
 
-export function StepLegalInfo({ formData, onChange }: StepLegalInfoProps) {
+export function StepLegalInfo({ formData, onChange, errors }: StepLegalInfoProps) {
+  const regimeLocked = isRegimeFiscalLocked(formData.entityType);
+
   return (
     <div className="space-y-4">
       <div>
@@ -46,7 +50,11 @@ export function StepLegalInfo({ formData, onChange }: StepLegalInfoProps) {
             value={formData.nom}
             onChange={(e) => onChange({ nom: e.target.value })}
             placeholder="Ex: ATOMGISTE"
+            className={errors?.nom ? "border-destructive" : ""}
           />
+          {errors?.nom && (
+            <p className="text-xs text-destructive">{errors.nom}</p>
+          )}
         </div>
 
         {/* Forme juridique */}
@@ -56,7 +64,7 @@ export function StepLegalInfo({ formData, onChange }: StepLegalInfoProps) {
           </Label>
           <select
             id="formeJuridique"
-            className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className={`flex h-11 w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${errors?.formeJuridique ? "border-destructive" : "border-input"}`}
             value={formData.formeJuridique}
             onChange={(e) => onChange({ formeJuridique: e.target.value })}
           >
@@ -67,6 +75,9 @@ export function StepLegalInfo({ formData, onChange }: StepLegalInfoProps) {
               </option>
             ))}
           </select>
+          {errors?.formeJuridique && (
+            <p className="text-xs text-destructive">{errors.formeJuridique}</p>
+          )}
         </div>
 
         {/* Régime fiscal */}
@@ -76,9 +87,10 @@ export function StepLegalInfo({ formData, onChange }: StepLegalInfoProps) {
           </Label>
           <select
             id="regimeFiscal"
-            className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="flex h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
             value={formData.regimeFiscal}
             onChange={(e) => onChange({ regimeFiscal: e.target.value })}
+            disabled={regimeLocked}
           >
             {REGIME_FISCAL_OPTIONS.map((o) => (
               <option key={o.value} value={o.value}>
@@ -86,6 +98,11 @@ export function StepLegalInfo({ formData, onChange }: StepLegalInfoProps) {
               </option>
             ))}
           </select>
+          {regimeLocked && (
+            <p className="text-xs text-muted-foreground">
+              Imposé par le type de structure sélectionné
+            </p>
+          )}
         </div>
 
         {/* SIRET */}
@@ -100,7 +117,11 @@ export function StepLegalInfo({ formData, onChange }: StepLegalInfoProps) {
             }}
             placeholder="123 456 789 01234"
             maxLength={17}
+            className={errors?.siret ? "border-destructive" : ""}
           />
+          {errors?.siret && (
+            <p className="text-xs text-destructive">{errors.siret}</p>
+          )}
         </div>
 
         {/* Capital social */}

--- a/components/entities/create/StepRepresentative.tsx
+++ b/components/entities/create/StepRepresentative.tsx
@@ -8,6 +8,7 @@ import type { EntityFormData } from "@/app/owner/entities/new/page";
 interface StepRepresentativeProps {
   formData: EntityFormData;
   onChange: (updates: Partial<EntityFormData>) => void;
+  errors?: Record<string, string>;
 }
 
 const QUALITE_OPTIONS: Record<string, string[]> = {
@@ -23,6 +24,7 @@ const QUALITE_OPTIONS: Record<string, string[]> = {
 export function StepRepresentative({
   formData,
   onChange,
+  errors,
 }: StepRepresentativeProps) {
   const qualiteOptions =
     QUALITE_OPTIONS[formData.formeJuridique] || ["Gérant(e)", "Président(e)"];
@@ -101,7 +103,13 @@ export function StepRepresentative({
                 onChange({ representantPrenom: e.target.value })
               }
               placeholder="Marie-Line"
+              className={errors?.representantPrenom ? "border-destructive" : ""}
             />
+            {errors?.representantPrenom && (
+              <p className="text-xs text-destructive">
+                {errors.representantPrenom}
+              </p>
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="representantNom">
@@ -114,7 +122,13 @@ export function StepRepresentative({
                 onChange({ representantNom: e.target.value })
               }
               placeholder="VOLBERG"
+              className={errors?.representantNom ? "border-destructive" : ""}
             />
+            {errors?.representantNom && (
+              <p className="text-xs text-destructive">
+                {errors.representantNom}
+              </p>
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="representantDateNaissance">


### PR DESCRIPTION
## Summary
Refactored the entity creation flow to use server-side validation via Zod schemas, implement step-by-step validation with inline error display, and add adaptive UI for "particulier" entity type. The stepper now intelligently skips steps based on entity type, auto-fills legal form and fiscal regime, and properly persists previously-lost contact information.

## Key Changes

### Server-Side Validation (actions.ts)
- Added strict Zod validation for postal codes (5 digits), IBAN (15-34 chars), and email format
- Implemented metadata JSONB storage for email and phone fields without dedicated DB columns
- Enhanced representative creation logic to support both "self" (authenticated user) and "other" (named representative) modes
- Added `representant_date_naissance` field to capture birth date

### Client-Side Form Logic (new/page.tsx)
- Implemented per-step validation with `validateStep()` that returns boolean and sets inline errors
- Added `canProceed()` check before advancing steps
- Created adaptive stepper: "particulier" type shows only 2 steps (Type → Bancaire) vs 5 for other types
- Auto-fill `formeJuridique` and `regimeFiscal` based on `entityType` selection
- Lock fiscal regime dropdown for types that force IS (SAS, SASU, SA, SCI-IS)
- Auto-set nom to "Patrimoine personnel" for particulier entities
- Replaced direct Supabase calls with `createEntity()` server action
- Added error state management with field-level error clearing on input change

### Component Updates
- **StepLegalInfo**: Added error display, disabled regime fiscal dropdown when locked, show explanatory text
- **StepAddress**: Added error display for address, postal code, city, and email fields
- **StepRepresentative**: Added error display for first/last name fields when "other" mode selected
- **StepBankDetails**: Added error display for IBAN, show nom field for particulier type

### Data Persistence
- Email, phone, and representative birth date now properly saved (previously lost)
- Representative mode ("self" vs "other") now controls associate creation logic
- All form data properly mapped to server action parameters with type safety

## Notable Implementation Details
- Validation runs on step transition and final submission
- Errors clear automatically when user modifies a field
- Stepper progress bar dynamically adjusts step count based on entity type
- IBAN/postal code formatting handled client-side with server-side re-validation
- Representative creation branches on mode: "self" links to authenticated profile, "other" creates named associate

https://claude.ai/code/session_014mZgM2Sd6GM1mTXKMtJpep