### PR TITLE
Fix entity connections and auto-propagate legal entities

### DIFF
--- a/app/api/invoices/generate-monthly/route.ts
+++ b/app/api/invoices/generate-monthly/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
     // Récupérer le bail
     const { data: lease, error: leaseError } = await serviceClient
       .from("leases")
-      .select("id, loyer, charges_forfaitaires, property_id")
+      .select("id, loyer, charges_forfaitaires, property_id, signatory_entity_id")
       .eq("id", validated.lease_id as any)
       .single();
 
@@ -147,6 +147,7 @@ export async function POST(request: Request) {
         montant_charges: Number(leaseData.charges_forfaitaires || 0),
         montant_total: Number(leaseData.loyer || 0) + Number(leaseData.charges_forfaitaires || 0),
         statut: "draft" as any,
+        issuer_entity_id: leaseData.signatory_entity_id ?? null,
       } as any)
       .select()
       .single();

--- a/app/api/leases/parking/route.ts
+++ b/app/api/leases/parking/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: Request) {
 
     const { data: property } = await serviceClient
       .from("properties")
-      .select("id, owner_id")
+      .select("id, owner_id, legal_entity_id")
       .eq("id", propertyId)
       .single();
 
@@ -64,6 +64,7 @@ export async function POST(request: Request) {
     const leaseData = {
       property_id: propertyId,
       type_bail: "parking",
+      signatory_entity_id: body.signatory_entity_id || (property as any).legal_entity_id || null,
       loyer: body.loyer || body.rent || 0,
       charges_forfaitaires: body.charges || 0,
       depot_de_garantie: body.depot_de_garantie || body.deposit || 0,

--- a/supabase/migrations/20260223100000_fix_entity_connections.sql
+++ b/supabase/migrations/20260223100000_fix_entity_connections.sql
@@ -1,0 +1,275 @@
+-- ============================================================================
+-- Migration: Correction des connexions entites juridiques
+-- Date: 2026-02-23
+-- Description:
+--   1. Backfill leases.signatory_entity_id pour TOUS les baux
+--   2. Backfill invoices.issuer_entity_id pour toutes les factures
+--   3. Backfill documents.entity_id pour tous les documents
+--   4. Backfill property_ownership manquants
+--   5. Triggers auto-propagation entity sur INSERT (properties, leases, invoices)
+--   6. Corriger get_entity_stats avec total_value et monthly_rent reels
+-- Idempotent: peut etre executee plusieurs fois sans effet secondaire.
+-- ============================================================================
+
+BEGIN;
+
+-- ============================================================================
+-- 1. BACKFILL : properties.legal_entity_id (re-passe pour les nouvelles)
+-- ============================================================================
+
+UPDATE properties p
+SET legal_entity_id = (
+  SELECT le.id FROM legal_entities le
+  WHERE le.owner_profile_id = p.owner_id
+    AND le.is_active = true
+  ORDER BY le.created_at ASC
+  LIMIT 1
+)
+WHERE p.legal_entity_id IS NULL
+  AND p.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1 FROM legal_entities le
+    WHERE le.owner_profile_id = p.owner_id
+      AND le.is_active = true
+  );
+
+-- ============================================================================
+-- 2. BACKFILL : leases.signatory_entity_id (TOUS les statuts)
+-- ============================================================================
+
+UPDATE leases l
+SET signatory_entity_id = p.legal_entity_id
+FROM properties p
+WHERE l.property_id = p.id
+  AND l.signatory_entity_id IS NULL
+  AND p.legal_entity_id IS NOT NULL;
+
+-- Pour les baux via unit_id (colocation)
+UPDATE leases l
+SET signatory_entity_id = p.legal_entity_id
+FROM units u
+JOIN properties p ON u.property_id = p.id
+WHERE l.unit_id = u.id
+  AND l.property_id IS NULL
+  AND l.signatory_entity_id IS NULL
+  AND p.legal_entity_id IS NOT NULL;
+
+-- ============================================================================
+-- 3. BACKFILL : invoices.issuer_entity_id
+-- ============================================================================
+
+UPDATE invoices i
+SET issuer_entity_id = l.signatory_entity_id
+FROM leases l
+WHERE i.lease_id = l.id
+  AND i.issuer_entity_id IS NULL
+  AND l.signatory_entity_id IS NOT NULL;
+
+-- ============================================================================
+-- 4. BACKFILL : documents.entity_id via property
+-- ============================================================================
+
+UPDATE documents d
+SET entity_id = p.legal_entity_id
+FROM properties p
+WHERE d.property_id = p.id
+  AND d.entity_id IS NULL
+  AND p.legal_entity_id IS NOT NULL;
+
+-- Documents lies a un bail (via lease_id → property → legal_entity)
+UPDATE documents d
+SET entity_id = p.legal_entity_id
+FROM leases l
+JOIN properties p ON l.property_id = p.id
+WHERE d.lease_id = l.id
+  AND d.entity_id IS NULL
+  AND d.property_id IS NULL
+  AND p.legal_entity_id IS NOT NULL;
+
+-- ============================================================================
+-- 5. BACKFILL : property_ownership manquants
+-- ============================================================================
+
+INSERT INTO property_ownership (
+  property_id,
+  legal_entity_id,
+  profile_id,
+  quote_part_numerateur,
+  quote_part_denominateur,
+  detention_type,
+  date_acquisition,
+  mode_acquisition,
+  is_current
+)
+SELECT
+  p.id,
+  p.legal_entity_id,
+  NULL,
+  1,
+  1,
+  'pleine_propriete',
+  p.created_at::DATE,
+  'achat',
+  true
+FROM properties p
+WHERE p.legal_entity_id IS NOT NULL
+  AND p.deleted_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM property_ownership po
+    WHERE po.property_id = p.id
+  );
+
+-- ============================================================================
+-- 6. TRIGGER : Auto-remplir legal_entity_id sur nouvelle propriete
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION auto_set_property_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.legal_entity_id IS NULL AND NEW.owner_id IS NOT NULL THEN
+    NEW.legal_entity_id := (
+      SELECT id FROM legal_entities
+      WHERE owner_profile_id = NEW.owner_id
+        AND is_active = true
+      ORDER BY created_at ASC
+      LIMIT 1
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_auto_set_property_entity ON properties;
+CREATE TRIGGER trg_auto_set_property_entity
+  BEFORE INSERT ON properties
+  FOR EACH ROW
+  EXECUTE FUNCTION auto_set_property_entity();
+
+-- ============================================================================
+-- 7. TRIGGER : Auto-remplir signatory_entity_id sur nouveau bail
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION auto_set_lease_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.signatory_entity_id IS NULL THEN
+    IF NEW.property_id IS NOT NULL THEN
+      NEW.signatory_entity_id := (
+        SELECT legal_entity_id FROM properties WHERE id = NEW.property_id
+      );
+    ELSIF NEW.unit_id IS NOT NULL THEN
+      NEW.signatory_entity_id := (
+        SELECT p.legal_entity_id
+        FROM units u
+        JOIN properties p ON u.property_id = p.id
+        WHERE u.id = NEW.unit_id
+      );
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_auto_set_lease_entity ON leases;
+CREATE TRIGGER trg_auto_set_lease_entity
+  BEFORE INSERT ON leases
+  FOR EACH ROW
+  EXECUTE FUNCTION auto_set_lease_entity();
+
+-- ============================================================================
+-- 8. TRIGGER : Auto-remplir issuer_entity_id sur nouvelle facture
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION auto_set_invoice_entity()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.issuer_entity_id IS NULL AND NEW.lease_id IS NOT NULL THEN
+    NEW.issuer_entity_id := (
+      SELECT signatory_entity_id FROM leases WHERE id = NEW.lease_id
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_auto_set_invoice_entity ON invoices;
+CREATE TRIGGER trg_auto_set_invoice_entity
+  BEFORE INSERT ON invoices
+  FOR EACH ROW
+  EXECUTE FUNCTION auto_set_invoice_entity();
+
+-- ============================================================================
+-- 9. CORRIGER get_entity_stats : total_value et monthly_rent reels
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_entity_stats(
+  p_owner_profile_id UUID
+) RETURNS TABLE (
+  entity_id UUID,
+  entity_name TEXT,
+  entity_type TEXT,
+  regime_fiscal TEXT,
+  properties_count BIGINT,
+  total_value DECIMAL(14,2),
+  monthly_rent DECIMAL(12,2),
+  active_leases BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH entity_props AS (
+    SELECT
+      le.id AS eid,
+      COUNT(DISTINCT p.id) AS prop_count,
+      COALESCE(SUM(p.loyer_hc), 0) AS rent_sum
+    FROM legal_entities le
+    LEFT JOIN properties p ON p.deleted_at IS NULL
+      AND (
+        p.legal_entity_id = le.id
+        OR (le.entity_type = 'particulier' AND p.owner_id = le.owner_profile_id AND p.legal_entity_id IS NULL)
+      )
+    WHERE le.owner_profile_id = p_owner_profile_id
+      AND le.is_active = true
+    GROUP BY le.id
+  ),
+  entity_values AS (
+    SELECT
+      po.legal_entity_id AS eid,
+      COALESCE(SUM(po.prix_acquisition), 0) AS total_val
+    FROM property_ownership po
+    WHERE po.legal_entity_id IN (
+      SELECT id FROM legal_entities WHERE owner_profile_id = p_owner_profile_id AND is_active = true
+    )
+    AND po.is_current = true
+    GROUP BY po.legal_entity_id
+  ),
+  entity_leases AS (
+    SELECT
+      l.signatory_entity_id AS eid,
+      COUNT(*) AS lease_count
+    FROM leases l
+    WHERE l.signatory_entity_id IN (
+      SELECT id FROM legal_entities WHERE owner_profile_id = p_owner_profile_id AND is_active = true
+    )
+    AND l.statut IN ('active', 'pending_signature', 'fully_signed')
+    GROUP BY l.signatory_entity_id
+  )
+  SELECT
+    le.id AS entity_id,
+    le.nom AS entity_name,
+    le.entity_type,
+    le.regime_fiscal,
+    COALESCE(ep.prop_count, 0)::BIGINT AS properties_count,
+    COALESCE(ev.total_val, 0)::DECIMAL(14,2) AS total_value,
+    COALESCE(ep.rent_sum, 0)::DECIMAL(12,2) AS monthly_rent,
+    COALESCE(el.lease_count, 0)::BIGINT AS active_leases
+  FROM legal_entities le
+  LEFT JOIN entity_props ep ON ep.eid = le.id
+  LEFT JOIN entity_values ev ON ev.eid = le.id
+  LEFT JOIN entity_leases el ON el.eid = le.id
+  WHERE le.owner_profile_id = p_owner_profile_id
+    AND le.is_active = true
+  ORDER BY properties_count DESC, le.nom;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+COMMIT;


### PR DESCRIPTION
## Summary
This PR fixes broken entity relationships across the property management system by backfilling missing `legal_entity_id` references and implementing automatic entity propagation through database triggers. It ensures all properties, leases, invoices, and documents are properly connected to their legal entities.

## Key Changes

### Database Migration (20260223100000_fix_entity_connections.sql)
- **Backfill properties**: Populate `legal_entity_id` for properties missing entity references
- **Backfill leases**: Set `signatory_entity_id` for all leases from their associated properties (handles both direct property_id and unit_id references)
- **Backfill invoices**: Populate `issuer_entity_id` from lease's signatory entity
- **Backfill documents**: Set `entity_id` from property or lease relationships
- **Backfill property_ownership**: Create missing ownership records for properties with legal entities
- **Auto-propagation triggers**: 
  - `trg_auto_set_property_entity`: Auto-assign legal entity when creating properties
  - `trg_auto_set_lease_entity`: Auto-assign signatory entity when creating leases
  - `trg_auto_set_invoice_entity`: Auto-assign issuer entity when creating invoices
- **Fix get_entity_stats function**: Corrected calculation of `total_value` (from property_ownership.prix_acquisition) and `monthly_rent` (from properties.loyer_hc) with proper aggregation logic

### API Endpoints
- **documents/upload**: Resolve and store `entity_id` from property or lease relationships
- **documents/upload-batch**: Resolve and store `entity_id` for batch document uploads
- **invoices/generate-monthly**: Include `signatory_entity_id` when fetching lease data
- **leases/parking**: Include `legal_entity_id` when fetching property data

## Implementation Details
- All backfill operations are idempotent and can be safely re-executed
- Entity resolution follows a priority chain: direct property/lease entity → parent property entity → null
- Triggers use BEFORE INSERT to ensure entities are set before record creation
- The `get_entity_stats` function now correctly aggregates values across multiple CTEs for accurate financial reporting

https://claude.ai/code/session_01G8XpGQp1W7wvpJcAzJyADB