### PR TITLE
Fix tenant dashboard: LEFT JOIN owner + handle incomplete addresses

### DIFF
--- a/app/tenant/_data/fetchTenantDashboard.ts
+++ b/app/tenant/_data/fetchTenantDashboard.ts
@@ -613,9 +613,9 @@ export async function fetchTenantDashboard(userId: string): Promise<TenantDashbo
       lease_signers: l.lease_signers || l.signers || [],
       property: l.property ? {
         ...l.property,
-        ville: l.property.ville || "Ville inconnue",
-        code_postal: l.property.code_postal || "00000",
-        adresse_complete: l.property.adresse_complete || "Adresse non renseignée",
+        ville: l.property.ville || "",
+        code_postal: l.property.code_postal || "",
+        adresse_complete: l.property.adresse_complete || null,
         // S'assurer que meters et keys sont des tableaux
         meters: l.property.meters || [],
         keys: l.property.keys || [],

--- a/app/tenant/dashboard/DashboardClient.tsx
+++ b/app/tenant/dashboard/DashboardClient.tsx
@@ -273,7 +273,8 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
   }, [dashboard, pendingEDLs, hasSignedLease]);
 
   // Vérifier si le bail/logement est lié
-  const hasLeaseData = currentLease && currentProperty?.adresse_complete && currentProperty.adresse_complete !== "Adresse à compléter";
+  // ✅ FIX: Un bail avec une propriété est considéré comme lié, même si l'adresse est incomplète
+  const hasLeaseData = !!(currentLease && currentProperty?.id);
   // ✅ FIX: L'onboarding est incomplet seulement si le locataire N'A PAS signé
   const isOnboardingIncomplete = !hasLeaseData || (currentLease?.statut === 'pending_signature' && !hasSignedLease);
 
@@ -682,11 +683,15 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
                     </div>
                     
                     <h2 className="text-3xl md:text-4xl font-black mb-2 tracking-tight">
-                      {currentProperty?.adresse_complete}
+                      {currentProperty?.adresse_complete && currentProperty.adresse_complete !== "Adresse à compléter"
+                        ? currentProperty.adresse_complete
+                        : "Votre logement"}
                     </h2>
                     <p className="text-lg text-white/70 font-medium flex items-center gap-2">
                       <MapPin className="h-4 w-4 text-indigo-400" />
-                      {currentProperty?.ville}{currentProperty?.code_postal ? `, ${currentProperty.code_postal}` : ""}
+                      {currentProperty?.ville || currentProperty?.code_postal
+                        ? `${currentProperty?.ville || ""}${currentProperty?.code_postal ? `, ${currentProperty.code_postal}` : ""}`
+                        : "Adresse en cours de saisie"}
                     </p>
                   </div>
 

