### PR TITLE
fix: replace hardcoded colors with CSS variables for owner dark mode

### DIFF
--- a/app/owner/_components/global-search.tsx
+++ b/app/owner/_components/global-search.tsx
@@ -54,7 +54,7 @@ export function GlobalSearch() {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="flex items-center gap-2 px-3 py-1.5 text-sm text-slate-500 bg-slate-100 hover:bg-slate-200 rounded-md transition-colors w-full max-w-[200px] border border-slate-200"
+        className="flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground bg-muted hover:bg-muted rounded-md transition-colors w-full max-w-[200px] border border-border"
       >
         <Search className="h-4 w-4" />
         <span className="flex-1 text-left">Recherche...</span>

--- a/app/owner/copro/charges/page.tsx
+++ b/app/owner/copro/charges/page.tsx
@@ -186,7 +186,7 @@ export default function BailleurChargesPage() {
             <h1 className="text-2xl font-bold text-white">
               Charges récupérables
             </h1>
-            <p className="text-slate-400">
+            <p className="text-muted-foreground">
               Détail des charges copropriété récupérables sur vos locataires
             </p>
           </div>
@@ -253,7 +253,7 @@ export default function BailleurChargesPage() {
                 <CardContent className="p-6">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm text-slate-400">Charges copro totales</p>
+                      <p className="text-sm text-muted-foreground">Charges copro totales</p>
                       <p className="text-2xl font-bold text-white">
                         {currentUnit.current_year_summary.total_copro.toLocaleString('fr-FR')} €
                       </p>
@@ -269,7 +269,7 @@ export default function BailleurChargesPage() {
                 <CardContent className="p-6">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm text-slate-400">Part récupérable</p>
+                      <p className="text-sm text-muted-foreground">Part récupérable</p>
                       <p className="text-2xl font-bold text-emerald-400">
                         {currentUnit.current_year_summary.total_recuperable.toLocaleString('fr-FR')} €
                       </p>
@@ -285,7 +285,7 @@ export default function BailleurChargesPage() {
                 <CardContent className="p-6">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm text-slate-400">Non récupérable</p>
+                      <p className="text-sm text-muted-foreground">Non récupérable</p>
                       <p className="text-2xl font-bold text-red-400">
                         {(currentUnit.current_year_summary.total_copro - currentUnit.current_year_summary.total_recuperable).toLocaleString('fr-FR')} €
                       </p>
@@ -307,13 +307,13 @@ export default function BailleurChargesPage() {
               <Card className="border-white/10 bg-white/5">
                 <CardContent className="p-6">
                   <div className="flex items-center justify-between mb-2">
-                    <span className="text-slate-400">Taux de récupérabilité</span>
+                    <span className="text-muted-foreground">Taux de récupérabilité</span>
                     <span className="text-lg font-semibold text-emerald-400">
                       {recuperablePercentage.toFixed(1)}%
                     </span>
                   </div>
                   <Progress value={recuperablePercentage} className="h-3 bg-slate-700" />
-                  <div className="flex justify-between mt-2 text-xs text-slate-500">
+                  <div className="flex justify-between mt-2 text-xs text-muted-foreground">
                     <span>0%</span>
                     <span>Décret 87-713</span>
                     <span>100%</span>
@@ -360,20 +360,20 @@ export default function BailleurChargesPage() {
                             </div>
                             <div>
                               <p className="text-white font-medium">{service.label}</p>
-                              <p className="text-xs text-slate-400">
+                              <p className="text-xs text-muted-foreground">
                                 {SERVICE_TYPE_LABELS[service.service_type]}
                               </p>
                             </div>
                           </div>
                           <div className="flex items-center gap-6">
                             <div className="text-right">
-                              <p className="text-sm text-slate-400">Copro</p>
+                              <p className="text-sm text-muted-foreground">Copro</p>
                               <p className="text-white font-medium">
                                 {service.copro_amount.toLocaleString('fr-FR')} €
                               </p>
                             </div>
                             <div className="text-right">
-                              <p className="text-sm text-slate-400">Récupérable</p>
+                              <p className="text-sm text-muted-foreground">Récupérable</p>
                               <p className={`font-semibold ${isRecuperable ? 'text-emerald-400' : 'text-red-400'}`}>
                                 {service.recuperable_amount.toLocaleString('fr-FR')} €
                               </p>
@@ -416,16 +416,16 @@ export default function BailleurChargesPage() {
                         <div className="flex items-start justify-between">
                           <div>
                             <p className="text-white font-medium">{charge.label}</p>
-                            <p className="text-xs text-slate-400">{charge.period}</p>
+                            <p className="text-xs text-muted-foreground">{charge.period}</p>
                           </div>
                           <Badge className={charge.recuperable_ratio === 1 ? 'bg-emerald-500/20 text-emerald-400' : charge.recuperable_ratio > 0 ? 'bg-amber-500/20 text-amber-400' : 'bg-red-500/20 text-red-400'}>
                             {(charge.recuperable_ratio * 100).toFixed(0)}%
                           </Badge>
                         </div>
                         <div className="grid grid-cols-3 gap-2 text-sm">
-                          <div><p className="text-slate-400">Copro</p><p className="text-white">{charge.copro_amount.toLocaleString('fr-FR')} €</p></div>
-                          <div><p className="text-slate-400">Prorata</p><p className="text-slate-300">{(charge.prorata_ratio * 100).toFixed(0)}%</p></div>
-                          <div><p className="text-slate-400">Récupérable</p><p className={`font-semibold ${charge.recuperable_amount > 0 ? 'text-emerald-400' : 'text-red-400'}`}>{charge.recuperable_amount.toLocaleString('fr-FR')} €</p></div>
+                          <div><p className="text-muted-foreground">Copro</p><p className="text-white">{charge.copro_amount.toLocaleString('fr-FR')} €</p></div>
+                          <div><p className="text-muted-foreground">Prorata</p><p className="text-slate-300">{(charge.prorata_ratio * 100).toFixed(0)}%</p></div>
+                          <div><p className="text-muted-foreground">Récupérable</p><p className={`font-semibold ${charge.recuperable_amount > 0 ? 'text-emerald-400' : 'text-red-400'}`}>{charge.recuperable_amount.toLocaleString('fr-FR')} €</p></div>
                         </div>
                       </div>
                     ))}
@@ -435,12 +435,12 @@ export default function BailleurChargesPage() {
                   <Table>
                     <TableHeader>
                       <TableRow className="border-white/10">
-                        <TableHead className="text-slate-400">Période</TableHead>
-                        <TableHead className="text-slate-400">Poste</TableHead>
-                        <TableHead className="text-slate-400 text-right">Montant copro</TableHead>
-                        <TableHead className="text-slate-400 text-right">Ratio</TableHead>
-                        <TableHead className="text-slate-400 text-right">Prorata</TableHead>
-                        <TableHead className="text-slate-400 text-right">Récupérable</TableHead>
+                        <TableHead className="text-muted-foreground">Période</TableHead>
+                        <TableHead className="text-muted-foreground">Poste</TableHead>
+                        <TableHead className="text-muted-foreground text-right">Montant copro</TableHead>
+                        <TableHead className="text-muted-foreground text-right">Ratio</TableHead>
+                        <TableHead className="text-muted-foreground text-right">Prorata</TableHead>
+                        <TableHead className="text-muted-foreground text-right">Récupérable</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -460,7 +460,7 @@ export default function BailleurChargesPage() {
                               {(charge.recuperable_ratio * 100).toFixed(0)}%
                             </Badge>
                           </TableCell>
-                          <TableCell className="text-right text-slate-400">
+                          <TableCell className="text-right text-muted-foreground">
                             {(charge.prorata_ratio * 100).toFixed(0)}%
                           </TableCell>
                           <TableCell className={`text-right font-semibold ${

--- a/app/owner/copro/regularisation/page.tsx
+++ b/app/owner/copro/regularisation/page.tsx
@@ -400,7 +400,7 @@ export default function RegularisationPage() {
                     }`}>
                       {regularisationData.balance > 0 ? '+' : ''}{regularisationData.balance.toLocaleString('fr-FR')} €
                     </p>
-                    <p className="text-xs text-slate-400">
+                    <p className="text-xs text-muted-foreground">
                       {regularisationData.balance > 0 ? 'à payer par le locataire' : 'à rembourser au locataire'}
                     </p>
                   </CardContent>
@@ -418,7 +418,7 @@ export default function RegularisationPage() {
                       <div key={charge.service_type} className="rounded-lg border border-border bg-muted/30 p-4 space-y-2">
                         <div>
                           <p className="text-foreground font-medium">{charge.label}</p>
-                          <p className="text-xs text-slate-400">{SERVICE_TYPE_LABELS[charge.service_type]}</p>
+                          <p className="text-xs text-muted-foreground">{SERVICE_TYPE_LABELS[charge.service_type]}</p>
                         </div>
                         <div className="grid grid-cols-2 gap-2 text-sm">
                           <div><p className="text-muted-foreground">Copro</p><p className="text-foreground">{charge.copro_amount.toLocaleString('fr-FR')} €</p></div>
@@ -509,26 +509,26 @@ export default function RegularisationPage() {
               exit={{ opacity: 0, x: -20 }}
               className="space-y-6"
             >
-              <Card className="border-border bg-white">
-                <CardContent className="p-4 sm:p-6 md:p-8 text-gray-800">
+              <Card className="border-border bg-card">
+                <CardContent className="p-4 sm:p-6 md:p-8 text-foreground">
                   {/* Document preview */}
                   <div className="space-y-4 md:space-y-6">
                     <div className="text-center border-b pb-4">
                       <h2 className="text-lg md:text-xl font-bold">DÉCOMPTE DE RÉGULARISATION</h2>
                       <h3 className="text-base md:text-lg">DES CHARGES LOCATIVES</h3>
-                      <p className="text-sm text-gray-500">Année {regularisationData.fiscal_year}</p>
+                      <p className="text-sm text-muted-foreground">Année {regularisationData.fiscal_year}</p>
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-8">
                       <div>
                         <p className="font-semibold">Bailleur</p>
                         <p>Nom du propriétaire</p>
-                        <p className="text-sm text-gray-500">Adresse du propriétaire</p>
+                        <p className="text-sm text-muted-foreground">Adresse du propriétaire</p>
                       </div>
                       <div>
                         <p className="font-semibold">Locataire</p>
                         <p>{selectedLeaseData.tenant_name}</p>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-muted-foreground">
                           {selectedLeaseData.property_name} - Lot {selectedLeaseData.unit_lot_number}
                         </p>
                       </div>
@@ -580,7 +580,7 @@ export default function RegularisationPage() {
                       </tfoot>
                     </table>
 
-                    <div className="text-sm text-gray-500 border-t pt-4">
+                    <div className="text-sm text-muted-foreground border-t pt-4">
                       <p>
                         {regularisationData.balance > 0 
                           ? `Le locataire devra s'acquitter de la somme de ${regularisationData.balance.toFixed(2)} € correspondant au complément de charges.`

--- a/app/owner/dashboard/DashboardClient.tsx
+++ b/app/owner/dashboard/DashboardClient.tsx
@@ -345,28 +345,28 @@ export function DashboardClient({ profileCompletion }: DashboardClientProps) {
           <div className="mt-4 sm:mt-6 lg:mt-8 grid grid-cols-2 lg:grid-cols-4 gap-2.5 xs:gap-3 sm:gap-4 border-t border-white/10 pt-4 sm:pt-6">
              {/* KPI 1: Revenus */}
              <div className="min-w-0">
-                <p className="text-slate-400 text-[10px] xs:text-xs sm:text-sm font-medium truncate">Revenus du mois</p>
+                <p className="text-muted-foreground text-[10px] xs:text-xs sm:text-sm font-medium truncate">Revenus du mois</p>
                 <p className="text-base xs:text-lg sm:text-xl lg:text-2xl font-bold mt-0.5 sm:mt-1 truncate">
                    <AnimatedCounter value={transformedData.zone2_finances.kpis.revenue_current_month.collected} type="currency" />
                 </p>
              </div>
              {/* KPI 2: Biens */}
              <div className="min-w-0">
-                <p className="text-slate-400 text-[10px] xs:text-xs sm:text-sm font-medium truncate">Biens gérés</p>
+                <p className="text-muted-foreground text-[10px] xs:text-xs sm:text-sm font-medium truncate">Biens gérés</p>
                 <p className="text-base xs:text-lg sm:text-xl lg:text-2xl font-bold mt-0.5 sm:mt-1">
                    <AnimatedCounter value={dashboard.properties?.total || 0} />
                 </p>
              </div>
              {/* KPI 3: Baux */}
              <div className="min-w-0">
-                <p className="text-slate-400 text-[10px] xs:text-xs sm:text-sm font-medium truncate">Baux actifs</p>
+                <p className="text-muted-foreground text-[10px] xs:text-xs sm:text-sm font-medium truncate">Baux actifs</p>
                 <p className="text-base xs:text-lg sm:text-xl lg:text-2xl font-bold mt-0.5 sm:mt-1">
                    <AnimatedCounter value={dashboard.leases?.active || 0} />
                 </p>
              </div>
              {/* KPI 4: Taux d'occupation */}
              <div className="min-w-0">
-                <p className="text-slate-400 text-[10px] xs:text-xs sm:text-sm font-medium truncate">Taux d'occupation</p>
+                <p className="text-muted-foreground text-[10px] xs:text-xs sm:text-sm font-medium truncate">Taux d'occupation</p>
                 {(() => {
                   const rate = dashboard.properties?.total > 0 
                     ? Math.round(((dashboard.leases?.active || 0) / dashboard.properties.total) * 100) 

--- a/app/owner/dashboard/loading.tsx
+++ b/app/owner/dashboard/loading.tsx
@@ -5,7 +5,7 @@ export default function DashboardLoading() {
     <div className="space-y-8 p-6 animate-in fade-in duration-500">
       {/* Header */}
       <div className="relative overflow-hidden">
-        <div className="relative flex items-center justify-between p-6 bg-white/50 rounded-2xl border border-white/20 shadow-xl">
+        <div className="relative flex items-center justify-between p-6 bg-card/50 rounded-2xl border border-white/20 shadow-xl">
           <div className="space-y-2">
             <Skeleton className="h-10 w-64" />
             <Skeleton className="h-5 w-96" />

--- a/app/owner/documents/OwnerDocumentsClient.tsx
+++ b/app/owner/documents/OwnerDocumentsClient.tsx
@@ -242,17 +242,17 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
       attestation_assurance: { label: "Assurance", filterValue: "assurance", color: "bg-cyan-100 text-cyan-700 border-cyan-200" },
       assurance_pno: { label: "Assurance", filterValue: "assurance", color: "bg-cyan-100 text-cyan-700 border-cyan-200" },
       // Identité
-      piece_identite: { label: "Identité", filterValue: "identite", color: "bg-slate-100 text-slate-700 border-slate-200" },
-      cni_recto: { label: "Identité", filterValue: "identite", color: "bg-slate-100 text-slate-700 border-slate-200" },
-      cni_verso: { label: "Identité", filterValue: "identite", color: "bg-slate-100 text-slate-700 border-slate-200" },
-      passeport: { label: "Identité", filterValue: "identite", color: "bg-slate-100 text-slate-700 border-slate-200" },
-      justificatif_domicile: { label: "Identité", filterValue: "identite", color: "bg-slate-100 text-slate-700 border-slate-200" },
-      rib: { label: "Identité", filterValue: "identite", color: "bg-slate-100 text-slate-700 border-slate-200" },
+      piece_identite: { label: "Identité", filterValue: "identite", color: "bg-muted text-foreground border-border" },
+      cni_recto: { label: "Identité", filterValue: "identite", color: "bg-muted text-foreground border-border" },
+      cni_verso: { label: "Identité", filterValue: "identite", color: "bg-muted text-foreground border-border" },
+      passeport: { label: "Identité", filterValue: "identite", color: "bg-muted text-foreground border-border" },
+      justificatif_domicile: { label: "Identité", filterValue: "identite", color: "bg-muted text-foreground border-border" },
+      rib: { label: "Identité", filterValue: "identite", color: "bg-muted text-foreground border-border" },
       // Autres
       courrier: { label: "Courrier", filterValue: "courrier", color: "bg-pink-100 text-pink-700 border-pink-200" },
       photo: { label: "Photo", filterValue: "autre", color: "bg-amber-100 text-amber-700 border-amber-200" },
     };
-    return categories[type] || { label: "Autre", filterValue: "autre", color: "bg-gray-100 text-gray-700 border-gray-200" };
+    return categories[type] || { label: "Autre", filterValue: "autre", color: "bg-muted text-foreground border-border" };
   };
 
   // Filtrer les documents (filtrage côté client, le hook gère déjà propertyId)
@@ -330,7 +330,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
                       <FileText className="h-5 w-5" />
                   </div>
                   <div className="space-y-1">
-                      <span className="font-semibold text-slate-900 block truncate max-w-[250px]" title={title}>
+                      <span className="font-semibold text-foreground block truncate max-w-[250px]" title={title}>
                         {title}
                       </span>
                       <div className="flex items-center gap-2">
@@ -355,7 +355,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
     {
         header: "Bien associé",
         cell: (doc: any) => (
-            <span className="text-sm text-slate-600 font-medium">
+            <span className="text-sm text-muted-foreground font-medium">
                 {doc.properties?.adresse_complete || doc.property?.adresse_complete || "Général"}
             </span>
         )
@@ -363,7 +363,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
     {
         header: "Date",
         cell: (doc: any) => (
-            <span className="text-sm text-slate-500">
+            <span className="text-sm text-muted-foreground">
                 {doc.created_at ? formatDateShort(doc.created_at) : "-"}
             </span>
         )
@@ -434,7 +434,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
             <AlertDialogDescription asChild>
               <div className="space-y-2">
                 <span className="block">Vous êtes sur le point de supprimer :</span>
-                <span className="block font-medium text-slate-900">
+                <span className="block font-medium text-foreground">
                   {documentToDelete?.title || getTypeLabel(documentToDelete?.type || "")}
                 </span>
                 <span className="block text-red-600 font-medium mt-4">
@@ -482,7 +482,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
               {activeSection === "bibliotheque" && (
                 <>
                   {/* Toggle vue */}
-                  <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as "table" | "cascade")} className="bg-white/80 rounded-lg border shadow-sm">
+                  <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as "table" | "cascade")} className="bg-card/80 rounded-lg border shadow-sm">
                     <TabsList className="grid grid-cols-2 h-9">
                       <TabsTrigger value="cascade" className="flex items-center gap-1.5 text-xs px-3">
                         <Home className="h-3.5 w-3.5" />
@@ -739,14 +739,14 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
                     placeholder="Rechercher par nom, type ou adresse..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="pl-10 bg-white border-slate-200"
+                    className="pl-10 bg-card border-border"
                     aria-label="Rechercher dans les documents"
                     />
                 </div>
                 </div>
                 {/* Filtre par catégorie */}
                 <Select value={categoryFilter} onValueChange={setCategoryFilter}>
-                <SelectTrigger className="bg-white border-slate-200">
+                <SelectTrigger className="bg-card border-border">
                     <FolderOpen className="h-4 w-4 mr-2 text-muted-foreground" />
                     <SelectValue placeholder="Catégorie" />
                 </SelectTrigger>
@@ -760,7 +760,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
                 </Select>
                 {/* Filtre par source (inter-compte) */}
                 <Select value={sourceFilter} onValueChange={setSourceFilter}>
-                <SelectTrigger className="bg-white border-slate-200">
+                <SelectTrigger className="bg-card border-border">
                     <SelectValue placeholder="Source" />
                 </SelectTrigger>
                 <SelectContent>
@@ -770,7 +770,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
                 </SelectContent>
                 </Select>
                 <Select value={typeFilter} onValueChange={setTypeFilter}>
-                <SelectTrigger className="bg-white border-slate-200">
+                <SelectTrigger className="bg-card border-border">
                     <SelectValue placeholder="Type" />
                 </SelectTrigger>
                 <SelectContent>
@@ -783,7 +783,7 @@ export function OwnerDocumentsClient({ initialDocuments, properties }: OwnerDocu
                 </SelectContent>
                 </Select>
                 <Select value={statusFilter} onValueChange={setStatusFilter}>
-                <SelectTrigger className="bg-white border-slate-200">
+                <SelectTrigger className="bg-card border-border">
                     <SelectValue placeholder="Statut" />
                 </SelectTrigger>
                 <SelectContent>

--- a/app/owner/documents/upload/page.tsx
+++ b/app/owner/documents/upload/page.tsx
@@ -207,7 +207,7 @@ export default function OwnerDocumentsUploadPage() {
               "hover:border-indigo-400 hover:bg-indigo-50/50",
               isDragOver 
                 ? "border-indigo-500 bg-indigo-50 scale-[1.02]" 
-                : "border-slate-300 bg-slate-50/50"
+                : "border-border bg-muted/50"
             )}
           >
             <input
@@ -222,16 +222,16 @@ export default function OwnerDocumentsUploadPage() {
             <div className="flex flex-col items-center justify-center text-center gap-3">
               <div className={cn(
                 "p-4 rounded-full transition-colors",
-                isDragOver ? "bg-indigo-100" : "bg-slate-100"
+                isDragOver ? "bg-indigo-100" : "bg-muted"
               )}>
                 <Upload className={cn(
                   "h-10 w-10 transition-colors",
-                  isDragOver ? "text-indigo-600" : "text-slate-400"
+                  isDragOver ? "text-indigo-600" : "text-muted-foreground"
                 )} />
               </div>
               
               <div>
-                <p className="text-lg font-medium text-slate-700">
+                <p className="text-lg font-medium text-foreground">
                   {isDragOver ? "Relâchez pour ajouter" : "Glissez vos fichiers ici"}
                 </p>
                 <p className="text-sm text-muted-foreground mt-1">
@@ -256,7 +256,7 @@ export default function OwnerDocumentsUploadPage() {
                 {files.map((file, index) => (
                   <div 
                     key={`${file.name}-${index}`}
-                    className="flex items-center justify-between p-3 bg-slate-50 rounded-lg border border-slate-200 group"
+                    className="flex items-center justify-between p-3 bg-muted rounded-lg border border-border group"
                   >
                     <div className="flex items-center gap-3 min-w-0">
                       <div className="p-2 bg-indigo-100 rounded-lg">

--- a/app/owner/error.tsx
+++ b/app/owner/error.tsx
@@ -40,7 +40,7 @@ export default function OwnerError({
 
         <CardContent className="space-y-4">
           {process.env.NODE_ENV === "development" && (
-            <details className="bg-slate-100 dark:bg-slate-800 rounded-lg p-3 text-sm">
+            <details className="bg-muted rounded-lg p-3 text-sm">
               <summary className="cursor-pointer font-medium">
                 Détails de l&apos;erreur (dev uniquement)
               </summary>

--- a/app/owner/indexation/IndexationCard.tsx
+++ b/app/owner/indexation/IndexationCard.tsx
@@ -108,7 +108,7 @@ export function IndexationCard({ indexation, showActions = false }: IndexationCa
       case "applied":
         return <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">Appliquée</Badge>;
       case "declined":
-        return <Badge variant="outline" className="bg-slate-50 text-slate-600 border-slate-200">Refusée</Badge>;
+        return <Badge variant="outline" className="bg-muted text-muted-foreground border-border">Refusée</Badge>;
       default:
         return null;
     }
@@ -138,7 +138,7 @@ export function IndexationCard({ indexation, showActions = false }: IndexationCa
 
       <CardContent className="space-y-4">
         {/* Détail de la révision */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 p-4 bg-slate-50 rounded-lg">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 p-4 bg-muted rounded-lg">
           <div>
             <p className="text-xs text-muted-foreground">Ancien loyer</p>
             <p className="font-semibold">{formatCurrency(indexation.old_rent)}</p>
@@ -168,11 +168,11 @@ export function IndexationCard({ indexation, showActions = false }: IndexationCa
         {/* Détail IRL */}
         <div className="flex items-center gap-4 text-sm">
           <div className="flex items-center gap-2">
-            <Info className="h-4 w-4 text-slate-400" />
+            <Info className="h-4 w-4 text-muted-foreground" />
             <span className="text-muted-foreground">IRL :</span>
             <span className="font-medium">{indexation.old_irl_quarter}</span>
             <span className="text-muted-foreground">({indexation.old_irl_value})</span>
-            <ArrowRight className="h-4 w-4 text-slate-400" />
+            <ArrowRight className="h-4 w-4 text-muted-foreground" />
             <span className="font-medium">{indexation.new_irl_quarter}</span>
             <span className="text-muted-foreground">({indexation.new_irl_value})</span>
           </div>

--- a/app/owner/indexation/page.tsx
+++ b/app/owner/indexation/page.tsx
@@ -104,12 +104,12 @@ async function IndexationContent() {
           </div>
         </div>
 
-        <div className="bg-slate-50 border border-slate-100 rounded-xl p-4">
+        <div className="bg-muted border border-slate-100 rounded-xl p-4">
           <div className="flex items-center gap-3">
-            <AlertTriangle className="h-8 w-8 text-slate-500" />
+            <AlertTriangle className="h-8 w-8 text-muted-foreground" />
             <div>
-              <p className="text-2xl font-bold text-slate-700">{declined.length}</p>
-              <p className="text-sm text-slate-600">Non appliquées</p>
+              <p className="text-2xl font-bold text-foreground">{declined.length}</p>
+              <p className="text-sm text-muted-foreground">Non appliquées</p>
             </div>
           </div>
         </div>
@@ -139,11 +139,11 @@ export default function IndexationPage() {
             </Button>
           </Link>
         </div>
-        <h1 className="text-3xl font-bold tracking-tight text-slate-900 flex items-center gap-3">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground flex items-center gap-3">
           <TrendingUp className="h-8 w-8 text-blue-600" />
           Révisions de loyer (IRL)
         </h1>
-        <p className="text-slate-500 mt-1">
+        <p className="text-muted-foreground mt-1">
           Gérez les révisions annuelles de loyer selon l'Indice de Référence des Loyers
         </p>
       </div>

--- a/app/owner/inspections/InspectionsClient.tsx
+++ b/app/owner/inspections/InspectionsClient.tsx
@@ -146,7 +146,7 @@ export function InspectionsClient({ inspections }: Props) {
       header: "Logement",
       cell: (edl: Inspection) => (
         <div className="min-w-0">
-          <p className="font-medium truncate max-w-[200px] sm:max-w-[280px] text-slate-900" title={edl.property_address}>{edl.property_address}</p>
+          <p className="font-medium truncate max-w-[200px] sm:max-w-[280px] text-foreground" title={edl.property_address}>{edl.property_address}</p>
           <p className="text-xs text-muted-foreground truncate">{edl.property_city}</p>
         </div>
       ),
@@ -154,7 +154,7 @@ export function InspectionsClient({ inspections }: Props) {
     {
       header: "Type",
       cell: (edl: Inspection) => (
-        <Badge variant="outline" className="bg-slate-50">
+        <Badge variant="outline" className="bg-muted">
           {edl.type === "entree" ? "Entrée" : "Sortie"}
         </Badge>
       ),
@@ -167,7 +167,7 @@ export function InspectionsClient({ inspections }: Props) {
     {
       header: "Date prévue",
       cell: (edl: Inspection) => (
-        <span className="text-sm text-slate-600">
+        <span className="text-sm text-muted-foreground">
           {edl.scheduled_date
             ? new Date(edl.scheduled_date).toLocaleDateString("fr-FR")
             : "—"}
@@ -324,8 +324,8 @@ export function InspectionsClient({ inspections }: Props) {
           <GlassCard className="border-amber-200 bg-amber-50/50">
             <CardContent className="flex flex-col gap-3 p-5 md:flex-row md:items-center md:justify-between">
               <div>
-                <p className="font-semibold text-slate-900">Le template PDF reste disponible avec votre forfait actuel.</p>
-                <p className="text-sm text-slate-600">
+                <p className="font-semibold text-foreground">Le template PDF reste disponible avec votre forfait actuel.</p>
+                <p className="text-sm text-muted-foreground">
                   Pour créer un EDL numérique avec signature électronique, passez au forfait {PLANS[digitalRequiredPlan].name}.
                 </p>
               </div>
@@ -341,11 +341,11 @@ export function InspectionsClient({ inspections }: Props) {
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm font-medium text-muted-foreground">Total</p>
-                  <p className="text-3xl font-bold text-slate-900">
+                  <p className="text-3xl font-bold text-foreground">
                     <AnimatedCounter value={inspections.length} />
                   </p>
                 </div>
-                <div className="p-3 bg-slate-100 rounded-full text-slate-600">
+                <div className="p-3 bg-muted rounded-full text-muted-foreground">
                   <ClipboardList className="h-6 w-6" />
                 </div>
               </div>
@@ -386,7 +386,7 @@ export function InspectionsClient({ inspections }: Props) {
         </div>
 
         {/* Filters */}
-        <div className="flex flex-col sm:flex-row gap-4 bg-white/50 backdrop-blur-sm p-1 rounded-xl border border-slate-200/50">
+        <div className="flex flex-col sm:flex-row gap-4 bg-card/50 backdrop-blur-sm p-1 rounded-xl border border-border/50">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
@@ -396,14 +396,14 @@ export function InspectionsClient({ inspections }: Props) {
               className="pl-9 bg-transparent border-none focus-visible:ring-0 shadow-none"
             />
           </div>
-          <div className="flex gap-1 bg-slate-100 p-1 rounded-lg">
+          <div className="flex gap-1 bg-muted p-1 rounded-lg">
             {["all", "entree", "sortie"].map((type) => (
               <Button
                 key={type}
                 variant={typeFilter === type ? "default" : "ghost"}
                 size="sm"
                 onClick={() => setTypeFilter(type)}
-                className={typeFilter === type ? "shadow-sm" : "hover:bg-white/50"}
+                className={typeFilter === type ? "shadow-sm" : "hover:bg-card/50"}
               >
                 {type === "all" ? "Tous" : type === "entree" ? "Entrée" : "Sortie"}
               </Button>
@@ -414,7 +414,7 @@ export function InspectionsClient({ inspections }: Props) {
         {/* Table */}
         {filteredInspections.length > 0 ? (
           <GlassCard className="p-0 overflow-hidden">
-            <CardHeader className="border-b bg-slate-50/50 px-6 py-4">
+            <CardHeader className="border-b bg-muted/50 px-6 py-4">
               <CardTitle className="text-base font-semibold">Liste des EDL</CardTitle>
               <CardDescription>
                 {filteredInspections.length} état{filteredInspections.length > 1 ? "s" : ""} des lieux affiché{filteredInspections.length > 1 ? "s" : ""}

--- a/app/owner/inspections/[id]/InspectionDetailClient.tsx
+++ b/app/owner/inspections/[id]/InspectionDetailClient.tsx
@@ -522,7 +522,7 @@ export function InspectionDetailClient({ data }: Props) {
   const actualSignaturesCount = (edl.edl_signatures || []).filter((s: any) => (s.signature_image_path || s.signature_image) && s.signed_at).length;
 
   return (
-    <div className="min-h-screen bg-slate-50/50 flex flex-col">
+    <div className="min-h-screen bg-muted/50 flex flex-col">
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 pt-4">
         <Breadcrumb
@@ -535,7 +535,7 @@ export function InspectionDetailClient({ data }: Props) {
       </div>
 
       {/* Barre supérieure fixe (Header) */}
-      <div className="sticky top-0 z-30 bg-white/80 backdrop-blur-md border-b border-slate-200">
+      <div className="sticky top-0 z-30 bg-card/80 backdrop-blur-md border-b border-border">
         <div className="container mx-auto px-3 sm:px-4 h-14 sm:h-16 flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">
             <Link
@@ -545,9 +545,9 @@ export function InspectionDetailClient({ data }: Props) {
               <ArrowLeft className="h-4 w-4 sm:mr-2" />
               <span className="hidden sm:inline">Retour</span>
             </Link>
-            <div className="h-6 w-px bg-slate-200 hidden sm:block flex-shrink-0" />
+            <div className="h-6 w-px bg-border hidden sm:block flex-shrink-0" />
             <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-              <h1 className="text-sm sm:text-lg font-bold text-slate-900 hidden md:block truncate">
+              <h1 className="text-sm sm:text-lg font-bold text-foreground hidden md:block truncate">
                 EDL {edl.type === "entree" ? "Entrée" : "Sortie"} - {edl.lease?.property?.ville}
               </h1>
               <Badge className={`${status.color} flex-shrink-0`} variant="outline">
@@ -610,7 +610,7 @@ export function InspectionDetailClient({ data }: Props) {
             {["draft", "scheduled", "in_progress", "completed"].includes(edl.status) && (
               <Link
                 href={`/owner/inspections/${edl.id}/edit`}
-                className={cn(buttonVariants({ variant: "outline", size: "sm" }), "bg-white border-slate-200 shadow-sm hover:bg-slate-50 h-9 sm:h-10 px-2.5 sm:px-3")}
+                className={cn(buttonVariants({ variant: "outline", size: "sm" }), "bg-card border-border shadow-sm hover:bg-muted h-9 sm:h-10 px-2.5 sm:px-3")}
                 aria-label="Modifier l'état des lieux"
               >
                 <Edit className="h-4 w-4 sm:mr-2 text-indigo-600" />
@@ -626,7 +626,7 @@ export function InspectionDetailClient({ data }: Props) {
 
           {/* Colonne de GAUCHE : L'APERÇU RÉEL DU DOCUMENT — Affiché en premier sur mobile */}
           <div className="lg:col-span-8 xl:col-span-9 order-1 lg:order-1">
-            <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden min-h-[300px] sm:min-h-[500px] lg:min-h-[800px]">
+            <div className="bg-white rounded-xl shadow-sm border border-border overflow-hidden min-h-[300px] sm:min-h-[500px] lg:min-h-[800px]">
               <EDLPreview 
                 edlData={edlTemplateData} 
                 edlId={edl.id} 
@@ -638,8 +638,8 @@ export function InspectionDetailClient({ data }: Props) {
           <div className="lg:col-span-4 xl:col-span-3 order-2 lg:order-2 space-y-4 sm:space-y-6">
             
             {/* Carte de Progression */}
-            <Card className="border-none shadow-sm bg-white overflow-hidden">
-              <CardHeader className="pb-2 border-b border-slate-50">
+            <Card className="border-none shadow-sm bg-card overflow-hidden">
+              <CardHeader className="pb-2 border-b border-border">
                 <CardTitle className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest flex items-center gap-2">
                   <ClipboardList className="h-3 w-3 text-blue-500" />
                   Progression de l&apos;inspection
@@ -649,11 +649,11 @@ export function InspectionDetailClient({ data }: Props) {
                 <div className="space-y-2">
                   <div className="flex justify-between text-sm">
                     <span className="text-muted-foreground text-xs font-medium">Éléments inspectés</span>
-                    <span className="font-bold text-slate-900 text-xs">
+                    <span className="font-bold text-foreground text-xs">
                       {stats.completedItems} / {stats.totalItems}
                     </span>
                   </div>
-                  <Progress value={completionPercentage} className="h-2 bg-slate-100" />
+                  <Progress value={completionPercentage} className="h-2 bg-muted" />
                   <p className="text-[10px] text-muted-foreground text-right">
                     {completionPercentage}% complété
                   </p>
@@ -682,13 +682,13 @@ export function InspectionDetailClient({ data }: Props) {
               </CardHeader>
               <CardContent className="p-4 space-y-4">
                 {/* Propriétaire */}
-                <div className={`p-3 rounded-lg border flex items-center justify-between ${ownerSigned ? "bg-green-50 border-green-200" : "bg-white border-slate-200 shadow-sm"}`}>
+                <div className={`p-3 rounded-lg border flex items-center justify-between ${ownerSigned ? "bg-green-50 border-green-200" : "bg-card border-border shadow-sm"}`}>
                   <div className="flex items-center gap-3">
-                    <div className={`h-8 w-8 rounded-full flex items-center justify-center ${ownerSigned ? "bg-green-100 text-green-600" : "bg-slate-100 text-slate-400"}`}>
+                    <div className={`h-8 w-8 rounded-full flex items-center justify-center ${ownerSigned ? "bg-green-100 text-green-600" : "bg-muted text-muted-foreground"}`}>
                       {ownerSigned ? <CheckCircle2 className="h-4 w-4" /> : <User className="h-4 w-4" />}
                     </div>
                     <div>
-                      <p className="text-xs font-bold text-slate-900">Bailleur</p>
+                      <p className="text-xs font-bold text-foreground">Bailleur</p>
                       <p className="text-[10px] text-muted-foreground">{ownerSigned ? `Signé le ${new Date(ownerSignature.signed_at).toLocaleDateString()}` : "En attente"}</p>
                     </div>
                   </div>
@@ -699,16 +699,16 @@ export function InspectionDetailClient({ data }: Props) {
 
                 {/* Locataire */}
                 <div className={`p-3 rounded-lg border flex items-center justify-between ${
-                  tenantSigned ? "bg-green-50 border-green-200" : "bg-white border-slate-200 shadow-sm"
+                  tenantSigned ? "bg-green-50 border-green-200" : "bg-card border-border shadow-sm"
                 }`}>
                   <div className="flex items-center gap-3">
                     <div className={`h-8 w-8 rounded-full flex items-center justify-center ${
-                      tenantSigned ? "bg-green-100 text-green-600" : "bg-slate-100 text-slate-400"
+                      tenantSigned ? "bg-green-100 text-green-600" : "bg-muted text-muted-foreground"
                     }`}>
                       {tenantSigned ? <CheckCircle2 className="h-4 w-4" /> : <User className="h-4 w-4" />}
                     </div>
                     <div>
-                      <p className="text-xs font-bold text-slate-900">{tenantName}</p>
+                      <p className="text-xs font-bold text-foreground">{tenantName}</p>
                       <p className="text-[10px] text-muted-foreground">
                         {tenantSigned 
                           ? `Signé le ${new Date(tenantSignature.signed_at).toLocaleDateString()}` 
@@ -759,7 +759,7 @@ export function InspectionDetailClient({ data }: Props) {
                   </div>
                 )}
 
-                <p className="text-[10px] text-slate-500 italic text-center leading-relaxed">
+                <p className="text-[10px] text-muted-foreground italic text-center leading-relaxed">
                   L&apos;état des lieux fait partie intégrante du bail. Les deux parties doivent signer pour sceller le document.
                 </p>
               </CardContent>
@@ -790,8 +790,8 @@ export function InspectionDetailClient({ data }: Props) {
             )}
 
             {/* Carte Photos de l'inspection */}
-            <Card className="border-none shadow-sm bg-white overflow-hidden">
-              <CardHeader className="pb-2 border-b border-slate-50">
+            <Card className="border-none shadow-sm bg-card overflow-hidden">
+              <CardHeader className="pb-2 border-b border-border">
                 <CardTitle className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest flex items-center gap-2">
                   <Camera className="h-3 w-3 text-indigo-500" />
                   Photos de l&apos;inspection
@@ -808,10 +808,10 @@ export function InspectionDetailClient({ data }: Props) {
                         .map((media: any, index: number) => (
                           <div
                             key={media.id || `photo-${index}`}
-                            className="relative aspect-square rounded-lg bg-slate-100 border border-slate-200 overflow-hidden group"
+                            className="relative aspect-square rounded-lg bg-muted border border-border overflow-hidden group"
                           >
                             <div className="absolute inset-0 flex items-center justify-center">
-                              <Image className="h-5 w-5 text-slate-300" />
+                              <Image className="h-5 w-5 text-muted-foreground" />
                             </div>
                             {media.room_name && (
                               <div className="absolute bottom-0 inset-x-0 bg-black/50 px-1 py-0.5">
@@ -826,8 +826,8 @@ export function InspectionDetailClient({ data }: Props) {
                         + {adaptedMedia.filter((m: any) => m.type === "photo").length - 6} autre(s) photo(s)
                       </p>
                     )}
-                    <div className="flex items-center justify-between pt-2 border-t border-slate-50">
-                      <span className="text-xs font-semibold text-slate-700">
+                    <div className="flex items-center justify-between pt-2 border-t border-border">
+                      <span className="text-xs font-semibold text-foreground">
                         {stats.totalPhotos} photo{stats.totalPhotos > 1 ? "s" : ""}
                       </span>
                       {["draft", "scheduled", "in_progress", "completed"].includes(edl.status) && (
@@ -843,11 +843,11 @@ export function InspectionDetailClient({ data }: Props) {
                   </div>
                 ) : (
                   <div className="text-center py-4 space-y-3">
-                    <div className="mx-auto h-12 w-12 rounded-full bg-slate-100 flex items-center justify-center">
-                      <Camera className="h-5 w-5 text-slate-400" />
+                    <div className="mx-auto h-12 w-12 rounded-full bg-muted flex items-center justify-center">
+                      <Camera className="h-5 w-5 text-muted-foreground" />
                     </div>
                     <div>
-                      <p className="text-xs font-medium text-slate-700">Aucune photo</p>
+                      <p className="text-xs font-medium text-foreground">Aucune photo</p>
                       <p className="text-[10px] text-muted-foreground mt-0.5">
                         Ajoutez des photos pour documenter l&apos;état de chaque pièce
                       </p>
@@ -867,20 +867,20 @@ export function InspectionDetailClient({ data }: Props) {
             </Card>
 
             {/* Détails du Logement */}
-            <Card className="border-none shadow-sm bg-white overflow-hidden">
-              <CardHeader className="pb-2 border-b border-slate-50">
+            <Card className="border-none shadow-sm bg-card overflow-hidden">
+              <CardHeader className="pb-2 border-b border-border">
                 <CardTitle className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest flex items-center gap-2">
-                  <Home className="h-3 w-3 text-slate-400" />
+                  <Home className="h-3 w-3 text-muted-foreground" />
                   Logement concerné
                 </CardTitle>
               </CardHeader>
               <CardContent className="p-4">
                 <div className="flex items-start gap-3 text-left">
-                  <div className="p-2 rounded bg-slate-50 border border-slate-100 flex-shrink-0">
-                    <Home className="h-4 w-4 text-slate-600" />
+                  <div className="p-2 rounded bg-muted border border-border flex-shrink-0">
+                    <Home className="h-4 w-4 text-muted-foreground" />
                   </div>
                   <div className="text-left">
-                    <p className="text-xs font-bold text-slate-900">{edl.lease?.property?.adresse_complete}</p>
+                    <p className="text-xs font-bold text-foreground">{edl.lease?.property?.adresse_complete}</p>
                     <p className="text-[10px] text-muted-foreground">
                       {edl.lease?.property?.code_postal} {edl.lease?.property?.ville}
                     </p>
@@ -891,25 +891,25 @@ export function InspectionDetailClient({ data }: Props) {
 
             {/* Compteurs du bien - 🔧 FIX: Utiliser unifiedMetersForDisplay */}
             {unifiedMetersForDisplay.length > 0 && (
-              <Card className="border-none shadow-sm bg-white overflow-hidden">
-                <CardHeader className="pb-2 border-b border-slate-50">
+              <Card className="border-none shadow-sm bg-card overflow-hidden">
+                <CardHeader className="pb-2 border-b border-border">
                   <CardTitle className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest flex items-center gap-2">
-                    <Home className="h-3 w-3 text-slate-400" />
+                    <Home className="h-3 w-3 text-muted-foreground" />
                     Données techniques
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="p-4 space-y-3">
                   {unifiedMetersForDisplay.map((meter: any, index: number) => (
-                    <div key={meter.id || `meter-${index}`} className="p-2 rounded-lg border border-slate-100 bg-slate-50/50">
+                    <div key={meter.id || `meter-${index}`} className="p-2 rounded-lg border border-border bg-muted/50">
                       <div className="flex justify-between items-start mb-1">
-                        <span className="text-[10px] font-bold uppercase text-slate-500">
+                        <span className="text-[10px] font-bold uppercase text-muted-foreground">
                           {meter.type === 'electricity' ? 'Électricité' : meter.type === 'gas' ? 'Gaz' : meter.type === 'water' ? 'Eau' : meter.type}
                         </span>
                         <Badge variant={meter.hasReading ? "secondary" : "outline"} className={`text-[10px] h-4 px-1 ${meter.hasReading ? "bg-green-100 text-green-700 border-none" : "bg-amber-50 text-amber-700 border-amber-200"}`}>
                           {meter.hasReading ? "Relevé effectué" : "À relever"}
                         </Badge>
                       </div>
-                      <p className="text-[11px] font-medium text-slate-900 leading-none">N° {meter.meter_number || meter.serial_number || "Non renseigné"}</p>
+                      <p className="text-[11px] font-medium text-foreground leading-none">N° {meter.meter_number || meter.serial_number || "Non renseigné"}</p>
                       {meter.hasReading && meter.readingValue !== null && (
                         <p className="text-[10px] text-blue-600 font-semibold mt-1">{meter.readingValue.toLocaleString('fr-FR')} {meter.readingUnit}</p>
                       )}

--- a/app/owner/inspections/[id]/edit/page.tsx
+++ b/app/owner/inspections/[id]/edit/page.tsx
@@ -331,7 +331,7 @@ export default function EditInspectionPage() {
   if (!inspection) return <div className="p-6 text-center"><h3 className="text-lg font-semibold">EDL introuvable</h3></div>;
 
   return (
-    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="bg-slate-50 min-h-screen pb-20">
+    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="bg-muted min-h-screen pb-20">
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <Breadcrumb
           items={[
@@ -367,12 +367,12 @@ export default function EditInspectionPage() {
             <CardContent className="p-6">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
                 {inspection.meter_readings.map((mr, i) => (
-                  <div key={i} className="space-y-4 p-4 border rounded-xl bg-white shadow-sm">
+                  <div key={i} className="space-y-4 p-4 border rounded-xl bg-card shadow-sm">
                     <div className="flex items-center justify-between border-b pb-2 mb-2">
-                      <span className="font-bold uppercase text-[10px] tracking-wider text-slate-500">
+                      <span className="font-bold uppercase text-[10px] tracking-wider text-muted-foreground">
                         {mr.type === 'water' ? '💧 Eau' : mr.type === 'electricity' ? '⚡ Électricité' : mr.type === 'gas' ? '🔥 Gaz' : mr.type}
                       </span>
-                      <Badge variant="outline" className="text-[10px] bg-slate-50">
+                      <Badge variant="outline" className="text-[10px] bg-muted">
                         {mr.id ? "Enregistré" : "Nouveau"}
                       </Badge>
                     </div>
@@ -408,7 +408,7 @@ export default function EditInspectionPage() {
                           className="text-lg font-mono font-bold"
                           placeholder="00000"
                         />
-                        <div className="bg-slate-100 px-3 flex items-center rounded-md font-bold text-slate-500">{mr.unit}</div>
+                        <div className="bg-muted px-3 flex items-center rounded-md font-bold text-muted-foreground">{mr.unit}</div>
                         
                         <div className="relative">
                           <Input
@@ -441,7 +441,7 @@ export default function EditInspectionPage() {
                   </div>
                 ))}
                 {inspection.meter_readings.length === 0 && (
-                  <p className="text-sm text-slate-400 italic md:col-span-2 text-center py-4">Aucun compteur enregistré sur cet EDL.</p>
+                  <p className="text-sm text-muted-foreground italic md:col-span-2 text-center py-4">Aucun compteur enregistré sur cet EDL.</p>
                 )}
               </div>
 
@@ -473,7 +473,7 @@ export default function EditInspectionPage() {
             </CardHeader>
             <CardContent className="p-6 space-y-4">
               {inspection.keys.map((key, i) => (
-                <div key={i} className="flex flex-col md:flex-row gap-4 p-4 border rounded-xl bg-white shadow-sm relative group">
+                <div key={i} className="flex flex-col md:flex-row gap-4 p-4 border rounded-xl bg-card shadow-sm relative group">
                   <div className="flex-1 space-y-2">
                     <Label>Type</Label>
                     <Select value={key.type} onValueChange={(v) => updateKey(i, 'type', v)}>
@@ -517,7 +517,7 @@ export default function EditInspectionPage() {
             </h3>
             {inspection.sections.map((section, sectionIdx) => (
               <Card key={sectionIdx} className="shadow-sm overflow-hidden">
-                <CardHeader className="bg-slate-50 border-b py-3">
+                <CardHeader className="bg-muted border-b py-3">
                   <div className="flex items-center justify-between">
                     <Input 
                       value={section.name} 
@@ -534,9 +534,9 @@ export default function EditInspectionPage() {
                 <CardContent className="p-0">
                   <div className="divide-y">
                     {section.items.map((item, itemIdx) => (
-                      <div key={itemIdx} className="p-4 space-y-3 hover:bg-slate-50/50 transition-colors">
+                      <div key={itemIdx} className="p-4 space-y-3 hover:bg-muted/50 transition-colors">
                         <div className="flex flex-col md:flex-row md:items-center justify-between gap-3">
-                          <span className="font-medium text-slate-700">{item.name}</span>
+                          <span className="font-medium text-foreground">{item.name}</span>
                           <div className="flex flex-wrap gap-2">
                             {stateOptions.map((opt) => (
                               <button
@@ -548,7 +548,7 @@ export default function EditInspectionPage() {
                                 }}
                                 className={cn(
                                   "px-3 py-1 rounded-full text-xs font-bold border transition-all",
-                                  item.condition === opt.value ? opt.color + " border-current shadow-sm" : "bg-white text-slate-400 border-slate-200"
+                                  item.condition === opt.value ? opt.color + " border-current shadow-sm" : "bg-card text-muted-foreground border-border"
                                 )}
                               >
                                 {opt.label}
@@ -564,7 +564,7 @@ export default function EditInspectionPage() {
                             setInspection({...inspection, sections: newSections});
                           }}
                           placeholder="Notes sur l'état..."
-                          className="bg-white resize-none text-sm h-20"
+                          className="bg-card resize-none text-sm h-20"
                         />
                       </div>
                     ))}

--- a/app/owner/inspections/[id]/loading.tsx
+++ b/app/owner/inspections/[id]/loading.tsx
@@ -2,14 +2,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function InspectionDetailLoading() {
   return (
-    <div className="min-h-screen bg-slate-50/50 flex flex-col">
+    <div className="min-h-screen bg-muted/50 flex flex-col">
       {/* Breadcrumb skeleton */}
       <div className="container mx-auto px-4 pt-4">
         <Skeleton className="h-4 w-64" />
       </div>
 
       {/* Header skeleton */}
-      <div className="sticky top-0 z-30 bg-white/80 backdrop-blur-md border-b border-slate-200">
+      <div className="sticky top-0 z-30 bg-card/80 backdrop-blur-md border-b border-border">
         <div className="container mx-auto px-4 h-16 flex items-center justify-between">
           <div className="flex items-center gap-4">
             <Skeleton className="h-8 w-20" />

--- a/app/owner/inspections/new/CreateInspectionWizard.tsx
+++ b/app/owner/inspections/new/CreateInspectionWizard.tsx
@@ -1008,7 +1008,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                       const hasExistingEdl = !!existingEntree || !!existingSortie;
 
                       const EDL_STATUS_LABELS: Record<string, { label: string; color: string }> = {
-                        draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700" },
+                        draft: { label: "Brouillon", color: "bg-muted text-foreground" },
                         scheduled: { label: "Planifié", color: "bg-blue-100 text-blue-700" },
                         in_progress: { label: "En cours", color: "bg-amber-100 text-amber-700" },
                         completed: { label: "Complété", color: "bg-indigo-100 text-indigo-700" },
@@ -1049,7 +1049,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                                   {existingEntree && (
                                     <Badge
                                       variant="outline"
-                                      className={`text-[10px] sm:text-xs ${EDL_STATUS_LABELS[existingEntree.status]?.color || "bg-slate-100 text-slate-700"}`}
+                                      className={`text-[10px] sm:text-xs ${EDL_STATUS_LABELS[existingEntree.status]?.color || "bg-muted text-foreground"}`}
                                     >
                                       <ClipboardList className="h-2.5 w-2.5 sm:h-3 sm:w-3 mr-1" />
                                       EDL Entrée : {EDL_STATUS_LABELS[existingEntree.status]?.label || existingEntree.status}
@@ -1058,7 +1058,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                                   {existingSortie && (
                                     <Badge
                                       variant="outline"
-                                      className={`text-[10px] sm:text-xs ${EDL_STATUS_LABELS[existingSortie.status]?.color || "bg-slate-100 text-slate-700"}`}
+                                      className={`text-[10px] sm:text-xs ${EDL_STATUS_LABELS[existingSortie.status]?.color || "bg-muted text-foreground"}`}
                                     >
                                       <ClipboardList className="h-2.5 w-2.5 sm:h-3 sm:w-3 mr-1" />
                                       EDL Sortie : {EDL_STATUS_LABELS[existingSortie.status]?.label || existingSortie.status}
@@ -1236,7 +1236,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                 {meterReadings.map((meter, index) => {
                   const meterType = METER_TYPES.find(m => m.type === meter.type);
                   return (
-                    <div key={index} className="p-4 border rounded-lg bg-slate-50/50 space-y-4">
+                    <div key={index} className="p-4 border rounded-lg bg-muted/50 space-y-4">
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
                           <span className="text-2xl">{meterType?.icon}</span>
@@ -1514,7 +1514,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                           variant="secondary" 
                           size="sm"
                           onClick={() => document.getElementById(`global-photo-${currentRoomIndex}`)?.click()}
-                          className="bg-white hover:bg-slate-50"
+                          className="bg-card hover:bg-muted"
                         >
                           <Plus className="h-4 w-4 mr-1" />
                           Ajouter
@@ -1546,9 +1546,9 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                   <div className="space-y-4">
                     <h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wider">Éléments détaillés</h4>
                     {currentRoom.items.map((item, itemIndex) => (
-                    <div key={itemIndex} className="p-3 sm:p-4 rounded-lg border space-y-3 sm:space-y-4 shadow-sm bg-white">
+                    <div key={itemIndex} className="p-3 sm:p-4 rounded-lg border space-y-3 sm:space-y-4 shadow-sm bg-card">
                       <div className="flex items-start sm:items-center justify-between gap-2">
-                        <h4 className="font-medium text-slate-800 text-sm sm:text-base">{item.name}</h4>
+                        <h4 className="font-medium text-foreground text-sm sm:text-base">{item.name}</h4>
                         <div className="flex gap-1.5 sm:gap-2 flex-shrink-0">
                           <Input
                             type="file"
@@ -1674,7 +1674,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
               <CardContent className="space-y-6">
                 <div className="space-y-4">
                   {keys.map((keyItem, index) => (
-                    <div key={index} className="p-4 border rounded-lg bg-slate-50/50 space-y-4">
+                    <div key={index} className="p-4 border rounded-lg bg-muted/50 space-y-4">
                       <div className="flex items-center justify-between">
                         <div className="font-medium text-sm text-muted-foreground uppercase tracking-wider">
                           Clé #{index + 1}
@@ -1703,7 +1703,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                                 setKeys(newKeys);
                               }}
                             >
-                              <SelectTrigger className="bg-white">
+                              <SelectTrigger className="bg-card">
                                 <SelectValue placeholder="Choisir un type..." />
                               </SelectTrigger>
                               <SelectContent>
@@ -1716,7 +1716,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                             {keyItem.type === "Autre" && (
                               <Input 
                                 placeholder="Précisez..." 
-                                className="bg-white"
+                                className="bg-card"
                                 onChange={(e) => {
                                   // Logic to handle custom type if needed
                                 }}
@@ -1735,7 +1735,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                               newKeys[index].count = parseInt(e.target.value) || 1;
                               setKeys(newKeys);
                             }}
-                            className="bg-white"
+                            className="bg-card"
                           />
                         </div>
                       </div>
@@ -1749,7 +1749,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                             newKeys[index].notes = e.target.value;
                             setKeys(newKeys);
                           }}
-                          className="bg-white"
+                          className="bg-card"
                         />
                       </div>
                     </div>
@@ -1845,7 +1845,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                     </p>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                       {meterReadings.filter(m => m.reading.trim() !== "").map((m, i) => (
-                        <div key={i} className="p-2.5 rounded-lg bg-slate-50 border flex items-center justify-between">
+                        <div key={i} className="p-2.5 rounded-lg bg-muted border flex items-center justify-between">
                           <div className="flex items-center gap-2">
                             <span className="text-lg">{
                               m.type === "electricity" ? "⚡" :
@@ -1968,7 +1968,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
       {/* Overlay de progression lors de la création */}
       {isSubmitting && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60">
-          <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl p-6 w-[90%] max-w-md mx-4 border">
+          <div className="bg-card rounded-2xl shadow-2xl p-6 w-[90%] max-w-md mx-4 border">
             <div className="text-center space-y-5">
               {/* Icône animée */}
               <div className="flex justify-center">
@@ -1981,7 +1981,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
                       stroke="currentColor"
                       strokeWidth="8"
                       fill="none"
-                      className="text-slate-200 dark:text-slate-700"
+                      className="text-muted"
                     />
                     <circle
                       cx="50"
@@ -2003,11 +2003,11 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
 
               {/* Texte de progression */}
               <div>
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                <h3 className="text-lg font-semibold text-foreground">
                   {uploadStep || "Création en cours..."}
                 </h3>
                 {uploadDetails && (
-                  <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                  <p className="text-sm text-muted-foreground mt-1">
                     {uploadDetails}
                   </p>
                 )}
@@ -2021,7 +2021,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
               </div>
 
               {/* Barre de progression linéaire */}
-              <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-3 overflow-hidden">
+              <div className="w-full bg-border rounded-full h-3 overflow-hidden">
                 <div
                   className="h-full bg-gradient-to-r from-primary to-blue-500 rounded-full transition-all duration-300 ease-out"
                   style={{ width: `${uploadProgress}%` }}
@@ -2029,7 +2029,7 @@ export function CreateInspectionWizard({ leases, preselectedLeaseId, preselected
               </div>
 
               {/* Message d'avertissement */}
-              <p className="text-xs text-slate-400 dark:text-slate-500">
+              <p className="text-xs text-muted-foreground">
                 Ne fermez pas cette page pendant la création
               </p>
             </div>

--- a/app/owner/invoices/[id]/page.tsx
+++ b/app/owner/invoices/[id]/page.tsx
@@ -35,7 +35,7 @@ import { cn } from "@/lib/utils";
 import { ManualPaymentDialog } from "@/components/payments";
 
 const statusConfig = {
-  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700", icon: FileText },
+  draft: { label: "Brouillon", color: "bg-muted text-foreground", icon: FileText },
   sent: { label: "Envoyée", color: "bg-blue-100 text-blue-700", icon: Send },
   paid: { label: "Payée", color: "bg-green-100 text-green-700", icon: CheckCircle2 },
   late: { label: "En retard", color: "bg-red-100 text-red-700", icon: AlertCircle },
@@ -186,7 +186,7 @@ export default function InvoiceDetailPage() {
   if (!invoice) {
     return (
       <div className="p-6">
-        <Card className="bg-white/80 backdrop-blur-sm">
+        <Card className="bg-card/80 backdrop-blur-sm">
           <CardContent className="py-16 text-center">
             <FileText className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
             <h3 className="text-lg font-semibold mb-2">Facture introuvable</h3>
@@ -274,7 +274,7 @@ export default function InvoiceDetailPage() {
           {/* Main content */}
           <div className="md:col-span-2 space-y-6">
             {/* Montants */}
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <Euro className="h-5 w-5 text-blue-500" />
@@ -314,7 +314,7 @@ export default function InvoiceDetailPage() {
             </Card>
 
             {/* Paiements */}
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <CreditCard className="h-5 w-5 text-blue-500" />
@@ -327,7 +327,7 @@ export default function InvoiceDetailPage() {
                     {invoice.payments.map((payment) => (
                       <div
                         key={payment.id}
-                        className="flex items-center justify-between p-3 bg-slate-50 rounded-lg"
+                        className="flex items-center justify-between p-3 bg-muted rounded-lg"
                       >
                         <div>
                           <p className="font-medium">{payment.montant.toLocaleString("fr-FR")} €</p>
@@ -370,7 +370,7 @@ export default function InvoiceDetailPage() {
           {/* Sidebar */}
           <div className="space-y-6">
             {/* Dates */}
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardHeader className="pb-3">
                 <CardTitle className="text-sm flex items-center gap-2">
                   <Calendar className="h-4 w-4 text-blue-500" />
@@ -403,7 +403,7 @@ export default function InvoiceDetailPage() {
 
             {/* Property */}
             {invoice.property && (
-              <Card className="bg-white/80 backdrop-blur-sm">
+              <Card className="bg-card/80 backdrop-blur-sm">
                 <CardHeader className="pb-3">
                   <CardTitle className="text-sm flex items-center gap-2">
                     <Building2 className="h-4 w-4 text-blue-500" />
@@ -423,7 +423,7 @@ export default function InvoiceDetailPage() {
 
             {/* Tenant */}
             {invoice.tenant && (
-              <Card className="bg-white/80 backdrop-blur-sm">
+              <Card className="bg-card/80 backdrop-blur-sm">
                 <CardHeader className="pb-3">
                   <CardTitle className="text-sm flex items-center gap-2">
                     <User className="h-4 w-4 text-blue-500" />

--- a/app/owner/leases/ContractsClient.tsx
+++ b/app/owner/leases/ContractsClient.tsx
@@ -590,7 +590,7 @@ export function ContractsClient() {
                           <Link 
                             key={lease.id}
                             href={`/owner/leases/${lease.id}`}
-                            className="inline-flex items-center gap-2 px-3 py-1.5 bg-white border border-orange-200 rounded-lg text-sm font-medium text-orange-800 hover:bg-orange-50 hover:border-orange-300 transition-all"
+                            className="inline-flex items-center gap-2 px-3 py-1.5 bg-card border border-orange-200 rounded-lg text-sm font-medium text-orange-800 hover:bg-orange-50 hover:border-orange-300 transition-all"
                           >
                             <PenLine className="h-3 w-3" />
                             {property?.adresse_complete?.slice(0, 30) || "Bail"}{property?.adresse_complete?.length > 30 ? "..." : ""}
@@ -621,7 +621,7 @@ export function ContractsClient() {
 
           {/* SOTA 2026 — Onglets Hub Gestion Locative */}
           <Tabs defaultValue="leases" className="space-y-4 md:space-y-6">
-            <TabsList className="bg-white/50 backdrop-blur-sm border w-full sm:w-auto overflow-x-auto">
+            <TabsList className="bg-card/50 backdrop-blur-sm border w-full sm:w-auto overflow-x-auto">
               <TabsTrigger value="leases" className="text-xs sm:text-sm gap-1.5">
                 <FileText className="h-3.5 w-3.5" />
                 Baux & contrats
@@ -658,12 +658,12 @@ export function ContractsClient() {
                       placeholder="Rechercher par adresse ou locataire..."
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
-                      className="pl-10 bg-white/80 backdrop-blur-sm"
+                      className="pl-10 bg-card/80 backdrop-blur-sm"
                     />
                   </div>
                 </div>
                 <Select value={typeFilter} onValueChange={setTypeFilter}>
-                  <SelectTrigger className="bg-white/80 backdrop-blur-sm">
+                  <SelectTrigger className="bg-card/80 backdrop-blur-sm">
                     <SelectValue placeholder="Type bail" />
                   </SelectTrigger>
                   <SelectContent>
@@ -679,7 +679,7 @@ export function ContractsClient() {
                   </SelectContent>
                 </Select>
                 <Select value={statusFilter} onValueChange={setStatusFilter}>
-                  <SelectTrigger className="bg-white/80 backdrop-blur-sm">
+                  <SelectTrigger className="bg-card/80 backdrop-blur-sm">
                     <SelectValue placeholder="Statut" />
                   </SelectTrigger>
                   <SelectContent>

--- a/app/owner/leases/[id]/LeaseDetailsClient.tsx
+++ b/app/owner/leases/[id]/LeaseDetailsClient.tsx
@@ -485,7 +485,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
       return {
         shell: "border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-green-50",
         badge: "bg-emerald-100 text-emerald-700",
-        panel: "bg-white/80 border-emerald-100",
+        panel: "bg-card/80 border-emerald-100",
         button: "bg-emerald-600 hover:bg-emerald-700",
       };
     }
@@ -493,7 +493,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
       return {
         shell: "border-indigo-200 bg-gradient-to-br from-indigo-50 via-white to-blue-50",
         badge: "bg-indigo-100 text-indigo-700",
-        panel: "bg-white/80 border-indigo-100",
+        panel: "bg-card/80 border-indigo-100",
         button: "bg-indigo-600 hover:bg-indigo-700",
       };
     }
@@ -501,7 +501,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
       return {
         shell: "border-blue-200 bg-gradient-to-br from-blue-50 via-white to-cyan-50",
         badge: "bg-blue-100 text-blue-700",
-        panel: "bg-white/80 border-blue-100",
+        panel: "bg-card/80 border-blue-100",
         button: "bg-blue-600 hover:bg-blue-700",
       };
     }
@@ -509,14 +509,14 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
       return {
         shell: "border-amber-200 bg-gradient-to-br from-amber-50 via-white to-orange-50",
         badge: "bg-amber-100 text-amber-700",
-        panel: "bg-white/80 border-amber-100",
+        panel: "bg-card/80 border-amber-100",
         button: "bg-amber-600 hover:bg-amber-700",
       };
     }
     return {
-      shell: "border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-100",
-      badge: "bg-slate-100 text-slate-700",
-      panel: "bg-white/80 border-slate-200",
+      shell: "border-border bg-gradient-to-br from-muted via-white to-muted",
+      badge: "bg-muted text-foreground",
+      panel: "bg-card/80 border-border",
       button: "bg-slate-700 hover:bg-slate-800",
     };
   }, [readinessState.hero.tone]);
@@ -576,7 +576,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
   ]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100/50">
+    <div className="min-h-screen bg-gradient-to-br from-muted to-muted/50">
       {/* Breadcrumb */}
       <div className="container mx-auto px-4 pt-4">
         <Breadcrumb
@@ -589,7 +589,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
       </div>
 
       {/* Barre supérieure fixe (Header) */}
-      <div className="sticky top-0 z-30 bg-white/80 backdrop-blur-md border-b border-slate-200">
+      <div className="sticky top-0 z-30 bg-card/80 backdrop-blur-md border-b border-border">
         <div className="container mx-auto px-4 h-16 flex items-center justify-between">
           <div className="flex items-center gap-4">
             <Link
@@ -599,9 +599,9 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
               <ArrowLeft className="mr-2 h-4 w-4" />
               Retour
             </Link>
-            <div className="h-6 w-px bg-slate-200 hidden sm:block" />
+            <div className="h-6 w-px bg-border hidden sm:block" />
             <div className="flex items-center gap-3">
-              <h1 className="text-lg font-bold text-slate-900 hidden sm:block">
+              <h1 className="text-lg font-bold text-foreground hidden sm:block">
                 Bail {property.ville}
               </h1>
               <Badge className={statusConfig.color} variant="outline">
@@ -636,7 +636,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                   disabled={isActivating || !canActivateNow}
                   className={canActivateNow
                     ? "bg-green-600 hover:bg-green-700 shadow-sm"
-                    : "bg-slate-300 text-slate-500 cursor-not-allowed shadow-none border border-slate-200"
+                    : "bg-muted text-muted-foreground cursor-not-allowed shadow-none border border-border"
                   }
                   title={canActivateNow
                     ? "Activer le bail"
@@ -653,7 +653,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
             {!isSealed ? (
               <Link
                 href={`/owner/leases/${leaseId}/edit`}
-                className={cn(buttonVariants({ variant: "outline", size: "sm" }), "bg-white hover:bg-slate-50 border-slate-200")}
+                className={cn(buttonVariants({ variant: "outline", size: "sm" }), "bg-card hover:bg-muted border-border")}
               >
                 <Edit className="h-4 w-4 mr-2" />
                 <span className="hidden sm:inline">Modifier</span>
@@ -671,7 +671,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                   <span className="hidden sm:inline">Télécharger PDF</span>
                   <span className="sm:hidden text-[10px]">PDF</span>
                 </Button>
-                <div className="hidden md:flex items-center gap-1 text-[10px] text-slate-400 font-medium uppercase tracking-wider px-2 py-1 bg-slate-50 rounded border border-slate-100">
+                <div className="hidden md:flex items-center gap-1 text-[10px] text-muted-foreground font-medium uppercase tracking-wider px-2 py-1 bg-muted rounded border border-border">
                   <Lock className="h-3 w-3" />
                   Scellé
                 </div>
@@ -691,10 +691,10 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                     {readinessState.hero.eyebrow}
                   </Badge>
                   <div className="space-y-2">
-                    <h2 className="text-2xl md:text-3xl font-bold text-slate-950">
+                    <h2 className="text-2xl md:text-3xl font-bold text-foreground">
                       {readinessState.hero.title}
                     </h2>
-                    <p className="text-sm md:text-base text-slate-600 max-w-3xl">
+                    <p className="text-sm md:text-base text-muted-foreground max-w-3xl">
                       {readinessState.hero.description}
                     </p>
                   </div>
@@ -702,9 +702,9 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                     {readinessState.hero.highlights.map((highlight) => (
                       <div
                         key={highlight}
-                        className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-700"
+                        className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-card/80 px-3 py-1.5 text-xs font-medium text-foreground"
                       >
-                        <Sparkles className="h-3.5 w-3.5 text-slate-400" />
+                        <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
                         {highlight}
                       </div>
                     ))}
@@ -738,35 +738,35 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
                 <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
                   <div className={cn("rounded-2xl border p-4", heroToneClasses.panel)}>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                       Documents
                     </p>
-                    <p className="mt-2 text-2xl font-bold text-slate-900">
+                    <p className="mt-2 text-2xl font-bold text-foreground">
                       {readinessState.documentState.completedCount}/{readinessState.documentState.totalCount}
                     </p>
-                    <p className="mt-1 text-xs text-slate-600">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       Prérequis visibles et réconciliés avec le workflow
                     </p>
                   </div>
                   <div className={cn("rounded-2xl border p-4", heroToneClasses.panel)}>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                       Paiement initial
                     </p>
-                    <p className="mt-2 text-base font-semibold text-slate-900">
+                    <p className="mt-2 text-base font-semibold text-foreground">
                       {readinessState.paymentState.label}
                     </p>
-                    <p className="mt-1 text-xs text-slate-600">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       {readinessState.paymentState.description}
                     </p>
                   </div>
                   <div className={cn("rounded-2xl border p-4", heroToneClasses.panel)}>
-                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                       Prochaine étape
                     </p>
-                    <p className="mt-2 text-base font-semibold text-slate-900">
+                    <p className="mt-2 text-base font-semibold text-foreground">
                       {readinessState.nextAction.label ?? "Aucune action requise"}
                     </p>
-                    <p className="mt-1 text-xs text-slate-600">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       {readinessState.nextAction.description}
                     </p>
                   </div>
@@ -790,8 +790,8 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
               className="flex flex-col lg:flex-1"
             >
               {/* Barre d'onglets */}
-              <TabsList className="w-full justify-start bg-white border border-slate-200 rounded-t-xl rounded-b-none h-12 px-2 gap-1">
-                <TabsTrigger value="contrat" className="gap-2 data-[state=active]:bg-slate-100">
+              <TabsList className="w-full justify-start bg-card border border-border rounded-t-xl rounded-b-none h-12 px-2 gap-1">
+                <TabsTrigger value="contrat" className="gap-2 data-[state=active]:bg-muted">
                   <FileText className="h-4 w-4" />
                   <span className="hidden sm:inline">Contrat</span>
                 </TabsTrigger>
@@ -811,7 +811,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                     <CheckCircle className="h-3.5 w-3.5 text-emerald-500" />
                   )}
                 </TabsTrigger>
-                <TabsTrigger value="documents" className="gap-2 data-[state=active]:bg-slate-100">
+                <TabsTrigger value="documents" className="gap-2 data-[state=active]:bg-muted">
                   <FolderOpen className="h-4 w-4" />
                   <span className="hidden sm:inline">Documents</span>
                   <Badge variant="secondary" className="text-[10px] h-5 px-1.5">
@@ -820,7 +820,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                 </TabsTrigger>
                 <TabsTrigger
                   value="paiements"
-                  className={`gap-2 data-[state=active]:bg-slate-100 ${
+                  className={`gap-2 data-[state=active]:bg-muted ${
                     !readinessState.tabs.paymentsEnabled ? "opacity-40 cursor-not-allowed" : ""
                   }`}
                   disabled={!readinessState.tabs.paymentsEnabled}
@@ -829,7 +829,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                   <CreditCard className="h-4 w-4" />
                   <span className="hidden sm:inline">Paiements</span>
                   {!readinessState.tabs.paymentsEnabled && (
-                    <Badge variant="outline" className="text-[9px] h-4 px-1 border-slate-200 text-slate-400 hidden sm:inline-flex">
+                    <Badge variant="outline" className="text-[9px] h-4 px-1 border-border text-muted-foreground hidden sm:inline-flex">
                       après signature
                     </Badge>
                   )}
@@ -838,7 +838,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
               {/* Contenu : Contrat */}
               <TabsContent value="contrat" className="flex-1 mt-0">
-                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 overflow-hidden flex-1 flex flex-col min-h-[80vh]">
+                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-border overflow-hidden flex-1 flex flex-col min-h-[80vh]">
                   {isSealed && signedPdfPath ? (
                     <div className="flex flex-col h-full">
                       <div className="flex items-center justify-between px-4 py-3 border-b bg-gradient-to-r from-emerald-50 to-green-50">
@@ -848,7 +848,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                             <span className="text-xs font-semibold text-emerald-700">Document scellé</span>
                           </div>
                           {sealedAt && (
-                            <span className="text-xs text-slate-500">
+                            <span className="text-xs text-muted-foreground">
                               le {new Date(sealedAt).toLocaleDateString("fr-FR")}
                             </span>
                           )}
@@ -879,8 +879,8 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                         className="flex-1 w-full border-0 min-h-[70vh]"
                         title="Bail de location signé"
                       />
-                      <div className="px-4 py-2 border-t bg-slate-50 text-center">
-                        <p className="text-xs text-slate-500">
+                      <div className="px-4 py-2 border-t bg-muted text-center">
+                        <p className="text-xs text-muted-foreground">
                           <Lock className="h-3 w-3 inline mr-1" />
                           Ce document est légalement scellé et ne peut plus être modifié.
                         </p>
@@ -892,8 +892,8 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
                         <Clock className="h-6 w-6 text-amber-600" />
                       </div>
                       <div className="text-center space-y-1">
-                        <p className="font-medium text-slate-800">PDF signé en cours de génération</p>
-                        <p className="text-sm text-slate-500 max-w-md">
+                        <p className="font-medium text-foreground">PDF signé en cours de génération</p>
+                        <p className="text-sm text-muted-foreground max-w-md">
                           Le document PDF du bail signé est en cours de préparation. Rafraîchissez la page dans quelques secondes.
                         </p>
                       </div>
@@ -910,7 +910,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
               {/* Contenu : EDL d'entrée */}
               <TabsContent value="edl" className="flex-1 mt-0">
-                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 lg:overflow-auto p-6 pb-24 md:pb-6 lg:h-full">
+                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-border lg:overflow-auto p-6 pb-24 md:pb-6 lg:h-full">
                   <LeaseEdlTab
                     leaseId={leaseId}
                     propertyId={property.id}
@@ -927,7 +927,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
               {/* Contenu : Documents */}
               <TabsContent value="documents" className="flex-1 mt-0">
-                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 lg:overflow-auto p-6 pb-24 md:pb-6 lg:h-full">
+                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-border lg:overflow-auto p-6 pb-24 md:pb-6 lg:h-full">
                   <LeaseDocumentsTab
                     leaseId={leaseId}
                     propertyId={property.id}
@@ -940,7 +940,7 @@ export function LeaseDetailsClient({ details, leaseId, ownerProfile }: LeaseDeta
 
               {/* Contenu : Paiements */}
               <TabsContent value="paiements" className="flex-1 mt-0">
-                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-slate-200 lg:overflow-auto p-6 pb-24 md:pb-6 lg:h-full">
+                <div className="bg-white rounded-b-xl shadow-sm border border-t-0 border-border lg:overflow-auto p-6 pb-24 md:pb-6 lg:h-full">
                   <LeasePaymentsTab
                     leaseId={leaseId}
                     payments={payments || []}

--- a/app/owner/leases/[id]/LeaseDetailsSidebar.tsx
+++ b/app/owner/leases/[id]/LeaseDetailsSidebar.tsx
@@ -113,21 +113,21 @@ export function LeaseDetailsSidebar({
 }: LeaseDetailsSidebarProps) {
   return (
     <div className="lg:col-span-4 xl:col-span-3 order-1 lg:order-2 space-y-6">
-      <Card className="border-none shadow-sm bg-white overflow-hidden">
+      <Card className="border-none shadow-sm bg-card overflow-hidden">
         <CardHeader className="pb-2 border-b border-slate-50">
           <CardTitle className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest">
             Lecture métier unifiée
           </CardTitle>
         </CardHeader>
         <CardContent className="p-4 space-y-3">
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+          <div className="rounded-2xl border border-border bg-muted p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
               Étape actuelle
             </p>
-            <p className="mt-2 text-base font-semibold text-slate-900">
+            <p className="mt-2 text-base font-semibold text-foreground">
               {readinessState.hero.title}
             </p>
-            <p className="mt-1 text-xs text-slate-600">
+            <p className="mt-1 text-xs text-muted-foreground">
               {readinessState.hero.description}
             </p>
           </div>
@@ -149,7 +149,7 @@ export function LeaseDetailsSidebar({
         </CardContent>
       </Card>
 
-      <Card className="border-none shadow-sm bg-white overflow-hidden">
+      <Card className="border-none shadow-sm bg-card overflow-hidden">
         <CardHeader className="pb-2 border-b border-slate-50">
           <CardTitle className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest flex items-center gap-2">
             <ShieldCheck className="h-3 w-3 text-emerald-500" />
@@ -195,7 +195,7 @@ export function LeaseDetailsSidebar({
       )}
 
       {/* Carte Info Rapide */}
-      <Card className="border-none shadow-sm bg-white">
+      <Card className="border-none shadow-sm bg-card">
         <CardHeader className="pb-3 border-b border-slate-50">
           <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
             Détails Clés
@@ -204,7 +204,7 @@ export function LeaseDetailsSidebar({
         <CardContent className="pt-4 space-y-4">
           <div>
             <p className="text-xs text-muted-foreground">Loyer mensuel</p>
-            <p className="text-2xl font-bold text-slate-900">
+            <p className="text-2xl font-bold text-foreground">
               {formatCurrency(displayLoyer + displayCharges)}
             </p>
             <p className="text-xs text-muted-foreground mt-1">
@@ -215,7 +215,7 @@ export function LeaseDetailsSidebar({
           <div className="grid grid-cols-2 gap-3 pt-3 border-t border-slate-50">
             <div>
               <p className="text-xs text-muted-foreground">Dépôt de garantie</p>
-              <p className="text-base font-semibold text-slate-800">{formatCurrency(displayDepot)}</p>
+              <p className="text-base font-semibold text-foreground">{formatCurrency(displayDepot)}</p>
             </div>
             <div>
               <p className="text-xs text-muted-foreground">1er versement</p>
@@ -418,7 +418,7 @@ function ChecklistRow({
       : status === "action_required"
         ? "bg-red-100"
         : status === "locked"
-          ? "bg-slate-100"
+          ? "bg-muted"
           : "bg-amber-100";
 
   const textColor =
@@ -427,7 +427,7 @@ function ChecklistRow({
       : status === "action_required"
         ? "text-red-700"
         : status === "locked"
-          ? "text-slate-500"
+          ? "text-muted-foreground"
           : "text-amber-700";
 
   return (
@@ -440,7 +440,7 @@ function ChecklistRow({
         ) : (
           <Clock
             className={`h-3 w-3 ${
-              status === "locked" ? "text-slate-400" : "text-amber-600"
+              status === "locked" ? "text-muted-foreground" : "text-amber-600"
             }`}
           />
         )}

--- a/app/owner/leases/[id]/OwnerSignatureModal.tsx
+++ b/app/owner/leases/[id]/OwnerSignatureModal.tsx
@@ -98,7 +98,7 @@ export function OwnerSignatureModal({
 
         <div className="space-y-6 py-4">
           {/* Récapitulatif du bail */}
-          <div className="rounded-xl bg-slate-50 dark:bg-slate-900 p-4 space-y-3">
+          <div className="rounded-xl bg-muted p-4 space-y-3">
             <div className="flex items-center justify-between">
               <Badge variant="secondary" className="text-xs">
                 {LEASE_TYPE_LABELS[leaseInfo.typeBail] || leaseInfo.typeBail}
@@ -138,7 +138,7 @@ export function OwnerSignatureModal({
 
           {/* Checkboxes de confirmation */}
           <div className="space-y-3">
-            <div className="flex items-start gap-3 p-3 rounded-lg border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
+            <div className="flex items-start gap-3 p-3 rounded-lg border border-border hover:bg-muted transition-colors">
               <Checkbox
                 id="read-lease"
                 checked={hasReadLease}
@@ -149,7 +149,7 @@ export function OwnerSignatureModal({
               </Label>
             </div>
 
-            <div className="flex items-start gap-3 p-3 rounded-lg border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
+            <div className="flex items-start gap-3 p-3 rounded-lg border border-border hover:bg-muted transition-colors">
               <Checkbox
                 id="accept-terms"
                 checked={hasAcceptedTerms}

--- a/app/owner/leases/[id]/edit/page.tsx
+++ b/app/owner/leases/[id]/edit/page.tsx
@@ -191,7 +191,7 @@ export default function EditLeasePage() {
   if (!lease) {
     return (
       <div className="p-6">
-        <Card className="bg-white/80 backdrop-blur-sm">
+        <Card className="bg-card/80 backdrop-blur-sm">
           <CardContent className="py-16 text-center">
             <FileText className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
             <h3 className="text-lg font-semibold mb-2">Bail introuvable</h3>
@@ -251,7 +251,7 @@ export default function EditLeasePage() {
           )}
 
           {/* Type de bail */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <FileText className="h-5 w-5 text-blue-500" />
@@ -263,7 +263,7 @@ export default function EditLeasePage() {
                 value={lease.type_bail}
                 onValueChange={handleTypeBailChange}
               >
-                <SelectTrigger className="bg-white">
+                <SelectTrigger className="bg-card">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -276,7 +276,7 @@ export default function EditLeasePage() {
               </Select>
 
               {/* Indice de révision IRL */}
-              <div className="p-3 bg-slate-50 rounded-lg border">
+              <div className="p-3 bg-muted rounded-lg border">
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="text-sm font-medium">Indice de révision</p>
@@ -291,7 +291,7 @@ export default function EditLeasePage() {
               </div>
 
               {/* Révision autorisée */}
-              <div className="flex items-center justify-between p-3 bg-slate-50 rounded-lg border">
+              <div className="flex items-center justify-between p-3 bg-muted rounded-lg border">
                 <div>
                   <p className="text-sm font-medium">Révision annuelle du loyer</p>
                   <p className="text-xs text-muted-foreground mt-0.5">
@@ -309,7 +309,7 @@ export default function EditLeasePage() {
           </Card>
 
           {/* Montants (lecture seule - viennent du BIEN) */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Euro className="h-5 w-5 text-blue-500" />
@@ -332,15 +332,15 @@ export default function EditLeasePage() {
 
               {/* Affichage en lecture seule */}
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="p-4 bg-slate-50 rounded-lg">
+                <div className="p-4 bg-muted rounded-lg">
                   <p className="text-xs text-muted-foreground">Loyer mensuel HC</p>
                   <p className="text-xl font-bold">{(lease.loyer ?? 0).toLocaleString("fr-FR")} €</p>
                 </div>
-                <div className="p-4 bg-slate-50 rounded-lg">
+                <div className="p-4 bg-muted rounded-lg">
                   <p className="text-xs text-muted-foreground">Charges</p>
                   <p className="text-xl font-bold">{(lease.charges_forfaitaires ?? 0).toLocaleString("fr-FR")} €</p>
                 </div>
-                <div className="p-4 bg-slate-50 rounded-lg">
+                <div className="p-4 bg-muted rounded-lg">
                   <p className="text-xs text-muted-foreground">Dépôt de garantie</p>
                   <p className="text-xl font-bold">{(lease.depot_garantie ?? 0).toLocaleString("fr-FR")} €</p>
                   <p className="text-xs text-muted-foreground">Max légal : {maxDepotLegal.toLocaleString("fr-FR")} €</p>
@@ -364,7 +364,7 @@ export default function EditLeasePage() {
                   value={lease.charges_type || "forfait"}
                   onValueChange={(value) => setLease({ ...lease, charges_type: value })}
                 >
-                  <SelectTrigger className="bg-white">
+                  <SelectTrigger className="bg-card">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -392,7 +392,7 @@ export default function EditLeasePage() {
           </Card>
 
           {/* Paiement */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <CreditCard className="h-5 w-5 text-blue-500" />
@@ -407,7 +407,7 @@ export default function EditLeasePage() {
                     value={lease.mode_paiement || "virement"}
                     onValueChange={(value) => setLease({ ...lease, mode_paiement: value })}
                   >
-                    <SelectTrigger className="bg-white">
+                    <SelectTrigger className="bg-card">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -425,7 +425,7 @@ export default function EditLeasePage() {
                     value={String(lease.jour_paiement || 5)}
                     onValueChange={(value) => setLease({ ...lease, jour_paiement: parseInt(value) })}
                   >
-                    <SelectTrigger className="bg-white">
+                    <SelectTrigger className="bg-card">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -442,7 +442,7 @@ export default function EditLeasePage() {
           </Card>
 
           {/* Dates */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <CalendarIcon className="h-5 w-5 text-blue-500" />
@@ -458,7 +458,7 @@ export default function EditLeasePage() {
                       <Button
                         variant="outline"
                         className={cn(
-                          "w-full justify-start text-left font-normal bg-white",
+                          "w-full justify-start text-left font-normal bg-card",
                           !lease.date_debut && "text-muted-foreground"
                         )}
                       >
@@ -489,7 +489,7 @@ export default function EditLeasePage() {
                       <Button
                         variant="outline"
                         className={cn(
-                          "w-full justify-start text-left font-normal bg-white",
+                          "w-full justify-start text-left font-normal bg-card",
                           !lease.date_fin && "text-muted-foreground"
                         )}
                       >
@@ -517,7 +517,7 @@ export default function EditLeasePage() {
           </Card>
 
           {/* Clauses particulières */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <ScrollText className="h-5 w-5 text-blue-500" />
@@ -529,7 +529,7 @@ export default function EditLeasePage() {
                 placeholder="Ajoutez ici les clauses particulières du bail (interdiction de fumer, animaux, travaux autorisés, etc.)"
                 value={lease.clauses_particulieres || ""}
                 onChange={(e) => setLease({ ...lease, clauses_particulieres: e.target.value })}
-                className="min-h-[120px] bg-white"
+                className="min-h-[120px] bg-card"
               />
               <p className="text-xs text-muted-foreground mt-2">
                 Ces clauses seront ajoutées au contrat de bail.

--- a/app/owner/leases/[id]/loading.tsx
+++ b/app/owner/leases/[id]/loading.tsx
@@ -9,7 +9,7 @@ export default function LeaseDetailLoading() {
       </div>
 
       {/* Header skeleton */}
-      <div className="sticky top-0 z-30 bg-white/80 backdrop-blur-md border-b border-slate-200">
+      <div className="sticky top-0 z-30 bg-card/80 backdrop-blur-md border-b border-border">
         <div className="container mx-auto px-4 h-16 flex items-center justify-between">
           <div className="flex items-center gap-4">
             <Skeleton className="h-8 w-20" />

--- a/app/owner/leases/[id]/signers/SignersClient.tsx
+++ b/app/owner/leases/[id]/signers/SignersClient.tsx
@@ -272,14 +272,14 @@ export function SignersClient({
           <div className="flex items-start gap-4">
             <Avatar className="h-12 w-12">
               <AvatarImage src={signer.profile?.avatar_url || undefined} />
-              <AvatarFallback className="bg-slate-100 text-slate-700">
+              <AvatarFallback className="bg-muted text-foreground">
                 {getInitials(signer.profile?.prenom, signer.profile?.nom)}
               </AvatarFallback>
             </Avatar>
 
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
-                <h3 className="font-semibold text-slate-900">
+                <h3 className="font-semibold text-foreground">
                   {signer.profile
                     ? `${signer.profile.prenom} ${signer.profile.nom}`
                     : signer.invited_name || "En attente d'inscription"}
@@ -360,7 +360,7 @@ export function SignersClient({
                           {signer.profile 
                             ? `${signer.profile.prenom} ${signer.profile.nom} sera retiré du bail.`
                             : "Ce signataire sera retiré du bail."}
-                          <span className="block mt-2 font-medium text-slate-900">
+                          <span className="block mt-2 font-medium text-foreground">
                             Vous pourrez ensuite inviter le bon locataire.
                           </span>
                           {signer.signature_status === "signed" && (
@@ -398,10 +398,10 @@ export function SignersClient({
     title: string; 
     role: "locataire_principal" | "colocataire" | "garant";
   }) => (
-    <Card className="border-2 border-dashed border-slate-200 bg-slate-50/50">
+    <Card className="border-2 border-dashed border-border bg-muted/50">
       <CardContent className="p-6 text-center">
-        <UserPlus className="h-10 w-10 text-slate-300 mx-auto mb-3" />
-        <h3 className="font-semibold text-slate-700 mb-2">Aucun {title.toLowerCase()}</h3>
+        <UserPlus className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+        <h3 className="font-semibold text-foreground mb-2">Aucun {title.toLowerCase()}</h3>
         <p className="text-sm text-muted-foreground mb-4">
           {canEdit 
             ? "Invitez une personne pour qu'elle puisse signer le bail."
@@ -434,7 +434,7 @@ export function SignersClient({
 
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div>
-              <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
                 <Users className="h-6 w-6 text-blue-600" />
                 Signataires du bail
               </h1>
@@ -448,8 +448,8 @@ export function SignersClient({
 
             {/* Stats */}
             <div className="flex gap-3">
-              <div className="text-center px-4 py-2 bg-white rounded-lg border">
-                <p className="text-2xl font-bold text-slate-900">{signedCount}/{totalSigners}</p>
+              <div className="text-center px-4 py-2 bg-card rounded-lg border">
+                <p className="text-2xl font-bold text-foreground">{signedCount}/{totalSigners}</p>
                 <p className="text-xs text-muted-foreground">Signatures</p>
               </div>
               {pendingCount > 0 && (
@@ -467,7 +467,7 @@ export function SignersClient({
           {/* Propriétaire */}
           {owner && (
             <section>
-              <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">
+              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
                 Bailleur
               </h2>
               <SignerCard signer={owner} roleLabel={ROLE_LABELS[owner.role]} showActions={false} />
@@ -477,7 +477,7 @@ export function SignersClient({
           {/* Locataire principal - TOUJOURS AFFICHÉ */}
             <section>
             <div className="flex items-center justify-between mb-3">
-              <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide">
+              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
                 Locataire principal
               </h2>
               {mainTenant && canEdit && (
@@ -503,7 +503,7 @@ export function SignersClient({
           {isColocation && (
             <section>
               <div className="flex items-center justify-between mb-3">
-                <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide">
+                <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
                 Colocataires ({cotenants.length})
               </h2>
                 {canEdit && (
@@ -528,7 +528,7 @@ export function SignersClient({
                 ))}
               </div>
               ) : (
-                <Card className="border-dashed border-slate-200 bg-slate-50/50">
+                <Card className="border-dashed border-border bg-muted/50">
                   <CardContent className="p-4 text-center text-sm text-muted-foreground">
                     Aucun colocataire pour le moment
                   </CardContent>
@@ -540,7 +540,7 @@ export function SignersClient({
           {/* Garants */}
           {guarantors.length > 0 && (
             <section>
-              <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">
+              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
                 Garants ({guarantors.length})
               </h2>
               <div className="grid gap-3">

--- a/app/owner/leases/[id]/signers/TenantInviteModal.tsx
+++ b/app/owner/leases/[id]/signers/TenantInviteModal.tsx
@@ -201,10 +201,10 @@ export function TenantInviteModal({
           </div>
 
           {/* Info signature */}
-          <div className="p-3 bg-slate-50 rounded-lg border border-slate-200">
+          <div className="p-3 bg-muted rounded-lg border border-border">
             <div className="flex items-start gap-2">
-              <Shield className="h-4 w-4 text-slate-500 mt-0.5 shrink-0" />
-              <div className="text-sm text-slate-600">
+              <Shield className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+              <div className="text-sm text-muted-foreground">
                 <p className="font-medium">Processus sécurisé</p>
                 <p className="text-xs mt-1">
                   La personne recevra un email avec un lien pour créer son compte

--- a/app/owner/leases/[id]/tabs/LeaseDocumentsTab.tsx
+++ b/app/owner/leases/[id]/tabs/LeaseDocumentsTab.tsx
@@ -318,13 +318,13 @@ export function LeaseDocumentsTab({
       {/* Toolbar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-semibold text-slate-700">
+          <span className="text-sm font-semibold text-foreground">
             Documents du bail
           </span>
           <Badge variant="secondary" className="text-[10px] h-5 px-1.5">
             {activeDocs.length}
           </Badge>
-          <span className="text-xs text-slate-400">
+          <span className="text-xs text-muted-foreground">
             {completedRequired}/{totalRequired} requis
           </span>
         </div>
@@ -362,7 +362,7 @@ export function LeaseDocumentsTab({
             className={`text-xs px-3 py-1 rounded-full border transition-colors ${
               filter === f.key
                 ? "bg-blue-50 border-blue-200 text-blue-700 font-semibold"
-                : "border-slate-100 text-slate-400 hover:border-slate-200"
+                : "border-border text-muted-foreground hover:border-border"
             }`}
           >
             {f.label}
@@ -405,7 +405,7 @@ export function LeaseDocumentsTab({
       {/* Section: Documents requis */}
       {(filter === "all" || filter === "required" || filter === "expired") && (
         <div>
-          <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">
+          <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-2">
             Documents obligatoires
           </p>
           <div className="space-y-1.5">
@@ -450,7 +450,7 @@ export function LeaseDocumentsTab({
       {filteredOptional.length > 0 &&
         filter !== "required" && (
           <div>
-            <p className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">
+            <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-2">
               Annexes &amp; optionnels ({filteredOptional.length})
             </p>
             <div className="space-y-1.5">
@@ -484,7 +484,7 @@ export function LeaseDocumentsTab({
       {activeDocs.length === 0 && filter === "all" && (
         <div className="flex flex-col items-center justify-center py-12">
           <FolderOpen className="h-10 w-10 text-slate-200 mb-3" />
-          <p className="text-sm text-slate-400">
+          <p className="text-sm text-muted-foreground">
             Aucun document lié à ce bail
           </p>
           <Button
@@ -500,7 +500,7 @@ export function LeaseDocumentsTab({
       )}
 
       {/* Footer: compteur + lien GED */}
-      <div className="flex items-center justify-between pt-2 border-t border-slate-100">
+      <div className="flex items-center justify-between pt-2 border-t border-border">
         <p className="text-xs text-muted-foreground">
           {activeDocs.length} document{activeDocs.length > 1 ? "s" : ""}{" "}
           actif{activeDocs.length > 1 ? "s" : ""}
@@ -584,17 +584,17 @@ function DocumentRow({
 
   return (
     <div
-      className={`flex items-center gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100 transition-colors group ${
+      className={`flex items-center gap-3 p-3 rounded-lg bg-muted hover:bg-muted transition-colors group ${
         isPending ? "opacity-60 pointer-events-none" : ""
       }`}
     >
-      <div className="h-9 w-9 rounded-lg bg-white border border-slate-200 flex items-center justify-center flex-shrink-0">
-        <Icon className="h-4 w-4 text-slate-500" />
+      <div className="h-9 w-9 rounded-lg bg-card border border-border flex items-center justify-center flex-shrink-0">
+        <Icon className="h-4 w-4 text-muted-foreground" />
       </div>
 
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <p className="text-sm font-medium text-slate-800 truncate">
+          <p className="text-sm font-medium text-foreground truncate">
             {getDocLabel(doc)}
           </p>
           {status !== "valid" && (
@@ -606,10 +606,10 @@ function DocumentRow({
             </Badge>
           )}
           {doc.visible_tenant === false && (
-            <EyeOff className="h-3 w-3 text-slate-300 flex-shrink-0" />
+            <EyeOff className="h-3 w-3 text-muted-foreground flex-shrink-0" />
           )}
         </div>
-        <p className="text-xs text-slate-400 mt-0.5">
+        <p className="text-xs text-muted-foreground mt-0.5">
           Ajouté le{" "}
           {new Date(doc.created_at).toLocaleDateString("fr-FR")}
           {doc.expiry_date &&
@@ -719,13 +719,13 @@ function WorkflowDocumentRow({
           : "Produit par le workflow";
 
   return (
-    <div className="flex items-center gap-3 p-3 rounded-lg border border-dashed border-slate-200 bg-slate-50/80">
-      <div className="h-9 w-9 rounded-lg bg-white border border-slate-200 flex items-center justify-center flex-shrink-0">
-        <Icon className="h-4 w-4 text-slate-500" />
+    <div className="flex items-center gap-3 p-3 rounded-lg border border-dashed border-border bg-muted/80">
+      <div className="h-9 w-9 rounded-lg bg-card border border-border flex items-center justify-center flex-shrink-0">
+        <Icon className="h-4 w-4 text-muted-foreground" />
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
-          <p className="text-sm font-medium text-slate-800">{config.label}</p>
+          <p className="text-sm font-medium text-foreground">{config.label}</p>
           <Badge variant="outline" className="text-[10px] h-5 px-1.5">
             {workflowDoc.source === "diagnostics" ? "Diagnostics" : "Workflow"}
           </Badge>
@@ -737,13 +737,13 @@ function WorkflowDocumentRow({
                 ? "bg-emerald-100 text-emerald-700"
                 : readinessStatus === "expired"
                   ? "bg-red-100 text-red-700"
-                  : "bg-slate-100 text-slate-700"
+                  : "bg-muted text-foreground"
             )}
           >
             {statusLabel}
           </Badge>
         </div>
-        <p className="text-xs text-slate-500 mt-0.5">{workflowDoc.description}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{workflowDoc.description}</p>
       </div>
       <div className="flex-shrink-0">
         {workflowDoc.storagePath ? (
@@ -796,7 +796,7 @@ function MissingDocumentRow({
         <Icon className="h-4 w-4 text-orange-500" />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-slate-600">{config.label}</p>
+        <p className="text-sm font-medium text-muted-foreground">{config.label}</p>
         <p className="text-xs text-orange-500">Document requis non fourni</p>
       </div>
       {isDPE ? (

--- a/app/owner/leases/[id]/tabs/LeaseEdlTab.tsx
+++ b/app/owner/leases/[id]/tabs/LeaseEdlTab.tsx
@@ -52,7 +52,7 @@ interface LeaseEdlTabProps {
 }
 
 const EDL_STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof Clock }> = {
-  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700", icon: FileText },
+  draft: { label: "Brouillon", color: "bg-muted text-foreground", icon: FileText },
   scheduled: { label: "Planifié", color: "bg-blue-100 text-blue-700", icon: Calendar },
   in_progress: { label: "En cours", color: "bg-amber-100 text-amber-700", icon: Loader2 },
   completed: { label: "Complété", color: "bg-indigo-100 text-indigo-700", icon: CheckCircle },
@@ -77,16 +77,16 @@ export function LeaseEdlTab({
   if (bailNotReady) {
     return (
       <div className="flex flex-col items-center justify-center py-12 sm:py-16 px-4">
-        <div className="p-4 bg-slate-100 rounded-full mb-4">
-          <ClipboardCheck className="h-8 w-8 text-slate-400" />
+        <div className="p-4 bg-muted rounded-full mb-4">
+          <ClipboardCheck className="h-8 w-8 text-muted-foreground" />
         </div>
-        <h3 className="text-lg font-semibold text-slate-700 mb-2">
+        <h3 className="text-lg font-semibold text-foreground mb-2">
           État des lieux non disponible
         </h3>
-        <p className="text-sm text-slate-500 text-center max-w-md">
+        <p className="text-sm text-muted-foreground text-center max-w-md">
           L&apos;état des lieux d&apos;entrée sera disponible une fois que le bail aura été signé par toutes les parties.
         </p>
-        <div className="mt-6 flex items-center gap-2 text-xs text-slate-400">
+        <div className="mt-6 flex items-center gap-2 text-xs text-muted-foreground">
           <Clock className="h-3.5 w-3.5" />
           En attente de la signature du bail
         </div>
@@ -107,12 +107,12 @@ export function LeaseEdlTab({
         <div className={`p-4 rounded-full mb-4 ${isAlreadyActive ? "bg-amber-100" : "bg-indigo-100"}`}>
           <ClipboardCheck className={`h-8 w-8 ${isAlreadyActive ? "text-amber-600" : "text-indigo-600"}`} />
         </div>
-        <h3 className="text-lg font-semibold text-slate-900 mb-2">
+        <h3 className="text-lg font-semibold text-foreground mb-2">
           {isAlreadyActive
             ? "État des lieux d\u2019entrée non réalisé"
             : "Créer l\u2019état des lieux d\u2019entrée"}
         </h3>
-        <p className="text-sm text-slate-600 text-center max-w-md mb-4">
+        <p className="text-sm text-muted-foreground text-center max-w-md mb-4">
           {isAlreadyActive
             ? "Le bail est actif mais aucun état des lieux d\u2019entrée n\u2019a été réalisé. Il est recommandé d\u2019en créer un pour la conformité du dossier."
             : "Le bail est signé. L\u2019état des lieux d\u2019entrée est requis pour activer le bail et remettre les clés au locataire."}
@@ -133,7 +133,7 @@ export function LeaseEdlTab({
 
         <Card className="w-full max-w-lg border-2 border-dashed border-indigo-200 bg-indigo-50/50 mt-6">
           <CardContent className="p-4 sm:p-6">
-            <div className="space-y-3 text-sm text-slate-600">
+            <div className="space-y-3 text-sm text-muted-foreground">
               <div className="flex items-start gap-3">
                 <Camera className="h-4 w-4 mt-0.5 text-indigo-500 flex-shrink-0" />
                 <span>Inspection pièce par pièce avec photos</span>
@@ -190,7 +190,7 @@ export function LeaseEdlTab({
             <div className="space-y-2">
               <div className="flex justify-between items-center text-xs">
                 <span className="text-muted-foreground font-medium">Éléments inspectés</span>
-                <span className="font-semibold text-slate-700">
+                <span className="font-semibold text-foreground">
                   {edl.completed_items || 0} / {edl.total_items} ({completionPercent}%)
                 </span>
               </div>

--- a/app/owner/leases/[id]/tabs/LeasePaymentsTab.tsx
+++ b/app/owner/leases/[id]/tabs/LeasePaymentsTab.tsx
@@ -55,11 +55,11 @@ const PAYMENT_STATUS: Record<string, { label: string; color: string; icon: typeo
   paid: { label: "Payé", color: "bg-emerald-100 text-emerald-700", icon: CheckCircle },
   pending: { label: "En attente", color: "bg-amber-100 text-amber-700", icon: Clock },
   failed: { label: "Échoué", color: "bg-red-100 text-red-700", icon: XCircle },
-  refunded: { label: "Remboursé", color: "bg-slate-100 text-slate-700", icon: CreditCard },
+  refunded: { label: "Remboursé", color: "bg-muted text-foreground", icon: CreditCard },
 };
 
 const INVOICE_STATUS: Record<string, { label: string; color: string }> = {
-  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-600" },
+  draft: { label: "Brouillon", color: "bg-muted text-muted-foreground" },
   sent: { label: "Envoyée", color: "bg-blue-100 text-blue-700" },
   paid: { label: "Payée", color: "bg-emerald-100 text-emerald-700" },
   late: { label: "En retard", color: "bg-red-100 text-red-700" },
@@ -93,13 +93,13 @@ export function LeasePaymentsTab({
   if (isFinancialLocked) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-4">
-        <div className="p-4 bg-slate-100 rounded-full mb-4">
-          <Euro className="h-8 w-8 text-slate-400" />
+        <div className="p-4 bg-muted rounded-full mb-4">
+          <Euro className="h-8 w-8 text-muted-foreground" />
         </div>
-        <h3 className="text-lg font-semibold text-slate-700 mb-2">
+        <h3 className="text-lg font-semibold text-foreground mb-2">
           Paiements non disponibles
         </h3>
-        <p className="text-sm text-slate-500 text-center max-w-md">
+        <p className="text-sm text-muted-foreground text-center max-w-md">
           Le suivi financier se débloque après la signature complète du bail.
         </p>
       </div>
@@ -114,10 +114,10 @@ export function LeasePaymentsTab({
         <div className="p-4 bg-amber-100 rounded-full mb-4">
           <Clock className="h-8 w-8 text-amber-600" />
         </div>
-        <h3 className="text-lg font-semibold text-slate-700 mb-2">
+        <h3 className="text-lg font-semibold text-foreground mb-2">
           {readinessState.paymentState.label}
         </h3>
-        <p className="text-sm text-slate-500 text-center max-w-md">
+        <p className="text-sm text-muted-foreground text-center max-w-md">
           {readinessState.paymentState.description}
         </p>
         <Button variant="outline" size="sm" className="mt-4" asChild>
@@ -157,13 +157,13 @@ export function LeasePaymentsTab({
         animate={{ opacity: 1, y: 0 }}
         className="space-y-6 py-4"
       >
-        <div className="p-4 bg-slate-50 border border-slate-200 rounded-lg flex items-start gap-3">
-          <Clock className="h-5 w-5 text-slate-500 flex-shrink-0" />
+        <div className="p-4 bg-muted border border-border rounded-lg flex items-start gap-3">
+          <Clock className="h-5 w-5 text-muted-foreground flex-shrink-0" />
           <div>
-            <p className="text-sm font-semibold text-slate-800">
+            <p className="text-sm font-semibold text-foreground">
               {readinessState.paymentState.label}
             </p>
-            <p className="text-xs text-slate-600">
+            <p className="text-xs text-muted-foreground">
               {readinessState.paymentState.description}
             </p>
           </div>
@@ -179,9 +179,9 @@ export function LeasePaymentsTab({
             <p className="text-xs text-amber-600 font-medium mb-1">En attente</p>
             <p className="text-lg font-bold text-amber-700">{formatCurrency(totalPending)}</p>
           </div>
-          <div className="p-4 bg-slate-50 rounded-lg border border-slate-100 text-center">
-            <p className="text-xs text-slate-600 font-medium mb-1">Factures</p>
-            <p className="text-lg font-bold text-slate-700">{invoices.length}</p>
+          <div className="p-4 bg-muted rounded-lg border border-border text-center">
+            <p className="text-xs text-muted-foreground font-medium mb-1">Factures</p>
+            <p className="text-lg font-bold text-foreground">{invoices.length}</p>
           </div>
         </div>
 
@@ -207,7 +207,7 @@ export function LeasePaymentsTab({
               <FileText className="h-3.5 w-3.5" />
               Factures
             </h4>
-            <div className="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+            <div className="bg-card rounded-lg border border-border divide-y divide-border">
               {invoices.slice(0, 12).map((invoice) => {
                 const invStatus = INVOICE_STATUS[invoice.statut] || INVOICE_STATUS.draft;
                 const isInitial = invoice.metadata?.type === "initial_invoice";
@@ -215,8 +215,8 @@ export function LeasePaymentsTab({
                 return (
                   <div key={invoice.id} className="flex items-center justify-between p-4">
                     <div className="flex items-center gap-3">
-                      <div className="h-8 w-8 rounded-full bg-slate-100 flex items-center justify-center flex-shrink-0">
-                        <FileText className="h-4 w-4 text-slate-500" />
+                      <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+                        <FileText className="h-4 w-4 text-muted-foreground" />
                       </div>
                       <div>
                         <p className="text-sm font-medium">
@@ -258,7 +258,7 @@ export function LeasePaymentsTab({
               <CreditCard className="h-3.5 w-3.5" />
               Paiements reçus
             </h4>
-            <div className="bg-white rounded-lg border border-slate-200 divide-y divide-slate-100">
+            <div className="bg-card rounded-lg border border-border divide-y divide-border">
               {payments.map((payment) => {
                 const statusConf = PAYMENT_STATUS[payment.statut] || PAYMENT_STATUS.pending;
                 const StatusIcon = statusConf.icon;

--- a/app/owner/leases/[id]/tabs/components/DocumentUploadDialog.tsx
+++ b/app/owner/leases/[id]/tabs/components/DocumentUploadDialog.tsx
@@ -160,7 +160,7 @@ export function DocumentUploadDialog({
         <div className="space-y-4">
           {/* Type selector */}
           <div>
-            <label className="text-xs font-semibold text-slate-600 mb-1.5 block">
+            <label className="text-xs font-semibold text-muted-foreground mb-1.5 block">
               Type de document
             </label>
             <div className="grid grid-cols-2 gap-1.5">
@@ -171,7 +171,7 @@ export function DocumentUploadDialog({
                   className={`text-left px-3 py-2 rounded-lg border text-xs transition-colors ${
                     selectedType === config.type
                       ? "border-blue-300 bg-blue-50 text-blue-700 font-semibold"
-                      : "border-slate-200 text-slate-600 hover:border-slate-300 hover:bg-slate-50"
+                      : "border-border text-muted-foreground hover:border-border hover:bg-muted"
                   }`}
                 >
                   {config.label}
@@ -185,7 +185,7 @@ export function DocumentUploadDialog({
 
           {/* Dropzone */}
           <div>
-            <label className="text-xs font-semibold text-slate-600 mb-1.5 block">
+            <label className="text-xs font-semibold text-muted-foreground mb-1.5 block">
               Fichier
             </label>
             {!file ? (
@@ -200,17 +200,17 @@ export function DocumentUploadDialog({
                 className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
                   dragOver
                     ? "border-blue-400 bg-blue-50"
-                    : "border-slate-200 hover:border-slate-300 hover:bg-slate-50"
+                    : "border-border hover:border-border hover:bg-muted"
                 }`}
               >
-                <Upload className="h-8 w-8 text-slate-300 mx-auto mb-2" />
-                <p className="text-sm text-slate-500">
+                <Upload className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+                <p className="text-sm text-muted-foreground">
                   Glissez un fichier ici ou{" "}
                   <span className="text-blue-600 font-medium">
                     cliquez pour parcourir
                   </span>
                 </p>
-                <p className="text-xs text-slate-400 mt-1">
+                <p className="text-xs text-muted-foreground mt-1">
                   PDF, JPG, PNG · 10 Mo max
                 </p>
                 <input
@@ -228,16 +228,16 @@ export function DocumentUploadDialog({
               <div className="flex items-center gap-3 p-3 bg-green-50 border border-green-200 rounded-lg">
                 <CheckCircle className="h-5 w-5 text-green-600 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-slate-700 truncate">
+                  <p className="text-sm font-medium text-foreground truncate">
                     {file.name}
                   </p>
-                  <p className="text-xs text-slate-400">
+                  <p className="text-xs text-muted-foreground">
                     {(file.size / 1024 / 1024).toFixed(1)} Mo
                   </p>
                 </div>
                 <button
                   onClick={() => setFile(null)}
-                  className="text-slate-400 hover:text-slate-600"
+                  className="text-muted-foreground hover:text-muted-foreground"
                 >
                   <X className="h-4 w-4" />
                 </button>

--- a/app/owner/leases/new/ColocationConfig.tsx
+++ b/app/owner/leases/new/ColocationConfig.tsx
@@ -162,18 +162,18 @@ export function ColocationConfig({
               "relative flex flex-col p-4 rounded-xl border-2 cursor-pointer transition-all",
               config.bailType === "unique"
                 ? "border-violet-500 bg-violet-50/50 dark:bg-violet-950/30"
-                : "border-slate-200 hover:border-slate-300 dark:border-slate-700"
+                : "border-border hover:border-border"
             )}
           >
             <RadioGroupItem value="unique" className="absolute top-4 right-4" />
             <div className="flex items-center gap-2 mb-2">
               <div className={cn(
                 "p-2 rounded-lg",
-                config.bailType === "unique" ? "bg-violet-100" : "bg-slate-100"
+                config.bailType === "unique" ? "bg-violet-100" : "bg-muted"
               )}>
                 <FileText className={cn(
                   "h-5 w-5",
-                  config.bailType === "unique" ? "text-violet-600" : "text-slate-600"
+                  config.bailType === "unique" ? "text-violet-600" : "text-muted-foreground"
                 )} />
               </div>
               <span className="font-semibold">Bail unique</span>
@@ -195,18 +195,18 @@ export function ColocationConfig({
               "relative flex flex-col p-4 rounded-xl border-2 cursor-pointer transition-all",
               config.bailType === "individuel"
                 ? "border-violet-500 bg-violet-50/50 dark:bg-violet-950/30"
-                : "border-slate-200 hover:border-slate-300 dark:border-slate-700"
+                : "border-border hover:border-border"
             )}
           >
             <RadioGroupItem value="individuel" className="absolute top-4 right-4" />
             <div className="flex items-center gap-2 mb-2">
               <div className={cn(
                 "p-2 rounded-lg",
-                config.bailType === "individuel" ? "bg-violet-100" : "bg-slate-100"
+                config.bailType === "individuel" ? "bg-violet-100" : "bg-muted"
               )}>
                 <Home className={cn(
                   "h-5 w-5",
-                  config.bailType === "individuel" ? "text-violet-600" : "text-slate-600"
+                  config.bailType === "individuel" ? "text-violet-600" : "text-muted-foreground"
                 )} />
               </div>
               <span className="font-semibold">Baux individuels</span>
@@ -330,7 +330,7 @@ export function ColocationConfig({
               "relative flex flex-col p-3 rounded-lg border-2 cursor-pointer transition-all",
               config.splitMode === "equal"
                 ? "border-emerald-500 bg-emerald-50/50"
-                : "border-slate-200 hover:border-slate-300"
+                : "border-border hover:border-border"
             )}
           >
             <RadioGroupItem value="equal" className="absolute top-3 right-3 h-4 w-4" />
@@ -349,7 +349,7 @@ export function ColocationConfig({
               "relative flex flex-col p-3 rounded-lg border-2 cursor-pointer transition-all",
               config.splitMode === "by_room"
                 ? "border-emerald-500 bg-emerald-50/50"
-                : "border-slate-200 hover:border-slate-300"
+                : "border-border hover:border-border"
             )}
           >
             <RadioGroupItem value="by_room" className="absolute top-3 right-3 h-4 w-4" />
@@ -365,7 +365,7 @@ export function ColocationConfig({
               "relative flex flex-col p-3 rounded-lg border-2 cursor-pointer transition-all",
               config.splitMode === "custom"
                 ? "border-emerald-500 bg-emerald-50/50"
-                : "border-slate-200 hover:border-slate-300"
+                : "border-border hover:border-border"
             )}
           >
             <RadioGroupItem value="custom" className="absolute top-3 right-3 h-4 w-4" />
@@ -382,7 +382,7 @@ export function ColocationConfig({
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.3 }}
-        className="p-4 rounded-xl bg-slate-50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-800"
+        className="p-4 rounded-xl bg-muted border border-border"
       >
         <h4 className="font-medium text-sm mb-3 flex items-center gap-2">
           <Check className="h-4 w-4 text-emerald-600" />

--- a/app/owner/leases/new/FurnitureInventoryStep.tsx
+++ b/app/owner/leases/new/FurnitureInventoryStep.tsx
@@ -226,7 +226,7 @@ export function FurnitureInventoryStep({
               className={cn(
                 "flex items-center gap-3 p-3 rounded-lg border transition-colors",
                 isPresent
-                  ? "bg-white border-slate-200"
+                  ? "bg-card border-border"
                   : "bg-red-50 border-red-200"
               )}
             >
@@ -304,7 +304,7 @@ export function FurnitureInventoryStep({
           {value.additionalItems.map((item, index) => (
             <div
               key={index}
-              className="flex items-center gap-3 p-2 rounded-lg border bg-white"
+              className="flex items-center gap-3 p-2 rounded-lg border bg-card"
             >
               <div className="flex-1 text-sm">{item.name}</div>
               <Select

--- a/app/owner/leases/new/GarantForm.tsx
+++ b/app/owner/leases/new/GarantForm.tsx
@@ -76,7 +76,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
   return (
     <div className="space-y-4">
       {/* Toggle Garant */}
-      <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg border">
+      <div className="flex items-center justify-between p-4 bg-muted rounded-lg border">
         <div className="flex items-center gap-3">
           <Shield className="h-5 w-5 text-blue-500" />
           <div>
@@ -100,7 +100,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                 value={currentGarant.type_garantie}
                 onValueChange={(value) => updateGarant("type_garantie", value)}
               >
-                <SelectTrigger className="bg-white">
+                <SelectTrigger className="bg-card">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -127,7 +127,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                   <Label>Numéro de visa Visale (optionnel)</Label>
                   <Input
                     placeholder="Ex: VISALE-2024-XXXXX"
-                    className="bg-white"
+                    className="bg-card"
                   />
                 </div>
               </div>
@@ -153,7 +153,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.prenom}
                       onChange={(e) => updateGarant("prenom", e.target.value)}
                       placeholder="Jean"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                   <div className="space-y-2">
@@ -162,7 +162,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.nom}
                       onChange={(e) => updateGarant("nom", e.target.value)}
                       placeholder="Dupont"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                 </div>
@@ -173,7 +173,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                     value={currentGarant.adresse}
                     onChange={(e) => updateGarant("adresse", e.target.value)}
                     placeholder="123 rue de la Paix"
-                    className="bg-white"
+                    className="bg-card"
                   />
                 </div>
 
@@ -184,7 +184,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.code_postal}
                       onChange={(e) => updateGarant("code_postal", e.target.value)}
                       placeholder="75001"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                   <div className="space-y-2">
@@ -193,7 +193,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.ville}
                       onChange={(e) => updateGarant("ville", e.target.value)}
                       placeholder="Paris"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                 </div>
@@ -206,7 +206,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.email || ""}
                       onChange={(e) => updateGarant("email", e.target.value)}
                       placeholder="jean.dupont@email.com"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                   <div className="space-y-2">
@@ -215,7 +215,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.telephone || ""}
                       onChange={(e) => updateGarant("telephone", e.target.value)}
                       placeholder="06 12 34 56 78"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                 </div>
@@ -226,7 +226,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                     value={currentGarant.lien_parente || ""}
                     onValueChange={(value) => updateGarant("lien_parente", value)}
                   >
-                    <SelectTrigger className="bg-white">
+                    <SelectTrigger className="bg-card">
                       <SelectValue placeholder="Sélectionner..." />
                     </SelectTrigger>
                     <SelectContent>
@@ -251,7 +251,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                     value={currentGarant.raison_sociale || ""}
                     onChange={(e) => updateGarant("raison_sociale", e.target.value)}
                     placeholder="Nom de l'entreprise"
-                    className="bg-white"
+                    className="bg-card"
                   />
                 </div>
 
@@ -261,7 +261,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                     value={currentGarant.siret || ""}
                     onChange={(e) => updateGarant("siret", e.target.value)}
                     placeholder="123 456 789 00012"
-                    className="bg-white"
+                    className="bg-card"
                   />
                 </div>
 
@@ -271,7 +271,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                     value={currentGarant.adresse}
                     onChange={(e) => updateGarant("adresse", e.target.value)}
                     placeholder="Adresse complète"
-                    className="bg-white"
+                    className="bg-card"
                   />
                 </div>
 
@@ -282,7 +282,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.code_postal}
                       onChange={(e) => updateGarant("code_postal", e.target.value)}
                       placeholder="75001"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                   <div className="space-y-2">
@@ -291,7 +291,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.ville}
                       onChange={(e) => updateGarant("ville", e.target.value)}
                       placeholder="Paris"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                 </div>
@@ -303,7 +303,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.nom}
                       onChange={(e) => updateGarant("nom", e.target.value)}
                       placeholder="Nom"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                   <div className="space-y-2">
@@ -312,7 +312,7 @@ export function GarantForm({ garant, onGarantChange, hasGarant, onHasGarantChang
                       value={currentGarant.prenom}
                       onChange={(e) => updateGarant("prenom", e.target.value)}
                       placeholder="Prénom"
-                      className="bg-white"
+                      className="bg-card"
                     />
                   </div>
                 </div>

--- a/app/owner/leases/new/LeaseTypeCards.tsx
+++ b/app/owner/leases/new/LeaseTypeCards.tsx
@@ -343,10 +343,10 @@ export function LeaseTypeCards({ selectedType, onSelect, propertyType }: LeaseTy
 
               {/* Card */}
               <div className={cn(
-                "relative bg-white/90 dark:bg-slate-900/90 backdrop-blur-xl rounded-xl border-2 overflow-hidden shadow-lg transition-all duration-300",
+                "relative bg-card/90 backdrop-blur-xl rounded-xl border-2 overflow-hidden shadow-lg transition-all duration-300",
                 isSelected 
                   ? "border-primary ring-2 ring-primary/20" 
-                  : "border-white/30 dark:border-slate-700/50 hover:border-slate-300"
+                  : "border-white/30/50 hover:border-border"
               )}>
                 {/* Header avec gradient */}
                 <div
@@ -402,7 +402,7 @@ export function LeaseTypeCards({ selectedType, onSelect, propertyType }: LeaseTy
                 {/* Content */}
                 <div className="p-4 space-y-3">
                   <div>
-                    <h4 className="text-base font-bold text-slate-900 dark:text-white">
+                    <h4 className="text-base font-bold text-foreground">
                       {config.name}
                     </h4>
                     <p className="text-xs text-muted-foreground mt-0.5">

--- a/app/owner/leases/new/LeaseWizard.tsx
+++ b/app/owner/leases/new/LeaseWizard.tsx
@@ -957,7 +957,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 pb-20">
+    <div className="min-h-screen bg-muted pb-20">
       <div className={cn("container mx-auto px-4 py-8", currentStep === 3 ? "max-w-7xl" : "max-w-5xl")}>
         {/* Header */}
         <div className="mb-8">
@@ -973,7 +973,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
               <FileText className="h-7 w-7 text-white" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+              <h1 className="text-2xl font-bold text-foreground">
                 Nouveau bail
               </h1>
               <p className="text-muted-foreground">
@@ -1000,7 +1000,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                           scale: isActive ? 1.1 : 1,
                           backgroundColor: isCompleted ? "rgb(34 197 94)" : isActive ? "rgb(37 99 235)" : "rgb(226 232 240)",
                         }}
-                        className={cn("w-10 h-10 rounded-full flex items-center justify-center transition-colors", isActive || isCompleted ? "text-white" : "text-slate-500")}
+                        className={cn("w-10 h-10 rounded-full flex items-center justify-center transition-colors", isActive || isCompleted ? "text-white" : "text-muted-foreground")}
                       >
                         {isCompleted ? <Check className="h-5 w-5" /> : <Icon className="h-5 w-5" />}
                       </motion.div>
@@ -1009,7 +1009,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                       </span>
                     </div>
                     {index < STEPS.length - 1 && (
-                      <div className="flex-1 mx-4 h-0.5 bg-slate-200 dark:bg-slate-700">
+                      <div className="flex-1 mx-4 h-0.5 bg-border">
                         <motion.div initial={false} animate={{ width: currentStep > step.id ? "100%" : "0%" }} className="h-full bg-green-500" transition={{ duration: 0.3 }} />
                       </div>
                     )}
@@ -1031,7 +1031,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
           >
             {/* Étape 1 : Type de bail */}
             {currentStep === 1 && (
-              <div className="bg-white rounded-xl border shadow-sm p-6">
+              <div className="bg-card rounded-xl border shadow-sm p-6">
                 <LeaseTypeCards
                   selectedType={selectedType}
                   onSelect={handleTypeSelect}
@@ -1045,7 +1045,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
               <div className="space-y-6">
                 {/* Sélecteur d'entité signataire */}
                 {entities.length > 0 && (
-                  <div className="bg-white rounded-xl border shadow-sm p-6">
+                  <div className="bg-card rounded-xl border shadow-sm p-6">
                     <EntitySelector
                       value={selectedEntityId}
                       onChange={setSelectedEntityId}
@@ -1057,7 +1057,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                   </div>
                 )}
 
-                <div className="bg-white rounded-xl border shadow-sm p-6">
+                <div className="bg-card rounded-xl border shadow-sm p-6">
                   {initialPropertyId && selectedProperty ? (
                     <div className="p-4 rounded-xl bg-blue-50 border border-blue-100 mb-6">
                       <div className="flex items-center gap-3 mb-2">
@@ -1312,7 +1312,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                                     id="sous-location"
                                     checked={sousLocationAutorisee}
                                     onChange={(e) => setSousLocationAutorisee(e.target.checked)}
-                                    className="rounded border-gray-300"
+                                    className="rounded border-border"
                                   />
                                   <Label htmlFor="sous-location" className="text-sm font-normal cursor-pointer">
                                     Sous-location autorisée
@@ -1324,7 +1324,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                                     id="droit-preference"
                                     checked={droitPreference}
                                     onChange={(e) => setDroitPreference(e.target.checked)}
-                                    className="rounded border-gray-300"
+                                    className="rounded border-border"
                                   />
                                   <Label htmlFor="droit-preference" className="text-sm font-normal cursor-pointer">
                                     Droit de préférence du locataire (Art. L.145-46-1)
@@ -1520,7 +1520,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
               <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-6 lg:h-[calc(100vh-200px)] pb-20 lg:pb-0">
                 {/* Colonne Gauche : Formulaire (Scrollable) */}
                 <div className="lg:col-span-5 lg:overflow-y-auto lg:pr-2">
-                  <div className="bg-white rounded-xl border shadow-sm p-4 sm:p-6 space-y-5 sm:space-y-6">
+                  <div className="bg-card rounded-xl border shadow-sm p-4 sm:p-6 space-y-5 sm:space-y-6">
                     <div>
                       <h3 className="text-base sm:text-lg font-bold mb-1">Finalisation</h3>
                       <p className="text-xs sm:text-sm text-muted-foreground">Complétez les informations du locataire</p>
@@ -1566,8 +1566,8 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                 </div>
 
                 {/* Colonne Droite : Live Preview avec onglets Bail / EDL */}
-                <div className="lg:col-span-7 bg-slate-100 rounded-xl border overflow-hidden flex flex-col min-h-[400px] sm:min-h-[500px] lg:h-full">
-                  <div className="bg-slate-200 px-3 sm:px-4 py-2 border-b flex justify-between items-center">
+                <div className="lg:col-span-7 bg-muted rounded-xl border overflow-hidden flex flex-col min-h-[400px] sm:min-h-[500px] lg:h-full">
+                  <div className="bg-border px-3 sm:px-4 py-2 border-b flex justify-between items-center">
                     {/* Onglets Bail / EDL — touch-friendly */}
                     <div className="flex items-center gap-1">
                       <button
@@ -1576,8 +1576,8 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                         className={cn(
                           "flex items-center gap-1 sm:gap-1.5 px-3 py-2 sm:py-1.5 rounded-md text-xs font-semibold uppercase tracking-wider transition-colors min-h-[36px]",
                           previewTab === "bail"
-                            ? "bg-white text-slate-800 shadow-sm"
-                            : "text-slate-500 hover:text-slate-700 hover:bg-slate-100"
+                            ? "bg-card text-foreground shadow-sm"
+                            : "text-muted-foreground hover:text-foreground hover:bg-muted"
                         )}
                         aria-label="Aperçu du bail"
                       >
@@ -1590,8 +1590,8 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                         className={cn(
                           "flex items-center gap-1 sm:gap-1.5 px-3 py-2 sm:py-1.5 rounded-md text-xs font-semibold uppercase tracking-wider transition-colors min-h-[36px]",
                           previewTab === "edl"
-                            ? "bg-white text-slate-800 shadow-sm"
-                            : "text-slate-500 hover:text-slate-700 hover:bg-slate-100"
+                            ? "bg-card text-foreground shadow-sm"
+                            : "text-muted-foreground hover:text-foreground hover:bg-muted"
                         )}
                         aria-label="Aperçu de l'état des lieux d'entrée"
                       >
@@ -1600,11 +1600,11 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                         <span className="sm:hidden">EDL</span>
                       </button>
                     </div>
-                    <Badge variant="outline" className="bg-white text-[10px] sm:text-xs">
+                    <Badge variant="outline" className="bg-card text-[10px] sm:text-xs">
                       {selectedType?.toUpperCase()}
                     </Badge>
                   </div>
-                  <div className="flex-1 overflow-auto bg-slate-50 p-2 sm:p-4">
+                  <div className="flex-1 overflow-auto bg-muted p-2 sm:p-4">
                     {previewTab === "bail" ? (
                       <div className="lg:scale-90 lg:origin-top-left lg:w-[111%] lg:h-[111%]">
                         <LeasePreview typeBail={selectedType! as any} bailData={previewData as any} />
@@ -1620,7 +1620,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
         </AnimatePresence>
 
         {/* Navigation Bar (Fixed Bottom) — responsive avec safe area */}
-        <div className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-sm border-t p-3 sm:p-4 z-50 safe-area-bottom">
+        <div className="fixed bottom-0 left-0 right-0 bg-card/95 backdrop-blur-sm border-t p-3 sm:p-4 z-50 safe-area-bottom">
           <div className="container mx-auto max-w-5xl flex justify-between items-center gap-3">
             <Button variant="outline" onClick={goBack} disabled={currentStep === 1} className="gap-1.5 sm:gap-2 h-10 sm:h-9 text-xs sm:text-sm">
               <ArrowLeft className="h-4 w-4" />
@@ -1640,7 +1640,7 @@ export function LeaseWizard({ properties, initialPropertyId }: LeaseWizardProps)
                     "gap-1.5 sm:gap-2 h-10 sm:h-9 text-xs sm:text-sm transition-all duration-300",
                     canProceed 
                       ? "bg-blue-600 hover:bg-blue-700 shadow-lg shadow-blue-600/30" 
-                      : "bg-slate-300"
+                      : "bg-muted"
                   )}
                 >
                   Suivant <ArrowRight className="h-4 w-4" />

--- a/app/owner/leases/new/MultiTenantInvite.tsx
+++ b/app/owner/leases/new/MultiTenantInvite.tsx
@@ -196,7 +196,7 @@ export function MultiTenantInvite({
       </div>
 
       {/* Indicateur de progression */}
-      <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+      <div className="h-2 bg-muted rounded-full overflow-hidden">
         <motion.div
           className="h-full bg-gradient-to-r from-violet-500 to-purple-500"
           initial={{ width: 0 }}
@@ -219,7 +219,7 @@ export function MultiTenantInvite({
                 "relative p-4 rounded-xl border-2 transition-all",
                 invitee.role === "principal"
                   ? "border-amber-300 bg-gradient-to-r from-amber-50/50 to-orange-50/50"
-                  : "border-slate-200 bg-white dark:bg-slate-900"
+                  : "border-border bg-card"
               )}
             >
               {/* Badge rôle */}
@@ -251,7 +251,7 @@ export function MultiTenantInvite({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="absolute top-2 right-2 h-8 w-8 text-slate-400 hover:text-red-500 hover:bg-red-50"
+                  className="absolute top-2 right-2 h-8 w-8 text-muted-foreground hover:text-red-500 hover:bg-red-50"
                   onClick={() => removeInvitee(invitee.tempId)}
                 >
                   <X className="h-4 w-4" />
@@ -270,7 +270,7 @@ export function MultiTenantInvite({
                     placeholder="Marie Martin"
                     value={invitee.name}
                     onChange={(e) => updateInvitee(invitee.tempId, { name: e.target.value })}
-                    className="bg-white dark:bg-slate-800"
+                    className="bg-card"
                   />
                 </div>
 
@@ -287,7 +287,7 @@ export function MultiTenantInvite({
                     value={invitee.email}
                     onChange={(e) => updateInvitee(invitee.tempId, { email: e.target.value })}
                     className={cn(
-                      "bg-white dark:bg-slate-800",
+                      "bg-card",
                       emailErrors[invitee.tempId] && "border-red-500"
                     )}
                   />
@@ -307,7 +307,7 @@ export function MultiTenantInvite({
                       value={invitee.roomLabel || ""}
                       onValueChange={(value) => updateInvitee(invitee.tempId, { roomLabel: value })}
                     >
-                      <SelectTrigger className="bg-white dark:bg-slate-800">
+                      <SelectTrigger className="bg-card">
                         <SelectValue placeholder="Sélectionner" />
                       </SelectTrigger>
                       <SelectContent>
@@ -346,7 +346,7 @@ export function MultiTenantInvite({
                         onChange={(e) => updateInvitee(invitee.tempId, { 
                           weight: (parseFloat(e.target.value) || 0) / 100 
                         })}
-                        className="bg-white dark:bg-slate-800 w-24"
+                        className="bg-card w-24"
                       />
                       <span className="text-muted-foreground">%</span>
                       {invitee.weight !== undefined && totalRent > 0 && (
@@ -360,14 +360,14 @@ export function MultiTenantInvite({
               </div>
 
               {/* Garant */}
-              <div className="mt-4 pt-4 border-t border-slate-100 dark:border-slate-800">
+              <div className="mt-4 pt-4 border-t border-border">
                 <div className="flex items-center justify-between">
                   <Label className="text-sm flex items-center gap-2 cursor-pointer">
                     <input
                       type="checkbox"
                       checked={invitee.hasGuarantor}
                       onChange={(e) => updateInvitee(invitee.tempId, { hasGuarantor: e.target.checked })}
-                      className="rounded border-slate-300"
+                      className="rounded border-border"
                     />
                     <Shield className="h-4 w-4 text-emerald-600" />
                     Ajouter un garant
@@ -386,7 +386,7 @@ export function MultiTenantInvite({
                         placeholder="Jean Martin"
                         value={invitee.guarantorName || ""}
                         onChange={(e) => updateInvitee(invitee.tempId, { guarantorName: e.target.value })}
-                        className="bg-slate-50 dark:bg-slate-800 h-9"
+                        className="bg-muted h-9"
                       />
                     </div>
                     <div className="space-y-1">
@@ -396,7 +396,7 @@ export function MultiTenantInvite({
                         placeholder="garant@email.com"
                         value={invitee.guarantorEmail || ""}
                         onChange={(e) => updateInvitee(invitee.tempId, { guarantorEmail: e.target.value })}
-                        className="bg-slate-50 dark:bg-slate-800 h-9"
+                        className="bg-muted h-9"
                       />
                     </div>
                   </motion.div>
@@ -490,7 +490,7 @@ export function MultiTenantInvite({
                   {inv.role === "principal" ? (
                     <Crown className="h-4 w-4 text-amber-500" />
                   ) : (
-                    <User className="h-4 w-4 text-slate-400" />
+                    <User className="h-4 w-4 text-muted-foreground" />
                   )}
                   <span className="font-medium">{inv.name || inv.email}</span>
                   {inv.hasGuarantor && (

--- a/app/owner/leases/new/PropertySelector.tsx
+++ b/app/owner/leases/new/PropertySelector.tsx
@@ -77,9 +77,9 @@ export function PropertySelector({ properties, selectedPropertyId, onSelect }: P
 
   if (properties.length === 0) {
     return (
-      <div className="text-center py-12 bg-slate-50 dark:bg-slate-900/50 rounded-xl border-2 border-dashed border-slate-200 dark:border-slate-700">
-        <Building2 className="h-12 w-12 mx-auto text-slate-400 mb-4" />
-        <h3 className="text-lg font-semibold text-slate-600 dark:text-slate-300">
+      <div className="text-center py-12 bg-muted rounded-xl border-2 border-dashed border-border">
+        <Building2 className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+        <h3 className="text-lg font-semibold text-muted-foreground">
           Aucun bien disponible
         </h3>
         <p className="text-sm text-muted-foreground mt-1">
@@ -106,7 +106,7 @@ export function PropertySelector({ properties, selectedPropertyId, onSelect }: P
             placeholder="Rechercher par adresse, ville..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm"
+            className="pl-10 bg-card/80 backdrop-blur-sm"
           />
         </div>
       )}
@@ -131,10 +131,10 @@ export function PropertySelector({ properties, selectedPropertyId, onSelect }: P
             >
               <div className={cn(
                 "relative p-4 rounded-xl border-2 transition-all duration-300",
-                "bg-white dark:bg-slate-900",
+                "bg-card",
                 isSelected
                   ? "border-primary shadow-lg shadow-primary/10 ring-2 ring-primary/20"
-                  : "border-slate-200 dark:border-slate-700 hover:border-slate-300 hover:shadow-md"
+                  : "border-border hover:border-border hover:shadow-md"
               )}>
                 <div className="flex items-start gap-4">
                   {/* Icône */}
@@ -142,7 +142,7 @@ export function PropertySelector({ properties, selectedPropertyId, onSelect }: P
                     "p-3 rounded-xl shrink-0 transition-colors",
                     isSelected
                       ? "bg-primary text-white"
-                      : "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400"
+                      : "bg-muted text-muted-foreground"
                   )}>
                     <Icon className="h-6 w-6" />
                   </div>
@@ -151,7 +151,7 @@ export function PropertySelector({ properties, selectedPropertyId, onSelect }: P
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-2">
                       <div className="flex-1 min-w-0">
-                        <h4 className="font-semibold text-slate-900 dark:text-white truncate">
+                        <h4 className="font-semibold text-foreground truncate">
                           {address}
                         </h4>
                         <p className="text-sm text-muted-foreground flex items-center gap-1 mt-0.5">
@@ -208,7 +208,7 @@ export function PropertySelector({ properties, selectedPropertyId, onSelect }: P
 
                     {/* Loyer suggéré */}
                     {totalRent > 0 && (
-                      <div className="mt-3 pt-3 border-t border-slate-100 dark:border-slate-800">
+                      <div className="mt-3 pt-3 border-t border-border">
                         <div className="flex items-center justify-between">
                           <span className="text-xs text-muted-foreground flex items-center gap-1">
                             <Euro className="h-3 w-3" />

--- a/app/owner/leases/new/TenantInvite.tsx
+++ b/app/owner/leases/new/TenantInvite.tsx
@@ -91,7 +91,7 @@ export function TenantInvite({
                   placeholder="Marie Martin"
                   value={tenantName}
                   onChange={(e) => onNameChange(e.target.value)}
-                  className="bg-white dark:bg-slate-900"
+                  className="bg-card"
                 />
               </div>
 
@@ -108,7 +108,7 @@ export function TenantInvite({
                   value={tenantEmail}
                   onChange={handleEmailChange}
                   className={cn(
-                    "bg-white dark:bg-slate-900",
+                    "bg-card",
                     emailError && "border-red-500 focus-visible:ring-red-500"
                   )}
                 />
@@ -161,7 +161,7 @@ export function TenantInvite({
                   placeholder="Laisser vide pour un bail vierge"
                   value={tenantName}
                   onChange={(e) => onNameChange(e.target.value)}
-                  className="bg-white dark:bg-slate-900"
+                  className="bg-card"
                 />
               </div>
             </div>

--- a/app/owner/money/tabs/CompteBancaireTab.tsx
+++ b/app/owner/money/tabs/CompteBancaireTab.tsx
@@ -41,7 +41,7 @@ const TRANSFER_STATUS: Record<string, { label: string; icon: React.ReactNode; cl
   paid: { label: "Versé", icon: <CheckCircle2 className="h-3 w-3" />, classes: "bg-emerald-500/20 text-emerald-600 border-emerald-500/30" },
   pending: { label: "En cours", icon: <Clock className="h-3 w-3" />, classes: "bg-amber-500/20 text-amber-600 border-amber-500/30" },
   failed: { label: "Échoué", icon: <AlertCircle className="h-3 w-3" />, classes: "bg-red-500/20 text-red-600 border-red-500/30" },
-  canceled: { label: "Annulé", icon: <Ban className="h-3 w-3" />, classes: "bg-slate-500/20 text-slate-600 border-slate-500/30" },
+  canceled: { label: "Annulé", icon: <Ban className="h-3 w-3" />, classes: "bg-slate-500/20 text-muted-foreground border-slate-500/30" },
   reversed: { label: "Reversé", icon: <RotateCcw className="h-3 w-3" />, classes: "bg-orange-500/20 text-orange-600 border-orange-500/30" },
 };
 

--- a/app/owner/money/tabs/MonForfaitTab.tsx
+++ b/app/owner/money/tabs/MonForfaitTab.tsx
@@ -325,11 +325,11 @@ function InvoiceStatusBadge({ status }: { status: string }) {
   const configs: Record<string, { label: string; icon: React.ElementType; classes: string }> = {
     paid: { label: "Payée", icon: CheckCircle2, classes: "bg-emerald-500/20 text-emerald-600 border-emerald-500/30" },
     open: { label: "En attente", icon: Clock, classes: "bg-amber-500/20 text-amber-600 border-amber-500/30" },
-    draft: { label: "Brouillon", icon: FileText, classes: "bg-slate-500/20 text-slate-500 border-slate-500/30" },
-    void: { label: "Annulée", icon: X, classes: "bg-slate-500/20 text-slate-500 border-slate-500/30" },
+    draft: { label: "Brouillon", icon: FileText, classes: "bg-slate-500/20 text-muted-foreground border-slate-500/30" },
+    void: { label: "Annulée", icon: X, classes: "bg-slate-500/20 text-muted-foreground border-slate-500/30" },
     uncollectible: { label: "Irrécouvrable", icon: AlertTriangle, classes: "bg-red-500/20 text-red-600 border-red-500/30" },
   };
-  const config = configs[status] || { label: status, icon: Info, classes: "bg-slate-500/20 text-slate-500 border-slate-500/30" };
+  const config = configs[status] || { label: status, icon: Info, classes: "bg-slate-500/20 text-muted-foreground border-slate-500/30" };
   const StatusIcon = config.icon;
   return (
     <Badge className={cn("gap-1", config.classes)}>
@@ -860,7 +860,7 @@ export function MonForfaitTab() {
                         ? "bg-violet-500/20 text-violet-600 border-violet-500/30"
                         : subscription?.status === "past_due"
                           ? "bg-red-500/20 text-red-600 border-red-500/30"
-                          : "bg-slate-500/20 text-slate-500"
+                          : "bg-slate-500/20 text-muted-foreground"
                   )}
                 >
                   {subscription?.status === "active"

--- a/app/owner/onboarding/profile/page.tsx
+++ b/app/owner/onboarding/profile/page.tsx
@@ -85,21 +85,21 @@ export default function OwnerProfileOnboardingPage() {
         {/* Colonne gauche : Infos contextuelles */}
         <div className="hidden md:flex md:col-span-2 flex-col justify-center space-y-6 p-4">
           <div>
-            <h1 className="text-3xl font-bold text-slate-900 mb-2">Bienvenue.</h1>
-            <p className="text-lg text-slate-600">Configurons votre espace propriétaire ensemble.</p>
+            <h1 className="text-3xl font-bold text-foreground mb-2">Bienvenue.</h1>
+            <p className="text-lg text-muted-foreground">Configurons votre espace propriétaire ensemble.</p>
           </div>
           
           <div className="space-y-4">
-            <div className="p-4 bg-white rounded-xl shadow-sm border border-slate-100">
-              <div className="text-sm font-medium text-slate-500 mb-1">Type</div>
+            <div className="p-4 bg-card rounded-xl shadow-sm border border-slate-100">
+              <div className="text-sm font-medium text-muted-foreground mb-1">Type</div>
               <div className="text-lg font-semibold capitalize">{formData.type}</div>
             </div>
             
             {formData.type === 'societe' && (
-               <div className="p-4 bg-white rounded-xl shadow-sm border border-slate-100">
-                <div className="text-sm font-medium text-slate-500 mb-1">Société</div>
+               <div className="p-4 bg-card rounded-xl shadow-sm border border-slate-100">
+                <div className="text-sm font-medium text-muted-foreground mb-1">Société</div>
                 <div className="font-semibold">{formData.raison_sociale || "..."}</div>
-                {formData.siret && <div className="text-sm text-slate-400 font-mono mt-1">{formData.siret}</div>}
+                {formData.siret && <div className="text-sm text-muted-foreground font-mono mt-1">{formData.siret}</div>}
               </div>
             )}
           </div>

--- a/app/owner/profile/identity/page.tsx
+++ b/app/owner/profile/identity/page.tsx
@@ -262,8 +262,8 @@ export default function OwnerIdentityPage() {
                   <CheckCircle2 className="h-5 w-5 text-green-600" />
                 </div>
               ) : (
-                <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center">
-                  <CreditCard className="h-5 w-5 text-slate-500" />
+                <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center">
+                  <CreditCard className="h-5 w-5 text-muted-foreground" />
                 </div>
               )}
               <div>
@@ -291,7 +291,7 @@ export default function OwnerIdentityPage() {
                 initial={{ opacity: 0, scale: 0.95 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.95 }}
-                className="relative aspect-[3/2] rounded-lg overflow-hidden border bg-white"
+                className="relative aspect-[3/2] rounded-lg overflow-hidden border bg-card"
               >
                 <Image
                   src={previewUrl}
@@ -322,11 +322,11 @@ export default function OwnerIdentityPage() {
                 <div className="grid grid-cols-1 gap-3">
                   <Button
                     variant="outline"
-                    className="h-24 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-slate-200 hover:border-blue-400 hover:bg-blue-50/50 hover:text-blue-600 group transition-all"
+                    className="h-24 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-border hover:border-blue-400 hover:bg-blue-50/50 hover:text-blue-600 group transition-all"
                     onClick={() => setIsScanning(side)}
                   >
-                    <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center group-hover:bg-blue-100">
-                      <FileImage className="h-5 w-5 text-slate-500 group-hover:text-blue-600" />
+                    <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center group-hover:bg-blue-100">
+                      <FileImage className="h-5 w-5 text-muted-foreground group-hover:text-blue-600" />
                     </div>
                     <span className="text-xs font-medium">Prendre une photo</span>
                   </Button>
@@ -336,7 +336,7 @@ export default function OwnerIdentityPage() {
                       <span className="w-full border-t" />
                     </div>
                     <div className="relative flex justify-center text-[10px] uppercase">
-                      <span className="bg-white px-2 text-muted-foreground">Ou uploader un fichier</span>
+                      <span className="bg-card px-2 text-muted-foreground">Ou uploader un fichier</span>
                     </div>
                   </div>
 
@@ -347,7 +347,7 @@ export default function OwnerIdentityPage() {
                       cursor-pointer transition-all
                       ${isUploading 
                         ? "border-blue-300 bg-blue-50" 
-                        : "border-slate-200 hover:border-blue-400 hover:bg-blue-50/50"
+                        : "border-border hover:border-blue-400 hover:bg-blue-50/50"
                       }
                     `}
                   >
@@ -358,8 +358,8 @@ export default function OwnerIdentityPage() {
                       </div>
                     ) : (
                       <div className="flex items-center gap-2 px-4">
-                        <Upload className="h-4 w-4 text-slate-500" />
-                        <span className="text-xs font-medium text-slate-700">
+                        <Upload className="h-4 w-4 text-muted-foreground" />
+                        <span className="text-xs font-medium text-foreground">
                           Choisir un fichier
                         </span>
                       </div>
@@ -524,7 +524,7 @@ export default function OwnerIdentityPage() {
 
         {/* Données OCR extraites */}
         {hasOcrData && rectoMeta && (
-          <Card className="border-slate-200">
+          <Card className="border-border">
             <CardContent className="py-4">
               <h3 className="font-medium mb-3 flex items-center gap-2 text-sm">
                 <Shield className="h-4 w-4" />
@@ -622,7 +622,7 @@ export default function OwnerIdentityPage() {
         </div>
 
         {/* Info */}
-        <Card className="bg-slate-50 border-slate-200">
+        <Card className="bg-muted border-border">
           <CardContent className="py-4">
             <h3 className="font-medium mb-2 flex items-center gap-2">
               <FileImage className="h-4 w-4" />

--- a/app/owner/properties/[id]/PropertyDetailsClient.tsx
+++ b/app/owner/properties/[id]/PropertyDetailsClient.tsx
@@ -620,7 +620,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
 
       {/* Bouton retour */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-        <Link href="/owner/properties" className={cn(buttonVariants({ variant: "ghost" }), "pl-0 hover:pl-2 transition-all text-slate-500 hover:text-slate-900 w-fit")}>
+        <Link href="/owner/properties" className={cn(buttonVariants({ variant: "ghost" }), "pl-0 hover:pl-2 transition-all text-muted-foreground hover:text-foreground w-fit")}>
           <ArrowLeft className="mr-2 h-4 w-4" />
           Retour à la liste
         </Link>
@@ -744,12 +744,12 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
 
         {allDisplayPhotos.length === 0 ? (
           // Aucune photo
-          <div className="h-[300px] md:h-[400px] rounded-2xl overflow-hidden bg-slate-50 border-2 border-dashed border-slate-300 flex flex-col items-center justify-center text-slate-500 gap-4">
-            <div className="p-4 bg-white rounded-full shadow-sm">
-              <ImageIcon className="w-10 h-10 text-slate-400" />
+          <div className="h-[300px] md:h-[400px] rounded-2xl overflow-hidden bg-muted border-2 border-dashed border-border flex flex-col items-center justify-center text-muted-foreground gap-4">
+            <div className="p-4 bg-card rounded-full shadow-sm">
+              <ImageIcon className="w-10 h-10 text-muted-foreground" />
             </div>
             <div className="text-center">
-              <h3 className="text-lg font-semibold text-slate-700">Aucune photo</h3>
+              <h3 className="text-lg font-semibold text-foreground">Aucune photo</h3>
               <p className="text-sm text-muted-foreground mb-4">
                 {isEditing ? "Ajoutez des photos pour mettre en valeur votre bien" : "Cliquez sur 'Modifier le bien' pour ajouter des photos"}
               </p>
@@ -766,7 +766,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4 h-[300px] md:h-[450px]">
             {/* Photo principale */}
             <div 
-              className="col-span-1 md:col-span-3 relative rounded-2xl overflow-hidden bg-slate-100 group cursor-pointer"
+              className="col-span-1 md:col-span-3 relative rounded-2xl overflow-hidden bg-muted group cursor-pointer"
               onClick={() => !isEditing && openGallery(0)}
             >
               {mainPhoto && (
@@ -809,7 +809,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
                         <Button 
                           size="sm" 
                           variant="outline"
-                          className="bg-white"
+                          className="bg-card"
                           onClick={() => handleUnmarkPhotoForDeletion(mainPhoto.id)}
                         >
                           Annuler
@@ -900,7 +900,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
                         <Button 
                           size="icon" 
                           variant="outline"
-                          className="h-7 w-7 bg-white"
+                          className="h-7 w-7 bg-card"
                           onClick={() => handleUnmarkPhotoForDeletion(photo.id)}
                         >
                           <Check className="w-4 h-4" />
@@ -934,17 +934,17 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
                 <motion.div 
                   initial={{ opacity: 0, scale: 0.9 }}
                   animate={{ opacity: 1, scale: 1 }}
-                  className="flex-1 bg-slate-100 border-2 border-dashed border-slate-300 rounded-xl flex flex-col items-center justify-center cursor-pointer hover:bg-slate-50 hover:border-blue-400 transition-all min-h-[100px]"
+                  className="flex-1 bg-muted border-2 border-dashed border-border rounded-xl flex flex-col items-center justify-center cursor-pointer hover:bg-muted/80 hover:border-blue-400 transition-all min-h-[100px]"
                   onClick={() => fileInputRef.current?.click()}
                 >
-                  <Camera className="w-8 h-8 text-slate-400 mb-2" />
-                  <span className="text-sm text-slate-500 font-medium">Ajouter</span>
+                  <Camera className="w-8 h-8 text-muted-foreground mb-2" />
+                  <span className="text-sm text-muted-foreground font-medium">Ajouter</span>
                 </motion.div>
               )}
 
               {/* Info loyer si pas en mode édition */}
               {!isEditing && allDisplayPhotos.length <= 2 && (
-                <div className="flex-1 bg-white border rounded-xl p-4 flex flex-col justify-center items-center">
+                <div className="flex-1 bg-card border rounded-xl p-4 flex flex-col justify-center items-center">
                   <p className="text-xs text-muted-foreground uppercase tracking-wider">Loyer</p>
                   <p className="text-2xl font-bold">{formatCurrency(property.loyer_hc || 0)}</p>
                   <span className="text-xs text-muted-foreground">/mois HC</span>
@@ -984,7 +984,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
             <CardContent>
               {/* Mode édition : afficher les champs d'adresse */}
               {isEditing && (
-                <div className="mb-6 p-4 bg-slate-50 rounded-lg border border-dashed border-slate-200">
+                <div className="mb-6 p-4 bg-muted rounded-lg border border-dashed border-border">
                   <p className="text-xs text-muted-foreground mb-3 font-medium flex items-center gap-1">
                     <MapPin className="h-3 w-3" />
                     Modifier l'adresse
@@ -1124,7 +1124,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
                     {property.digicode && (
                       <div className="flex items-center justify-between p-3 rounded-xl bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-100 dark:border-indigo-900/50">
                         <div className="flex items-center gap-3">
-                          <div className="h-8 w-8 rounded-lg bg-white dark:bg-card flex items-center justify-center shadow-sm">
+                          <div className="h-8 w-8 rounded-lg bg-card flex items-center justify-center shadow-sm">
                             <Key className="h-4 w-4 text-indigo-600" />
                           </div>
                           <span className="text-sm font-medium text-muted-foreground">Digicode</span>
@@ -1137,7 +1137,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
                     {property.interphone && (
                       <div className="flex items-center justify-between p-3 rounded-xl bg-muted border border-border">
                         <div className="flex items-center gap-3">
-                          <div className="h-8 w-8 rounded-lg bg-white dark:bg-card flex items-center justify-center shadow-sm">
+                          <div className="h-8 w-8 rounded-lg bg-card flex items-center justify-center shadow-sm">
                             <Phone className="h-4 w-4 text-muted-foreground" />
                           </div>
                           <span className="text-sm font-medium text-muted-foreground">Interphone</span>
@@ -1493,7 +1493,7 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
             initial={{ y: 100, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: 100, opacity: 0 }}
-            className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t shadow-lg md:hidden z-50"
+            className="fixed bottom-0 left-0 right-0 p-4 bg-card border-t shadow-lg md:hidden z-50"
           >
             <div className="flex gap-3">
               <Button variant="outline" onClick={handleCancelEditing} disabled={isSaving} className="flex-1">

--- a/app/owner/providers/[id]/page.tsx
+++ b/app/owner/providers/[id]/page.tsx
@@ -254,25 +254,25 @@ export default function ProviderDetailPage() {
               
               {/* Stats rapides */}
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                <div className="text-center p-3 bg-muted rounded-lg">
                   <div className="text-2xl font-bold text-primary">
                     {provider.stats.completed_interventions}
                   </div>
                   <div className="text-xs text-muted-foreground">Interventions</div>
                 </div>
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                <div className="text-center p-3 bg-muted rounded-lg">
                   <div className="text-2xl font-bold text-green-600">
                     {provider.stats.on_time_rate}%
                   </div>
                   <div className="text-xs text-muted-foreground">À l'heure</div>
                 </div>
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                <div className="text-center p-3 bg-muted rounded-lg">
                   <div className="text-2xl font-bold text-blue-600">
                     {provider.stats.satisfaction_rate}%
                   </div>
                   <div className="text-xs text-muted-foreground">Satisfaction</div>
                 </div>
-                <div className="text-center p-3 bg-gray-50 rounded-lg">
+                <div className="text-center p-3 bg-muted rounded-lg">
                   <div className="text-2xl font-bold text-amber-600">
                     {provider.stats.recommendation_rate}%
                   </div>
@@ -534,8 +534,8 @@ export default function ProviderDetailPage() {
                 
                 <div className="flex items-center justify-between p-4 border rounded-lg">
                   <div className="flex items-center gap-3">
-                    <div className={`p-2 rounded-full ${provider.kyc_status === 'verified' ? 'bg-green-100' : 'bg-gray-100'}`}>
-                      <Shield className={`h-5 w-5 ${provider.kyc_status === 'verified' ? 'text-green-600' : 'text-gray-400'}`} />
+                    <div className={`p-2 rounded-full ${provider.kyc_status === 'verified' ? 'bg-green-100' : 'bg-muted'}`}>
+                      <Shield className={`h-5 w-5 ${provider.kyc_status === 'verified' ? 'text-green-600' : 'text-muted-foreground'}`} />
                     </div>
                     <div>
                       <div className="font-medium">Assurance RC Pro</div>
@@ -578,7 +578,7 @@ export default function ProviderDetailPage() {
 function PortfolioCard({ item, showDetails = false }: { item: PortfolioItem; showDetails?: boolean }) {
   return (
     <div className="border rounded-lg overflow-hidden group">
-      <div className="relative aspect-[4/3] bg-gray-100">
+      <div className="relative aspect-[4/3] bg-muted">
         {item.before_photo_url && (
           <div className="absolute inset-0 flex">
             <div className="flex-1 relative">

--- a/app/owner/providers/page.tsx
+++ b/app/owner/providers/page.tsx
@@ -181,7 +181,7 @@ export default function ProvidersMarketplacePage() {
             </div>
             <div>
               <CardTitle>Catalogue prestataires réservé au forfait {PLANS[requiredPlan].name}</CardTitle>
-              <p className="mt-2 text-sm text-slate-600">
+              <p className="mt-2 text-sm text-muted-foreground">
                 Depuis ce forfait, vous pouvez rechercher des artisans, comparer les profils et lancer une demande de devis sans quitter Talok.
               </p>
             </div>
@@ -189,7 +189,7 @@ export default function ProvidersMarketplacePage() {
           <CardContent className="space-y-4">
             <div className="grid gap-3 md:grid-cols-3">
               {["Recherche par métier", "Profils vérifiés", "Demande de devis contextualisée"].map((item) => (
-                <div key={item} className="rounded-xl border bg-white p-4 text-sm text-slate-700">
+                <div key={item} className="rounded-xl border bg-card p-4 text-sm text-foreground">
                   {item}
                 </div>
               ))}

--- a/app/owner/settings/branding/page.tsx
+++ b/app/owner/settings/branding/page.tsx
@@ -193,7 +193,7 @@ export default function OwnerBrandingPage() {
         {/* Loading */}
         {isLoading && (
           <div className="flex items-center justify-center py-12">
-            <Loader2 className="w-8 h-8 animate-spin text-slate-400" />
+            <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
           </div>
         )}
 
@@ -219,18 +219,18 @@ export default function OwnerBrandingPage() {
                     <Building2 className="w-8 h-8 text-white" />
                   </div>
 
-                  <h2 className="text-2xl font-bold text-slate-900 mb-3">
+                  <h2 className="text-2xl font-bold text-foreground mb-3">
                     White-Label non disponible
                   </h2>
 
-                  <p className="text-slate-600 mb-6">
+                  <p className="text-muted-foreground mb-6">
                     La personnalisation de marque blanche est disponible à partir du forfait
-                    <strong className="text-slate-900"> Enterprise M</strong>.
+                    <strong className="text-foreground"> Enterprise M</strong>.
                     Passez à un forfait supérieur pour personnaliser votre plateforme.
                   </p>
 
                   <div className="space-y-4 mb-8">
-                    <h3 className="font-medium text-slate-700">
+                    <h3 className="font-medium text-foreground">
                       Fonctionnalités disponibles :
                     </h3>
                     <FeatureList
@@ -264,17 +264,17 @@ export default function OwnerBrandingPage() {
 
         {/* Niveau actuel info */}
         {!isLoading && level !== "none" && (
-          <Card className="bg-slate-50 border-slate-200">
+          <Card className="bg-muted border-border">
             <CardHeader>
               <CardTitle className="text-base">Votre niveau actuel</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="font-medium text-slate-900">
+                  <p className="font-medium text-foreground">
                     {WHITE_LABEL_LEVEL_INFO[level].label}
                   </p>
-                  <p className="text-sm text-slate-500">
+                  <p className="text-sm text-muted-foreground">
                     {WHITE_LABEL_LEVEL_INFO[level].description}
                   </p>
                 </div>

--- a/app/owner/settings/page.tsx
+++ b/app/owner/settings/page.tsx
@@ -97,7 +97,7 @@ export default function OwnerSettingsPage() {
                       <item.icon className="h-5 w-5" />
                     </div>
                     {item.locked ? (
-                      <Badge variant="outline" className="border-amber-300 bg-white text-amber-700">
+                      <Badge variant="outline" className="border-amber-300 bg-card text-amber-700">
                         <Lock className="mr-1 h-3 w-3" />
                         {item.requiredPlanName}
                       </Badge>

--- a/app/owner/tenants/TenantsClient.tsx
+++ b/app/owner/tenants/TenantsClient.tsx
@@ -122,11 +122,11 @@ function LeaseStatusBadge({ status }: { status: string }) {
     partially_signed: { label: "Partiellement signé", className: "bg-orange-100 text-orange-700 border-orange-200" },
     fully_signed: { label: "Signé", className: "bg-indigo-100 text-indigo-700 border-indigo-200" },
     amended: { label: "Avenant", className: "bg-blue-100 text-blue-700 border-blue-200" },
-    terminated: { label: "Terminé", className: "bg-slate-100 text-slate-600 border-slate-200" },
+    terminated: { label: "Terminé", className: "bg-muted text-muted-foreground border-border" },
     invitation_pending: { label: "Invitation envoyée", className: "bg-purple-100 text-purple-700 border-purple-200" },
   };
 
-  const { label, className } = config[status] || { label: status, className: "bg-slate-100 text-slate-600" };
+  const { label, className } = config[status] || { label: status, className: "bg-muted text-muted-foreground" };
 
   return (
     <Badge variant="outline" className={cn("font-medium", className)}>
@@ -156,7 +156,7 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
 
   return (
     <motion.div variants={itemVariants}>
-      <Card className="group hover:shadow-xl transition-all duration-300 hover:scale-[1.01] border-slate-200/60 bg-white/80 backdrop-blur-sm overflow-hidden">
+      <Card className="group hover:shadow-xl transition-all duration-300 hover:scale-[1.01] border-border/60 bg-card/80 backdrop-blur-sm overflow-hidden">
         <CardContent className="p-0">
           {/* Header avec gradient */}
           <div className="relative h-20 bg-gradient-to-br from-slate-800 via-slate-700 to-indigo-800">
@@ -178,8 +178,8 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
           <div className="pt-10 px-6 pb-4">
             <div className="flex items-start justify-between mb-4">
               <div>
-                <h3 className="text-lg font-semibold text-slate-900">{fullName}</h3>
-                <p className="text-sm text-slate-500 flex items-center gap-1.5 mt-0.5">
+                <h3 className="text-lg font-semibold text-foreground">{fullName}</h3>
+                <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-0.5">
                   <Home className="h-3.5 w-3.5" />
                   {tenant.property_address}
                 </p>
@@ -199,7 +199,7 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
                       </Link>
                     </DropdownMenuItem>
                   ) : (
-                    <DropdownMenuItem disabled className="text-slate-400">
+                    <DropdownMenuItem disabled className="text-muted-foreground">
                       <Clock className="h-4 w-4 mr-2" />
                       Profil en attente
                     </DropdownMenuItem>
@@ -240,7 +240,7 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
             {/* Badges */}
             <div className="flex flex-wrap gap-2 mb-4">
               <LeaseStatusBadge status={tenant.lease_status} />
-              <Badge variant="outline" className="bg-slate-50">
+              <Badge variant="outline" className="bg-muted">
                 <Calendar className="h-3 w-3 mr-1" />
                 {leaseDuration()}
               </Badge>
@@ -248,9 +248,9 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
 
             {/* Métriques */}
             <div className="grid grid-cols-2 gap-3 mb-4">
-              <div className="p-3 rounded-lg bg-slate-50">
-                <p className="text-xs text-slate-500 mb-0.5">Loyer mensuel</p>
-                <p className="text-lg font-bold text-slate-900">
+              <div className="p-3 rounded-lg bg-muted">
+                <p className="text-xs text-muted-foreground mb-0.5">Loyer mensuel</p>
+                <p className="text-lg font-bold text-foreground">
                   {formatCurrency(tenant.loyer + tenant.charges)}
                 </p>
               </div>
@@ -258,7 +258,7 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
                 "p-3 rounded-lg",
                 tenant.current_balance > 0 ? "bg-red-50" : "bg-emerald-50"
               )}>
-                <p className="text-xs text-slate-500 mb-0.5">Solde</p>
+                <p className="text-xs text-muted-foreground mb-0.5">Solde</p>
                 <p className={cn(
                   "text-lg font-bold",
                   tenant.current_balance > 0 ? "text-red-600" : "text-emerald-600"
@@ -274,7 +274,7 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
             {/* Barre de paiements */}
             <div className="space-y-2">
               <div className="flex items-center justify-between text-sm">
-                <span className="text-slate-600">Paiements à l'heure</span>
+                <span className="text-muted-foreground">Paiements à l'heure</span>
                 <span className={cn(
                   "font-semibold",
                   paymentRate >= 90 ? "text-emerald-600" :
@@ -283,7 +283,7 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
                   {paymentRate}%
                 </span>
               </div>
-              <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+              <div className="h-2 bg-muted rounded-full overflow-hidden">
                 <div 
                   className={cn(
                     "h-full rounded-full transition-all duration-500",
@@ -293,15 +293,15 @@ function TenantCard({ tenant }: { tenant: TenantWithDetails }) {
                   style={{ width: `${paymentRate}%` }}
                 />
               </div>
-              <p className="text-xs text-slate-400">
+              <p className="text-xs text-muted-foreground">
                 {tenant.payments_on_time} à l'heure • {tenant.payments_late} en retard sur {tenant.payments_total} paiements
               </p>
             </div>
           </div>
 
           {/* Footer avec actions rapides */}
-          <div className="px-6 py-3 bg-slate-50/50 border-t border-slate-100 flex items-center justify-between">
-            <div className="text-xs text-slate-500">
+          <div className="px-6 py-3 bg-muted/50 border-t border-slate-100 flex items-center justify-between">
+            <div className="text-xs text-muted-foreground">
               {tenant.last_payment_date 
                 ? `Dernier paiement: ${formatDateShort(tenant.last_payment_date)}`
                 : "Aucun paiement enregistré"
@@ -422,7 +422,7 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
             <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent">
               Mes Locataires
             </h1>
-            <p className="text-slate-500 mt-1">
+            <p className="text-muted-foreground mt-1">
               Gérez vos {stats.total} locataire{stats.total > 1 ? 's' : ''} et suivez leurs paiements
             </p>
           </div>
@@ -436,8 +436,8 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
                 <Users className="h-5 w-5 text-blue-600" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-slate-900">{stats.active}</p>
-                <p className="text-xs text-slate-500">Locataires actifs</p>
+                <p className="text-2xl font-bold text-foreground">{stats.active}</p>
+                <p className="text-xs text-muted-foreground">Locataires actifs</p>
               </div>
             </div>
           </GlassCard>
@@ -448,8 +448,8 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
                 <Euro className="h-5 w-5 text-emerald-600" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-slate-900">{formatCurrency(stats.totalMonthlyRent)}</p>
-                <p className="text-xs text-slate-500">Revenus mensuels</p>
+                <p className="text-2xl font-bold text-foreground">{formatCurrency(stats.totalMonthlyRent)}</p>
+                <p className="text-xs text-muted-foreground">Revenus mensuels</p>
               </div>
             </div>
           </GlassCard>
@@ -463,7 +463,7 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
                 <p className={cn("text-2xl font-bold", stats.totalBalance > 0 ? "text-red-600" : "text-emerald-600")}>
                   {stats.totalBalance > 0 ? formatCurrency(stats.totalBalance) : "0 €"}
                 </p>
-                <p className="text-xs text-slate-500">
+                <p className="text-xs text-muted-foreground">
                   {stats.withBalance > 0 ? `${stats.withBalance} impayé(s)` : "Aucun impayé"}
                 </p>
               </div>
@@ -476,8 +476,8 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
                 <Star className="h-5 w-5 text-amber-600" />
               </div>
               <div>
-                <p className="text-2xl font-bold text-slate-900">{stats.avgScore}/5</p>
-                <p className="text-xs text-slate-500">Score moyen</p>
+                <p className="text-2xl font-bold text-foreground">{stats.avgScore}/5</p>
+                <p className="text-xs text-muted-foreground">Score moyen</p>
               </div>
             </div>
           </GlassCard>
@@ -486,18 +486,18 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
         {/* Filtres */}
         <motion.div variants={itemVariants} className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
               placeholder="Rechercher par nom, adresse, email..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 bg-white"
+              className="pl-10 bg-card"
             />
           </div>
           
           <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-full sm:w-[180px] bg-white">
-              <Filter className="h-4 w-4 mr-2 text-slate-400" />
+            <SelectTrigger className="w-full sm:w-[180px] bg-card">
+              <Filter className="h-4 w-4 mr-2 text-muted-foreground" />
               <SelectValue placeholder="Statut" />
             </SelectTrigger>
             <SelectContent>
@@ -509,8 +509,8 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
           </Select>
 
           <Select value={sortBy} onValueChange={setSortBy}>
-            <SelectTrigger className="w-full sm:w-[180px] bg-white">
-              <ArrowUpDown className="h-4 w-4 mr-2 text-slate-400" />
+            <SelectTrigger className="w-full sm:w-[180px] bg-card">
+              <ArrowUpDown className="h-4 w-4 mr-2 text-muted-foreground" />
               <SelectValue placeholder="Trier par" />
             </SelectTrigger>
             <SelectContent>
@@ -524,11 +524,11 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
 
         {filteredTenants.length > 0 && (
           <motion.div variants={itemVariants}>
-            <Card className="border-slate-200/70 bg-slate-50/80">
+            <Card className="border-border/70 bg-muted/80">
               <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-sm font-semibold text-slate-900">{visibleTenantsLabel}</p>
-                  <p className="text-sm text-slate-500">
+                  <p className="text-sm font-semibold text-foreground">{visibleTenantsLabel}</p>
+                  <p className="text-sm text-muted-foreground">
                     {hasActiveFilters
                       ? `Affichage filtré sur ${stats.total} locataire${stats.total > 1 ? "s" : ""}.`
                       : "Tous les locataires chargés sont affichés ci-dessous."}
@@ -565,8 +565,8 @@ export function TenantsClient({ tenants }: TenantsClientProps) {
           <motion.div variants={itemVariants}>
             <Card className="p-6 sm:p-8 md:p-12 text-center">
               <Search className="h-12 w-12 mx-auto text-slate-300 mb-4" />
-              <h3 className="text-lg font-semibold text-slate-700 mb-2">Aucun résultat</h3>
-              <p className="text-slate-500 mb-4">
+              <h3 className="text-lg font-semibold text-foreground mb-2">Aucun résultat</h3>
+              <p className="text-muted-foreground mb-4">
                 Aucun locataire ne correspond à vos critères de recherche.
               </p>
               <Button variant="outline" onClick={() => {

--- a/app/owner/tenants/[id]/TenantProfileClient.tsx
+++ b/app/owner/tenants/[id]/TenantProfileClient.tsx
@@ -167,7 +167,7 @@ export function TenantProfileClient({ tenant, isAdmin = false }: TenantProfileCl
                 </AvatarFallback>
               </Avatar>
               <div>
-                <h1 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
+                <h1 className="text-2xl md:text-3xl font-bold text-foreground">
                   {tenant.prenom} {tenant.nom}
                 </h1>
                 <div className="flex items-center gap-2 mt-1">
@@ -315,7 +315,7 @@ export function TenantProfileClient({ tenant, isAdmin = false }: TenantProfileCl
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="p-4 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700">
+                  <div className="p-4 rounded-xl bg-muted border border-border border-border">
                     <div className="flex items-start justify-between mb-3">
                       <div>
                         <p className="font-semibold">
@@ -420,10 +420,10 @@ export function TenantProfileClient({ tenant, isAdmin = false }: TenantProfileCl
                       {tp?.cni_recto_path && (
                         <button
                           onClick={() => setImagePreview(getCniUrl(tp.cni_recto_path) || "")}
-                          className="relative aspect-[3/2] rounded-lg overflow-hidden border-2 border-slate-200 dark:border-slate-700 hover:border-blue-500 transition-colors group"
+                          className="relative aspect-[3/2] rounded-lg overflow-hidden border-2 border-border border-border hover:border-blue-500 transition-colors group"
                         >
-                          <div className="absolute inset-0 bg-slate-100 dark:bg-slate-800 flex items-center justify-center">
-                            <CreditCard className="h-8 w-8 text-slate-400" />
+                          <div className="absolute inset-0 bg-muted flex items-center justify-center">
+                            <CreditCard className="h-8 w-8 text-muted-foreground" />
                           </div>
                           <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                             <ZoomIn className="h-6 w-6 text-white" />
@@ -436,10 +436,10 @@ export function TenantProfileClient({ tenant, isAdmin = false }: TenantProfileCl
                       {tp?.cni_verso_path && (
                         <button
                           onClick={() => setImagePreview(getCniUrl(tp.cni_verso_path) || "")}
-                          className="relative aspect-[3/2] rounded-lg overflow-hidden border-2 border-slate-200 dark:border-slate-700 hover:border-blue-500 transition-colors group"
+                          className="relative aspect-[3/2] rounded-lg overflow-hidden border-2 border-border border-border hover:border-blue-500 transition-colors group"
                         >
-                          <div className="absolute inset-0 bg-slate-100 dark:bg-slate-800 flex items-center justify-center">
-                            <CreditCard className="h-8 w-8 text-slate-400" />
+                          <div className="absolute inset-0 bg-muted flex items-center justify-center">
+                            <CreditCard className="h-8 w-8 text-muted-foreground" />
                           </div>
                           <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                             <ZoomIn className="h-6 w-6 text-white" />
@@ -455,7 +455,7 @@ export function TenantProfileClient({ tenant, isAdmin = false }: TenantProfileCl
 
                 {/* Données extraites */}
                 {identityData.nom && (
-                  <div className="p-3 rounded-lg bg-slate-50 dark:bg-slate-800/50 text-sm space-y-1">
+                  <div className="p-3 rounded-lg bg-muted text-sm space-y-1">
                     <p className="font-medium text-xs text-muted-foreground uppercase tracking-wide mb-2">
                       Données extraites de la CNI
                     </p>
@@ -499,14 +499,14 @@ export function TenantProfileClient({ tenant, isAdmin = false }: TenantProfileCl
                     {tenant.documents.map((doc) => (
                       <div
                         key={doc.id}
-                        className="flex items-center justify-between p-3 rounded-lg border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors"
+                        className="flex items-center justify-between p-3 rounded-lg border border-border border-border hover:bg-muted transition-colors"
                       >
                         <div className="flex items-center gap-3">
                           <div className={cn(
                             "p-2 rounded-lg",
                             doc.is_valid 
                               ? "bg-green-100 dark:bg-green-900/50 text-green-600"
-                              : "bg-slate-100 dark:bg-slate-800 text-slate-500"
+                              : "bg-muted text-muted-foreground"
                           )}>
                             <FileText className="h-4 w-4" />
                           </div>
@@ -547,10 +547,10 @@ export function TenantProfileClient({ tenant, isAdmin = false }: TenantProfileCl
           <DialogHeader>
             <DialogTitle>Pièce d'identité</DialogTitle>
           </DialogHeader>
-          <div className="relative aspect-[3/2] bg-slate-100 dark:bg-slate-800 rounded-lg overflow-hidden">
+          <div className="relative aspect-[3/2] bg-muted rounded-lg overflow-hidden">
             {imagePreview && (
               <div className="absolute inset-0 flex items-center justify-center">
-                <CreditCard className="h-16 w-16 text-slate-400" />
+                <CreditCard className="h-16 w-16 text-muted-foreground" />
                 <p className="absolute bottom-4 text-sm text-muted-foreground">
                   Aperçu du document
                 </p>

--- a/app/owner/tickets/[id]/page.tsx
+++ b/app/owner/tickets/[id]/page.tsx
@@ -392,7 +392,7 @@ function ProviderSearchModal({
           </div>
         )}
 
-        <div className="px-6 py-4 border-b bg-slate-50/50 dark:bg-slate-900/50">
+        <div className="px-6 py-4 border-b bg-muted/50">
           <div className="flex items-center gap-3">
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -423,10 +423,10 @@ function ProviderSearchModal({
                   </div>
                 ) : filteredProviders.length === 0 ? (
                   <div className="text-center py-8 px-4">
-                    <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center">
-                      <HardHat className="h-8 w-8 text-slate-400" />
+                    <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-muted flex items-center justify-center">
+                      <HardHat className="h-8 w-8 text-muted-foreground" />
                     </div>
-                    <h4 className="font-semibold text-slate-700 dark:text-slate-300 mb-2">
+                    <h4 className="font-semibold text-foreground mb-2">
                       Aucun prestataire disponible
                     </h4>
                     <p className="text-sm text-muted-foreground mb-4">
@@ -437,8 +437,8 @@ function ProviderSearchModal({
                     </p>
                     
                     {/* LIENS EXTERNES - Toujours visible quand pas de prestataires */}
-                    <div className="mt-6 p-4 rounded-xl bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-blue-950 border border-slate-200 dark:border-slate-700">
-                      <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
+                    <div className="mt-6 p-4 rounded-xl bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-blue-950 border border-border">
+                      <p className="text-sm font-medium text-foreground mb-3">
                         🔍 Rechercher un artisan en dehors de la plateforme :
                       </p>
                       <div className="flex flex-col sm:flex-row gap-2">
@@ -529,7 +529,7 @@ function ProviderSearchModal({
                           "p-4 rounded-xl border-2 cursor-pointer transition-all",
                           isSelected 
                             ? "border-blue-500 bg-blue-50/50 dark:bg-blue-950/30" 
-                            : "border-slate-200 hover:border-blue-300 dark:border-slate-700"
+                            : "border-border hover:border-blue-300"
                         )}
                         onClick={() => toggleProvider(provider.id)}
                       >
@@ -550,7 +550,7 @@ function ProviderSearchModal({
 
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 flex-wrap">
-                          <h4 className="font-semibold text-slate-900 dark:text-slate-100">
+                          <h4 className="font-semibold text-foreground">
                             {provider.prenom} {provider.nom}
                           </h4>
                           {provider.rating && provider.rating >= 4.5 && (
@@ -617,7 +617,7 @@ function ProviderSearchModal({
                     <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-emerald-100 dark:bg-emerald-900/50 flex items-center justify-center">
                       <ExternalLink className="h-8 w-8 text-emerald-500" />
                     </div>
-                    <h4 className="font-semibold text-slate-700 dark:text-slate-300 mb-2">
+                    <h4 className="font-semibold text-foreground mb-2">
                       Aucun prestataire trouvé à proximité
                     </h4>
                     <p className="text-sm text-muted-foreground mb-4">
@@ -651,7 +651,7 @@ function ProviderSearchModal({
                         key={provider.id}
                         initial={{ opacity: 0, y: 10 }}
                         animate={{ opacity: 1, y: 0 }}
-                        className="p-4 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-emerald-300 dark:hover:border-emerald-700 transition-all"
+                        className="p-4 rounded-xl border border-border hover:border-emerald-300 dark:hover:border-emerald-700 transition-all"
                       >
                         <div className="flex items-start gap-4">
                           <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-emerald-100 to-teal-100 dark:from-emerald-900 dark:to-teal-900 flex items-center justify-center overflow-hidden">
@@ -664,7 +664,7 @@ function ProviderSearchModal({
 
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2 flex-wrap">
-                              <h4 className="font-semibold text-slate-900 dark:text-slate-100">
+                              <h4 className="font-semibold text-foreground">
                                 {provider.name}
                               </h4>
                               {provider.is_open && (
@@ -729,7 +729,7 @@ function ProviderSearchModal({
           </div>
         </ScrollArea>
 
-        <DialogFooter className="px-6 py-4 border-t bg-slate-50/50 dark:bg-slate-900/50">
+        <DialogFooter className="px-6 py-4 border-t bg-muted/50">
           <div className="flex items-center justify-between w-full">
             <span className="text-sm text-muted-foreground">
               {activeTab === "platform" ? (
@@ -1009,7 +1009,7 @@ export default function TicketDetailPage() {
   if (!ticket) {
     return (
       <div className="p-6">
-        <Card className="bg-white/80 backdrop-blur-sm dark:bg-slate-900/80">
+        <Card className="bg-card/80 backdrop-blur-sm">
           <CardContent className="py-16 text-center">
             <Wrench className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
             <h3 className="text-lg font-semibold mb-2">Ticket introuvable</h3>
@@ -1063,7 +1063,7 @@ export default function TicketDetailPage() {
                     </Badge>
                   )}
                 </div>
-                <h1 className="text-2xl lg:text-3xl font-bold text-slate-900 dark:text-slate-100">
+                <h1 className="text-2xl lg:text-3xl font-bold text-foreground">
                   {ticket.titre}
                 </h1>
                 <p className="text-muted-foreground text-sm mt-2">
@@ -1079,7 +1079,7 @@ export default function TicketDetailPage() {
                   onValueChange={handleStatusChange}
                   disabled={updating}
                 >
-                  <SelectTrigger className="w-[180px] bg-white dark:bg-slate-900">
+                  <SelectTrigger className="w-[180px] bg-card">
                     <SelectValue placeholder="Changer le statut" />
                   </SelectTrigger>
                   <SelectContent>
@@ -1123,7 +1123,7 @@ export default function TicketDetailPage() {
             {/* Main content */}
             <div className="lg:col-span-2 space-y-6">
               {/* Description */}
-              <Card className="bg-white/80 backdrop-blur-sm dark:bg-slate-900/80">
+              <Card className="bg-card/80 backdrop-blur-sm">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <FileText className="h-5 w-5 text-blue-500" />
@@ -1131,14 +1131,14 @@ export default function TicketDetailPage() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="whitespace-pre-wrap text-slate-700 dark:text-slate-300">
+                  <p className="whitespace-pre-wrap text-foreground">
                     {ticket.description}
                   </p>
                 </CardContent>
               </Card>
 
               {/* Comments / Échanges */}
-              <Card className="bg-white/80 backdrop-blur-sm dark:bg-slate-900/80">
+              <Card className="bg-card/80 backdrop-blur-sm">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <MessageSquare className="h-5 w-5 text-blue-500" />
@@ -1173,7 +1173,7 @@ export default function TicketDetailPage() {
                                 {formatDistanceToNow(new Date(comment.created_at), { addSuffix: true, locale: fr })}
                               </span>
                             </div>
-                            <p className="text-sm bg-slate-50 dark:bg-slate-800 rounded-xl p-3 text-slate-700 dark:text-slate-300">
+                            <p className="text-sm bg-muted rounded-xl p-3 text-foreground">
                               {comment.content}
                             </p>
                           </div>
@@ -1196,7 +1196,7 @@ export default function TicketDetailPage() {
                       value={newComment}
                       onChange={(e) => setNewComment(e.target.value)}
                       rows={3}
-                      className="bg-white dark:bg-slate-800 resize-none"
+                      className="bg-card resize-none"
                     />
                     <Button
                       onClick={handleAddComment}
@@ -1228,7 +1228,7 @@ export default function TicketDetailPage() {
 
               {/* Property info */}
               {ticket.property && (
-                <Card className="bg-white/80 backdrop-blur-sm dark:bg-slate-900/80">
+                <Card className="bg-card/80 backdrop-blur-sm">
                   <CardHeader className="pb-3">
                     <CardTitle className="text-sm flex items-center gap-2">
                       <Building2 className="h-4 w-4 text-blue-500" />
@@ -1249,7 +1249,7 @@ export default function TicketDetailPage() {
 
               {/* Created by */}
               {ticket.created_by && (
-                <Card className="bg-white/80 backdrop-blur-sm dark:bg-slate-900/80">
+                <Card className="bg-card/80 backdrop-blur-sm">
                   <CardHeader className="pb-3">
                     <CardTitle className="text-sm flex items-center gap-2">
                       <User className="h-4 w-4 text-blue-500" />
@@ -1283,7 +1283,7 @@ export default function TicketDetailPage() {
               )}
 
               {/* Timeline */}
-              <Card className="bg-white/80 backdrop-blur-sm dark:bg-slate-900/80">
+              <Card className="bg-card/80 backdrop-blur-sm">
                 <CardHeader className="pb-3">
                   <CardTitle className="text-sm flex items-center gap-2">
                     <Clock className="h-4 w-4 text-blue-500" />
@@ -1292,16 +1292,16 @@ export default function TicketDetailPage() {
                 </CardHeader>
                 <CardContent>
                   <div className="relative">
-                    <div className="absolute left-[9px] top-3 bottom-3 w-0.5 bg-slate-200 dark:bg-slate-700" />
+                    <div className="absolute left-[9px] top-3 bottom-3 w-0.5 bg-border" />
                     
                     <div className="space-y-4 text-sm">
                       {/* Création */}
                       <div className="flex items-start gap-3 relative">
-                        <div className="h-5 w-5 rounded-full bg-emerald-500 border-2 border-white dark:border-slate-900 shadow-sm z-10 mt-0.5 flex items-center justify-center">
+                        <div className="h-5 w-5 rounded-full bg-emerald-500 border-2 border-background shadow-sm z-10 mt-0.5 flex items-center justify-center">
                           <Sparkles className="h-3 w-3 text-white" />
                         </div>
                         <div className="flex-1 pb-1">
-                          <p className="font-medium text-slate-900 dark:text-slate-100">Ticket créé</p>
+                          <p className="font-medium text-foreground">Ticket créé</p>
                           <p className="text-xs text-muted-foreground">
                             {format(new Date(ticket.created_at), "dd MMM yyyy 'à' HH:mm", { locale: fr })}
                           </p>
@@ -1311,11 +1311,11 @@ export default function TicketDetailPage() {
                       {/* Commentaires */}
                       {ticket.comments?.slice(0, 3).map((comment, index) => (
                         <div key={comment.id || index} className="flex items-start gap-3 relative">
-                          <div className="h-5 w-5 rounded-full bg-blue-500 border-2 border-white dark:border-slate-900 shadow-sm z-10 mt-0.5 flex items-center justify-center">
+                          <div className="h-5 w-5 rounded-full bg-blue-500 border-2 border-background shadow-sm z-10 mt-0.5 flex items-center justify-center">
                             <MessageSquare className="h-3 w-3 text-white" />
                           </div>
                           <div className="flex-1 pb-1">
-                            <p className="font-medium text-slate-900 dark:text-slate-100">
+                            <p className="font-medium text-foreground">
                               {comment.author?.prenom || "Quelqu'un"} a commenté
                             </p>
                             <p className="text-xs text-muted-foreground">
@@ -1328,11 +1328,11 @@ export default function TicketDetailPage() {
                       {/* Devis reçus */}
                       {quotesCount > 0 && (
                         <div className="flex items-start gap-3 relative">
-                          <div className="h-5 w-5 rounded-full bg-amber-500 border-2 border-white dark:border-slate-900 shadow-sm z-10 mt-0.5 flex items-center justify-center">
+                          <div className="h-5 w-5 rounded-full bg-amber-500 border-2 border-background shadow-sm z-10 mt-0.5 flex items-center justify-center">
                             <Receipt className="h-3 w-3 text-white" />
                           </div>
                           <div className="flex-1 pb-1">
-                            <p className="font-medium text-slate-900 dark:text-slate-100">
+                            <p className="font-medium text-foreground">
                               {quotesCount} devis reçu{quotesCount > 1 ? "s" : ""}
                             </p>
                             <p className="text-xs text-muted-foreground">
@@ -1345,11 +1345,11 @@ export default function TicketDetailPage() {
                       {/* Work order */}
                       {ticket.work_order && (
                         <div className="flex items-start gap-3 relative">
-                          <div className="h-5 w-5 rounded-full bg-violet-500 border-2 border-white dark:border-slate-900 shadow-sm z-10 mt-0.5 flex items-center justify-center">
+                          <div className="h-5 w-5 rounded-full bg-violet-500 border-2 border-background shadow-sm z-10 mt-0.5 flex items-center justify-center">
                             <HardHat className="h-3 w-3 text-white" />
                           </div>
                           <div className="flex-1 pb-1">
-                            <p className="font-medium text-slate-900 dark:text-slate-100">
+                            <p className="font-medium text-foreground">
                               Prestataire assigné
                             </p>
                             <p className="text-xs text-muted-foreground">
@@ -1363,7 +1363,7 @@ export default function TicketDetailPage() {
                       {ticket.statut !== "open" && (
                         <div className="flex items-start gap-3 relative">
                           <div className={cn(
-                            "h-5 w-5 rounded-full border-2 border-white dark:border-slate-900 shadow-sm z-10 mt-0.5 flex items-center justify-center",
+                            "h-5 w-5 rounded-full border-2 border-background shadow-sm z-10 mt-0.5 flex items-center justify-center",
                             ticket.statut === "resolved" || ticket.statut === "closed" 
                               ? "bg-green-500" 
                               : ticket.statut === "in_progress" 
@@ -1373,7 +1373,7 @@ export default function TicketDetailPage() {
                             <StatusIcon className="h-3 w-3 text-white" />
                           </div>
                           <div className="flex-1 pb-1">
-                            <p className="font-medium text-slate-900 dark:text-slate-100">
+                            <p className="font-medium text-foreground">
                               {status.label}
                             </p>
                             <p className="text-xs text-muted-foreground">

--- a/app/owner/tickets/[id]/quotes/page.tsx
+++ b/app/owner/tickets/[id]/quotes/page.tsx
@@ -92,7 +92,7 @@ const statusConfig = {
   },
   expired: {
     label: "Expiré",
-    color: "bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-300",
+    color: "bg-muted text-foreground",
     icon: AlertTriangle,
   },
 };

--- a/app/owner/tickets/new/page.tsx
+++ b/app/owner/tickets/new/page.tsx
@@ -48,12 +48,12 @@ const categories = [
   { value: "plomberie", label: "Plomberie", icon: Droplet, color: "text-blue-500" },
   { value: "electricite", label: "Électricité", icon: Zap, color: "text-yellow-500" },
   { value: "chauffage", label: "Chauffage/Climatisation", icon: Thermometer, color: "text-orange-500" },
-  { value: "serrurerie", label: "Serrurerie", icon: Lock, color: "text-slate-500" },
+  { value: "serrurerie", label: "Serrurerie", icon: Lock, color: "text-muted-foreground" },
   { value: "autre", label: "Autre", icon: HelpCircle, color: "text-purple-500" },
 ];
 
 const priorities = [
-  { value: "basse", label: "Basse", description: "Peut attendre quelques semaines", color: "bg-slate-100 text-slate-700", hasFees: false },
+  { value: "basse", label: "Basse", description: "Peut attendre quelques semaines", color: "bg-muted text-foreground", hasFees: false },
   { value: "normale", label: "Normale", description: "À traiter dans la semaine", color: "bg-blue-100 text-blue-700", hasFees: false },
   { value: "haute", label: "Haute", description: "Urgent - sous 48h", color: "bg-orange-100 text-orange-700", hasFees: false },
   { 
@@ -216,7 +216,7 @@ export default function NewOwnerTicketPage() {
           </p>
         </div>
 
-        <Card className="bg-white/80 backdrop-blur-sm shadow-lg">
+        <Card className="bg-card/80 backdrop-blur-sm shadow-lg">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Wrench className="h-5 w-5 text-blue-600" />
@@ -239,7 +239,7 @@ export default function NewOwnerTicketPage() {
                   onValueChange={(value) => setForm({ ...form, property_id: value })}
                   disabled={loadingProperties}
                 >
-                  <SelectTrigger className="bg-white">
+                  <SelectTrigger className="bg-card">
                     <SelectValue placeholder={loadingProperties ? "Chargement..." : "Sélectionner un bien"} />
                   </SelectTrigger>
                   <SelectContent>
@@ -260,7 +260,7 @@ export default function NewOwnerTicketPage() {
                   placeholder="Ex: Fuite d'eau dans la salle de bain"
                   value={form.titre}
                   onChange={(e) => setForm({ ...form, titre: e.target.value })}
-                  className="bg-white"
+                  className="bg-card"
                   required
                 />
               </div>
@@ -284,7 +284,7 @@ export default function NewOwnerTicketPage() {
                             "flex flex-col items-center gap-1 p-3 rounded-lg border-2 transition-all",
                             isSelected
                               ? "border-blue-500 bg-blue-50"
-                              : "border-slate-200 hover:border-slate-300 bg-white"
+                              : "border-border hover:border-border bg-card"
                           )}
                         >
                           <Icon className={cn("h-5 w-5", isSelected ? "text-blue-600" : cat.color)} />
@@ -302,7 +302,7 @@ export default function NewOwnerTicketPage() {
                       value={form.priorite}
                       onValueChange={(value) => setForm({ ...form, priorite: value })}
                     >
-                      <SelectTrigger className="bg-white">
+                      <SelectTrigger className="bg-card">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -356,7 +356,7 @@ export default function NewOwnerTicketPage() {
                   value={form.description}
                   onChange={(e) => setForm({ ...form, description: e.target.value })}
                   rows={5}
-                  className="bg-white resize-none"
+                  className="bg-card resize-none"
                   required
                 />
                 <p className="text-xs text-muted-foreground">

--- a/app/owner/work-orders/page.tsx
+++ b/app/owner/work-orders/page.tsx
@@ -76,13 +76,13 @@ const statusConfig = {
   },
   cancelled: {
     label: "Annulé",
-    color: "bg-slate-100 text-slate-800 dark:bg-slate-800 dark:text-slate-300",
+    color: "bg-muted text-foreground",
     icon: XCircle,
   },
 };
 
 const priorityConfig = {
-  basse: "bg-slate-100 text-slate-700",
+  basse: "bg-muted text-foreground",
   normale: "bg-blue-100 text-blue-700",
   haute: "bg-orange-100 text-orange-700",
   urgente: "bg-red-100 text-red-700",
@@ -207,8 +207,8 @@ export default function WorkOrdersPage() {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-slate-100 dark:bg-slate-800">
-                <XCircle className="h-5 w-5 text-slate-600 dark:text-slate-400" />
+              <div className="p-2 rounded-lg bg-muted">
+                <XCircle className="h-5 w-5 text-muted-foreground dark:text-muted-foreground" />
               </div>
               <div>
                 <p className="text-2xl font-bold">{stats.cancelled}</p>

--- a/components/layout/owner-app-layout.tsx
+++ b/components/layout/owner-app-layout.tsx
@@ -166,7 +166,7 @@ export function OwnerAppLayout({ children, profile: serverProfile }: OwnerAppLay
     <ProtectedRoute allowedRoles={["owner"]}>
       <OnboardingTourProvider role="owner" profileId={profile?.id}>
       <TooltipProvider delayDuration={0}>
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-slate-50">
+      <div className="min-h-screen bg-background">
         {/* Offline indicator - visible when device loses connectivity */}
         <OfflineIndicator />
 

--- a/components/owner/cards/OwnerPropertyCard.tsx
+++ b/components/owner/cards/OwnerPropertyCard.tsx
@@ -33,7 +33,7 @@ export function OwnerPropertyCard({ property, index = 0 }: OwnerPropertyCardProp
       whileHover={{ y: -4, scale: 1.02 }}
       whileTap={{ scale: 0.98 }}
     >
-      <Card className="group relative overflow-hidden backdrop-blur-xl bg-white/80 dark:bg-slate-900/80 border border-white/20 dark:border-slate-700/50 hover:border-blue-300 dark:hover:border-blue-600 shadow-lg hover:shadow-xl transition-all duration-300 cursor-pointer h-full flex flex-col">
+      <Card className="group relative overflow-hidden backdrop-blur-xl bg-card/80 border border-border hover:border-blue-300 dark:hover:border-blue-600 shadow-lg hover:shadow-xl transition-all duration-300 cursor-pointer h-full flex flex-col">
         {/* Image de couverture */}
         {property.cover_url ? (
           <div className="relative h-48 w-full overflow-hidden">
@@ -53,8 +53,8 @@ export function OwnerPropertyCard({ property, index = 0 }: OwnerPropertyCardProp
             </div>
           </div>
         ) : (
-          <div className="relative h-48 w-full bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center">
-            <ImageIcon className="h-16 w-16 text-slate-400" />
+          <div className="relative h-48 w-full bg-gradient-to-br from-muted to-muted flex items-center justify-center">
+            <ImageIcon className="h-16 w-16 text-muted-foreground" />
             <div className="absolute top-3 right-3">
               <Badge variant={statusVariants[property.status] || "outline"}>
                 {PROPERTY_STATUS_LABELS[property.status] || property.status}

--- a/components/owner/cards/OwnerSectionCard.tsx
+++ b/components/owner/cards/OwnerSectionCard.tsx
@@ -29,7 +29,7 @@ export function OwnerSectionCard({
       transition={{ delay: index * 0.1, type: "spring", stiffness: 100, damping: 15 }}
       whileHover={{ y: -2 }}
     >
-      <Card className={cn("bg-white/80 backdrop-blur-sm border-slate-200/80", className)}>
+      <Card className={cn("bg-card/80 backdrop-blur-sm border-border/80", className)}>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
           <div>
             <CardTitle className="text-xl font-semibold">{title}</CardTitle>

--- a/components/owner/dashboard/cashflow-widget.tsx
+++ b/components/owner/dashboard/cashflow-widget.tsx
@@ -60,8 +60,8 @@ const CustomTooltip = ({ active, payload, label }: any) => {
   if (!active || !payload) return null;
 
   return (
-    <div className="bg-white border rounded-lg shadow-lg p-3 text-sm">
-      <p className="font-semibold text-slate-900 mb-2">{label}</p>
+    <div className="bg-card border rounded-lg shadow-lg p-3 text-sm">
+      <p className="font-semibold text-foreground mb-2">{label}</p>
       <div className="space-y-1">
         {payload.map((entry: any, index: number) => (
           <div key={index} className="flex items-center justify-between gap-4">
@@ -70,7 +70,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
                 className="w-3 h-3 rounded-full"
                 style={{ backgroundColor: entry.color }}
               />
-              <span className="text-slate-600">{entry.name}</span>
+              <span className="text-muted-foreground">{entry.name}</span>
             </div>
             <span className="font-medium">
               {formatCurrency(entry.value)}
@@ -230,9 +230,9 @@ export function CashflowWidget({ data, currentBalance = 0, className }: Cashflow
         </motion.div>
 
         {/* Info */}
-        <div className="flex items-start gap-2 p-3 rounded-lg bg-slate-50 border border-slate-100">
-          <Info className="h-4 w-4 text-slate-500 mt-0.5 shrink-0" />
-          <p className="text-xs text-slate-600">
+        <div className="flex items-start gap-2 p-3 rounded-lg bg-muted border border-border">
+          <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+          <p className="text-xs text-muted-foreground">
             Les prévisions sont basées sur vos loyers actuels et les charges récurrentes. 
             Les dépenses exceptionnelles ne sont pas incluses.
           </p>

--- a/components/owner/dashboard/finance-chart.tsx
+++ b/components/owner/dashboard/finance-chart.tsx
@@ -34,7 +34,7 @@ function FinanceChart({ chartData }: FinanceChartProps) {
   return (
     <ResponsiveContainer width="100%" height={256} minHeight={256}>
       <LineChart data={chartData}>
-        <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200" />
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
         <XAxis
           dataKey="period"
           className="text-xs"

--- a/components/owner/dashboard/owner-finance-summary.tsx
+++ b/components/owner/dashboard/owner-finance-summary.tsx
@@ -62,7 +62,7 @@ export function OwnerFinanceSummary({ chartData, kpis }: OwnerFinanceSummaryProp
   // Vérification de sécurité pour éviter les erreurs si les données ne sont pas encore chargées
   if (!kpis || !kpis.revenue_current_month || !kpis.revenue_last_month) {
     return (
-      <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl">
+      <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl">
         <CardContent className="py-12 text-center">
           <Skeleton className="h-64 w-full mb-4" />
           <Skeleton className="h-8 w-48 mx-auto" />
@@ -80,7 +80,7 @@ export function OwnerFinanceSummary({ chartData, kpis }: OwnerFinanceSummaryProp
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl hover:shadow-2xl transition-all duration-300">
+      <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl hover:shadow-2xl transition-all duration-300">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <motion.div
@@ -120,7 +120,7 @@ export function OwnerFinanceSummary({ chartData, kpis }: OwnerFinanceSummaryProp
                 value: kpis.revenue_last_month.collected,
                 diff: lastMonthDiff,
                 percentage: kpis.revenue_last_month.percentage,
-                gradient: "from-slate-50 to-slate-100/50",
+                gradient: "from-muted to-muted/50",
               },
               {
                 label: "Impayés",
@@ -138,9 +138,9 @@ export function OwnerFinanceSummary({ chartData, kpis }: OwnerFinanceSummaryProp
                 whileHover={{ scale: 1.02, y: -2 }}
                 className={`p-4 rounded-lg border bg-gradient-to-br ${kpi.gradient} cursor-pointer transition-all duration-300`}
               >
-                <p className="text-xs font-medium text-slate-600 mb-1">{kpi.label}</p>
+                <p className="text-xs font-medium text-muted-foreground mb-1">{kpi.label}</p>
                 <motion.p
-                  className={`text-2xl font-bold ${kpi.isArrears ? "text-red-600" : "text-slate-900"}`}
+                  className={`text-2xl font-bold ${kpi.isArrears ? "text-red-600" : "text-foreground"}`}
                   initial={{ scale: 0.8 }}
                   animate={{ scale: 1 }}
                   transition={{ delay: index * 0.1 + 0.3, type: "spring", stiffness: 200 }}
@@ -168,19 +168,19 @@ export function OwnerFinanceSummary({ chartData, kpis }: OwnerFinanceSummaryProp
                       {formatCurrency(Math.abs(kpi.diff))}
                     </span>
                     {kpi.expected && (
-                      <span className="text-xs text-slate-500">
+                      <span className="text-xs text-muted-foreground">
                         / {formatCurrency(kpi.expected)} attendus
                       </span>
                     )}
                   </div>
                 )}
                 {kpi.percentage !== undefined && (
-                  <p className="text-xs text-slate-500 mt-1">
+                  <p className="text-xs text-muted-foreground mt-1">
                     {kpi.percentage.toFixed(1)}% du montant attendu
                   </p>
                 )}
                 {kpi.isArrears && (
-                  <p className="text-xs text-slate-500 mt-2">Montant total en retard</p>
+                  <p className="text-xs text-muted-foreground mt-2">Montant total en retard</p>
                 )}
               </motion.div>
             ))}

--- a/components/owner/dashboard/owner-portfolio-by-module.tsx
+++ b/components/owner/dashboard/owner-portfolio-by-module.tsx
@@ -71,7 +71,7 @@ export function OwnerPortfolioByModule({ modules }: OwnerPortfolioByModuleProps)
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl hover:shadow-2xl transition-all duration-300">
+        <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl hover:shadow-2xl transition-all duration-300">
           <CardHeader>
             <CardTitle>Portefeuille par module</CardTitle>
             <CardDescription>Commencer avec votre premier bien</CardDescription>
@@ -95,7 +95,7 @@ export function OwnerPortfolioByModule({ modules }: OwnerPortfolioByModuleProps)
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl hover:shadow-2xl transition-all duration-300">
+      <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl hover:shadow-2xl transition-all duration-300">
         <CardHeader>
           <CardTitle>Portefeuille par module</CardTitle>
           <CardDescription>Vue d'ensemble de vos biens par catégorie</CardDescription>
@@ -104,7 +104,7 @@ export function OwnerPortfolioByModule({ modules }: OwnerPortfolioByModuleProps)
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {safeModules.map((module, index) => {
               const Icon = moduleIcons[module.module] || Building2; // Icône par défaut
-              const colorClass = moduleColors[module.module] || "bg-slate-50 text-slate-700 border-slate-200";
+              const colorClass = moduleColors[module.module] || "bg-muted text-foreground border-border";
               
               return (
                 <motion.div

--- a/components/owner/dashboard/owner-risk-section.tsx
+++ b/components/owner/dashboard/owner-risk-section.tsx
@@ -66,7 +66,7 @@ export function OwnerRiskSection({ risks }: OwnerRiskSectionProps) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl hover:shadow-2xl transition-all duration-300">
+        <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl hover:shadow-2xl transition-all duration-300">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <motion.div
@@ -95,7 +95,7 @@ export function OwnerRiskSection({ risks }: OwnerRiskSectionProps) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl hover:shadow-2xl transition-all duration-300">
+      <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl hover:shadow-2xl transition-all duration-300">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <motion.div

--- a/components/owner/dashboard/owner-todo-section.tsx
+++ b/components/owner/dashboard/owner-todo-section.tsx
@@ -69,7 +69,7 @@ export function OwnerTodoSection({ todos }: OwnerTodoSectionProps) {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl hover:shadow-2xl transition-all duration-300">
+        <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl hover:shadow-2xl transition-all duration-300">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <motion.div
@@ -98,7 +98,7 @@ export function OwnerTodoSection({ todos }: OwnerTodoSectionProps) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
     >
-      <Card className="backdrop-blur-sm bg-white/80 border-white/20 shadow-xl hover:shadow-2xl transition-all duration-300">
+      <Card className="backdrop-blur-sm bg-card/80 border-border shadow-xl hover:shadow-2xl transition-all duration-300">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <motion.div

--- a/components/owner/dashboard/profile-completion-card.tsx
+++ b/components/owner/dashboard/profile-completion-card.tsx
@@ -268,7 +268,7 @@ function CircularProgress({ percentage, size = 100, className }: CircularProgres
           stroke="currentColor"
           strokeWidth={strokeWidth}
           fill="none"
-          className="text-slate-100"
+          className="text-muted"
         />
         {/* Cercle de progression avec gradient */}
         <motion.circle
@@ -329,7 +329,7 @@ function TaskItem({ task, index }: { task: CompletionTask; index: number }) {
           "flex items-center gap-2.5 xs:gap-3 sm:gap-4 p-2.5 xs:p-3 sm:p-4 rounded-lg xs:rounded-xl border transition-all duration-300 touch-target",
           task.completed
             ? "bg-green-50/50 border-green-200"
-            : "bg-white hover:bg-slate-50 border-slate-200 hover:border-blue-300 active:bg-slate-100 hover:shadow-md"
+            : "bg-card hover:bg-muted border-border hover:border-blue-300 active:bg-muted hover:shadow-md"
         )}
       >
         {/* Icône - Taille adaptative */}
@@ -353,7 +353,7 @@ function TaskItem({ task, index }: { task: CompletionTask; index: number }) {
           <div className="flex items-center gap-1 xs:gap-1.5 sm:gap-2">
             <h4 className={cn(
               "font-semibold text-[11px] xs:text-xs sm:text-sm truncate",
-              task.completed ? "text-green-700 line-through" : "text-slate-900"
+              task.completed ? "text-green-700 line-through" : "text-foreground"
             )}>
               {task.title}
             </h4>
@@ -373,7 +373,7 @@ function TaskItem({ task, index }: { task: CompletionTask; index: number }) {
 
         {/* Flèche */}
         {!task.completed && (
-          <ChevronRight className="w-4 h-4 xs:w-5 xs:h-5 text-slate-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all shrink-0" />
+          <ChevronRight className="w-4 h-4 xs:w-5 xs:h-5 text-muted-foreground group-hover:text-blue-500 group-hover:translate-x-1 transition-all shrink-0" />
         )}
       </Link>
     </motion.div>
@@ -477,7 +477,7 @@ export function ProfileCompletionCard({ data, className }: ProfileCompletionCard
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       className={cn(
-        "relative overflow-hidden rounded-2xl bg-white border border-slate-200 shadow-sm",
+        "relative overflow-hidden rounded-2xl bg-card border border-border shadow-sm",
         className
       )}
     >
@@ -485,7 +485,7 @@ export function ProfileCompletionCard({ data, className }: ProfileCompletionCard
       <div className="hidden xs:block absolute top-0 right-0 w-48 sm:w-64 h-48 sm:h-64 bg-gradient-to-br from-blue-100/50 via-purple-100/50 to-pink-100/50 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" />
 
       {/* Header - Toujours en ligne */}
-      <div className="relative p-3 xs:p-4 sm:p-6 pb-3 sm:pb-4 border-b border-slate-100">
+      <div className="relative p-3 xs:p-4 sm:p-6 pb-3 sm:pb-4 border-b border-border">
         <div className="flex flex-row items-center gap-3 xs:gap-4 sm:gap-6">
           {/* Cercle de progression - Taille adaptative */}
           <CircularProgress 
@@ -496,7 +496,7 @@ export function ProfileCompletionCard({ data, className }: ProfileCompletionCard
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 xs:gap-2 mb-1">
               <Sparkles className="w-4 h-4 xs:w-5 xs:h-5 text-amber-500 shrink-0" />
-              <h3 className="text-sm xs:text-base sm:text-lg font-bold text-slate-900 truncate">
+              <h3 className="text-sm xs:text-base sm:text-lg font-bold text-foreground truncate">
                 {message.title}
               </h3>
             </div>
@@ -505,7 +505,7 @@ export function ProfileCompletionCard({ data, className }: ProfileCompletionCard
             </p>
             <div className="flex items-center gap-2 xs:gap-3">
               <Progress value={percentage} className="h-1.5 xs:h-2 flex-1" />
-              <span className="text-[10px] xs:text-xs sm:text-sm font-medium text-slate-600 shrink-0">
+              <span className="text-[10px] xs:text-xs sm:text-sm font-medium text-muted-foreground shrink-0">
                 {completedCount}/{totalCount}
               </span>
             </div>
@@ -520,7 +520,7 @@ export function ProfileCompletionCard({ data, className }: ProfileCompletionCard
           <div className="space-y-1.5 xs:space-y-2">
             <div className="flex items-center gap-1.5 xs:gap-2 px-1 xs:px-2 mb-2 xs:mb-3">
               <Zap className="w-3.5 h-3.5 xs:w-4 xs:h-4 text-amber-500" />
-              <span className="text-[10px] xs:text-xs font-semibold text-slate-500 uppercase tracking-wider">
+              <span className="text-[10px] xs:text-xs font-semibold text-muted-foreground uppercase tracking-wider">
                 Actions recommandées
               </span>
             </div>
@@ -550,7 +550,7 @@ export function ProfileCompletionCard({ data, className }: ProfileCompletionCard
         {/* Tâches complétées (collapsées) */}
         {completedTasks.length > 0 && (
           <details className="group">
-            <summary className="flex items-center gap-1.5 xs:gap-2 px-1 xs:px-2 py-1.5 xs:py-2 cursor-pointer text-[10px] xs:text-xs font-semibold text-slate-400 uppercase tracking-wider hover:text-slate-600 transition-colors touch-target">
+            <summary className="flex items-center gap-1.5 xs:gap-2 px-1 xs:px-2 py-1.5 xs:py-2 cursor-pointer text-[10px] xs:text-xs font-semibold text-muted-foreground uppercase tracking-wider hover:text-foreground transition-colors touch-target">
               <CheckCircle2 className="w-3.5 h-3.5 xs:w-4 xs:h-4 text-green-500" />
               <span>{completedTasks.length} tâche{completedTasks.length > 1 ? "s" : ""} complétée{completedTasks.length > 1 ? "s" : ""}</span>
               <ChevronRight className="w-3.5 h-3.5 xs:w-4 xs:h-4 ml-auto group-open:rotate-90 transition-transform" />
@@ -565,9 +565,9 @@ export function ProfileCompletionCard({ data, className }: ProfileCompletionCard
       </div>
 
       {/* Footer motivant - Toujours en ligne */}
-      <div className="relative px-3 xs:px-4 sm:px-6 py-2.5 xs:py-3 sm:py-4 bg-gradient-to-r from-slate-50 to-blue-50/50 border-t border-slate-100">
+      <div className="relative px-3 xs:px-4 sm:px-6 py-2.5 xs:py-3 sm:py-4 bg-gradient-to-r from-muted to-blue-50/50 border-t border-border">
         <div className="flex flex-row items-center justify-between gap-2 xs:gap-3">
-          <div className="flex items-center gap-1.5 xs:gap-2 text-[10px] xs:text-xs sm:text-sm text-slate-600 min-w-0">
+          <div className="flex items-center gap-1.5 xs:gap-2 text-[10px] xs:text-xs sm:text-sm text-muted-foreground min-w-0">
             <Rocket className="w-3 h-3 xs:w-3.5 xs:h-3.5 sm:w-4 sm:h-4 text-blue-500 shrink-0" />
             <span className="truncate">
               <strong className="text-blue-600">{100 - percentage}%</strong> <span className="hidden xs:inline">pour débloquer tout</span>

--- a/components/owner/dashboard/realtime-revenue-widget.tsx
+++ b/components/owner/dashboard/realtime-revenue-widget.tsx
@@ -82,8 +82,8 @@ export function RealtimeRevenueWidget() {
           <Euro className="h-6 w-6 text-emerald-600" />
         </div>
         <div>
-          <h3 className="font-semibold text-slate-800">Revenus du mois</h3>
-          <p className="text-xs text-slate-500">
+          <h3 className="font-semibold text-foreground">Revenus du mois</h3>
+          <p className="text-xs text-muted-foreground">
             Mise à jour en temps réel
           </p>
         </div>
@@ -96,12 +96,12 @@ export function RealtimeRevenueWidget() {
           initial={{ scale: 1 }}
           animate={{ scale: [1, 1.02, 1] }}
           transition={{ duration: 0.3 }}
-          className="text-4xl font-bold text-slate-900"
+          className="text-4xl font-bold text-foreground"
         >
           <AnimatedCounter value={totalRevenue} type="currency" />
         </motion.div>
         {lastUpdate && (
-          <p className="text-xs text-slate-400 mt-1 flex items-center gap-1">
+          <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
             <Activity className="h-3 w-3" />
             Mis à jour {formatDistanceToNow(lastUpdate, { addSuffix: true, locale: fr })}
           </p>
@@ -133,9 +133,9 @@ export function RealtimeRevenueWidget() {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
-            className="border-t border-slate-100 pt-4"
+            className="border-t border-border pt-4"
           >
-            <h4 className="text-xs font-medium text-slate-500 mb-2 flex items-center gap-1">
+            <h4 className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1">
               <Zap className="h-3 w-3" />
               Activité récente
             </h4>
@@ -160,8 +160,8 @@ export function RealtimeRevenueWidget() {
                     {event.type === "signature" && <CheckCircle2 className="h-3 w-3" />}
                     {event.type === "ticket" && <AlertTriangle className="h-3 w-3" />}
                   </div>
-                  <span className="text-slate-700 truncate flex-1">{event.title}</span>
-                  <span className="text-xs text-slate-400">
+                  <span className="text-foreground truncate flex-1">{event.title}</span>
+                  <span className="text-xs text-muted-foreground">
                     {formatDistanceToNow(event.timestamp, { addSuffix: true, locale: fr })}
                   </span>
                 </motion.div>
@@ -193,7 +193,7 @@ export function RealtimeStatusIndicator({ isConnected = false, loading = false }
           isConnected ? "bg-emerald-500 animate-pulse" : "bg-red-500"
         )}
       />
-      <span className="text-xs text-slate-500">
+      <span className="text-xs text-muted-foreground">
         {isConnected ? "Temps réel" : "Déconnecté"}
       </span>
     </div>

--- a/components/owner/dashboard/recent-activity.tsx
+++ b/components/owner/dashboard/recent-activity.tsx
@@ -42,7 +42,7 @@ const activityConfig = {
 export function OwnerRecentActivity({ activities }: OwnerRecentActivityProps) {
   if (!activities || activities.length === 0) {
     return (
-      <Card className="border-0 shadow-sm bg-white/60 backdrop-blur-sm">
+      <Card className="border-0 shadow-sm bg-card/60 backdrop-blur-sm">
         <CardHeader>
           <CardTitle className="text-lg font-semibold">Activité récente</CardTitle>
         </CardHeader>
@@ -56,7 +56,7 @@ export function OwnerRecentActivity({ activities }: OwnerRecentActivityProps) {
   }
 
   return (
-    <Card className="border-0 shadow-sm bg-white/60 backdrop-blur-sm">
+    <Card className="border-0 shadow-sm bg-card/60 backdrop-blur-sm">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle className="text-lg font-semibold">Activité récente</CardTitle>
         <Badge variant="outline" className="font-normal text-xs">
@@ -79,13 +79,13 @@ export function OwnerRecentActivity({ activities }: OwnerRecentActivityProps) {
                 initial={{ opacity: 0, x: -10 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ delay: index * 0.05 }}
-                className="group flex items-start gap-4 p-2 rounded-lg hover:bg-slate-50 transition-colors"
+                className="group flex items-start gap-4 p-2 rounded-lg hover:bg-muted transition-colors"
               >
                 <div className={`p-2 rounded-full ${config.bgColor}`}>
                   <Icon className={`h-4 w-4 ${config.color}`} />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-slate-900 group-hover:text-blue-600 transition-colors truncate">
+                  <p className="text-sm font-medium text-foreground group-hover:text-blue-600 transition-colors truncate">
                     {activity.title}
                   </p>
                   <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
@@ -93,7 +93,7 @@ export function OwnerRecentActivity({ activities }: OwnerRecentActivityProps) {
                     {timeAgo}
                   </p>
                 </div>
-                <ChevronRight className="h-4 w-4 text-slate-300 group-hover:text-slate-400 transition-colors mt-1" />
+                <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors mt-1" />
               </motion.div>
             );
           })}

--- a/components/owner/dashboard/signature-alert-banner.tsx
+++ b/components/owner/dashboard/signature-alert-banner.tsx
@@ -106,17 +106,17 @@ export function SignatureAlertBanner({ className, dismissible = true }: Signatur
                 <Link
                   key={sig.id}
                   href={`/owner/leases/${sig.lease_id}`}
-                  className="group flex items-center justify-between p-3 bg-white/80 backdrop-blur rounded-xl border border-orange-100 hover:border-orange-300 hover:shadow-md transition-all duration-200"
+                  className="group flex items-center justify-between p-3 bg-card/80 backdrop-blur rounded-xl border border-orange-100 hover:border-orange-300 hover:shadow-md transition-all duration-200"
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <div className="p-2 bg-orange-100 rounded-lg group-hover:bg-orange-200 transition-colors">
                       <PenLine className="h-4 w-4 text-orange-600" />
                     </div>
                     <div className="min-w-0">
-                      <p className="font-medium text-slate-900 truncate">
+                      <p className="font-medium text-foreground truncate">
                         {sig.property.adresse || "Adresse non renseignée"}
                       </p>
-                      <p className="text-xs text-slate-500">
+                      <p className="text-xs text-muted-foreground">
                         {sig.lease.loyer ? `${formatCurrency(sig.lease.loyer)}/mois` : "Loyer non renseigné"}
                       </p>
                     </div>
@@ -125,7 +125,7 @@ export function SignatureAlertBanner({ className, dismissible = true }: Signatur
                     <span className="text-xs font-medium text-orange-600 bg-orange-100 px-2 py-1 rounded-full">
                       À signer
                     </span>
-                    <ChevronRight className="h-4 w-4 text-slate-400 group-hover:text-orange-600 group-hover:translate-x-1 transition-all" />
+                    <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-orange-600 group-hover:translate-x-1 transition-all" />
                   </div>
                 </Link>
               ))}

--- a/components/owner/dashboard/smart-alerts-widget.tsx
+++ b/components/owner/dashboard/smart-alerts-widget.tsx
@@ -143,10 +143,10 @@ function AlertItem({
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-2">
             <div>
-              <p className="font-semibold text-sm text-slate-900">
+              <p className="font-semibold text-sm text-foreground">
                 {alert.title}
               </p>
-              <p className="text-sm text-slate-600 mt-0.5">
+              <p className="text-sm text-muted-foreground mt-0.5">
                 {alert.message}
               </p>
             </div>
@@ -220,7 +220,7 @@ export function SmartAlertsWidget({ alerts, onDismiss, className }: SmartAlertsW
             <div className="p-4 rounded-full bg-emerald-100 mb-3">
               <CheckCircle2 className="h-10 w-10 text-emerald-600" />
             </div>
-            <p className="text-slate-600 font-medium">Aucune alerte</p>
+            <p className="text-muted-foreground font-medium">Aucune alerte</p>
             <p className="text-sm text-muted-foreground mt-1">
               Votre gestion locative est à jour
             </p>

--- a/components/owner/dashboard/urgent-actions-section.tsx
+++ b/components/owner/dashboard/urgent-actions-section.tsx
@@ -126,7 +126,7 @@ function UrgentActionCard({ action, index }: { action: UrgentAction; index: numb
               {/* Contenu */}
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
-                  <h4 className="font-semibold text-slate-900 truncate">
+                  <h4 className="font-semibold text-foreground truncate">
                     {action.title}
                   </h4>
                   {action.priority === "critical" && (
@@ -136,7 +136,7 @@ function UrgentActionCard({ action, index }: { action: UrgentAction; index: numb
                     </Badge>
                   )}
                 </div>
-                <p className="text-sm text-slate-500 line-clamp-1">
+                <p className="text-sm text-muted-foreground line-clamp-1">
                   {action.description}
                 </p>
                 
@@ -152,7 +152,7 @@ function UrgentActionCard({ action, index }: { action: UrgentAction; index: numb
                       <span className={cn(
                         "font-medium",
                         action.metadata.daysLeft <= 7 ? "text-red-600" :
-                        action.metadata.daysLeft <= 30 ? "text-amber-600" : "text-slate-500"
+                        action.metadata.daysLeft <= 30 ? "text-amber-600" : "text-muted-foreground"
                       )}>
                         <Clock className="h-3 w-3 inline mr-1" />
                         {action.metadata.daysLeft}j restants
@@ -226,7 +226,7 @@ export function UrgentActionsSection({ actions }: UrgentActionsSectionProps) {
       {/* Header avec compteurs */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <h2 className="text-xl font-semibold text-slate-800 flex items-center gap-2">
+          <h2 className="text-xl font-semibold text-foreground flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-600" />
             Actions urgentes
           </h2>
@@ -243,7 +243,7 @@ export function UrgentActionsSection({ actions }: UrgentActionsSectionProps) {
             )}
           </div>
         </div>
-        <span className="text-sm text-slate-500">
+        <span className="text-sm text-muted-foreground">
           {actions.length} action{actions.length > 1 ? "s" : ""} en attente
         </span>
       </div>

--- a/components/owner/leases/LeaseProgressTracker.tsx
+++ b/components/owner/leases/LeaseProgressTracker.tsx
@@ -113,12 +113,12 @@ export function LeaseProgressTracker({
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
               <Sparkles className="h-4 w-4 text-amber-500" />
-              <span className="text-sm font-semibold text-slate-700">
+              <span className="text-sm font-semibold text-foreground">
                 Progression du bail
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="h-2 w-24 bg-slate-100 rounded-full overflow-hidden">
+              <div className="h-2 w-24 bg-muted rounded-full overflow-hidden">
                 <motion.div 
                   initial={{ width: 0 }}
                   animate={{ width: `${progressPercent}%` }}
@@ -142,7 +142,7 @@ export function LeaseProgressTracker({
         {/* Steps */}
         <div className="relative flex justify-between items-start">
           {/* Ligne de fond */}
-          <div className="absolute top-5 left-[10%] right-[10%] h-1 bg-slate-100 rounded-full -z-10" />
+          <div className="absolute top-5 left-[10%] right-[10%] h-1 bg-muted rounded-full -z-10" />
           
           {/* Ligne de progression active */}
           <motion.div 
@@ -203,7 +203,7 @@ export function LeaseProgressTracker({
                         }}
                         className={cn(
                           "w-10 h-10 rounded-full flex items-center justify-center transition-all relative z-10",
-                          step.isDone || step.isInProgress ? "text-white" : "text-slate-400"
+                          step.isDone || step.isInProgress ? "text-white" : "text-muted-foreground"
                         )}
                       >
                         <AnimatePresence mode="wait">
@@ -244,14 +244,14 @@ export function LeaseProgressTracker({
                     <div className="mt-3 text-center px-1">
                       <p className={cn(
                         "text-xs font-bold uppercase tracking-tight transition-colors",
-                        step.isDone ? "text-emerald-600" : step.isInProgress ? "text-blue-600" : "text-slate-400"
+                        step.isDone ? "text-emerald-600" : step.isInProgress ? "text-blue-600" : "text-muted-foreground"
                       )}>
                         {step.label}
                       </p>
                       {!compact && (
                         <p className={cn(
                           "text-[10px] font-medium mt-0.5 leading-tight hidden sm:block transition-colors",
-                          step.isDone ? "text-emerald-500" : step.isInProgress ? "text-blue-500" : "text-slate-400"
+                          step.isDone ? "text-emerald-500" : step.isInProgress ? "text-blue-500" : "text-muted-foreground"
                         )}>
                           {step.description}
                         </p>
@@ -289,7 +289,7 @@ export function LeaseProgressTracker({
                 </span>
               </div>
             ) : (
-              <div className="bg-slate-50 rounded-lg border border-slate-100 p-3">
+              <div className="bg-muted rounded-lg border border-border p-3">
                 <div className="flex items-start gap-3">
                   {/* Étape en cours */}
                   {(() => {
@@ -305,22 +305,22 @@ export function LeaseProgressTracker({
                           <CurrentIcon className="h-3.5 w-3.5 text-blue-600" />
                         </div>
                         <div className="flex-1 min-w-0">
-                          <p className="text-xs font-bold text-slate-800">
+                          <p className="text-xs font-bold text-foreground">
                             En cours : {currentStep.label}
                           </p>
-                          <p className="text-[11px] text-slate-600 mt-0.5">
+                          <p className="text-[11px] text-muted-foreground mt-0.5">
                             {currentStep.detailInProgress}
                           </p>
                           {nextPendingStep && (
-                            <p className="text-[10px] text-slate-400 mt-1.5 flex items-center gap-1">
+                            <p className="text-[10px] text-muted-foreground mt-1.5 flex items-center gap-1">
                               <span>Ensuite :</span>
-                              <span className="font-medium text-slate-500">{nextPendingStep.label}</span>
+                              <span className="font-medium text-muted-foreground">{nextPendingStep.label}</span>
                               <span>— {nextPendingStep.detailPending}</span>
                             </p>
                           )}
                         </div>
                         <div className="text-right flex-shrink-0">
-                          <span className="text-[10px] font-medium text-slate-400">
+                          <span className="text-[10px] font-medium text-muted-foreground">
                             {completedSteps}/{steps.length} terminées
                           </span>
                         </div>

--- a/components/owner/leases/LeaseTimeline.tsx
+++ b/components/owner/leases/LeaseTimeline.tsx
@@ -247,8 +247,8 @@ export function LeaseTimeline({ lease, signers, edl, payments }: LeaseTimelinePr
   const previewEvents = isExpanded ? allEvents : [lastCompleted, ...futureSteps.slice(0, 1)].filter(Boolean);
 
   return (
-    <Card className="border-none shadow-sm bg-white overflow-hidden">
-      <CardHeader className="pb-2 border-b border-slate-50">
+    <Card className="border-none shadow-sm bg-card overflow-hidden">
+      <CardHeader className="pb-2 border-b border-border">
         <button
           onClick={() => setIsExpanded(!isExpanded)}
           className="w-full flex items-center justify-between group"
@@ -283,34 +283,34 @@ export function LeaseTimeline({ lease, signers, edl, payments }: LeaseTimelinePr
                 {!isLast && (
                   <div className={cn(
                     "absolute left-[11px] top-6 bottom-0 w-0.5",
-                    event.completed ? colors.line : "bg-slate-100"
+                    event.completed ? colors.line : "bg-muted"
                   )} />
                 )}
                 {/* Point/Icône */}
                 <div className={cn(
                   "relative z-10 flex-shrink-0 h-6 w-6 rounded-full flex items-center justify-center",
-                  event.completed ? colors.dot : "bg-slate-100 border-2 border-dashed border-slate-300"
+                  event.completed ? colors.dot : "bg-muted border-2 border-dashed border-border"
                 )}>
-                  <Icon className={cn("h-3 w-3", event.completed ? "text-white" : "text-slate-400")} />
+                  <Icon className={cn("h-3 w-3", event.completed ? "text-white" : "text-muted-foreground")} />
                 </div>
                 {/* Contenu */}
                 <div className="flex-1 min-w-0 pt-0.5">
                   <p className={cn(
                     "text-xs font-semibold leading-tight",
-                    event.completed ? "text-slate-800" : "text-slate-400"
+                    event.completed ? "text-foreground" : "text-muted-foreground"
                   )}>
                     {event.label}
                   </p>
                   {event.description && (
                     <p className={cn(
                       "text-[10px] mt-0.5",
-                      event.completed ? "text-slate-500" : "text-slate-400"
+                      event.completed ? "text-muted-foreground" : "text-muted-foreground"
                     )}>
                       {event.description}
                     </p>
                   )}
                   {event.completed && (
-                    <p className="text-[10px] text-slate-400 mt-0.5">
+                    <p className="text-[10px] text-muted-foreground mt-0.5">
                       {event.date.toLocaleDateString("fr-FR", { day: "numeric", month: "short", year: "numeric" })}
                     </p>
                   )}
@@ -323,7 +323,7 @@ export function LeaseTimeline({ lease, signers, edl, payments }: LeaseTimelinePr
         {!isExpanded && allEvents.length > 2 && (
           <button
             onClick={() => setIsExpanded(true)}
-            className="w-full text-center pt-2 mt-2 border-t border-slate-50 text-[10px] text-blue-600 hover:text-blue-700 font-medium"
+            className="w-full text-center pt-2 mt-2 border-t border-border text-[10px] text-blue-600 hover:text-blue-700 font-medium"
           >
             Voir tout l&apos;historique ({allEvents.length} étapes)
           </button>

--- a/components/owner/properties/OwnerPropertyPhotosEnhanced.tsx
+++ b/components/owner/properties/OwnerPropertyPhotosEnhanced.tsx
@@ -100,7 +100,7 @@ export function OwnerPropertyPhotosEnhanced({
 
   if (!photos || photos.length === 0) {
     return (
-      <Card className="backdrop-blur-xl bg-white/80 dark:bg-slate-900/80 border border-white/20 dark:border-slate-700/50 shadow-xl">
+      <Card className="backdrop-blur-xl bg-card/80 border border-border shadow-xl">
         <CardContent className="py-12 text-center">
           <motion.div
             initial={{ opacity: 0, scale: 0.9 }}
@@ -136,7 +136,7 @@ export function OwnerPropertyPhotosEnhanced({
 
   return (
     <>
-      <Card className="backdrop-blur-xl bg-white/80 dark:bg-slate-900/80 border border-white/20 dark:border-slate-700/50 shadow-xl overflow-hidden">
+      <Card className="backdrop-blur-xl bg-card/80 border border-border shadow-xl overflow-hidden">
         <CardContent className="p-0">
           {/* Photo principale avec animation */}
           <motion.div
@@ -191,7 +191,7 @@ export function OwnerPropertyPhotosEnhanced({
                 <Button
                   variant="secondary"
                   size="sm"
-                  className="shadow-lg backdrop-blur-sm bg-white/90"
+                  className="shadow-lg backdrop-blur-sm bg-card/90"
                   onClick={() => openLightbox(0)}
                 >
                   <ZoomIn className="mr-2 h-4 w-4" />

--- a/components/owner/properties/PropertyHero.tsx
+++ b/components/owner/properties/PropertyHero.tsx
@@ -57,12 +57,12 @@ export function PropertyHero({ property, activeLease, onDelete, photos = [], pro
   if (photos.length === 0) {
     return (
       <div className="relative w-full max-w-7xl mx-auto mb-8">
-        <div className="h-[300px] md:h-[400px] rounded-2xl overflow-hidden bg-slate-50 border-2 border-dashed border-slate-300 flex flex-col items-center justify-center text-slate-500 gap-4 shadow-inner">
-          <div className="p-4 bg-white rounded-full shadow-sm">
-            <ImageIcon className="w-10 h-10 text-slate-400" />
+        <div className="h-[300px] md:h-[400px] rounded-2xl overflow-hidden bg-muted border-2 border-dashed border-border flex flex-col items-center justify-center text-muted-foreground gap-4 shadow-inner">
+          <div className="p-4 bg-card rounded-full shadow-sm">
+            <ImageIcon className="w-10 h-10 text-muted-foreground" />
           </div>
           <div className="text-center">
-            <h3 className="text-lg font-semibold text-slate-700">Aucune photo pour le moment</h3>
+            <h3 className="text-lg font-semibold text-foreground">Aucune photo pour le moment</h3>
             <p className="text-sm text-muted-foreground mb-4">Ajoutez des photos pour mettre en valeur votre bien</p>
             {propertyId && (
               <Button 
@@ -133,7 +133,7 @@ export function PropertyHero({ property, activeLease, onDelete, photos = [], pro
       </Dialog>
 
       {/* Layout Photos Responsive */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 h-[300px] md:h-[500px] rounded-2xl overflow-hidden shadow-2xl bg-slate-100">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 h-[300px] md:h-[500px] rounded-2xl overflow-hidden shadow-2xl bg-muted">
         {/* Grande photo principale (Mobile: Full width, Desktop: 3/4) */}
         <motion.div 
           initial={{ opacity: 0, x: -20 }}
@@ -249,21 +249,21 @@ export function PropertyHero({ property, activeLease, onDelete, photos = [], pro
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ delay: 0.5 }}
-            className="flex-1 bg-white/80 backdrop-blur-lg border border-white/20 p-6 rounded-xl flex flex-col justify-center items-center shadow-sm hover:shadow-md transition-all"
+            className="flex-1 bg-card/80 backdrop-blur-lg border border-border p-6 rounded-xl flex flex-col justify-center items-center shadow-sm hover:shadow-md transition-all"
           >
             <div className="text-center w-full">
-              <p className="text-xs text-slate-500 font-medium uppercase tracking-wider mb-1">Loyer estimé</p>
+              <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider mb-1">Loyer estimé</p>
               
               <div className="flex justify-center">
                 <EditableText
                     value={property.loyer_hc}
                     type="currency"
                     onSave={(val) => handleUpdateField("loyer_hc", parseFloat(val))}
-                    className="text-2xl font-bold text-slate-900 tracking-tight hover:bg-slate-100 rounded px-2 -mx-2"
+                    className="text-2xl font-bold text-foreground tracking-tight hover:bg-muted rounded px-2 -mx-2"
                     inputClassName="text-center font-bold text-lg h-10"
                 />
               </div>
-              <span className="text-xs text-slate-400 font-normal block -mt-1 mb-1">/mois (HC)</span>
+              <span className="text-xs text-muted-foreground font-normal block -mt-1 mb-1">/mois (HC)</span>
 
               {((property as any).charges_mensuelles || 0) > 0 && (
                  <div className="flex justify-center items-center gap-1 mt-1">
@@ -272,7 +272,7 @@ export function PropertyHero({ property, activeLease, onDelete, photos = [], pro
                         value={(property as any).charges_mensuelles}
                         type="currency"
                         onSave={(val) => handleUpdateField("charges_mensuelles", parseFloat(val))}
-                        className="text-[10px] text-muted-foreground hover:bg-slate-100 px-1 rounded"
+                        className="text-[10px] text-muted-foreground hover:bg-muted px-1 rounded"
                         inputClassName="h-6 w-20 text-xs"
                     />
                      <span className="text-[10px] text-muted-foreground">charges</span>

--- a/components/owner/properties/PropertyMetersSection.tsx
+++ b/components/owner/properties/PropertyMetersSection.tsx
@@ -350,7 +350,7 @@ export function PropertyMetersSection({ propertyId, className }: PropertyMetersS
                   key={meter.id}
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
-                  className="flex items-center justify-between p-4 rounded-lg border bg-white dark:bg-slate-800"
+                  className="flex items-center justify-between p-4 rounded-lg border bg-card"
                 >
                   <div className="flex items-center gap-4">
                     <div className={cn("p-3 rounded-xl", config.bgColor)}>


### PR DESCRIPTION
- Owner layout: bg-gradient from-slate-50 → bg-background (root cause of grey background)
- bg-white → bg-card across 71 files (376+ occurrences)
- bg-slate-50/gray-50/slate-100 → bg-muted
- border-slate-200/gray-200 → border-border
- text-slate-*/gray-* → text-foreground/text-muted-foreground
- Removed redundant dark: overrides now handled by CSS variables
- Preserved bg-white on document preview containers (lease, EDL)
- Owner dark mode now consistent with tenant dark mode (#0F172A background)