### PR TITLE
fix: add worker-src CSP directive to allow Tesseract.js blob workers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -259,6 +259,7 @@ const nextConfig = {
               "img-src 'self' blob: data: https://*.supabase.co https://*.googleapis.com https://images.unsplash.com https://*.tile.openstreetmap.org https://tile.openstreetmap.org https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org https://unpkg.com https://*.stripe.com",
               "font-src 'self' https://fonts.gstatic.com",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com",
+              "worker-src 'self' blob:",
             ].join("; "),
           },
           // Headers de sécurité (anciennement dans netlify.toml)


### PR DESCRIPTION
Tesseract.js (used for OCR on identity documents) creates web workers
from blob URLs. Without an explicit worker-src directive, browsers fall
back to script-src which doesn't allow blob: URLs, blocking OCR and
causing the /api/tenant/identity/upload 500 error.

https://claude.ai/code/session_01DUyf4vgwD3vjiPFaYewkc3