### PR TITLE
fix: audit comptes - harmoniser z-index, boutons et liens manquants

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -57,7 +57,7 @@ export default async function AdminLayout({
       </a>
       <div className="flex min-h-screen mesh-gradient">
         <AdminSidebar />
-        <main className="flex-1 lg:pl-64 transition-all duration-200" id="admin-main-content">
+        <main className="flex-1 pl-14 lg:pl-64 transition-all duration-200" id="admin-main-content">
           <AdminShellHeader />
           <div className="container mx-auto max-w-7xl px-4 py-6 lg:px-8">
             <Breadcrumb homeHref="/admin/dashboard" className="mb-4" />

--- a/components/layout/owner-app-layout.tsx
+++ b/components/layout/owner-app-layout.tsx
@@ -286,7 +286,7 @@ export function OwnerAppLayout({ children, profile: serverProfile }: OwnerAppLay
         <aside
           data-tour-sidebar
           aria-label="Navigation principale"
-          className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-64 xl:w-72 lg:flex-col"
+          className="hidden lg:fixed lg:inset-y-0 lg:z-40 lg:flex lg:w-64 xl:w-72 lg:flex-col"
         >
           <div className="flex grow flex-col gap-y-4 lg:gap-y-5 overflow-y-auto bg-card border-r border-border px-4 lg:px-6 pb-4">
             <div className="flex h-16 shrink-0 items-center gap-2">

--- a/components/messages/MessagesPageContent.tsx
+++ b/components/messages/MessagesPageContent.tsx
@@ -18,6 +18,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface TenantOption {
   tenantProfileId: string;
@@ -252,7 +258,7 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
             <div className="p-4">
               <div className="flex items-center justify-between mb-4">
                 <h1 className="text-2xl font-bold">Messages</h1>
-                {canCreateConversation && (
+                {canCreateConversation ? (
                   ownerTenants.length > 0 ? (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
@@ -288,6 +294,25 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
                       {isCreatingConversation ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
                     </Button>
                   )
+                ) : (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span tabIndex={0}>
+                          <Button
+                            size="sm"
+                            disabled
+                            className="rounded-xl font-bold"
+                          >
+                            <Plus className="h-4 w-4" />
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>Un bail actif est requis pour envoyer un message</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )}
               </div>
               <ConversationsList
@@ -314,7 +339,7 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
             <h1 className="text-3xl font-bold">Messages</h1>
             <p className="text-muted-foreground mt-1">{subtitle}</p>
           </div>
-          {canCreateConversation && (
+          {canCreateConversation ? (
             ownerTenants.length > 0 ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -358,6 +383,25 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
                 Nouvelle conversation
               </Button>
             )
+          ) : (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span tabIndex={0}>
+                    <Button
+                      disabled
+                      className="rounded-xl font-bold"
+                    >
+                      <Plus className="h-4 w-4 mr-2" />
+                      Nouvelle conversation
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Un bail actif est requis pour envoyer un message</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </motion.div>
 

--- a/features/auth/components/sign-in-form.tsx
+++ b/features/auth/components/sign-in-form.tsx
@@ -267,6 +267,12 @@ export function SignInForm() {
       </CardContent>
       <CardFooter className="flex flex-col space-y-2 text-sm text-muted-foreground">
         <p>
+          Pas encore inscrit ?{" "}
+          <Link href="/signup/role" className="text-primary underline-offset-2 hover:underline">
+            Créer un compte
+          </Link>
+        </p>
+        <p>
           Mot de passe oublié ?{" "}
           <Link href="/auth/forgot-password" className="text-primary underline-offset-2 hover:underline">
             Réinitialiser


### PR DESCRIPTION
- Harmoniser z-index sidebar owner desktop (z-50 → z-40) pour cohérence avec tenant/admin
- Ajouter lien "Créer un compte" dans le formulaire de connexion (SignInForm)
- Ajouter padding-left mobile pour éviter chevauchement hamburger admin
- Rendre bouton "Nouvelle conversation" toujours visible (désactivé avec tooltip si pas de bail actif)

https://claude.ai/code/session_0199qr2tSHqEEpKPnFqGLuVC