### PR TITLE
fix: properties list empty when entity filter persisted in localStorage

### DIFF
--- a/app/owner/properties/page.tsx
+++ b/app/owner/properties/page.tsx
@@ -721,10 +721,17 @@ export default function OwnerPropertiesPage() {
                   exit={{ opacity: 0, scale: 0.9 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <EmptyState 
-                    title="Aucun bien"
-                    description="Aucun bien ne correspond à vos critères de recherche."
-                  />
+                  {entityFilterId === "personal" && properties.length === 0 ? (
+                    <EmptyState
+                      title="Aucun bien en nom propre"
+                      description="Vos biens sont associés à une entité juridique. Sélectionnez une entité dans le menu ou choisissez « Tous mes biens » pour les voir."
+                    />
+                  ) : (
+                    <EmptyState
+                      title="Aucun bien"
+                      description="Aucun bien ne correspond à vos critères de recherche."
+                    />
+                  )}
                 </motion.div>
               ) : !isLoading ? (
                 viewMode === "grid" ? (

--- a/components/entities/CompanySwitcher.tsx
+++ b/components/entities/CompanySwitcher.tsx
@@ -119,12 +119,12 @@ export function CompanySwitcher({ variant = "sidebar" }: CompanySwitcherProps) {
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium truncate">
-              {activeEntity?.nom || "Toutes les entités"}
+              {activeEntity?.nom || "Tous mes biens"}
             </p>
             <p className="text-xs text-muted-foreground">
               {activeEntity
                 ? getEntityTypeLabel(activeEntity.entityType)
-                : `${entities.length} entité${entities.length > 1 ? "s" : ""}`}
+                : `${entities.length} entité${entities.length > 1 ? "s" : ""} · vue globale`}
             </p>
           </div>
           <ArrowUpDown className="h-4 w-4 text-muted-foreground shrink-0" />
@@ -185,9 +185,9 @@ function EntityList({
       >
         <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
         <div className="flex-1 text-left min-w-0">
-          <p className="font-medium truncate">Toutes les entités</p>
+          <p className="font-medium truncate">Tous mes biens</p>
           <p className="text-xs text-muted-foreground">
-            {totalProperties} bien{totalProperties > 1 ? "s" : ""}
+            {totalProperties} bien{totalProperties > 1 ? "s" : ""} · vue globale
           </p>
         </div>
         {activeEntityId === null && (

--- a/stores/useEntityStore.ts
+++ b/stores/useEntityStore.ts
@@ -127,8 +127,15 @@ export const useEntityStore = create<EntityState>()(
             entitySummaries[0].isDefault = true;
           }
 
+          // Valider que l'entité persistée (localStorage) existe toujours
+          const { activeEntityId } = get();
+          const resetEntity =
+            activeEntityId !== null &&
+            !entitySummaries.some((e) => e.id === activeEntityId);
+
           set({
             entities: entitySummaries,
+            activeEntityId: resetEntity ? null : activeEntityId,
             isLoading: false,
             lastFetchedAt: Date.now(),
           });


### PR DESCRIPTION
- Validate persisted activeEntityId on store hydration; reset to null if the entity no longer exists in the fetched list
- Rename entity switcher label to "Tous mes biens" with "vue globale" hint for clearer UX
- Add explanatory empty state when personal filter returns no results but user has properties under a legal entity

Root cause: localStorage persisted an activeEntityId that triggered the "personal" filter (.is("legal_entity_id", null)), hiding all properties belonging to a legal entity (SCI, etc.).