### PR TITLE
Add entity filtering and patrimoine tab for legal entities

### DIFF
--- a/features/properties/components/properties-list.tsx
+++ b/features/properties/components/properties-list.tsx
@@ -24,15 +24,6 @@ export function PropertiesList() {
   const { data: properties = [], isLoading, error, isError } = useProperties();
   const deleteProperty = useDeleteProperty();
 
-  // Debug logs
-  console.log("[PropertiesList] State:", {
-    propertiesCount: properties.length,
-    isLoading,
-    isError,
-    error: error?.message,
-    properties,
-  });
-
   const pagination = usePagination({
     totalItems: properties.length,
     itemsPerPage: 12,

--- a/lib/types/owner-property.ts
+++ b/lib/types/owner-property.ts
@@ -121,6 +121,11 @@ export interface OwnerProperty extends Omit<PropertyRow, 'surface' | 'nb_pieces'
   cover_document_id: string | null;
   documents_count: number;
 
+  // Entité propriétaire (ajoutée par l'API)
+  entity_nom?: string | null;
+  entity_type?: string | null;
+  entity_couleur?: string | null;
+
   // Données calculées côté client (optionnel)
   status?: "loue" | "en_preavis" | "vacant";
   currentLease?: LeaseInfo | null;


### PR DESCRIPTION
## Summary
This PR adds entity-based filtering for properties and introduces a new "Patrimoine" (Assets) tab in the entity detail view. Properties can now be filtered by legal entity, and the system properly handles personal properties (biens en nom propre) as a special case.

## Key Changes

### Backend API (`/api/owner/properties`)
- Added optional `entityId` query parameter to filter properties by legal entity
- Support for special "personal" filter to show only properties without an assigned entity (legal_entity_id = null)
- Enhanced property selection to include related legal entity data (nom, entity_type, couleur)
- Normalized response to include flattened entity fields (entity_nom, entity_type, entity_couleur) instead of nested objects

### Entity Detail Page
- Added new "Patrimoine" tab (6th tab) to display properties held by a legal entity
- New `PatrimoineTab` component that:
  - Fetches properties via `/api/owner/legal-entities/{entityId}/properties`
  - Displays summary cards (count, acquisition value, monthly rent, total surface)
  - Lists properties with detention type and quote-part information
  - Shows empty state with helpful guidance
  - Includes links to individual property pages

### Properties List Page
- Integrated entity filtering using `useEntityStore`
- Automatically filters properties based on active entity selection
- Handles "particulier" entity type by converting to "personal" filter
- Updated page title and subtitle to reflect active entity context
- Added entity name badge to property cards when viewing all entities
- Enhanced property subtitle to include entity name when applicable

### Hooks & Store
- Updated `useProperties()` hook to accept optional `entityId` parameter
- Implemented segmented cache keys to prevent data collision between different entity filters
- Enhanced `useEntityStore` to count properties for "particulier" entities (personal properties)
- Properties without legal_entity_id are now properly attributed to the "particulier" entity

### Type Updates
- Extended `OwnerProperty` interface with optional entity fields (entity_nom, entity_type, entity_couleur)

## Implementation Details
- Personal properties (legal_entity_id = null) are treated as belonging to the "particulier" entity type
- Entity filtering is transparent: null/undefined entityId shows all properties across all entities
- Cache keys are segmented by entityId to prevent stale data issues when switching between entities
- UI properly handles both entity-assigned and personal properties with appropriate labeling

https://claude.ai/code/session_01DGeBNgVXsR8pwQe4NPZ25B