### PR TITLE
Fix password reset flow by using token_hash instead of PKCE code

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -76,6 +76,27 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: true });
     }
 
+    // Construire un lien direct vers /auth/callback avec le token_hash.
+    // On bypass le redirect Supabase car generateLink() côté serveur ne pose
+    // pas de code verifier PKCE dans le navigateur de l'utilisateur, ce qui
+    // fait échouer exchangeCodeForSession() dans le callback.
+    const actionUrl = new URL(actionLink);
+    const tokenHash = actionUrl.searchParams.get("token");
+    if (!tokenHash) {
+      console.error("[ForgotPassword] No token in action_link");
+      return NextResponse.json({ success: true });
+    }
+
+    const requestOrigin =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      request.headers.get("origin") ||
+      "https://talok.fr";
+    const directResetUrl = new URL("/auth/callback", requestOrigin);
+    directResetUrl.searchParams.set("token_hash", tokenHash);
+    directResetUrl.searchParams.set("type", "recovery");
+    directResetUrl.searchParams.set("flow", "pw-reset");
+    directResetUrl.searchParams.set("rid", requestId);
+
     let resetRequestId: string | null = null;
     try {
       const resetRequest = await createPasswordResetRequest({
@@ -112,7 +133,7 @@ export async function POST(request: NextRequest) {
     // Générer l'email via le design system Talok (lib/emails/templates.ts)
     const template = emailTemplates.passwordReset({
       userName,
-      resetUrl: actionLink,
+      resetUrl: directResetUrl.toString(),
       expiresIn: "1 heure",
     });
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -28,6 +28,76 @@ export async function GET(request: Request) {
   const flow = requestUrl.searchParams.get("flow");
   const requestId = requestUrl.searchParams.get("rid");
 
+  // Chemin 1 : Vérification directe par token_hash (liens email custom via generateLink)
+  // generateLink() côté serveur ne pose pas de code verifier PKCE dans le navigateur,
+  // donc on utilise verifyOtp() avec le token_hash au lieu de exchangeCodeForSession().
+  const tokenHash = requestUrl.searchParams.get("token_hash");
+  const type = requestUrl.searchParams.get("type");
+
+  if (tokenHash && type) {
+    const supabase = await createClient();
+    const { data, error } = await supabase.auth.verifyOtp({
+      token_hash: tokenHash,
+      type: type as "recovery",
+    });
+
+    if (error || !data.user) {
+      console.error("Error verifying OTP token:", error);
+      if (flow === "pw-reset") {
+        return NextResponse.redirect(new URL("/auth/forgot-password?error=invalid_reset_link", origin));
+      }
+      return NextResponse.redirect(new URL("/auth/signin?error=invalid_code", origin));
+    }
+
+    if (flow === "pw-reset" && requestId && data.user) {
+      const validation = await validatePasswordResetRequestForCallback({
+        requestId,
+        userId: data.user.id,
+      });
+
+      if (!validation.valid || !validation.request) {
+        return NextResponse.redirect(new URL("/auth/forgot-password?error=invalid_reset_link", origin));
+      }
+
+      const response = NextResponse.redirect(new URL(`/recovery/password/${requestId}`, origin));
+      response.cookies.set(
+        PASSWORD_RESET_COOKIE_NAME,
+        createPasswordResetCookieToken({
+          requestId,
+          userId: data.user.id,
+          expiresAt: new Date(validation.request.expires_at).getTime(),
+        }),
+        getPasswordResetCookieOptions(validation.request.expires_at)
+      );
+      response.headers.set("Cache-Control", "no-store");
+      return response;
+    }
+
+    // Token vérifié mais pas un flow pw-reset : traiter comme une connexion normale
+    // (fallthrough vers la logique de redirection par rôle ci-dessous)
+    if (data.user && data.user.email_confirmed_at) {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("id, role, onboarding_completed_at")
+        .eq("user_id", data.user.id)
+        .maybeSingle();
+
+      const profileData = profile as ProfilePartial | null;
+      if (!profileData?.role) {
+        return NextResponse.redirect(new URL("/signup/role", origin));
+      }
+      if (!profileData?.onboarding_completed_at) {
+        const dashUrl = getRoleDashboardUrl(profileData.role);
+        return NextResponse.redirect(new URL(dashUrl, origin));
+      }
+      const dashUrl = getRoleDashboardUrl(profileData.role);
+      return NextResponse.redirect(new URL(dashUrl, origin));
+    }
+
+    return NextResponse.redirect(new URL("/auth/signin", origin));
+  }
+
+  // Chemin 2 : Échange de code PKCE (flux standard Supabase, rétrocompatibilité)
   if (code) {
     const supabase = await createClient();
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);


### PR DESCRIPTION
## Summary
This PR fixes the password reset flow by implementing a direct token verification path using Supabase's `verifyOtp()` method instead of relying on PKCE code exchange. The issue stems from `generateLink()` being called server-side, which doesn't establish a PKCE code verifier in the user's browser, causing `exchangeCodeForSession()` to fail in the callback.

## Key Changes

- **Added token_hash verification path in `/auth/callback`**: Implements a new flow that checks for `token_hash` and `type` parameters and uses `verifyOtp()` to authenticate users directly, bypassing the PKCE code exchange requirement.

- **Password reset flow handling**: When `flow=pw-reset` is detected, the callback validates the reset request, creates a secure password reset cookie, and redirects to the password recovery page.

- **Fallback to role-based redirection**: For non-password-reset flows, verified users are redirected based on their profile role and onboarding status.

- **Updated forgot-password endpoint**: Modified `/api/auth/forgot-password` to construct a direct callback URL with `token_hash`, `type`, `flow`, and `rid` parameters instead of using Supabase's redirect URL.

- **Email template update**: Changed the password reset email to use the new direct reset URL instead of the Supabase action link.

## Implementation Details

- The solution maintains backward compatibility by keeping the existing PKCE code exchange path (labeled as "Chemin 2") for standard Supabase flows.
- Password reset requests are validated server-side to ensure the reset link hasn't expired and matches the user.
- The password reset cookie is set with appropriate expiration and security options.
- Cache-Control headers are set to prevent caching of authenticated responses.

https://claude.ai/code/session_01B3K6CbHZ6MbGDcuKicYunB