### PR TITLE
Fix password reset cookie path to root directory

### DIFF
--- a/lib/auth/password-recovery.service.ts
+++ b/lib/auth/password-recovery.service.ts
@@ -127,7 +127,7 @@ export function getPasswordResetCookieOptions(expiresAt: string | Date) {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax" as const,
-    path: "/recovery/password",
+    path: "/",
     expires: expiresAt instanceof Date ? expiresAt : new Date(expiresAt),
   };
 }


### PR DESCRIPTION
## Summary
Updated the password reset cookie path from a specific recovery route to the root directory to ensure the cookie is accessible across the entire application.

## Changes
- Changed password reset cookie `path` option from `/recovery/password` to `/` in `getPasswordResetCookieOptions()`

## Details
This change allows the password reset cookie to be sent with requests to all routes within the application, rather than being limited to the `/recovery/password` path. This is necessary if password reset functionality needs to be accessible from multiple routes or if the cookie needs to be validated across different parts of the application.

https://claude.ai/code/session_01FUP3bnnzdJtBdfXjjxQ1yy