### PR TITLE
Add EDL document preview to lease EDL tab

### DIFF
--- a/app/owner/leases/[id]/tabs/LeaseEdlTab.tsx
+++ b/app/owner/leases/[id]/tabs/LeaseEdlTab.tsx
@@ -20,6 +20,7 @@ import {
   Loader2,
   Home,
 } from "lucide-react";
+import { EDLPreview } from "@/features/edl/components/edl-preview";
 
 interface EdlData {
   id: string;
@@ -225,6 +226,14 @@ export function LeaseEdlTab({ leaseId, propertyId, leaseStatus, edl, hasSignedEd
           </CardContent>
         </Card>
       )}
+
+      {/* Aperçu du document EDL */}
+      <div className="min-h-[400px] sm:min-h-[600px]">
+        <EDLPreview
+          edlData={{ type: edl.type as "entree" | "sortie" }}
+          edlId={edl.id}
+        />
+      </div>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
Added an EDL (État des Lieux) document preview component to the LeaseEdlTab, allowing users to view a visual representation of the EDL document directly within the lease details interface.

## Changes
- Imported the `EDLPreview` component from the edl features module
- Added a new preview section at the bottom of the LeaseEdlTab that displays the EDL document
- Configured the preview with responsive height constraints (400px on mobile, 600px on larger screens)
- Passed the EDL type and ID to the preview component for proper document rendering

## Implementation Details
- The preview section is wrapped in a responsive container with `min-h-[400px] sm:min-h-[600px]` for appropriate spacing across device sizes
- The EDL type is cast to the expected union type `"entree" | "sortie"` based on the edl data
- The preview is positioned after the existing EDL information cards, providing a complete view of the document

https://claude.ai/code/session_01Wug6mC6Guv9iiSjE9YdWhE