### PR TITLE
fix: resolve RLS recursion on profiles table causing 500 errors and infinite re-renders

### DIFF
--- a/app/agency/layout.tsx
+++ b/app/agency/layout.tsx
@@ -8,6 +8,7 @@ export const runtime = 'nodejs';
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { getServerProfile } from "@/lib/helpers/auth-helper";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { OfflineIndicator } from "@/components/ui/offline-indicator";
 import { AgencySidebar } from "./_components/AgencySidebar";
@@ -34,14 +35,13 @@ export default async function AgencyLayout({
     redirect("/auth/signin?redirect=/agency/dashboard");
   }
 
-  // 2. Récupérer le profil avec le rôle
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("id, role, prenom, nom")
-    .eq("user_id", user.id)
-    .single();
+  // 2. Récupérer le profil (avec fallback service role en cas de récursion RLS)
+  const { profile } = await getServerProfile<{ id: string; role: string; prenom: string | null; nom: string | null }>(
+    user.id,
+    "id, role, prenom, nom"
+  );
 
-  if (profileError || !profile) {
+  if (!profile) {
     redirect("/auth/signin");
   }
 

--- a/app/owner/layout.tsx
+++ b/app/owner/layout.tsx
@@ -3,6 +3,7 @@ export const runtime = 'nodejs';
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { getServerProfile } from "@/lib/helpers/auth-helper";
 import { fetchProperties, fetchDashboard, fetchContracts } from "./_data";
 import { OwnerDataProvider } from "./_data/OwnerDataProvider";
 import { OwnerAppLayout } from "@/components/layout/owner-app-layout";
@@ -30,14 +31,13 @@ export default async function OwnerLayout({
     redirect("/auth/signin");
   }
 
-  // Récupérer le profil
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("id, role, prenom, nom")
-    .eq("user_id", user.id)
-    .single();
+  // Récupérer le profil (avec fallback service role en cas de récursion RLS)
+  const { profile } = await getServerProfile<{ id: string; role: string; prenom: string | null; nom: string | null }>(
+    user.id,
+    "id, role, prenom, nom"
+  );
 
-  if (profileError || !profile) {
+  if (!profile) {
     redirect("/auth/signin");
   }
 

--- a/app/provider/layout.tsx
+++ b/app/provider/layout.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { getServerProfile } from "@/lib/helpers/auth-helper";
 import Link from "next/link";
 import {
   LayoutDashboard,
@@ -52,11 +53,11 @@ export default async function VendorLayout({
     redirect("/auth/signin");
   }
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("id, role, prenom, nom, avatar_url")
-    .eq("user_id", user.id)
-    .single();
+  // Récupérer le profil (avec fallback service role en cas de récursion RLS)
+  const { profile } = await getServerProfile<{ id: string; role: string; prenom: string | null; nom: string | null; avatar_url: string | null }>(
+    user.id,
+    "id, role, prenom, nom, avatar_url"
+  );
 
   if (!profile || profile.role !== "provider") {
     redirect("/dashboard");

--- a/lib/hooks/use-auth.ts
+++ b/lib/hooks/use-auth.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { User } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/client";
 import { Profile } from "@/lib/types";
@@ -56,7 +56,13 @@ export function useAuth() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const fetchingRef = React.useRef(false);
+
   async function fetchProfile(userId: string) {
+    // Prevent concurrent fetches that could cause re-render loops
+    if (fetchingRef.current) return;
+    fetchingRef.current = true;
+
     try {
       const { data, error } = await supabase
         .from("profiles")
@@ -73,8 +79,8 @@ export function useAuth() {
               credentials: "include",
             });
             if (response.ok) {
-              const profile = await response.json();
-              setProfile(profile as Profile);
+              const apiProfile = await response.json();
+              setProfile(apiProfile as Profile);
               setLoading(false);
               return;
             }
@@ -90,6 +96,7 @@ export function useAuth() {
       setProfile(null);
     } finally {
       setLoading(false);
+      fetchingRef.current = false;
     }
   }
 

--- a/supabase/migrations/20260213000000_fix_profiles_rls_recursion_v2.sql
+++ b/supabase/migrations/20260213000000_fix_profiles_rls_recursion_v2.sql
@@ -1,0 +1,163 @@
+-- =====================================================
+-- MIGRATION: Correction définitive de la récursion RLS sur profiles (v2)
+-- Date: 2026-02-13
+-- Problème: "RLS recursion detected" - erreur 500 sur profiles
+--
+-- CAUSE: Les politiques RLS sur `profiles` appellent des fonctions
+--        qui requêtent `profiles`, créant une boucle infinie (42P17).
+--
+-- SOLUTION:
+--   1. Fonctions SECURITY DEFINER qui bypassen les RLS
+--   2. Politiques RLS simplifiées utilisant auth.uid() directement
+--   3. Pas de sous-requête vers profiles dans les politiques profiles
+-- =====================================================
+
+-- 1. DÉSACTIVER TEMPORAIREMENT RLS POUR LE NETTOYAGE
+ALTER TABLE profiles DISABLE ROW LEVEL SECURITY;
+
+-- 2. SUPPRIMER TOUTES LES ANCIENNES POLITIQUES SUR profiles
+DO $$
+DECLARE
+  pol RECORD;
+BEGIN
+  FOR pol IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE tablename = 'profiles' AND schemaname = 'public'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON profiles', pol.policyname);
+  END LOOP;
+END $$;
+
+-- 3. CRÉER/REMPLACER LES FONCTIONS HELPER (SECURITY DEFINER = bypass RLS)
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM profiles
+    WHERE user_id = auth.uid()
+    AND role = 'admin'
+    LIMIT 1
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_my_role()
+RETURNS TEXT
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    (SELECT role FROM profiles WHERE user_id = auth.uid() LIMIT 1),
+    'anonymous'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_my_profile_id()
+RETURNS UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT id FROM profiles WHERE user_id = auth.uid() LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.user_profile_id()
+RETURNS UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT public.get_my_profile_id();
+$$;
+
+CREATE OR REPLACE FUNCTION public.user_role()
+RETURNS TEXT
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT public.get_my_role();
+$$;
+
+-- Versions avec paramètre (pour usage admin)
+CREATE OR REPLACE FUNCTION public.user_profile_id(p_user_id UUID)
+RETURNS UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT id FROM profiles WHERE user_id = p_user_id LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.user_role(p_user_id UUID)
+RETURNS TEXT
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT COALESCE(role, 'anonymous') FROM profiles WHERE user_id = p_user_id LIMIT 1;
+$$;
+
+-- 4. RÉACTIVER RLS
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- 5. CRÉER LES NOUVELLES POLITIQUES (SANS RÉCURSION)
+
+-- Politique principale : chaque utilisateur peut voir/modifier son propre profil
+-- Utilise auth.uid() directement, aucune sous-requête vers profiles
+CREATE POLICY "profiles_own_access" ON profiles
+FOR ALL TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());
+
+-- Politique admin : les admins peuvent voir tous les profils
+-- is_admin() est SECURITY DEFINER donc bypasse les RLS
+CREATE POLICY "profiles_admin_read" ON profiles
+FOR SELECT TO authenticated
+USING (public.is_admin());
+
+-- Politique propriétaire : peut voir les profils de ses locataires
+-- get_my_profile_id() est SECURITY DEFINER donc bypasse les RLS
+CREATE POLICY "profiles_owner_read_tenants" ON profiles
+FOR SELECT TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM lease_signers ls
+    INNER JOIN leases l ON l.id = ls.lease_id
+    INNER JOIN properties p ON p.id = l.property_id
+    WHERE ls.profile_id = profiles.id
+    AND p.owner_id = public.get_my_profile_id()
+  )
+);
+
+-- 6. ACCORDER LES PERMISSIONS SUR LES FONCTIONS
+GRANT EXECUTE ON FUNCTION public.is_admin() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_my_role() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_my_profile_id() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.user_profile_id() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.user_role() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.user_profile_id(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.user_role(UUID) TO authenticated;
+
+-- Permissions pour anon (nécessaire pour certaines requêtes pré-auth)
+GRANT EXECUTE ON FUNCTION public.is_admin() TO anon;
+GRANT EXECUTE ON FUNCTION public.get_my_role() TO anon;
+GRANT EXECUTE ON FUNCTION public.get_my_profile_id() TO anon;
+GRANT EXECUTE ON FUNCTION public.user_profile_id() TO anon;
+GRANT EXECUTE ON FUNCTION public.user_role() TO anon;
+
+-- 7. Permettre au service_role de bypass RLS (déjà le cas par défaut mais
+-- explicite pour la documentation)
+ALTER TABLE profiles FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
The profiles table RLS policies cause infinite recursion (PostgreSQL 42P17),
resulting in 500 errors on every profiles query. Three independent query sources
(useAuth, SubscriptionProvider, server-side layouts) all fail simultaneously,
causing cascading state updates and React error #310 (too many re-renders).

Changes:
- Add RLS recursion detection + API fallback to SubscriptionProvider
- Add concurrent fetch guard (useRef) to useAuth to prevent re-render loops
- Add getServerProfile() helper with service role fallback for all server layouts
- Update all 6 authenticated layouts (owner, tenant, admin, syndic, agency,
  provider) to use the resilient getServerProfile helper
- Add v2 migration to definitively fix profiles RLS policies

https://claude.ai/code/session_01Y9y9Zbt5u3MHkqWuQ7vC8b