### PR TITLE
Configure explicit publish directory for Next.js on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 
 [build]
   command = "npm run build"
-  # Ne pas spécifier publish - le plugin Next.js le gère automatiquement
+  publish = ".next"
 
 # Plugin Next.js pour Netlify (requis)
 [[plugins]]


### PR DESCRIPTION
## Summary
Updated the Netlify configuration to explicitly specify the publish directory for Next.js builds, replacing the previous comment that relied on automatic plugin handling.

## Changes
- Set `publish = ".next"` in the build configuration to explicitly define the output directory for Netlify deployments
- Removed the French comment that indicated the publish directory was being handled automatically by the Next.js plugin

## Details
This change makes the build configuration more explicit and ensures Netlify correctly identifies the `.next` directory as the publish target. While the Next.js plugin may handle this automatically, explicitly setting the publish directory provides clearer configuration and can help prevent deployment issues.

https://claude.ai/code/session_01KewgM4LgQb7UQr3rhjVeGm