### PR TITLE
fix: billing countdown showing '0 jour(s)' instead of readable date

### DIFF
--- a/app/owner/money/tabs/MonForfaitTab.tsx
+++ b/app/owner/money/tabs/MonForfaitTab.tsx
@@ -76,7 +76,7 @@ import { useToast } from "@/components/ui/use-toast";
 import type { SubscriptionInvoice } from "@/lib/subscriptions/types";
 import { PaymentMethod } from "@/components/billing/PaymentMethod";
 import { useOwnerCurrentPaymentMethod } from "@/lib/hooks/use-owner-payment-methods";
-import { isExpiringSoon } from "@/lib/billing-utils";
+import { isExpiringSoon, formatBillingCountdown } from "@/lib/billing-utils";
 import { useStripePortal } from "@/hooks/useStripePortal";
 
 // ── Constants ──
@@ -969,7 +969,7 @@ export function MonForfaitTab() {
                         : "-"}
                     </div>
                     {daysUntilRenewal !== null && daysUntilRenewal <= 7 && (
-                      <p className="text-xs text-amber-600 mt-1">Dans {daysUntilRenewal} jour(s)</p>
+                      <p className="text-xs text-amber-600 mt-1">{formatBillingCountdown(subscription.current_period_end)}</p>
                     )}
                   </div>
                   <div className="p-4 rounded-lg bg-muted/50 border">

--- a/components/billing/BillingCycle.tsx
+++ b/components/billing/BillingCycle.tsx
@@ -2,7 +2,7 @@
 
 import { Calendar, Clock, AlertCircle, Receipt } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { formatPrice, formatDateLong, daysUntil, computeYearlySavings } from "@/lib/billing-utils";
+import { formatPrice, formatDateLong, daysUntil, formatBillingCountdown, computeYearlySavings } from "@/lib/billing-utils";
 import type { BillingCycle as BillingCycleType, PlanDefinition } from "@/types/billing";
 import Link from "next/link";
 
@@ -65,19 +65,9 @@ export function BillingCycle({ cycle, periodEnd, plan, tvaTaux }: BillingCyclePr
         <p className={cn("text-sm font-medium", isOverdue ? "text-amber-400" : "text-white")}>
           {formatDateLong(periodEnd)}
         </p>
-        {isOverdue ? (
-          <p className="text-xs text-amber-400 mt-1">
-            Renouvellement en cours
-          </p>
-        ) : isUrgent ? (
-          <p className="text-xs text-red-400 mt-1">
-            Dans {daysLeft} jour{daysLeft > 1 ? "s" : ""}
-          </p>
-        ) : (
-          <p className="text-xs text-slate-400 mt-1">
-            Dans {daysLeft} jour{daysLeft > 1 ? "s" : ""}
-          </p>
-        )}
+        <p className={cn("text-xs mt-1", isOverdue ? "text-amber-400" : isUrgent ? "text-red-400" : "text-slate-400")}>
+          {formatBillingCountdown(periodEnd)}
+        </p>
       </div>
 
       {/* Monthly cost */}

--- a/lib/billing-utils.ts
+++ b/lib/billing-utils.ts
@@ -115,7 +115,35 @@ export function formatDateShort(date: string | Date): string {
 export function daysUntil(date: string | Date): number {
   const target = new Date(date);
   const now = new Date();
-  return Math.max(0, Math.ceil((target.getTime() - now.getTime()) / 86400000));
+  target.setHours(0, 0, 0, 0);
+  now.setHours(0, 0, 0, 0);
+  return Math.max(0, Math.round((target.getTime() - now.getTime()) / 86400000));
+}
+
+/**
+ * Formats a countdown to a billing date as a human-readable French string.
+ * Handles edge cases: expired, today, tomorrow, near future, and far future.
+ */
+export function formatBillingCountdown(date: string | Date | null | undefined): string {
+  if (!date) return "Date non disponible";
+
+  const target = new Date(date);
+  const now = new Date();
+  target.setHours(0, 0, 0, 0);
+  now.setHours(0, 0, 0, 0);
+
+  const diffDays = Math.round((target.getTime() - now.getTime()) / 86400000);
+
+  if (diffDays < 0) return "Renouvellement en cours";
+  if (diffDays === 0) return "Aujourd\u2019hui";
+  if (diffDays === 1) return "Demain";
+  if (diffDays <= 30) return `Dans ${diffDays} jour${diffDays > 1 ? "s" : ""}`;
+
+  return target.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
 }
 
 export function isExpiringSoon(expMonth: number, expYear: number, thresholdDays: number): boolean {


### PR DESCRIPTION
- Add formatBillingCountdown() utility with smart date formatting
- Handle edge cases: expired, today, tomorrow, near future, far future
- Normalize hours before day diff to avoid timezone rounding issues
- Replace raw day counter in MonForfaitTab and BillingCycle components
- Never shows '0 jour(s)' anymore