### PR TITLE
Add edit button for unsigned inspections

### DIFF
--- a/app/owner/inspections/InspectionsClient.tsx
+++ b/app/owner/inspections/InspectionsClient.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Plus, ClipboardList, Search, CheckCircle2, Clock, Eye, FileText, Printer, Trash2, Loader2, AlertTriangle, RefreshCw } from "lucide-react";
+import { Plus, ClipboardList, Search, CheckCircle2, Clock, Eye, Pencil, FileText, Printer, Trash2, Loader2, AlertTriangle, RefreshCw } from "lucide-react";
 import { CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -199,6 +199,15 @@ export function InspectionsClient({ inspections }: Props) {
               <span className="text-xs font-medium">Voir</span>
             </Link>
           </Button>
+
+          {edl.status !== "signed" && (
+            <Button size="sm" variant="outline" asChild className="hover:bg-amber-50 hover:border-amber-300 h-8 gap-1.5 px-2.5 text-amber-600 border-amber-200" title="Modifier l'état des lieux">
+              <Link href={`/owner/inspections/${edl.id}/edit`}>
+                <Pencil className="h-4 w-4" />
+                <span className="text-xs font-medium">Modifier</span>
+              </Link>
+            </Button>
+          )}
 
           {edl.status !== "signed" && (
             <Button 


### PR DESCRIPTION
## Summary
Added an edit button to the inspections list that allows users to modify inspection records that haven't been signed yet.

## Key Changes
- Imported the `Pencil` icon from lucide-react for the edit button
- Added a conditional edit button that appears only when inspection status is not "signed"
- The button links to `/owner/inspections/{id}/edit` route
- Styled with amber color scheme to match the UI design system (amber-50 background, amber-300 border, amber-600 text on hover)

## Implementation Details
- The edit button is only displayed for unsigned inspections using the condition `edl.status !== "signed"`
- Button uses consistent styling with other action buttons (size="sm", variant="outline")
- Includes a tooltip title "Modifier l'état des lieux" (Modify the inspection record in French)
- Positioned before the delete button in the action buttons row

https://claude.ai/code/session_018eG3v5fymaDk26tXnq79bo