### PR TITLE
Auto-detect payment method type from Stripe API

### DIFF
--- a/features/billing/components/v2/PaymentMethodSelector.tsx
+++ b/features/billing/components/v2/PaymentMethodSelector.tsx
@@ -60,7 +60,6 @@ export function PaymentMethodSelector({
     try {
       const res = await addMutation.mutateAsync({
         stripe_payment_method_id: stripePaymentMethodId,
-        type: "card",
         is_default: methods.length === 0,
       });
       setShowAddForm(false);

--- a/lib/helpers/api-error.ts
+++ b/lib/helpers/api-error.ts
@@ -85,9 +85,7 @@ export function handleApiError(error: unknown): NextResponse {
   }
 
   // Erreur Stripe configuration / authentification (clé API invalide, etc.)
-  const isStripeConfigError =
-    (error && typeof error === "object" && (error as any).type === "StripeAuthenticationError") ||
-    (error instanceof Error && error.message?.includes("Invalid API Key"));
+  const isStripeConfigError = isStripeConfigurationError(error);
 
   if (isStripeConfigError) {
     return NextResponse.json(
@@ -198,5 +196,22 @@ export function requireQuotaAvailable(
   if (current >= max) {
     throw new QuotaExceededError(resourceType, current, max, plan);
   }
+}
+
+/**
+ * Détecte si une erreur est liée à la configuration Stripe (clés API manquantes,
+ * Supabase non configuré pour les credentials, etc.)
+ */
+export function isStripeConfigurationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : "";
+  return (
+    message.includes("Stripe non configurée") ||
+    message.includes("Clé API Stripe") ||
+    message.includes("Missing Supabase URL") ||
+    message.includes("Invalid API Key") ||
+    (error !== null &&
+      typeof error === "object" &&
+      (error as any).type === "StripeAuthenticationError")
+  );
 }
 

--- a/lib/hooks/use-tenant-payment-methods.ts
+++ b/lib/hooks/use-tenant-payment-methods.ts
@@ -58,7 +58,7 @@ export function useAddPaymentMethod() {
   return useMutation({
     mutationFn: async (payload: {
       stripe_payment_method_id: string;
-      type: string;
+      type?: string;
       is_default?: boolean;
       label?: string;
     }) => {

--- a/lib/types/payment-methods.ts
+++ b/lib/types/payment-methods.ts
@@ -95,7 +95,7 @@ export interface PaymentMethodAuditEntry {
 
 export interface AddPaymentMethodPayload {
   stripe_payment_method_id: string;
-  type: PaymentMethodType;
+  type?: PaymentMethodType;
   is_default?: boolean;
   label?: string;
 }


### PR DESCRIPTION
## Summary
This PR improves payment method handling by making the `type` field optional and auto-detecting it from Stripe's authoritative source, while maintaining backward compatibility for wallet sub-types (Apple Pay, Google Pay).

## Key Changes

- **Made `type` field optional** in payment method creation (`AddPaymentMethodPayload` and API schema)
  - Frontend no longer required to specify payment method type
  - Reduces client-side logic and potential type mismatches

- **Implemented server-side type auto-detection**
  - Retrieves actual payment method type from Stripe API (`pm.type`)
  - Falls back to frontend-provided type only for wallet sub-types (apple_pay, google_pay) which Stripe reports as "card"
  - Ensures database always contains the authoritative type from Stripe

- **Added duplicate prevention**
  - Checks for existing active payment methods with the same Stripe ID
  - Returns existing method instead of creating duplicate if already attached

- **Improved error handling**
  - Gracefully handles "resource_already_attached" errors when attaching payment methods
  - Extracted `isStripeConfigurationError()` helper function for consistent error detection across routes
  - Applied to both `/stripe/connect` and `/tenant/payment-methods` endpoints

- **Updated payment method selector**
  - Removed hardcoded `type: "card"` from mutation call
  - Relies on server-side auto-detection instead

## Implementation Details

- The `actualType` logic prioritizes Stripe's type detection while preserving wallet distinctions that Stripe doesn't expose
- Duplicate check queries for active payment methods to prevent re-adding the same Stripe payment method
- Error handling for attachment failures is non-blocking to support idempotent operations
- Audit logging uses the detected `actualType` for accurate records

https://claude.ai/code/session_011GdidTZmFRawoWmeiDgCka