### PR TITLE
Refactor: Move email service to services directory

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
-import { sendEmail } from "@/lib/emails/resend.service";
+import { sendEmail } from "@/lib/services/email-service";
 import { emailTemplates } from "@/lib/emails/templates";
 
 export async function POST(request: NextRequest) {


### PR DESCRIPTION
## Summary
Reorganized the email service module by moving it from the `emails` directory to a dedicated `services` directory for better code organization and separation of concerns.

## Key Changes
- Moved email service import from `@/lib/emails/resend.service` to `@/lib/services/email-service`
- Updated the import path in the forgot-password route handler to reference the new location

## Implementation Details
This is a structural refactoring that improves the project's directory organization by consolidating service-layer utilities in a dedicated `services` directory, making it easier to locate and maintain service implementations across the codebase.

https://claude.ai/code/session_011y1utNzjvexmy9zzLiz77A