### PR TITLE
Change default plan from starter to gratuit

### DIFF
--- a/app/admin/_data/fetchAdminOwnerDetails.ts
+++ b/app/admin/_data/fetchAdminOwnerDetails.ts
@@ -202,8 +202,8 @@ export async function fetchAdminOwnerDetails(ownerId: string): Promise<AdminOwne
     // Subscription
     subscription: subscriptionData ? ({
       id: subscriptionData.id,
-      plan_slug: subscriptionData.plan?.slug || "starter",
-      plan_name: subscriptionData.plan?.name || "Starter",
+      plan_slug: subscriptionData.plan?.slug || "gratuit",
+      plan_name: subscriptionData.plan?.name || "Gratuit",
       status: subscriptionData.status,
       billing_cycle: subscriptionData.billing_cycle,
       current_period_start: subscriptionData.current_period_start,

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -109,7 +109,7 @@ export async function GET(request: NextRequest) {
       .eq("status", "active")
       .single();
 
-    const planSlug = subscription?.plan_slug || "starter";
+    const planSlug = subscription?.plan_slug || "gratuit";
     const premiumPlans = ["confort", "pro", "enterprise"];
 
     if (!premiumPlans.includes(planSlug)) {

--- a/app/api/subscriptions/recommend/route.ts
+++ b/app/api/subscriptions/recommend/route.ts
@@ -38,7 +38,7 @@ export async function GET() {
       .eq("user_id", user.id)
       .single();
 
-    const currentPlan = (subscription?.plan_slug || "starter") as PlanSlug;
+    const currentPlan = (subscription?.plan_slug || "gratuit") as PlanSlug;
 
     // Compter les propriétés
     const { count: propertiesCount } = await supabase

--- a/app/api/subscriptions/usage/route.ts
+++ b/app/api/subscriptions/usage/route.ts
@@ -68,8 +68,8 @@ export async function GET() {
       .eq("owner_id", profile.id)
       .maybeSingle();
 
-    const planSlug = (subscription?.plan_slug || 'starter') as PlanSlug;
-    const limits = PLANS[planSlug]?.limits || PLANS.starter.limits;
+    const planSlug = (subscription?.plan_slug || 'gratuit') as PlanSlug;
+    const limits = PLANS[planSlug]?.limits || PLANS.gratuit.limits;
 
     // Compter les propriétés
     const { count: propertiesCount } = await supabase

--- a/app/settings/billing/page.tsx
+++ b/app/settings/billing/page.tsx
@@ -894,7 +894,7 @@ export default function BillingPage() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            plan_slug: subscription?.plan.slug || "starter",
+            plan_slug: subscription?.plan.slug || "gratuit",
             billing_cycle: subscription?.billing_cycle || "monthly",
           }),
         });

--- a/components/admin/owner-subscription-card.tsx
+++ b/components/admin/owner-subscription-card.tsx
@@ -100,6 +100,14 @@ const PLAN_THEMES: Record<string, {
   ring: string;
   iconColor: string;
 }> = {
+  gratuit: {
+    gradient: "from-gray-500/20 via-gray-400/10 to-gray-600/20",
+    glow: "shadow-gray-500/10",
+    icon: Shield,
+    badge: "bg-gray-100 text-gray-600 border-gray-300",
+    ring: "ring-gray-400/30",
+    iconColor: "text-gray-500",
+  },
   starter: {
     gradient: "from-slate-500/20 via-slate-400/10 to-slate-600/20",
     glow: "shadow-slate-500/10",
@@ -437,7 +445,7 @@ export function OwnerSubscriptionCard({
 }: OwnerSubscriptionCardProps) {
   const [changeDialogOpen, setChangeDialogOpen] = React.useState(false);
   
-  const theme = PLAN_THEMES[subscription?.plan_slug || "starter"] || PLAN_THEMES.starter;
+  const theme = PLAN_THEMES[subscription?.plan_slug || "gratuit"] || PLAN_THEMES.gratuit;
   const statusConfig = STATUS_CONFIG[subscription?.status || "active"] || STATUS_CONFIG.active;
   const PlanIcon = theme.icon;
   const StatusIcon = statusConfig.icon;

--- a/lib/middleware/subscription-check.ts
+++ b/lib/middleware/subscription-check.ts
@@ -76,14 +76,34 @@ export async function withSubscriptionLimit(
     let max = 0;
 
     switch (limitType) {
-      case "properties":
-        current = subscription.properties_count || 0;
+      case "properties": {
+        const { count: propCount } = await serviceClient
+          .from("properties")
+          .select("id", { count: "exact", head: true })
+          .eq("owner_id", ownerId);
+        current = propCount || 0;
         max = plan.max_properties ?? 1;
         break;
-      case "leases":
-        current = subscription.leases_count || 0;
+      }
+      case "leases": {
+        const { data: ownerProperties } = await serviceClient
+          .from("properties")
+          .select("id")
+          .eq("owner_id", ownerId);
+        if (ownerProperties && ownerProperties.length > 0) {
+          const propertyIds = ownerProperties.map((p: { id: string }) => p.id);
+          const { count: leaseCount } = await serviceClient
+            .from("leases")
+            .select("id", { count: "exact", head: true })
+            .in("property_id", propertyIds)
+            .in("statut", ["active", "pending_signature"]);
+          current = leaseCount || 0;
+        } else {
+          current = 0;
+        }
         max = plan.max_leases ?? 1;
         break;
+      }
       case "users":
         // Compter les team members actifs
         const { count: userCount } = await serviceClient


### PR DESCRIPTION
## Summary
This PR updates the default subscription plan from "starter" to "gratuit" across the application, and improves the subscription limit checking logic to query actual database counts instead of relying on potentially stale denormalized fields.

## Key Changes

- **Default Plan Update**: Changed all default plan references from "starter" to "gratuit" throughout the codebase
  - Updated fallback values in subscription queries and API routes
  - Modified admin UI theme defaults to use the new "gratuit" plan
  - Updated data fetching defaults in admin owner details

- **Subscription Limit Checking Improvements**: Refactored `withSubscriptionLimit` middleware to query actual database counts
  - **Properties**: Now queries the `properties` table directly with `count: "exact"` instead of using `subscription.properties_count`
  - **Leases**: Now queries the `leases` table for active/pending_signature leases filtered by owner's properties, instead of using `subscription.leases_count`
  - This ensures accurate, real-time usage counts rather than relying on potentially outdated denormalized fields

- **UI Theme Addition**: Added "gratuit" plan theme configuration to the admin subscription card with gray color scheme

## Files Modified
- `lib/middleware/subscription-check.ts` - Improved limit checking logic
- `components/admin/owner-subscription-card.tsx` - Added gratuit theme and updated default
- `app/admin/_data/fetchAdminOwnerDetails.ts` - Updated default plan
- `app/api/subscriptions/usage/route.ts` - Updated default plan
- `app/api/providers/nearby/route.ts` - Updated default plan
- `app/api/subscriptions/recommend/route.ts` - Updated default plan
- `app/settings/billing/page.tsx` - Updated default plan

https://claude.ai/code/session_01EvfAfWfVaUgGDYJbuFeA85