### PR TITLE
fix: prevent duplicate pending payments on same invoice

### DIFF
--- a/app/api/payments/create-intent/route.ts
+++ b/app/api/payments/create-intent/route.ts
@@ -138,11 +138,8 @@ export async function POST(request: NextRequest) {
         }
       | null;
 
-    if (
-      typedPendingPayment?.id &&
-      typedPendingPayment.provider_ref &&
-      isRecentPendingPayment(typedPendingPayment.created_at)
-    ) {
+    // If a pending payment exists, always try to reuse it (regardless of age)
+    if (typedPendingPayment?.id && typedPendingPayment.provider_ref) {
       try {
         const existingIntent = await stripe.paymentIntents.retrieve(typedPendingPayment.provider_ref);
         const existingIntentStatus = existingIntent.status;
@@ -168,8 +165,25 @@ export async function POST(request: NextRequest) {
             reused: true,
           });
         }
+
+        // Intent exists but is no longer reusable (expired/cancelled) — cancel old payment
+        if (["canceled", "succeeded"].includes(existingIntentStatus)) {
+          await serviceClient
+            .from("payments")
+            .update({ statut: existingIntentStatus === "succeeded" ? "succeeded" : "failed" })
+            .eq("id", typedPendingPayment.id);
+        } else {
+          // Intent in unexpected state — block duplicate creation
+          throw new ApiError(409, "Un paiement est deja en cours pour cette facture");
+        }
       } catch (error) {
-        console.warn("[create-intent] Impossible de reutiliser le PaymentIntent existant:", error);
+        if (error instanceof ApiError) throw error;
+        // Stripe retrieval failed (invalid intent) — clean up stale payment
+        console.warn("[create-intent] PaymentIntent invalide, nettoyage du paiement stale:", error);
+        await serviceClient
+          .from("payments")
+          .update({ statut: "failed" })
+          .eq("id", typedPendingPayment.id);
       }
     }
 

--- a/supabase/migrations/20260324100000_prevent_duplicate_payments.sql
+++ b/supabase/migrations/20260324100000_prevent_duplicate_payments.sql
@@ -1,0 +1,15 @@
+-- ============================================
+-- Migration : Anti-doublon paiements
+-- Date : 2026-03-24
+-- Description :
+--   1. Contrainte UNIQUE partielle sur payments : un seul paiement pending par facture
+--   2. Empêche la race condition qui a causé le double paiement sur bail da2eb9da
+-- ============================================
+
+-- Un seul paiement 'pending' par facture à la fois
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_one_pending_per_invoice
+  ON payments (invoice_id)
+  WHERE statut = 'pending';
+
+COMMENT ON INDEX idx_payments_one_pending_per_invoice
+  IS 'Empêche plusieurs paiements pending simultanés sur la même facture (anti-doublon)';


### PR DESCRIPTION
A race condition in create-intent allowed a second pending payment to be created when the first one was older than 15 minutes. Remove the time-window gate so existing pending PaymentIntents are always reused or cleaned up. Add a UNIQUE partial index on payments(invoice_id) WHERE statut='pending' as a DB-level safety net.

Fixes double 55€ payment on lease da2eb9da.