### PR TITLE
fix(entities): repair disconnected entity-property data model

### DIFF
--- a/providers/EntityProvider.tsx
+++ b/providers/EntityProvider.tsx
@@ -16,7 +16,7 @@ interface EntityProviderProps {
 
 export function EntityProvider({ children }: EntityProviderProps) {
   const { profile } = useAuth();
-  const { fetchEntities, entities, lastFetchedAt } = useEntityStore();
+  const fetchEntities = useEntityStore((s) => s.fetchEntities);
 
   useEffect(() => {
     if (!profile?.id) return;
@@ -25,6 +25,7 @@ export function EntityProvider({ children }: EntityProviderProps) {
     // No intermediate query needed — profile.id is the owner_profile_id FK value.
     const loadEntities = async () => {
       try {
+        const { entities, lastFetchedAt } = useEntityStore.getState();
         const isStale =
           !lastFetchedAt || Date.now() - lastFetchedAt > 5 * 60 * 1000;
         if (entities.length === 0 || isStale) {
@@ -36,7 +37,7 @@ export function EntityProvider({ children }: EntityProviderProps) {
     };
 
     loadEntities();
-  }, [profile?.id, fetchEntities, entities.length, lastFetchedAt]);
+  }, [profile?.id, fetchEntities]);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
- Fix wrong table name `property_ownerships` → `property_ownership` in deleteEntity action
  that silently allowed deletion of entities with active properties
- Add missing `sci_construction_vente` to Zod entityTypeSchema preventing SCCV creation
- Fix getPropertiesByEntity to query both `property_ownership` AND `properties.legal_entity_id`
  — properties created via wizard only set legal_entity_id without creating ownership records,
  causing entity detail patrimoine tab to show "Aucun bien rattaché" despite properties existing
- Fix getEntityFiscalSummary to count properties from `properties` table (source of truth)
  instead of only `property_ownership`
- Fix EntityProvider useEffect dependency on entities.length causing unnecessary refetches;
  use getState() to read store values inside effect without re-triggering

https://claude.ai/code/session_01PK3WdMVD2fhA8awiHzn5PU