--- a/supabase/migrations/20260221300000_fix_tenant_dashboard_owner_join.sql
+++ b/supabase/migrations/20260221300000_fix_tenant_dashboard_owner_join.sql
@@ -1,0 +1,344 @@
+-- ============================================================================
+-- MIGRATION: Fix tenant_dashboard — LEFT JOIN sur owner_prof + adresse_complete
+-- Date: 2026-02-21
+--
+-- PROBLÈMES CORRIGÉS:
+--   1. INNER JOIN sur profiles owner_prof exclut silencieusement les baux
+--      si owner_id est NULL ou si le profil propriétaire n'existe pas.
+--      → Changé en LEFT JOIN pour que les baux soient toujours retournés.
+--
+--   2. COALESCE(p.adresse_complete, 'Adresse à compléter') est inutile car
+--      le frontend gère maintenant les adresses NULL/incomplètes.
+--      → Remplacé par COALESCE pour retourner une chaîne vide au lieu d'un
+--      placeholder qui causait des faux négatifs.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION tenant_dashboard(p_tenant_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_profile_id UUID;
+  v_user_email TEXT;
+  v_tenant_data JSONB;
+  v_leases JSONB;
+  v_invoices JSONB;
+  v_tickets JSONB;
+  v_notifications JSONB;
+  v_pending_edls JSONB;
+  v_insurance_status JSONB;
+  v_stats JSONB;
+  v_kyc_status TEXT := 'pending';
+  v_result JSONB;
+BEGIN
+  -- 1. Récupérer l'ID du profil ET l'email de l'utilisateur
+  SELECT p.id, u.email,
+         jsonb_build_object(
+           'id', p.id,
+           'prenom', p.prenom,
+           'nom', p.nom,
+           'email', u.email,
+           'telephone', p.telephone,
+           'avatar_url', p.avatar_url
+         )
+  INTO v_profile_id, v_user_email, v_tenant_data
+  FROM profiles p
+  JOIN auth.users u ON u.id = p.user_id
+  WHERE p.user_id = p_tenant_user_id AND p.role = 'tenant';
+
+  IF v_profile_id IS NULL THEN
+    RAISE NOTICE '[tenant_dashboard] Aucun profil trouvé pour user_id: %', p_tenant_user_id;
+    RETURN NULL;
+  END IF;
+
+  RAISE NOTICE '[tenant_dashboard] Profil trouvé: %, email: %', v_profile_id, v_user_email;
+
+  -- 2. Récupérer TOUS les baux avec données techniques enrichies + clés + compteurs
+  --    ✅ FIX: LEFT JOIN sur owner_prof pour ne pas perdre les baux si le propriétaire manque
+  --    ✅ FIX: Inclure 'draft' pour que le locataire voie le bail dès qu'il est invité
+  SELECT jsonb_agg(lease_data ORDER BY lease_data->>'statut' = 'active' DESC, lease_data->>'created_at' DESC)
+  INTO v_leases
+  FROM (
+    SELECT
+      jsonb_build_object(
+        'id', l.id,
+        'type_bail', l.type_bail,
+        'statut', l.statut,
+        'loyer', l.loyer,
+        'charges_forfaitaires', l.charges_forfaitaires,
+        'depot_de_garantie', l.depot_de_garantie,
+        'date_debut', l.date_debut,
+        'date_fin', l.date_fin,
+        'created_at', l.created_at,
+        -- Signataires complets avec profils + invited fallback
+        'signers', (
+          SELECT COALESCE(jsonb_agg(
+            jsonb_build_object(
+              'id', ls2.id,
+              'profile_id', ls2.profile_id,
+              'role', ls2.role,
+              'signature_status', ls2.signature_status,
+              'signed_at', ls2.signed_at,
+              'invited_name', ls2.invited_name,
+              'invited_email', ls2.invited_email,
+              'prenom', COALESCE(p_sig.prenom, SPLIT_PART(COALESCE(ls2.invited_name, ''), ' ', 1)),
+              'nom', COALESCE(p_sig.nom, NULLIF(SPLIT_PART(COALESCE(ls2.invited_name, ''), ' ', 2), '')),
+              'avatar_url', p_sig.avatar_url
+            )
+          ), '[]'::jsonb)
+          FROM lease_signers ls2
+          LEFT JOIN profiles p_sig ON p_sig.id = ls2.profile_id
+          WHERE ls2.lease_id = l.id
+        ),
+        -- Propriété avec champs techniques complets
+        'property', jsonb_build_object(
+          'id', p.id,
+          'owner_id', p.owner_id,
+          'adresse_complete', p.adresse_complete,
+          'ville', COALESCE(p.ville, ''),
+          'code_postal', COALESCE(p.code_postal, ''),
+          'type', COALESCE(p.type, 'appartement'),
+          'surface', p.surface,
+          'surface_habitable_m2', p.surface_habitable_m2,
+          'nb_pieces', p.nb_pieces,
+          'etage', p.etage,
+          'ascenseur', p.ascenseur,
+          'annee_construction', p.annee_construction,
+          'parking_numero', p.parking_numero,
+          'has_cave', p.has_cave,
+          'num_lot', p.num_lot,
+          'digicode', p.digicode,
+          'interphone', p.interphone,
+          -- DPE complet : COALESCE pour supporter ancien + nouveau nommage
+          'energie', p.energie,
+          'ges', p.ges,
+          'dpe_classe_energie', COALESCE(p.dpe_classe_energie, p.energie),
+          'dpe_classe_climat', COALESCE(p.dpe_classe_climat, p.ges),
+          'dpe_consommation', p.dpe_consommation,
+          'dpe_emissions', p.dpe_emissions,
+          'dpe_date_realisation', p.dpe_date_realisation,
+          'dpe_date_expiration', p.dpe_date_expiration,
+          -- Caractéristiques techniques
+          'chauffage_type', p.chauffage_type,
+          'chauffage_energie', p.chauffage_energie,
+          'eau_chaude_type', p.eau_chaude_type,
+          'regime', p.regime,
+          -- Photo de couverture
+          'cover_url', (
+            SELECT url FROM property_photos
+            WHERE property_id = p.id AND is_main = true
+            LIMIT 1
+          ),
+          -- Compteurs actifs avec dernière lecture
+          'meters', (
+            SELECT COALESCE(jsonb_agg(
+              jsonb_build_object(
+                'id', m.id,
+                'type', m.type,
+                'serial_number', m.serial_number,
+                'unit', m.unit,
+                'last_reading_value', (
+                  SELECT reading_value FROM meter_readings
+                  WHERE meter_id = m.id ORDER BY reading_date DESC LIMIT 1
+                ),
+                'last_reading_date', (
+                  SELECT reading_date FROM meter_readings
+                  WHERE meter_id = m.id ORDER BY reading_date DESC LIMIT 1
+                )
+              )
+            ), '[]'::jsonb)
+            FROM meters m
+            WHERE m.property_id = p.id AND m.is_active = true
+          ),
+          -- Clés depuis le dernier EDL signé ou complété
+          'keys', (
+            SELECT e_keys.keys
+            FROM edl e_keys
+            WHERE e_keys.property_id = p.id
+              AND e_keys.status IN ('signed', 'completed')
+              AND e_keys.keys IS NOT NULL
+              AND e_keys.keys != '[]'::jsonb
+            ORDER BY COALESCE(e_keys.completed_date, e_keys.created_at) DESC
+            LIMIT 1
+          )
+        ),
+        -- Propriétaire (peut être NULL si owner_prof manquant)
+        'owner', CASE
+          WHEN owner_prof.id IS NOT NULL THEN
+            jsonb_build_object(
+              'id', owner_prof.id,
+              'name', COALESCE(
+                (SELECT raison_sociale FROM owner_profiles WHERE profile_id = owner_prof.id),
+                CONCAT(COALESCE(owner_prof.prenom, ''), ' ', COALESCE(owner_prof.nom, ''))
+              ),
+              'email', owner_prof.email,
+              'telephone', owner_prof.telephone
+            )
+          ELSE
+            jsonb_build_object(
+              'id', p.owner_id,
+              'name', 'Propriétaire',
+              'email', NULL,
+              'telephone', NULL
+            )
+        END
+      ) as lease_data
+    FROM leases l
+    JOIN lease_signers ls ON ls.lease_id = l.id
+    JOIN properties p ON p.id = l.property_id
+    LEFT JOIN profiles owner_prof ON owner_prof.id = p.owner_id
+    WHERE
+      (ls.profile_id = v_profile_id OR LOWER(ls.invited_email) = LOWER(v_user_email))
+      AND l.statut IN ('draft', 'active', 'pending_signature', 'fully_signed', 'terminated')
+  ) sub;
+
+  RAISE NOTICE '[tenant_dashboard] Baux trouvés: %', COALESCE(jsonb_array_length(v_leases), 0);
+
+  -- 3. Factures (10 dernières)
+  SELECT COALESCE(jsonb_agg(invoice_data), '[]'::jsonb) INTO v_invoices
+  FROM (
+    SELECT
+      i.id,
+      i.periode,
+      i.montant_total,
+      i.statut,
+      i.created_at,
+      i.due_date,
+      p.type as property_type,
+      p.adresse_complete as property_address
+    FROM invoices i
+    JOIN leases l ON l.id = i.lease_id
+    JOIN lease_signers ls ON ls.lease_id = l.id
+    JOIN properties p ON p.id = l.property_id
+    WHERE (ls.profile_id = v_profile_id OR LOWER(ls.invited_email) = LOWER(v_user_email))
+    ORDER BY i.periode DESC, i.created_at DESC
+    LIMIT 10
+  ) invoice_data;
+
+  -- 4. Tickets récents (10 derniers)
+  SELECT COALESCE(jsonb_agg(ticket_data), '[]'::jsonb) INTO v_tickets
+  FROM (
+    SELECT
+      t.id,
+      t.titre,
+      t.description,
+      t.priorite,
+      t.statut,
+      t.created_at,
+      p.adresse_complete as property_address,
+      p.type as property_type
+    FROM tickets t
+    JOIN properties p ON p.id = t.property_id
+    WHERE t.created_by_profile_id = v_profile_id
+    ORDER BY t.created_at DESC
+    LIMIT 10
+  ) ticket_data;
+
+  -- 5. Notifications récentes
+  SELECT COALESCE(jsonb_agg(notif_data), '[]'::jsonb) INTO v_notifications
+  FROM (
+    SELECT n.id, n.title, n.message, n.type, n.is_read, n.created_at, n.action_url
+    FROM notifications n
+    WHERE n.profile_id = v_profile_id
+    ORDER BY n.is_read ASC, n.created_at DESC
+    LIMIT 5
+  ) notif_data;
+
+  -- 6. EDLs en attente de signature
+  SELECT COALESCE(jsonb_agg(edl_data), '[]'::jsonb) INTO v_pending_edls
+  FROM (
+    SELECT
+      e.id,
+      e.type,
+      e.status,
+      e.scheduled_at,
+      es.invitation_token,
+      p.adresse_complete as property_address,
+      p.type as property_type
+    FROM edl e
+    JOIN edl_signatures es ON es.edl_id = e.id
+    JOIN properties p ON p.id = e.property_id
+    WHERE (es.signer_profile_id = v_profile_id OR LOWER(es.signer_email) = LOWER(v_user_email))
+    AND es.signed_at IS NULL
+    AND e.status IN ('draft', 'scheduled', 'in_progress', 'completed')
+    ORDER BY e.created_at DESC
+  ) edl_data;
+
+  -- 7. Vérifier l'assurance
+  SELECT jsonb_build_object(
+    'has_insurance', EXISTS (
+      SELECT 1 FROM documents
+      WHERE tenant_id = v_profile_id
+      AND type = 'attestation_assurance'
+      AND is_archived = false
+      AND (expiry_date IS NULL OR expiry_date > NOW())
+    ),
+    'last_expiry_date', (
+      SELECT expiry_date FROM documents
+      WHERE tenant_id = v_profile_id
+      AND type = 'attestation_assurance'
+      AND is_archived = false
+      ORDER BY expiry_date DESC LIMIT 1
+    )
+  ) INTO v_insurance_status;
+
+  -- 8. Stats globales
+  SELECT jsonb_build_object(
+    'unpaid_amount', COALESCE(SUM(i.montant_total) FILTER (WHERE i.statut IN ('sent', 'late')), 0),
+    'unpaid_count', COUNT(*) FILTER (WHERE i.statut IN ('sent', 'late')),
+    'total_monthly_rent', COALESCE(
+      (SELECT SUM(l2.loyer + l2.charges_forfaitaires)
+       FROM leases l2
+       JOIN lease_signers ls2 ON ls2.lease_id = l2.id
+       WHERE (ls2.profile_id = v_profile_id OR LOWER(ls2.invited_email) = LOWER(v_user_email))
+       AND l2.statut = 'active'),
+      0
+    ),
+    'active_leases_count', (
+      SELECT COUNT(DISTINCT l2.id)
+      FROM leases l2
+      JOIN lease_signers ls2 ON ls2.lease_id = l2.id
+      WHERE (ls2.profile_id = v_profile_id OR LOWER(ls2.invited_email) = LOWER(v_user_email))
+      AND l2.statut = 'active'
+    )
+  ) INTO v_stats
+  FROM leases l
+  JOIN lease_signers ls ON ls.lease_id = l.id
+  LEFT JOIN invoices i ON i.lease_id = l.id
+  WHERE (ls.profile_id = v_profile_id OR LOWER(ls.invited_email) = LOWER(v_user_email));
+
+  -- 9. KYC status
+  BEGIN
+    SELECT COALESCE(tp.kyc_status, 'pending') INTO v_kyc_status
+    FROM tenant_profiles tp
+    WHERE tp.profile_id = v_profile_id;
+  EXCEPTION WHEN OTHERS THEN
+    v_kyc_status := 'pending';
+  END;
+
+  -- 10. Assembler le résultat final
+  v_result := jsonb_build_object(
+    'profile_id', v_profile_id,
+    'tenant', v_tenant_data,
+    'kyc_status', COALESCE(v_kyc_status, 'pending'),
+    'leases', COALESCE(v_leases, '[]'::jsonb),
+    'lease', CASE WHEN v_leases IS NOT NULL AND jsonb_array_length(v_leases) > 0 THEN v_leases->0 ELSE NULL END,
+    'property', CASE WHEN v_leases IS NOT NULL AND jsonb_array_length(v_leases) > 0 THEN (v_leases->0)->'property' ELSE NULL END,
+    'invoices', v_invoices,
+    'tickets', v_tickets,
+    'notifications', v_notifications,
+    'pending_edls', v_pending_edls,
+    'insurance', v_insurance_status,
+    'stats', COALESCE(v_stats, '{"unpaid_amount": 0, "unpaid_count": 0, "total_monthly_rent": 0, "active_leases_count": 0}'::jsonb)
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION tenant_dashboard(UUID) IS
+'RPC dashboard locataire v6. Cherche par profile_id OU invited_email.
+FIX: LEFT JOIN sur owner_prof pour ne pas perdre les baux si le propriétaire manque.
+FIX: adresse_complete retourné tel quel (le frontend gère les NULL).
+Inclut baux draft, signers enrichis, property complète (DPE, meters, keys), insurance, KYC status.';


### PR DESCRIPTION
## Summary
This PR fixes critical issues in the tenant dashboard where leases were silently excluded if the owner profile was missing, and improves handling of incomplete property addresses throughout the application.

## Key Changes

### Database Migration (`tenant_dashboard` function)
- **Changed INNER JOIN to LEFT JOIN on `owner_prof`**: Prevents leases from being silently excluded when `owner_id` is NULL or the owner profile doesn't exist. Leases are now always returned with owner data gracefully degraded if unavailable.
- **Removed placeholder text for addresses**: Replaced `COALESCE(p.adresse_complete, 'Adresse à compléter')` with direct field return, allowing the frontend to handle NULL/incomplete addresses appropriately.
- **Enhanced property data**: Ensured complete technical fields are returned (DPE data, meters, keys, heating type, etc.) with proper COALESCE fallbacks for backward compatibility.

### Frontend Updates (`DashboardClient.tsx`)
- **Fixed lease linkage detection**: Changed from checking `adresse_complete !== "Adresse à compléter"` to simply checking if property ID exists (`currentProperty?.id`). A lease with a property is now considered linked regardless of address completeness.
- **Improved address display**: Added conditional rendering to show "Votre logement" as fallback when address is missing or contains the old placeholder text, preventing display of incomplete data to users.

### Data Fetching (`fetchTenantDashboard.ts`)
- **Removed placeholder defaults**: Changed fallback values from `"Ville inconnue"`, `"00000"`, and `"Adresse non renseignée"` to empty strings or `null`, allowing the frontend to handle missing data consistently.
- **Preserved data integrity**: Ensures meters and keys default to empty arrays while addresses default to `null` for proper frontend handling.

## Implementation Details
- The migration maintains backward compatibility by using COALESCE for DPE field naming (supports both old `energie`/`ges` and new `dpe_classe_energie`/`dpe_classe_climat`).
- Owner data is now returned as a minimal object with ID and name even when the profile is missing, preventing null reference errors.
- The frontend now treats incomplete addresses as a valid state rather than an error condition, improving UX for properties with missing address data.

https://claude.ai/code/session_01SwPLm9a5CEVUM9xqsLwmZD