### PR TITLE
fix: add missing deleted_at filter in GET /api/properties

### DIFF
--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -140,12 +140,14 @@ export async function GET(request: Request) {
         baseQuery = dbClient
           .from("properties")
           .select(essentialColumns, { count: "exact" })
+          .is("deleted_at", null)
           .order("created_at", { ascending: false });
       } else {
         baseQuery = dbClient
           .from("properties")
           .select(essentialColumns, { count: "exact" })
           .eq("owner_id", profile.id)
+          .is("deleted_at", null)
           .order("created_at", { ascending: false });
       }
 


### PR DESCRIPTION
## Summary

- **Diagnostic**: Verified `owner_id` data integrity — all properties correctly reference `profiles.id` (not `auth.users.id`). No mismatch found.
- **Bug found**: `GET /api/properties` was missing `.is("deleted_at", null)` filter, potentially returning soft-deleted properties in the list. The `/api/owner/properties` endpoint already had this filter.
- **Fix**: Added `deleted_at IS NULL` filter to both admin and owner query paths in `/api/properties/route.ts`.

## Diagnostic Results

| Check | Status |
|---|---|
| `owner_id` = `profiles.id` | OK |
| RLS policies use `user_profile_id()` | OK |
| `user_profile_id()` is SECURITY DEFINER | OK |
| `/api/owner/properties` has `deleted_at` filter | OK |
| `/api/properties` has `deleted_at` filter | **Fixed** |

## Test plan

- [ ] Verify `GET /api/properties` no longer returns soft-deleted properties
- [ ] Verify admin view also excludes soft-deleted properties
- [ ] Confirm properties list loads correctly for owners

https://claude.ai/code/session_019RgU941VCgfSsMMr9aKVf4