### PR TITLE
feat: intégrer l'aperçu EDL d'entrée dans le wizard de création de bail

### DIFF
--- a/app/owner/leases/new/EdlPreviewStep.tsx
+++ b/app/owner/leases/new/EdlPreviewStep.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * Wrapper pour l'aperçu EDL dans le wizard de création de bail.
+ *
+ * Utilise le composant EDLPreview existant avec un HTML pré-généré
+ * côté client (aucun appel API supplémentaire). Les données du wizard
+ * sont mappées vers le format EDLComplet via mapBailWizardToEdlPreview.
+ *
+ * @see {@link mapBailWizardToEdlPreview} pour la logique de mapping
+ * @see {@link EDLPreview} pour le composant d'aperçu réutilisé
+ */
+
+import { useMemo } from "react";
+import dynamic from "next/dynamic";
+import { Badge } from "@/components/ui/badge";
+import { ClipboardCheck, AlertCircle, FileText } from "lucide-react";
+import {
+  mapBailWizardToEdlPreview,
+  generateDefaultRooms,
+  type BailWizardEdlInput,
+} from "@/lib/mappers/bail-wizard-to-edl-preview";
+import { generateEDLViergeHTML } from "@/lib/templates/edl";
+
+/** Lazy load EDLPreview pour ne pas alourdir le bundle du wizard */
+const EDLPreview = dynamic(
+  () =>
+    import("@/features/edl/components/edl-preview").then((mod) => ({
+      default: mod.EDLPreview,
+    })),
+  {
+    loading: () => (
+      <div className="flex items-center justify-center h-64">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <FileText className="h-8 w-8 text-muted-foreground/50 animate-pulse" />
+          <p className="text-sm text-muted-foreground">
+            Chargement de l&apos;aperçu EDL...
+          </p>
+        </div>
+      </div>
+    ),
+    ssr: false,
+  }
+);
+
+interface EdlPreviewStepProps {
+  /** Données du wizard de bail à mapper vers le format EDL */
+  data: BailWizardEdlInput;
+}
+
+/**
+ * Composant wrapper qui intègre l'aperçu EDL dans le wizard de bail.
+ *
+ * - Mappe les données du wizard vers `Partial<EDLComplet>`
+ * - Génère le HTML côté client via `generateEDLViergeHTML` (aucun appel API)
+ * - Affiche un badge "Aperçu préliminaire" pour distinguer de l'EDL final
+ * - Gère l'état vide (pas de propriété sélectionnée)
+ * - Mémorise le mapping et la génération HTML pour éviter les re-renders inutiles
+ */
+export function EdlPreviewStep({ data }: EdlPreviewStepProps) {
+  /** Données EDL mappées depuis le wizard */
+  const edlData = useMemo(
+    () => mapBailWizardToEdlPreview(data),
+    [data]
+  );
+
+  /** Pièces par défaut basées sur le bien sélectionné */
+  const rooms = useMemo(
+    () => generateDefaultRooms(data.property?.nb_pieces, data.property?.type),
+    [data.property?.nb_pieces, data.property?.type]
+  );
+
+  /** HTML pré-généré côté client (pas d'appel API) */
+  const generatedHtml = useMemo(() => {
+    if (!data.property) return "";
+    try {
+      return generateEDLViergeHTML(edlData, rooms);
+    } catch (error) {
+      console.error("[EdlPreviewStep] Erreur génération HTML:", error);
+      return "";
+    }
+  }, [edlData, rooms, data.property]);
+
+  // État vide : pas de propriété sélectionnée
+  if (!data.property) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+        <AlertCircle className="h-12 w-12 text-muted-foreground/50 mb-4" />
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          Aucun bien sélectionné
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Sélectionnez un bien immobilier pour voir l&apos;aperçu
+          de l&apos;état des lieux d&apos;entrée.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Badge et description */}
+      <div className="flex items-center gap-2 mb-3 flex-shrink-0">
+        <Badge
+          variant="outline"
+          className="bg-blue-50 text-blue-700 border-blue-200"
+        >
+          <ClipboardCheck className="h-3 w-3 mr-1" />
+          Aperçu préliminaire
+        </Badge>
+        <span className="text-xs text-muted-foreground">
+          Ce document sera complété lors de l&apos;état des lieux d&apos;entrée
+        </span>
+      </div>
+
+      {/* Composant EDLPreview réutilisé avec HTML pré-généré */}
+      <div className="flex-1 min-h-0">
+        <EDLPreview
+          edlData={edlData}
+          isVierge
+          rooms={rooms}
+          previewHtml={generatedHtml}
+        />
+      </div>
+    </div>
+  );
+}

