### PR TITLE
Fix mobile layout spacing in lease details tabs

### DIFF
--- a/app/owner/leases/[id]/LeaseDetailsClient.tsx
+++ b/app/owner/leases/[id]/LeaseDetailsClient.tsx
@@ -851,7 +851,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
 
           {/* Colonne de gauche : Onglets Contrat / EDL / Documents / Paiements */}
-          <div className="lg:col-span-8 xl:col-span-9 order-2 lg:order-1 flex flex-col h-[calc(100vh-8rem)]">
+          <div className="lg:col-span-8 xl:col-span-9 order-2 lg:order-1 flex flex-col h-[calc(100vh-8rem-4rem)] md:h-[calc(100vh-8rem)]">
             <Tabs value={activeTab} onValueChange={setActiveTab} className="flex flex-col flex-1">
               {/* Barre d'onglets */}
               <TabsList className="w-full justify-start bg-white border border-slate-200 rounded-t-xl rounded-b-none h-12 px-2 gap-1">
@@ -951,7 +951,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
               {/* Contenu : EDL d'entrée */}
               <TabsContent value="edl" className="flex-1 mt-0">
-                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 overflow-auto p-6 h-full">
+                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 overflow-auto p-6 pb-24 md:pb-6 h-full">
                   <LeaseEdlTab
                     leaseId={leaseId}
                     propertyId={property.id}
@@ -964,7 +964,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
               {/* Contenu : Documents */}
               <TabsContent value="documents" className="flex-1 mt-0">
-                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 overflow-auto p-6 h-full">
+                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 overflow-auto p-6 pb-24 md:pb-6 h-full">
                   <LeaseDocumentsTab
                     leaseId={leaseId}
                     propertyId={property.id}
@@ -976,7 +976,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
               {/* Contenu : Paiements */}
               <TabsContent value="paiements" className="flex-1 mt-0">
-                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 overflow-auto p-6 h-full">
+                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 overflow-auto p-6 pb-24 md:pb-6 h-full">
                   <LeasePaymentsTab
                     leaseId={leaseId}
                     payments={payments || []}


### PR DESCRIPTION
## Summary
Adjusted responsive spacing and height calculations in the LeaseDetailsClient component to improve mobile layout and prevent content overflow issues.

## Key Changes
- Modified the main content container height calculation to account for additional spacing on mobile devices (`md:h-[calc(100vh-8rem)]`) while maintaining the original height on smaller screens
- Added responsive bottom padding (`pb-24 md:pb-6`) to three tab content sections (EDL, Documents, and Payments) to prevent content from being hidden behind fixed elements on mobile while reducing unnecessary padding on larger screens

## Implementation Details
These changes specifically target mobile responsiveness by:
- Using Tailwind's responsive breakpoints to apply different spacing rules based on screen size
- Increasing bottom padding on mobile (`pb-24`) to ensure scrollable content isn't obscured
- Reverting to standard padding on medium screens and above (`md:pb-6`)
- Adjusting the container height calculation to better accommodate mobile viewport constraints

https://claude.ai/code/session_01XPVQRdKuLkYhG9iU3b32so