### PR TITLE
fix: resolve dead CTA routes and add PostHog tracking on landing page

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -12,6 +12,7 @@
  */
 
 import React, { useState, useEffect } from "react";
+import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/lib/hooks/use-auth";
@@ -893,11 +894,11 @@ export default function PricingPage() {
               à compter de la souscription.
             </p>
             <p>
-              <a href="/legal/cgv" className="underline hover:text-slate-300 transition-colors">Conditions Générales de Vente</a>
+              <Link href="/legal/cgv" className="underline hover:text-slate-300 transition-colors">Conditions Générales de Vente</Link>
               {" — "}
-              <a href="/legal/cgu" className="underline hover:text-slate-300 transition-colors">Conditions Générales d&apos;Utilisation</a>
+              <Link href="/legal/cgu" className="underline hover:text-slate-300 transition-colors">Conditions Générales d&apos;Utilisation</Link>
               {" — "}
-              <a href="/legal/privacy" className="underline hover:text-slate-300 transition-colors">Politique de confidentialité</a>
+              <Link href="/legal/privacy" className="underline hover:text-slate-300 transition-colors">Politique de confidentialité</Link>
             </p>
           </div>
         </div>

--- a/components/landing/FinalCtaSection.tsx
+++ b/components/landing/FinalCtaSection.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { fadeUp, stagger, ctaPulse, defaultViewport } from "@/lib/marketing/animations";
+import { track } from "@/lib/analytics/posthog";
 
 export function FinalCtaSection() {
   return (
@@ -41,14 +42,14 @@ export function FinalCtaSection() {
         <motion.div variants={fadeUp} className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
           <motion.div variants={ctaPulse} animate="animate">
             <Button size="lg" className="bg-white text-[#1E293B] hover:bg-white/90" asChild>
-              <Link href="/inscription">
+              <Link href="/signup/role" onClick={() => track("cta_final_signup_clicked", { source: "final_cta" })}>
                 Commencer gratuitement
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
           </motion.div>
           <Button size="lg" variant="outline" className="border-white/30 text-white hover:bg-white/10" asChild>
-            <Link href="/demo">Demander une démo</Link>
+            <Link href="/contact?subject=demo">Demander une démo</Link>
           </Button>
         </motion.div>
       </motion.div>

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { fadeUp, stagger, floatVariants, ctaPulse } from "@/lib/marketing/animations";
+import { track } from "@/lib/analytics/posthog";
 
 // ============================================
 // STATIC DATA — no useEffect, no fetch
@@ -54,14 +55,14 @@ export function HeroSection() {
             <motion.div variants={fadeUp} className="mt-8 flex flex-col gap-3 sm:flex-row">
               <motion.div variants={ctaPulse} animate="animate">
                 <Button size="lg" className="bg-[#2563EB] text-white hover:bg-[#1D4ED8]" asChild>
-                  <Link href="/inscription">
+                  <Link href="/signup/role" onClick={() => track("cta_hero_signup_clicked", { source: "hero" })}>
                     Commencer gratuitement
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </Link>
                 </Button>
               </motion.div>
               <Button size="lg" variant="outline" asChild>
-                <a href="#comment-ca-marche">Comment ça marche ?</a>
+                <a href="#comment-ca-marche" onClick={() => track("cta_hero_demo_clicked", { source: "hero" })}>Comment ça marche ?</a>
               </Button>
             </motion.div>
 

--- a/components/landing/PricingSection.tsx
+++ b/components/landing/PricingSection.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { fadeUp, stagger, ctaPulse, defaultViewport } from "@/lib/marketing/animations";
+import { track } from "@/lib/analytics/posthog";
 
 const PLANS = [
   {
@@ -22,7 +23,7 @@ const PLANS = [
       "Tableau de bord basique",
     ],
     cta: "Commencer gratuitement",
-    href: "/inscription",
+    href: "/signup/role",
     featured: false,
   },
   {
@@ -41,7 +42,7 @@ const PLANS = [
       "Support prioritaire",
     ],
     cta: "Essayer 14 jours gratuit",
-    href: "/inscription?plan=pro",
+    href: "/signup/role?plan=pro",
     featured: true,
   },
   {
@@ -139,7 +140,7 @@ export function PricingSection() {
                     className="w-full bg-[#2563EB] text-white hover:bg-[#1D4ED8]"
                     asChild
                   >
-                    <Link href={plan.href}>{plan.cta}</Link>
+                    <Link href={plan.href} onClick={() => track("cta_pricing_plan_clicked", { plan: plan.name.toLowerCase(), source: "landing_pricing" })}>{plan.cta}</Link>
                   </Button>
                 </motion.div>
               ) : (
@@ -148,7 +149,7 @@ export function PricingSection() {
                   variant="outline"
                   asChild
                 >
-                  <Link href={plan.href}>{plan.cta}</Link>
+                  <Link href={plan.href} onClick={() => track("cta_pricing_plan_clicked", { plan: plan.name.toLowerCase(), source: "landing_pricing" })}>{plan.cta}</Link>
                 </Button>
               )}
             </motion.div>

--- a/components/layout/public-footer.tsx
+++ b/components/layout/public-footer.tsx
@@ -90,7 +90,7 @@ export function PublicFooter({ variant = "dark", compact = false }: PublicFooter
 
             {/* Copyright */}
             <p className={`text-xs ${isDark ? "text-slate-500" : "text-slate-400"}`}>
-              2026 Talok. Tous droits reserves.
+              © {new Date().getFullYear()} Talok. Tous droits reserves.
             </p>
           </div>
         </div>
@@ -145,7 +145,7 @@ export function PublicFooter({ variant = "dark", compact = false }: PublicFooter
         {/* Bottom Bar */}
         <div className={`pt-8 border-t ${isDark ? "border-slate-800" : "border-slate-200"} flex flex-col md:flex-row items-center justify-between gap-4`}>
           <p className={`text-sm ${isDark ? "text-slate-500" : "text-slate-400"}`}>
-            2026 Talok. Tous droits reserves. Fait avec passion en France.
+            © {new Date().getFullYear()} Talok. Tous droits reserves. Fait avec passion en France.
           </p>
           <div className="flex items-center gap-4">
             <span className={`text-xs ${isDark ? "text-slate-600" : "text-slate-400"}`}>


### PR DESCRIPTION
- Replace all /inscription links (dead route) with /signup/role across Hero, Pricing, and FinalCta sections
- Redirect /demo CTA to /contact?subject=demo since no demo page exists
- Add PostHog event tracking on critical CTAs (hero, pricing, final CTA)
- Replace <a href> with Next.js <Link> for legal links on pricing page
- Make footer copyright year dynamic with Date().getFullYear()