### PR TITLE
Add SMS messaging table and extend roommate invitation fields

### DIFF
--- a/app/api/leases/[id]/roommates/route.ts
+++ b/app/api/leases/[id]/roommates/route.ts
@@ -194,6 +194,10 @@ export async function POST(
       joined_on: validated.joined_on || new Date().toISOString().split("T")[0],
       invitation_status: existingProfile ? "accepted" : "pending",
       invited_email: validated.email,
+      room_label: validated.room_label ?? null,
+      has_guarantor: validated.has_guarantor ?? false,
+      guarantor_email: validated.guarantor_email ?? null,
+      guarantor_name: validated.guarantor_name ?? null,
     };
 
     if (existingProfile) {

--- a/features/tenant/services/roommates.service.ts
+++ b/features/tenant/services/roommates.service.ts
@@ -4,14 +4,20 @@ import { apiClient } from "@/lib/api-client";
 export interface Roommate {
   id: string;
   lease_id: string;
-  user_id: string;
-  profile_id: string;
+  user_id: string | null;
+  profile_id: string | null;
   role: "principal" | "tenant" | "occupant" | "guarantor";
-  first_name: string;
-  last_name: string;
+  first_name: string | null;
+  last_name: string | null;
   weight: number;
   joined_on: string;
   left_on?: string | null;
+  invited_email?: string | null;
+  invitation_status?: "pending" | "accepted" | "declined";
+  room_label?: string | null;
+  has_guarantor?: boolean;
+  guarantor_email?: string | null;
+  guarantor_name?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20260209100000_create_sms_messages_table.sql
+++ b/supabase/migrations/20260209100000_create_sms_messages_table.sql
@@ -1,0 +1,108 @@
+-- Migration: Create sms_messages table for Twilio SMS tracking (2026-02-09)
+--
+-- The application code (API routes) already references this table:
+--   - POST /api/notifications/sms/send  → inserts SMS records
+--   - POST /api/webhooks/twilio          → updates delivery status
+-- But the table was never created in a migration.
+
+-- ============================================================
+-- 1. Create sms_messages table
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS sms_messages (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id    UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  from_number   TEXT NOT NULL,
+  to_number     TEXT NOT NULL,
+  message       TEXT NOT NULL,
+  segments      INT DEFAULT 1,
+  twilio_sid    TEXT,
+  twilio_status TEXT,
+  status        TEXT NOT NULL DEFAULT 'queued'
+                CHECK (status IN ('queued', 'sent', 'delivered', 'undelivered', 'failed')),
+  error_code    TEXT,
+  error_message TEXT,
+  sent_at       TIMESTAMPTZ,
+  delivered_at  TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  sms_messages IS 'Journal des SMS envoyés via Twilio';
+COMMENT ON COLUMN sms_messages.profile_id    IS 'Profil destinataire (nullable si envoi à un numéro libre)';
+COMMENT ON COLUMN sms_messages.from_number   IS 'Numéro ou service Twilio expéditeur';
+COMMENT ON COLUMN sms_messages.to_number     IS 'Numéro de téléphone du destinataire (format E.164)';
+COMMENT ON COLUMN sms_messages.segments      IS 'Nombre de segments SMS (1 segment = 160 caractères)';
+COMMENT ON COLUMN sms_messages.twilio_sid    IS 'SID du message Twilio (pour corrélation webhook)';
+COMMENT ON COLUMN sms_messages.twilio_status IS 'Dernier statut brut renvoyé par Twilio';
+COMMENT ON COLUMN sms_messages.status        IS 'Statut normalisé : queued, sent, delivered, undelivered, failed';
+
+-- ============================================================
+-- 2. Indexes
+-- ============================================================
+
+-- Lookup by Twilio SID (webhook updates)
+CREATE INDEX IF NOT EXISTS idx_sms_messages_twilio_sid
+  ON sms_messages (twilio_sid)
+  WHERE twilio_sid IS NOT NULL;
+
+-- Lookup by profile
+CREATE INDEX IF NOT EXISTS idx_sms_messages_profile_id
+  ON sms_messages (profile_id)
+  WHERE profile_id IS NOT NULL;
+
+-- Recent messages
+CREATE INDEX IF NOT EXISTS idx_sms_messages_created_at
+  ON sms_messages (created_at DESC);
+
+-- ============================================================
+-- 3. Auto-update updated_at trigger
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION update_sms_messages_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_sms_messages_updated_at ON sms_messages;
+CREATE TRIGGER trg_sms_messages_updated_at
+  BEFORE UPDATE ON sms_messages
+  FOR EACH ROW
+  EXECUTE FUNCTION update_sms_messages_updated_at();
+
+-- ============================================================
+-- 4. Row Level Security
+-- ============================================================
+
+ALTER TABLE sms_messages ENABLE ROW LEVEL SECURITY;
+
+-- Admins can see all SMS
+CREATE POLICY sms_messages_admin_all ON sms_messages
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.user_id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+-- Owners can see SMS they sent (via their profile)
+CREATE POLICY sms_messages_owner_select ON sms_messages
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.user_id = auth.uid()
+        AND p.role = 'owner'
+        AND p.id = sms_messages.profile_id
+    )
+  );
+
+-- Service role inserts (API routes use service role client, bypasses RLS)
+-- No explicit INSERT policy needed for service role, but add one for completeness
+CREATE POLICY sms_messages_service_insert ON sms_messages
+  FOR INSERT
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
This PR adds support for SMS message tracking via Twilio and extends the roommate invitation system with additional fields for guarantor information and room assignment.

## Key Changes

### SMS Messages Table (New Migration)
- Created `sms_messages` table to track all SMS communications sent through Twilio
- Includes fields for message content, delivery status, Twilio SID correlation, and error tracking
- Added indexes on `twilio_sid`, `profile_id`, and `created_at` for efficient querying
- Implemented auto-updating `updated_at` trigger
- Configured Row Level Security (RLS) policies:
  - Admins can view all SMS messages
  - Owners can view SMS they sent
  - Service role can insert records (used by API routes)

### Roommate Invitation Enhancement
- Extended `Roommate` interface to support invitation workflow:
  - Made `user_id` and `profile_id` nullable (users can be invited before account creation)
  - Made `first_name` and `last_name` nullable
  - Added `invited_email`, `invitation_status` fields for tracking pending invitations
  - Added guarantor-related fields: `has_guarantor`, `guarantor_email`, `guarantor_name`
  - Added `room_label` for room assignment tracking

- Updated POST endpoint to populate new roommate fields:
  - `room_label` from validated input
  - `has_guarantor` flag (defaults to false)
  - `guarantor_email` and `guarantor_name` from validated input

## Implementation Details
- The SMS table migration includes comprehensive comments in French and English
- RLS policies ensure data isolation while allowing service role (used by API) to bypass restrictions
- Roommate fields use nullish coalescing (`??`) to provide sensible defaults
- Migration timestamp: 2026-02-09 (note: future date, may need adjustment)

https://claude.ai/code/session_018UvYQwj6YJRUZPaQGy2Ufd