### PR TITLE
Add navigation to payments tab for pending first payment

### DIFF
--- a/app/owner/leases/[id]/LeaseDetailsClient.tsx
+++ b/app/owner/leases/[id]/LeaseDetailsClient.tsx
@@ -464,12 +464,12 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
         icon: Euro,
         title: "En attente du 1er paiement",
         description: `${formatCurrency(premierVersement)} (loyer + charges + dépôt)`,
-        action: null,
-        actionLabel: null,
+        action: () => setActiveTab("paiements"),
+        actionLabel: "Voir les paiements",
         color: "amber"
       };
     }
-    
+
     // 6. Tout est OK
     if (lease.statut === "active") {
       return {


### PR DESCRIPTION
## Summary
Enhanced the lease details UI to provide users with a direct way to navigate to the payments section when the first payment is pending.

## Key Changes
- Updated the "En attente du 1er paiement" (Awaiting first payment) status card to include an action button
- Added `action` callback that navigates to the "paiements" (payments) tab when clicked
- Set `actionLabel` to "Voir les paiements" (View payments) to clearly indicate the button's purpose
- Removed null values that previously disabled the action button
- Fixed trailing whitespace

## Implementation Details
The change allows users to quickly access the payments section directly from the lease status card, improving the user experience when a first payment is pending. The action uses the existing `setActiveTab` function to navigate within the same page.

https://claude.ai/code/session_0186yaGddE1ZovEE8vLPBemE