### PR TITLE
Add syndic role support and refactor auth signup flow

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
-import { sendEmail } from "@/lib/services/email-service";
+import { sendEmail } from "@/lib/emails/resend.service";
 import { emailTemplates } from "@/lib/emails/templates";
 
 export async function POST(request: NextRequest) {

--- a/app/api/v1/auth/register/route.ts
+++ b/app/api/v1/auth/register/route.ts
@@ -81,6 +81,7 @@ export async function POST(request: NextRequest) {
           { onConflict: "profile_id", ignoreDuplicates: true }
         );
       }
+      // Note: syndic uses base profile only (no syndic_profiles table yet)
 
       // Audit log
       await logAudit(

--- a/app/signup/account/page.tsx
+++ b/app/signup/account/page.tsx
@@ -116,6 +116,8 @@ export default function AccountCreationPage() {
         return "prestataire";
       case "guarantor":
         return "garant";
+      case "syndic":
+        return "syndic";
       default:
         return "";
     }

--- a/app/signup/verify-email/page.tsx
+++ b/app/signup/verify-email/page.tsx
@@ -56,49 +56,20 @@ export default function VerifyEmailOnboardingPage() {
     }
 
     setLoading(true);
-    
-    try {
-      // Essayer d'envoyer l'email via le service
-      try {
-        await authService.resendConfirmationEmail(email);
-      } catch (serviceError: any) {
-        
-        // Si erreur de session, essayer directement avec Supabase
-        if (
-          serviceError.message?.includes("session") ||
-          serviceError.message?.includes("Auth session missing")
-        ) {
-          const supabase = (await import("@/lib/supabase/client")).createClient();
-          const { getAuthCallbackUrl } = await import("@/lib/utils/redirect-url");
-          const redirectUrl = getAuthCallbackUrl();
-          
-          const { error: resendError } = await supabase.auth.resend({
-            type: "signup",
-            email,
-            options: {
-              emailRedirectTo: redirectUrl,
-            },
-          });
 
-          if (resendError) {
-            console.error("[VerifyEmail] Erreur Supabase resend:", resendError);
-            throw resendError;
-          }
-        } else {
-          throw serviceError;
-        }
-      }
+    try {
+      // Le service gère déjà le fallback en cas d'erreur de session
+      await authService.resendConfirmationEmail(email);
 
       setEmailSent(true);
       toast({
-        title: "Email envoyé ✅",
+        title: "Email envoyé",
         description: "Un nouvel email de confirmation a été envoyé. Vérifiez aussi vos spams !",
       });
     } catch (error: unknown) {
-      
       // Messages d'erreur plus explicites
       let errorMessage = error instanceof Error ? (error as Error).message : "Impossible d'envoyer l'email.";
-      
+
       if ((error as Error).message?.includes("rate limit") || (error as Error).message?.includes("too many")) {
         errorMessage = "Trop de tentatives. Attendez quelques minutes avant de réessayer.";
       } else if ((error as Error).message?.includes("already confirmed")) {
@@ -106,7 +77,7 @@ export default function VerifyEmailOnboardingPage() {
       } else if ((error as Error).message?.includes("not found") || (error as Error).message?.includes("User not found")) {
         errorMessage = "Aucun compte trouvé avec cet email. Vérifiez l'adresse ou inscrivez-vous.";
       }
-      
+
       toast({
         title: "Erreur d'envoi",
         description: errorMessage,
@@ -161,11 +132,10 @@ export default function VerifyEmailOnboardingPage() {
     }
   };
 
-  const goToNextStep = () => {
+  const goToNextStep = useCallback(() => {
     // Redirection selon le rôle
     switch (role) {
       case "owner":
-        // Les propriétaires doivent d'abord choisir leur forfait
         router.push(`/signup/plan?role=owner`);
         break;
       case "tenant":
@@ -177,10 +147,13 @@ export default function VerifyEmailOnboardingPage() {
       case "guarantor":
         router.push("/guarantor/onboarding/context");
         break;
+      case "syndic":
+        router.push("/syndic/onboarding/profile");
+        break;
       default:
         router.push("/dashboard");
     }
-  };
+  }, [role, router]);
 
   // Polling automatique toutes les 5 secondes pour détecter la confirmation
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -208,7 +181,7 @@ export default function VerifyEmailOnboardingPage() {
     return () => {
       if (pollingRef.current) clearInterval(pollingRef.current);
     };
-  }, [verified]);
+  }, [verified, goToNextStep, toast]);
 
   const handleContinue = () => {
     goToNextStep();

--- a/features/auth/services/auth.service.ts
+++ b/features/auth/services/auth.service.ts
@@ -20,31 +20,35 @@ export class AuthService {
   private supabase = createClient();
 
   async signUp(data: SignUpData) {
-    // Normaliser l'email de la même manière que lors de la connexion
+    // Normaliser l'email
     const normalizedEmail = data.email.trim().toLowerCase();
-    
-    // Créer l'utilisateur avec le rôle dans les metadata pour que le trigger le lise
-    const { data: authData, error: authError } = await this.supabase.auth.signUp({
-      email: normalizedEmail,
-      password: data.password,
-      options: {
-        data: {
-          role: data.role, // Passer le rôle dans les metadata
-          prenom: data.prenom,
-          nom: data.nom,
-          telephone: data.telephone,
-        },
-      },
+
+    // Passer par l'API serveur pour bénéficier de :
+    // - Rate limiting (3/h par IP)
+    // - Création des profils spécialisés (owner_profiles, tenant_profiles, etc.)
+    // - Audit logging
+    const response = await fetch("/api/v1/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: normalizedEmail,
+        password: data.password,
+        role: data.role,
+        prenom: data.prenom,
+        nom: data.nom,
+      }),
     });
 
-    if (authError) throw authError;
-    if (!authData.user) throw new Error("User creation failed");
+    const result = await response.json();
 
-    // Le profil est créé automatiquement par le trigger handle_new_user
-    // qui lit le rôle, prénom, nom et téléphone depuis les metadata de l'utilisateur
-    // Donc pas besoin de faire un upsert ici
-    
-    return authData;
+    if (!response.ok) {
+      const error = new Error(result.error || "Erreur lors de la création du compte");
+      (error as any).code = result.code;
+      (error as any).status = response.status;
+      throw error;
+    }
+
+    return result;
   }
 
   async signIn(data: SignInData) {

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -17,7 +17,7 @@ export const RegisterSchema = z.object({
     .regex(/[a-z]/, "Le mot de passe doit contenir au moins une minuscule")
     .regex(/[0-9]/, "Le mot de passe doit contenir au moins un chiffre")
     .regex(/[^A-Za-z0-9]/, "Le mot de passe doit contenir au moins un caractère spécial"),
-  role: z.enum(["owner", "tenant", "provider", "guarantor"]),
+  role: z.enum(["owner", "tenant", "provider", "guarantor", "syndic"]),
   prenom: z.string().min(1, "Prénom requis").max(80).regex(/^[\p{L}\s'\-]+$/u, "Caractères non autorisés dans le prénom"),
   nom: z.string().min(1, "Nom requis").max(80).regex(/^[\p{L}\s'\-]+$/u, "Caractères non autorisés dans le nom"),
 });

--- a/supabase/migrations/20260312100000_fix_handle_new_user_all_roles.sql
+++ b/supabase/migrations/20260312100000_fix_handle_new_user_all_roles.sql
@@ -1,0 +1,54 @@
+-- ============================================
+-- Migration: Ajouter guarantor et syndic au trigger handle_new_user
+-- Date: 2026-03-12
+-- Description: Le trigger acceptait uniquement admin/owner/tenant/provider.
+--              Les rôles guarantor et syndic étaient silencieusement convertis en tenant.
+-- ============================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role TEXT;
+  v_prenom TEXT;
+  v_nom TEXT;
+  v_telephone TEXT;
+BEGIN
+  -- Lire le rôle depuis les metadata, avec fallback sur 'tenant'
+  v_role := COALESCE(
+    NEW.raw_user_meta_data->>'role',
+    'tenant'
+  );
+
+  -- Valider le rôle (tous les rôles supportés par la plateforme)
+  IF v_role NOT IN ('admin', 'owner', 'tenant', 'provider', 'guarantor', 'syndic') THEN
+    v_role := 'tenant';
+  END IF;
+
+  -- Lire les autres données depuis les metadata
+  v_prenom := NEW.raw_user_meta_data->>'prenom';
+  v_nom := NEW.raw_user_meta_data->>'nom';
+  v_telephone := NEW.raw_user_meta_data->>'telephone';
+
+  -- Insérer le profil avec toutes les données
+  INSERT INTO public.profiles (user_id, role, prenom, nom, telephone)
+  VALUES (NEW.id, v_role, v_prenom, v_nom, v_telephone)
+  ON CONFLICT (user_id) DO UPDATE SET
+    role = EXCLUDED.role,
+    prenom = COALESCE(EXCLUDED.prenom, profiles.prenom),
+    nom = COALESCE(EXCLUDED.nom, profiles.nom),
+    telephone = COALESCE(EXCLUDED.telephone, profiles.telephone),
+    updated_at = NOW();
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.handle_new_user() IS
+'Crée automatiquement un profil lors de la création d''un utilisateur.
+Lit le rôle et les informations personnelles depuis les raw_user_meta_data.
+Supporte tous les rôles: admin, owner, tenant, provider, guarantor, syndic.
+Utilise ON CONFLICT pour gérer les cas où le profil existe déjà.';


### PR DESCRIPTION
## Summary
This PR extends the platform to support the "syndic" (building manager) role and refactors the authentication signup flow to use a server-side API endpoint instead of direct Supabase client calls.

## Key Changes

- **Database Migration**: Updated `handle_new_user()` trigger to support `guarantor` and `syndic` roles alongside existing roles (admin, owner, tenant, provider). Previously, unsupported roles were silently converted to tenant.

- **Auth Service Refactor**: Changed `signUp()` method to call `/api/v1/auth/register` server endpoint instead of direct Supabase client calls. This enables:
  - Rate limiting (3 requests/hour per IP)
  - Specialized profile creation (owner_profiles, tenant_profiles, etc.)
  - Audit logging
  - Centralized error handling

- **Email Verification Flow**: Simplified `VerifyEmailOnboardingPage` by removing nested try-catch fallback logic. The auth service now handles session errors internally.

- **Role Support**: Added "syndic" role throughout the application:
  - Updated schema validation to accept syndic role
  - Added syndic onboarding redirect (`/syndic/onboarding/profile`)
  - Added syndic role display label ("syndic")
  - Added note that syndic uses base profile only (no specialized syndic_profiles table yet)

- **Code Quality**: 
  - Wrapped `goToNextStep` in `useCallback` to prevent unnecessary re-renders
  - Fixed email service import path (`@/lib/emails/resend.service`)
  - Improved error messages and removed unnecessary emoji from toast notifications

## Implementation Details

The migration ensures backward compatibility by validating roles and defaulting to 'tenant' for invalid values. The auth service refactor centralizes signup logic on the server, improving security and maintainability while the client-side code becomes simpler and more focused on UI concerns.

https://claude.ai/code/session_011bD4bzcwwqH3UTvpRftP2W