--- a/lib/mappers/bail-wizard-to-edl-preview.ts
+++ b/lib/mappers/bail-wizard-to-edl-preview.ts
@@ -1,0 +1,234 @@
+/**
+ * Fonction de mapping : données wizard bail → format EDLComplet partiel
+ *
+ * Transforme les données collectées dans le wizard de création de bail
+ * vers le format attendu par le composant EDLPreview et la fonction
+ * generateEDLViergeHTML, permettant de prévisualiser l'état des lieux
+ * d'entrée directement depuis le wizard.
+ *
+ * @module bail-wizard-to-edl-preview
+ */
+
+import type { EDLComplet } from "@/lib/templates/edl/types";
+
+// ---------------------------------------------------------------------------
+// Types d'entrée
+// ---------------------------------------------------------------------------
+
+/** Données du bien immobilier provenant du wizard */
+interface WizardProperty {
+  adresse_complete?: string;
+  adresse?: string;
+  code_postal?: string;
+  ville?: string;
+  type?: string;
+  surface?: number;
+  surface_habitable_m2?: number | null;
+  nb_pieces?: number;
+  etage?: number;
+  numero_lot?: string;
+}
+
+/** Données du bailleur provenant du wizard */
+interface WizardBailleur {
+  nom?: string;
+  prenom?: string;
+  email?: string;
+  telephone?: string;
+  type?: string;
+  raison_sociale?: string;
+}
+
+/** Données d'un locataire provenant du wizard */
+interface WizardLocataire {
+  nom: string;
+  prenom?: string;
+  email?: string;
+  telephone?: string;
+}
+
+/**
+ * Données d'entrée provenant du wizard de création de bail.
+ * Tous les champs sont potentiellement incomplets puisque le wizard
+ * est en cours de remplissage.
+ */
+export interface BailWizardEdlInput {
+  /** Propriété sélectionnée (null si pas encore sélectionnée) */
+  property: WizardProperty | null;
+  /** Informations du bailleur */
+  bailleur: WizardBailleur;
+  /** Liste des locataires */
+  locataires: WizardLocataire[];
+  /** Type de bail sélectionné */
+  typeBail: string;
+  /** Loyer hors charges */
+  loyer: number;
+  /** Montant des charges */
+  charges: number;
+  /** Date de début du bail (YYYY-MM-DD) */
+  dateDebut: string;
+  /** Date de fin du bail (YYYY-MM-DD) — null si reconduction tacite */
+  dateFin?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Fonctions utilitaires
+// ---------------------------------------------------------------------------
+
+/**
+ * Génère une liste de pièces par défaut basée sur le nombre de pièces
+ * principales du bien et son type.
+ *
+ * @param nbPieces - Nombre de pièces principales du bien
+ * @param typeBien - Type de bien (appartement, maison, studio…)
+ * @returns Liste ordonnée des noms de pièces
+ */
+export function generateDefaultRooms(
+  nbPieces: number | undefined,
+  typeBien?: string
+): string[] {
+  // Studio / T1
+  if (!nbPieces || nbPieces <= 1) {
+    return [
+      "Entrée",
+      "Pièce principale",
+      "Cuisine / Kitchenette",
+      "Salle de bain / WC",
+    ];
+  }
+
+  const rooms: string[] = ["Entrée", "Salon / Séjour"];
+
+  // Chambres
+  const nbChambres = Math.max(1, nbPieces - 1);
+  for (let i = 1; i <= nbChambres; i++) {
+    rooms.push(nbChambres === 1 ? "Chambre" : `Chambre ${i}`);
+  }
+
+  rooms.push("Cuisine");
+  rooms.push("Salle de bain");
+
+  if (nbPieces >= 3) {
+    rooms.push("WC");
+  }
+
+  // Pour les maisons, ajouter des pièces supplémentaires courantes
+  if (typeBien === "maison") {
+    rooms.push("Garage / Cellier");
+  }
+
+  return rooms;
+}
+
+// ---------------------------------------------------------------------------
+// Fonction de mapping principale
+// ---------------------------------------------------------------------------
+
+/**
+ * Mappe les données du wizard de création de bail vers le format
+ * `Partial<EDLComplet>` attendu par le composant EDLPreview.
+ *
+ * Gère gracieusement les champs manquants en utilisant des placeholders
+ * explicites ("Non renseigné") plutôt que des chaînes vides.
+ *
+ * @param data - Données collectées dans le wizard de bail
+ * @returns Objet partiel EDLComplet prêt pour la prévisualisation
+ *
+ * @example
+ * ```ts
+ * const edlData = mapBailWizardToEdlPreview({
+ *   property: selectedProperty,
+ *   bailleur: { nom: "Dupont", prenom: "Jean" },
+ *   locataires: [{ nom: "Martin", email: "a@b.com" }],
+ *   typeBail: "meuble",
+ *   loyer: 850,
+ *   charges: 50,
+ *   dateDebut: "2026-03-01",
+ * });
+ * ```
+ */
+export function mapBailWizardToEdlPreview(
+  data: BailWizardEdlInput
+): Partial<EDLComplet> {
+  const surface =
+    data.property?.surface_habitable_m2 ?? data.property?.surface;
+
+  // Construire le nom complet du bailleur
+  const isSociete = data.bailleur.type === "societe";
+  const baileurNomComplet = isSociete
+    ? data.bailleur.raison_sociale || "Non renseigné"
+    : [data.bailleur.prenom, data.bailleur.nom]
+        .filter(Boolean)
+        .join(" ") || "Non renseigné";
+
+  // Mapper les locataires avec gestion des placeholders
+  const locataires =
+    data.locataires.length > 0
+      ? data.locataires.map((l) => {
+          const nomComplet =
+            [l.prenom, l.nom].filter(Boolean).join(" ") ||
+            l.nom ||
+            "Non renseigné";
+          return {
+            nom: l.nom || "Non renseigné",
+            prenom: l.prenom || "",
+            nom_complet: nomComplet,
+            email: l.email || undefined,
+            telephone: l.telephone || undefined,
+          };
+        })
+      : [];
+
+  return {
+    type: "entree",
+    reference: "APERCU-EDL",
+    created_at: new Date().toISOString(),
+    scheduled_date: data.dateDebut || undefined,
+
+    logement: {
+      adresse_complete:
+        data.property?.adresse_complete ||
+        data.property?.adresse ||
+        "Non renseigné",
+      code_postal: data.property?.code_postal || "",
+      ville: data.property?.ville || "",
+      type_bien: data.property?.type || "appartement",
+      surface: surface || undefined,
+      nb_pieces: data.property?.nb_pieces || undefined,
+      etage: data.property?.etage?.toString() || undefined,
+      numero_lot: data.property?.numero_lot || undefined,
+    },
+
+    bailleur: {
+      type: isSociete ? "societe" : "particulier",
+      nom_complet: baileurNomComplet,
+      raison_sociale: isSociete
+        ? data.bailleur.raison_sociale || undefined
+        : undefined,
+      telephone: data.bailleur.telephone || undefined,
+      email: data.bailleur.email || undefined,
+    },
+
+    locataires,
+
+    bail: {
+      id: "brouillon",
+      reference: "BROUILLON",
+      type_bail: data.typeBail || "",
+      date_debut: data.dateDebut || "",
+      date_fin: data.dateFin || undefined,
+      loyer_hc: data.loyer || 0,
+      charges: data.charges || 0,
+    },
+
+    // Sections vides — seront remplies lors de l'état des lieux réel
+    compteurs: [],
+    pieces: [],
+    signatures: [],
+    cles_remises: [],
+    observations_generales: undefined,
+    is_complete: false,
+    is_signed: false,
+    status: "draft",
+  };
+}


### PR DESCRIPTION
Réutilise le composant EDLPreview existant via un pattern wrapper/adapter
pour afficher un aperçu de l'état des lieux d'entrée directement dans
l'étape 3 du wizard de bail, sans appel API supplémentaire.

Fichiers créés :
- lib/mappers/bail-wizard-to-edl-preview.ts : fonction de mapping typée
  (BailWizardEdlInput → Partial<EDLComplet>) avec gestion des placeholders
  et génération de pièces par défaut selon le type de bien
- app/owner/leases/new/EdlPreviewStep.tsx : wrapper avec lazy loading,
  badge "Aperçu préliminaire", état vide, génération HTML côté client

Fichiers modifiés :
- features/edl/components/edl-preview.tsx : ajout prop optionnelle
  previewHtml pour bypasser l'appel API quand le HTML est pré-généré
- app/owner/leases/new/LeaseWizard.tsx : onglets Bail/EDL dans le panneau
  d'aperçu de l'étape 3, memo edlPreviewData mappant les données du wizard

https://claude.ai/code/session_019xERz66CujoZy9iq2Tpt3B