### PR TITLE
Improve error handling for unconfigured Stripe and missing tables

### DIFF
--- a/app/api/stripe/connect/route.ts
+++ b/app/api/stripe/connect/route.ts
@@ -132,8 +132,19 @@ export async function GET() {
     }
   } catch (error) {
     console.error("[Stripe Connect] Erreur GET:", error);
+
+    // If Stripe is not configured, return a clean "no account" response instead of 500
+    const errorMessage = error instanceof Error ? error.message : "";
+    if (errorMessage.includes("Stripe non configurée") || errorMessage.includes("Clé API Stripe")) {
+      return NextResponse.json({
+        has_account: false,
+        account: null,
+        not_configured: true,
+      });
+    }
+
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { error: errorMessage || "Erreur serveur" },
       { status: 500 }
     );
   }
@@ -235,8 +246,18 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     console.error("[Stripe Connect] Erreur POST:", error);
+
+    // If Stripe is not configured, return a user-friendly error instead of 500
+    const errorMessage = error instanceof Error ? error.message : "";
+    if (errorMessage.includes("Stripe non configurée") || errorMessage.includes("Clé API Stripe")) {
+      return NextResponse.json(
+        { error: "Le paiement en ligne n'est pas encore configuré. Contactez l'administrateur." },
+        { status: 503 }
+      );
+    }
+
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { error: errorMessage || "Erreur serveur" },
       { status: 500 }
     );
   }

--- a/app/api/subscriptions/invoices/route.ts
+++ b/app/api/subscriptions/invoices/route.ts
@@ -31,6 +31,16 @@ export async function GET(request: NextRequest) {
       .range(offset, offset + limit - 1);
 
     if (error) {
+      // Table doesn't exist (dev/staging) — return empty results instead of 500
+      if (error.code === "42P01" || error.message?.includes("does not exist")) {
+        console.warn("[Invoices GET] Table subscription_invoices not found, returning empty results");
+        return NextResponse.json({
+          invoices: [],
+          total: 0,
+          limit,
+          offset,
+        });
+      }
       throw error;
     }
 

--- a/lib/stripe/connect.service.ts
+++ b/lib/stripe/connect.service.ts
@@ -51,7 +51,7 @@ export interface Transfer {
 }
 
 export interface PayoutSchedule {
-  delay_days: number;
+  delay_days: number | "minimum";
   interval: "manual" | "daily" | "weekly" | "monthly";
   weekly_anchor?: string;
   monthly_anchor?: number;
@@ -147,7 +147,7 @@ export async function createConnectAccount(params: {
       payouts: {
         schedule: {
           interval: "daily", // Virements quotidiens
-          delay_days: 2, // Délai minimum pour la France
+          delay_days: "minimum", // Stripe choisit le délai minimum autorisé pour le pays/compte
         },
       },
     },


### PR DESCRIPTION
## Summary
This PR improves error handling across the Stripe Connect API and subscription invoices endpoints by gracefully handling cases where Stripe is not configured or database tables don't exist, rather than returning generic 500 errors.

## Key Changes

- **Stripe Connect GET endpoint**: Added detection for Stripe configuration errors to return a clean `has_account: false` response instead of a 500 error
- **Stripe Connect POST endpoint**: Added user-friendly error message (503 status) when Stripe is not configured, instead of exposing raw error details
- **Subscription invoices endpoint**: Added handling for missing `subscription_invoices` table (common in dev/staging environments) to return empty results instead of 500 error
- **PayoutSchedule type**: Updated `delay_days` field to accept `"minimum"` string value, allowing Stripe to automatically select the minimum allowed delay for the account's country

## Implementation Details

- Error detection uses message matching for "Stripe non configurée" and "Clé API Stripe" strings
- Database errors are detected via PostgreSQL error code `42P01` (undefined table)
- Stripe configuration errors now return appropriate HTTP status codes (200 for GET with `not_configured: true`, 503 for POST)
- Improved error message consistency by extracting error message once and reusing it

https://claude.ai/code/session_01KBFHjHQ6yRoNMh27WgVsq2