### PR TITLE
fix(ui): increase lease preview to proper A4 format with document viewer styling

### DIFF
--- a/components/documents/LeasePreview.tsx
+++ b/components/documents/LeasePreview.tsx
@@ -54,7 +54,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
   }, [html]);
 
   return (
-    <Card className="h-full">
+    <Card className="h-full flex flex-col">
       <CardHeader className="pb-3 border-b flex flex-row items-center justify-between">
         <div className="flex items-center gap-2">
           <FileText className="h-5 w-5 text-blue-600" />
@@ -76,35 +76,45 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
                 <Maximize2 className="h-4 w-4" />
               </Button>
             </DialogTrigger>
-            <DialogContent className="max-w-[90vw] max-h-[90vh] p-0" aria-describedby={undefined}>
-              <DialogHeader className="p-4 border-b">
+            <DialogContent className="max-w-[95vw] h-[95vh] p-0 flex flex-col" aria-describedby={undefined}>
+              <DialogHeader className="p-4 border-b shrink-0">
                 <DialogTitle>Contrat de location - Plein écran</DialogTitle>
               </DialogHeader>
-              <div className="h-[80vh] overflow-hidden">
-                <iframe
-                  srcDoc={html}
-                  className="w-full h-full border-0"
-                  title="Aperçu bail plein écran"
-                />
+              <div className="flex-1 min-h-0 bg-[#525659] overflow-y-auto">
+                <div className="flex justify-center py-6 px-4">
+                  <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)]">
+                    <iframe
+                      srcDoc={html}
+                      className="w-full border-0"
+                      style={{ height: "calc(297mm * 2)" }}
+                      title="Aperçu bail plein écran"
+                    />
+                  </div>
+                </div>
               </div>
             </DialogContent>
           </Dialog>
         </div>
       </CardHeader>
-      <CardContent className="p-0">
-        {/* Conteneur responsive avec hauteur adaptative */}
-        <div className="relative bg-slate-100 min-h-[300px] sm:min-h-[400px] md:min-h-[500px]">
+      <CardContent className="p-0 flex-1 flex flex-col min-h-0">
+        {/* Conteneur A4 Document Viewer */}
+        <div className="relative bg-[#525659] flex-1 min-h-[400px]">
           {loading ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center px-4">
               <Loader2 className="h-6 w-6 sm:h-8 sm:w-8 animate-spin text-blue-600 mb-2" />
-              <p className="text-xs sm:text-sm text-muted-foreground text-center">Chargement du contrat...</p>
+              <p className="text-xs sm:text-sm text-white/80 text-center">Chargement du contrat...</p>
             </div>
           ) : (
-            <iframe
-              ref={iframeRef}
-              className="w-full h-[50vh] sm:h-[60vh] md:h-[70vh] max-h-[700px] border-0 bg-white"
-              title="Aperçu du bail"
-            />
+            <div className="h-full overflow-y-auto flex justify-center py-4 px-2 sm:px-4">
+              <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)] flex-shrink-0 h-fit">
+                <iframe
+                  ref={iframeRef}
+                  className="w-full border-0 bg-white"
+                  style={{ height: "calc(297mm * 1.5)" }}
+                  title="Aperçu du bail"
+                />
+              </div>
+            </div>
           )}
         </div>
       </CardContent>

--- a/features/leases/components/lease-preview.tsx
+++ b/features/leases/components/lease-preview.tsx
@@ -447,12 +447,17 @@ export function LeasePreview({
                     </Button>
                   </div>
                 </DialogHeader>
-                <div className="flex-1 min-h-0">
-                  <iframe
-                    srcDoc={html}
-                    className="w-full h-full border-0"
-                    title="Prévisualisation du bail (plein écran)"
-                  />
+                <div className="flex-1 min-h-0 bg-[#525659] overflow-y-auto">
+                  <div className="flex justify-center py-6 px-4">
+                    <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)]">
+                      <iframe
+                        srcDoc={html}
+                        className="w-full border-0"
+                        style={{ height: "calc(297mm * 2)" }}
+                        title="Prévisualisation du bail (plein écran)"
+                      />
+                    </div>
+                  </div>
                 </div>
               </DialogContent>
             </Dialog>
@@ -551,10 +556,10 @@ export function LeasePreview({
           </div>
         )}
 
-        {/* Zone de prévisualisation - Responsive */}
-        <div className="flex-1 border rounded-lg overflow-hidden bg-slate-50 relative min-h-[300px] sm:min-h-[400px] md:min-h-[500px]">
+        {/* Zone de prévisualisation - Format A4 Document Viewer */}
+        <div className="flex-1 rounded-lg overflow-hidden bg-[#525659] relative min-h-0">
           {loading ? (
-            <div className="absolute inset-0 flex items-center justify-center bg-white/50 z-10 px-4">
+            <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-10 px-4">
                <div className="flex flex-col items-center gap-2 sm:gap-3 text-center">
                  <RefreshCw className="h-6 w-6 sm:h-8 sm:w-8 text-blue-600 animate-spin" />
                  <p className="text-xs sm:text-sm text-slate-500 font-medium">Génération de l'aperçu...</p>
@@ -562,12 +567,17 @@ export function LeasePreview({
                </div>
             </div>
           ) : (
-            <iframe
-              ref={iframeRef}
-              srcDoc={html}
-              className="w-full h-[50vh] sm:h-[60vh] md:h-full min-h-[300px] border-0 bg-white"
-              title="Prévisualisation du bail"
-            />
+            <div className="h-full flex justify-center overflow-y-auto py-4 px-2 sm:px-4">
+              <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)] flex-shrink-0 h-fit">
+                <iframe
+                  ref={iframeRef}
+                  srcDoc={html}
+                  className="w-full border-0 bg-white"
+                  style={{ height: "calc(297mm * 1.5)" }}
+                  title="Prévisualisation du bail"
+                />
+              </div>
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
The lease preview was too small and didn't feel like a real document. Changes:
- Render the preview at A4 width (210mm max-width) centered on a dark grey background
- Add paper shadow effect for a professional document viewer appearance
- Remove viewport-height constraints (h-[50vh]) that limited the preview size
- Apply same A4 styling to fullscreen dialog mode
- Update both lease preview components (features/ and components/documents/)

https://claude.ai/code/session_01YNfaBMw6q6627bYPcD1k2c