### PR TITLE
Add subscription usage limits for property creation

### DIFF
--- a/app/owner/properties/[id]/PropertyDetailsClient.tsx
+++ b/app/owner/properties/[id]/PropertyDetailsClient.tsx
@@ -38,6 +38,7 @@ import { PropertyMetersSection } from "@/components/owner/properties/PropertyMet
 import { FavoriteButton } from "@/components/ui/favorite-button";
 import { EntityNotes } from "@/components/ui/entity-notes";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { useSubscription } from "@/components/subscription";
 import Image from "next/image";
 import { Dialog, DialogContent, DialogClose } from "@/components/ui/dialog";
 import { ChevronLeft, ChevronRight, Navigation, CheckCircle2 } from "lucide-react";
@@ -122,6 +123,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
+  const { refresh: refreshSubscription } = useSubscription();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [property, setProperty] = useState(details.property);
@@ -197,6 +199,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
     errorMessage: "Impossible de supprimer le bien.",
     invalidateQueries: ["property-details", propertyId],
     onSuccess: () => {
+      refreshSubscription();
       router.push("/owner/properties");
     },
   });

--- a/app/owner/properties/[id]/PropertyDetailsWrapper.tsx
+++ b/app/owner/properties/[id]/PropertyDetailsWrapper.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useToast } from "@/components/ui/use-toast";
+import { useSubscription } from "@/components/subscription";
 
 // Composant partagé de visualisation
 import { 
@@ -116,7 +117,8 @@ export function PropertyDetailsWrapper({
 }: PropertyDetailsWrapperProps) {
   const router = useRouter();
   const { toast } = useToast();
-  
+  const { refresh: refreshSubscription } = useSubscription();
+
   const [isEditing, setIsEditing] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
@@ -140,6 +142,7 @@ export function PropertyDetailsWrapper({
     errorMessage: "Impossible de supprimer le bien.",
     invalidateQueries: ["properties"],
     onSuccess: () => {
+      refreshSubscription();
       router.push("/owner/properties");
     },
   });

--- a/app/owner/properties/page.tsx
+++ b/app/owner/properties/page.tsx
@@ -31,7 +31,7 @@ import { PullToRefreshContainer } from "@/components/ui/pull-to-refresh-containe
 
 // Imports SOTA
 import { PageTransition } from "@/components/ui/page-transition";
-import { UsageLimitBanner } from "@/components/subscription";
+import { UsageLimitBanner, useUsageLimit, UpgradeModal } from "@/components/subscription";
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -81,6 +81,9 @@ export default function OwnerPropertiesPage() {
   const { data: leases = [], error: leasesError } = useLeases(undefined, {
     enabled: !isLoading && properties.length > 0,
   });
+
+  const { isAtLimit, canAdd } = useUsageLimit("properties");
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
@@ -473,27 +476,39 @@ export default function OwnerPropertiesPage() {
                   <span className="hidden sm:inline">Exporter</span>
                 </Button>
                 
-                {/* Bouton Ajouter */}
-                <Button
-                  asChild
-                  className="relative overflow-hidden group shadow-lg hover:shadow-2xl transition-all duration-300 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
-                >
-                  <Link href="/owner/properties/new">
-                    <motion.div
-                      className="absolute inset-0 bg-gradient-to-r from-white/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                      whileHover={{ x: ["0%", "100%"], transition: { duration: 0.6, repeat: Infinity, repeatType: "reverse" } }}
-                    />
-                    <span className="relative flex items-center">
+                {/* Bouton Ajouter — conditionnel selon limites du forfait */}
+                {canAdd ? (
+                  <Button
+                    asChild
+                    className="relative overflow-hidden group shadow-lg hover:shadow-2xl transition-all duration-300 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
+                  >
+                    <Link href="/owner/properties/new">
                       <motion.div
-                        whileHover={{ rotate: 90 }}
-                        transition={{ duration: 0.3 }}
-                      >
-                        <Plus className="mr-2 h-4 w-4" />
-                      </motion.div>
+                        className="absolute inset-0 bg-gradient-to-r from-white/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                        whileHover={{ x: ["0%", "100%"], transition: { duration: 0.6, repeat: Infinity, repeatType: "reverse" } }}
+                      />
+                      <span className="relative flex items-center">
+                        <motion.div
+                          whileHover={{ rotate: 90 }}
+                          transition={{ duration: 0.3 }}
+                        >
+                          <Plus className="mr-2 h-4 w-4" />
+                        </motion.div>
+                        Ajouter un bien
+                      </span>
+                    </Link>
+                  </Button>
+                ) : (
+                  <Button
+                    onClick={() => setShowUpgradeModal(true)}
+                    className="relative overflow-hidden group shadow-lg transition-all duration-300 bg-gradient-to-r from-gray-400 to-gray-500 cursor-pointer"
+                  >
+                    <span className="relative flex items-center">
+                      <Plus className="mr-2 h-4 w-4" />
                       Ajouter un bien
                     </span>
-                  </Link>
-                </Button>
+                  </Button>
+                )}
               </motion.div>
             </motion.div>
 
@@ -714,6 +729,12 @@ export default function OwnerPropertiesPage() {
         </motion.div>
         </PullToRefreshContainer>
       </PageTransition>
+
+      {/* Modal d'upgrade quand limite atteinte */}
+      <UpgradeModal
+        open={showUpgradeModal}
+        onClose={() => setShowUpgradeModal(false)}
+      />
     </ProtectedRoute>
   );
 }


### PR DESCRIPTION
## Summary
Implement subscription-based usage limits for property creation, preventing users from exceeding their plan's property limit and prompting them to upgrade when at capacity.

## Key Changes

- **Usage Limit Hook & UI Components**: Import `useUsageLimit` and `UpgradeModal` from subscription components to check and display upgrade prompts
- **Conditional Add Property Button**: Replace unconditional "Add Property" button with conditional rendering:
  - Shows normal button when user can add properties
  - Shows disabled button that opens upgrade modal when at limit
- **API Endpoint Protection**: Add subscription limit check in `POST /api/properties/init` route that returns `SUBSCRIPTION_LIMIT` error (403) with detailed limit information when user exceeds their plan
- **Error Handling in Wizard Store**: Detect `SUBSCRIPTION_LIMIT` errors in property creation flow and display user-friendly toast notification with upgrade guidance
- **Subscription State Refresh**: Call `refreshSubscription()` after property deletion to update usage limits in real-time

## Implementation Details

- The `withSubscriptionLimit` middleware checks current property count against plan limits before allowing creation
- Error responses include current usage, max allowed, remaining quota, and plan information
- UI gracefully degrades to show upgrade prompt instead of broken functionality
- Subscription state is refreshed after mutations (deletion) to keep usage limits in sync

https://claude.ai/code/session_01RSTDrnJyfeU4MKrQvKyDdG