### PR TITLE
Fix Dialog/Sheet onOpenChange handlers to only close on false

### DIFF
--- a/components/ai/ai-command-palette.tsx
+++ b/components/ai/ai-command-palette.tsx
@@ -4,7 +4,7 @@
  * AI Command Palette - Interface principale AI-First
  * SOTA 2026 - Interaction naturelle par commandes
  * 
- * Accessible via ⌘K / Ctrl+K
+ * Opened programmatically via useAICommand store (⌘K handled by CommandPalette)
  * Combine recherche rapide et chat avec l'assistant Tom
  */
 
@@ -158,18 +158,8 @@ export function AICommandPalette({ open, onOpenChange }: AICommandPaletteProps) 
     },
   });
 
-  // Raccourci clavier global
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        onOpenChange(!open);
-      }
-    };
-
-    document.addEventListener("keydown", down);
-    return () => document.removeEventListener("keydown", down);
-  }, [open, onOpenChange]);
+  // Note: ⌘K shortcut is handled by CommandPalette (per-role search palette).
+  // AICommandPalette is opened programmatically via the Zustand store (useAICommand).
 
   // Reset au close
   useEffect(() => {

--- a/components/documents/pdf-preview-modal.tsx
+++ b/components/documents/pdf-preview-modal.tsx
@@ -64,7 +64,7 @@ export function PDFPreviewModal({
                   documentType?.includes("identite");
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog open={isOpen} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
       <DialogContent
         aria-describedby={undefined}
         className={cn(

--- a/components/subscription/cancel-modal.tsx
+++ b/components/subscription/cancel-modal.tsx
@@ -138,7 +138,7 @@ export function CancelModal({ open, onClose, onSuccess }: CancelModalProps) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={resetAndClose}>
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) resetAndClose(); }}>
       <DialogContent className="max-w-lg bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 border-slate-700/50" aria-describedby={undefined}>
         <DialogTitle className="sr-only">Résiliation d&apos;abonnement</DialogTitle>
         <AnimatePresence mode="wait">

--- a/components/subscription/upgrade-modal.tsx
+++ b/components/subscription/upgrade-modal.tsx
@@ -137,7 +137,7 @@ export function UpgradeModal({ open, onClose, feature, requiredPlan }: UpgradeMo
   };
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
       <DialogContent className="max-w-4xl bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 border-slate-700/50 p-0 overflow-hidden max-h-[90vh] overflow-y-auto">
         {/* Header avec gradient */}
         <div className="relative px-6 pt-6 pb-4 border-b border-slate-700/50">

--- a/features/identity-verification/components/document-selector.tsx
+++ b/features/identity-verification/components/document-selector.tsx
@@ -20,7 +20,7 @@ const iconMap = {
 
 export function DocumentSelector({ open, onSelect, onClose }: DocumentSelectorProps) {
   return (
-    <Sheet open={open} onOpenChange={onClose}>
+    <Sheet open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
       <SheetContent
         side="bottom"
         className="rounded-t-[2rem] bg-white px-0 pb-10 pt-0 border-0 max-h-[85vh]"


### PR DESCRIPTION
## Summary
This PR fixes Dialog and Sheet component handlers to properly distinguish between user-initiated closes and programmatic open state changes. Previously, `onOpenChange` was called for all state changes, causing unintended side effects when opening modals programmatically.

## Key Changes
- **AICommandPalette**: Removed duplicate ⌘K keyboard shortcut handler that conflicted with CommandPalette's implementation. Updated documentation to clarify that AICommandPalette is opened via Zustand store, not keyboard shortcuts.
- **PDFPreviewModal**: Changed `onOpenChange={onClose}` to `onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}` to only trigger close callback when dialog is actually closing
- **CancelModal**: Applied same pattern to prevent `resetAndClose()` from being called when modal opens programmatically
- **UpgradeModal**: Applied same pattern to prevent `onClose()` from being called on open
- **DocumentSelector**: Applied same pattern to prevent `onClose()` from being called on open

## Implementation Details
The fix uses a conditional check in the `onOpenChange` handler to only execute the close/reset logic when `isOpen` is `false`. This prevents side effects from being triggered when the modal/sheet is being opened programmatically via state management, while still properly handling user-initiated closes via the UI close button or backdrop click.

https://claude.ai/code/session_01EmCgatuqctAdvDsNPTtVen