### PR TITLE
feat: add editable landing images via admin interface

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,38 +1,10 @@
-"use client"
+import { getSiteConfigMap } from "@/lib/queries/site-config"
+import { LandingPageClient } from "@/components/marketing/LandingPageClient"
 
-import { ScrollProgressBar } from "@/components/marketing/ScrollProgressBar"
-import { MarketingNavbar } from "@/components/marketing/Navbar"
-import { HeroSection } from "@/components/marketing/sections/HeroSection"
-import { InnovationBar } from "@/components/marketing/sections/InnovationBar"
-import { ProblemSolution } from "@/components/marketing/sections/ProblemSolution"
-import { Arguments } from "@/components/marketing/sections/Arguments"
-import { Features } from "@/components/marketing/sections/Features"
-import { Testimonials } from "@/components/marketing/sections/Testimonials"
-import { PourQui } from "@/components/marketing/sections/PourQui"
-import { OutreMer } from "@/components/marketing/sections/OutreMer"
-import { Pricing } from "@/components/marketing/sections/Pricing"
-import { FAQ } from "@/components/marketing/sections/FAQ"
-import { FinalCTA, StickyMobileCTA } from "@/components/marketing/sections/FinalCTA"
+export const revalidate = 3600
 
-export default function LandingPage() {
-  return (
-    <>
-      <ScrollProgressBar />
-      <MarketingNavbar />
-      <div className="scroll-smooth">
-        <HeroSection />
-        <InnovationBar />
-        <ProblemSolution />
-        <Arguments />
-        <Features />
-        <Testimonials />
-        <PourQui />
-        <OutreMer />
-        <Pricing />
-        <FAQ />
-        <FinalCTA />
-      </div>
-      <StickyMobileCTA />
-    </>
-  )
+export default async function LandingPage() {
+  const images = await getSiteConfigMap()
+
+  return <LandingPageClient images={images} />
 }

--- a/app/admin/landing-images/LandingImagesClient.tsx
+++ b/app/admin/landing-images/LandingImagesClient.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/use-toast";
+import { Upload, Link as LinkIcon, Loader2 } from "lucide-react";
+
+interface SiteConfigEntry {
+  key: string;
+  value: string | null;
+  label: string | null;
+  section: string | null;
+  updated_at: string | null;
+}
+
+interface Props {
+  configs: SiteConfigEntry[];
+}
+
+function groupBySection(configs: SiteConfigEntry[]) {
+  const groups: Record<string, SiteConfigEntry[]> = {};
+  for (const c of configs) {
+    const section = c.section ?? "Autre";
+    if (!groups[section]) groups[section] = [];
+    groups[section].push(c);
+  }
+  return groups;
+}
+
+function ImageCard({ config, onUpdated }: { config: SiteConfigEntry; onUpdated: (key: string, value: string) => void }) {
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [savingUrl, setSavingUrl] = useState(false);
+  const [urlInput, setUrlInput] = useState("");
+  const [preview, setPreview] = useState(config.value ?? "");
+
+  async function handleFileUpload(file: File) {
+    if (!file.type.startsWith("image/")) {
+      toast({ title: "Erreur", description: "Seules les images sont acceptées", variant: "destructive" });
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast({ title: "Erreur", description: "Taille maximale : 5 Mo", variant: "destructive" });
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("key", config.key);
+
+      const res = await fetch("/api/admin/landing-images/upload", {
+        method: "POST",
+        body: formData,
+      });
+
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error);
+
+      setPreview(json.url);
+      onUpdated(config.key, json.url);
+      toast({ title: "Image mise à jour" });
+    } catch (err: any) {
+      toast({ title: "Erreur", description: err.message, variant: "destructive" });
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleUrlSave() {
+    if (!urlInput.trim()) return;
+
+    setSavingUrl(true);
+    try {
+      const res = await fetch("/api/admin/site-config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: config.key, value: urlInput.trim() }),
+      });
+
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error);
+
+      setPreview(urlInput.trim());
+      setUrlInput("");
+      onUpdated(config.key, urlInput.trim());
+      toast({ title: "URL mise à jour" });
+    } catch (err: any) {
+      toast({ title: "Erreur", description: err.message, variant: "destructive" });
+    } finally {
+      setSavingUrl(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-4">
+        <Label className="text-sm font-medium">{config.label ?? config.key}</Label>
+
+        {/* Preview */}
+        <div className="relative aspect-video w-full overflow-hidden rounded-lg border bg-muted">
+          {preview ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={preview}
+              alt={config.label ?? config.key}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Aucune image
+            </div>
+          )}
+        </div>
+
+        {/* Upload button */}
+        <div className="flex gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFileUpload(file);
+              e.target.value = "";
+            }}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+          >
+            {uploading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Upload className="mr-2 h-4 w-4" />
+            )}
+            {uploading ? "Upload…" : "Uploader"}
+          </Button>
+        </div>
+
+        {/* URL input */}
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <Input
+              placeholder="Ou coller une URL d'image…"
+              value={urlInput}
+              onChange={(e) => setUrlInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleUrlSave();
+              }}
+            />
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleUrlSave}
+            disabled={savingUrl || !urlInput.trim()}
+          >
+            {savingUrl ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <LinkIcon className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function LandingImagesClient({ configs }: Props) {
+  const [items, setItems] = useState(configs);
+  const groups = groupBySection(items);
+
+  function handleUpdated(key: string, value: string) {
+    setItems((prev) =>
+      prev.map((c) => (c.key === key ? { ...c, value } : c))
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {Object.entries(groups).map(([section, entries]) => (
+        <div key={section}>
+          <h2 className="text-lg font-semibold mb-4">{section}</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {entries.map((config) => (
+              <ImageCard
+                key={config.key}
+                config={config}
+                onUpdated={handleUpdated}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/admin/landing-images/page.tsx
+++ b/app/admin/landing-images/page.tsx
@@ -1,0 +1,44 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { getServerProfile } from "@/lib/helpers/auth-helper";
+import { LandingImagesClient } from "./LandingImagesClient";
+
+export default async function LandingImagesPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/auth/signin");
+
+  const { profile } = await getServerProfile<{ id: string; role: string }>(
+    user.id,
+    "id, role"
+  );
+
+  if (!profile || !["admin", "platform_admin"].includes(profile.role)) {
+    redirect("/admin/dashboard");
+  }
+
+  const { data: configs } = await supabase
+    .from("site_config")
+    .select("key, value, label, section, updated_at")
+    .order("section")
+    .order("key");
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-foreground">Images Vitrine</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Gérez les images affichées sur la page d&apos;accueil. Les changements sont visibles sous 1h.
+        </p>
+      </div>
+      <LandingImagesClient configs={configs ?? []} />
+    </div>
+  );
+}

--- a/app/api/admin/landing-images/upload/route.ts
+++ b/app/api/admin/landing-images/upload/route.ts
@@ -1,0 +1,99 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { createClient } from "@/lib/supabase/server";
+import { STORAGE_BUCKETS } from "@/lib/config/storage-buckets";
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile || !["admin", "platform_admin"].includes(profile.role)) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+    const key = formData.get("key") as string | null;
+
+    if (!file || !key) {
+      return NextResponse.json(
+        { error: "Fichier et clé requis" },
+        { status: 400 }
+      );
+    }
+
+    // Validate file type
+    if (!file.type.startsWith("image/")) {
+      return NextResponse.json(
+        { error: "Seules les images sont acceptées" },
+        { status: 400 }
+      );
+    }
+
+    // Max 5MB
+    if (file.size > 5 * 1024 * 1024) {
+      return NextResponse.json(
+        { error: "Taille maximale : 5 Mo" },
+        { status: 400 }
+      );
+    }
+
+    const fileExt = file.name.split(".").pop();
+    const filePath = `${key}/${Date.now()}.${fileExt}`;
+
+    const arrayBuffer = await file.arrayBuffer();
+    const { error: uploadError } = await supabase.storage
+      .from(STORAGE_BUCKETS.LANDING_IMAGES)
+      .upload(filePath, arrayBuffer, {
+        contentType: file.type,
+        upsert: true,
+      });
+
+    if (uploadError) {
+      console.error("[Landing Images] Upload error:", uploadError);
+      return NextResponse.json({ error: "Erreur d'upload" }, { status: 500 });
+    }
+
+    const { data: urlData } = supabase.storage
+      .from(STORAGE_BUCKETS.LANDING_IMAGES)
+      .getPublicUrl(filePath);
+
+    // Update site_config with the new URL
+    const { error: updateError } = await supabase
+      .from("site_config")
+      .update({ value: urlData.publicUrl, updated_at: new Date().toISOString() })
+      .eq("key", key);
+
+    if (updateError) {
+      console.error("[Landing Images] Config update error:", updateError);
+      return NextResponse.json({ error: "Erreur de mise à jour" }, { status: 500 });
+    }
+
+    revalidatePath("/(marketing)");
+
+    return NextResponse.json({
+      success: true,
+      url: urlData.publicUrl,
+    });
+  } catch (error) {
+    console.error("[Landing Images] Unexpected error:", error);
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 });
+  }
+}

--- a/app/api/admin/site-config/route.ts
+++ b/app/api/admin/site-config/route.ts
@@ -1,0 +1,78 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const section = request.nextUrl.searchParams.get("section");
+
+    let query = supabase
+      .from("site_config")
+      .select("key, value, label, section, updated_at")
+      .order("section")
+      .order("key");
+
+    if (section) {
+      query = query.eq("section", section);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ data });
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile || !["admin", "platform_admin"].includes(profile.role)) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const { key, value } = await request.json();
+
+    if (!key) {
+      return NextResponse.json({ error: "Clé requise" }, { status: 400 });
+    }
+
+    const { error } = await supabase
+      .from("site_config")
+      .update({ value, updated_at: new Date().toISOString() })
+      .eq("key", key);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    revalidatePath("/(marketing)");
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 });
+  }
+}

--- a/components/layout/admin-sidebar.tsx
+++ b/components/layout/admin-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Menu,
   X,
   Search,
+  ImageIcon,
   ScrollText,
   CreditCard,
   Wallet,
@@ -77,6 +78,7 @@ const adminNavItems: NavCategory[] = [
       { href: "/admin/templates", label: "Templates Baux", icon: ScrollText },
       { href: "/admin/email-templates", label: "Templates Email", icon: Mail },
       { href: "/admin/blog", label: "Blog", icon: BookOpen },
+      { href: "/admin/landing-images", label: "Images Vitrine", icon: ImageIcon },
     ],
   },
   {

--- a/components/marketing/LandingPageClient.tsx
+++ b/components/marketing/LandingPageClient.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { ScrollProgressBar } from "@/components/marketing/ScrollProgressBar"
+import { MarketingNavbar } from "@/components/marketing/Navbar"
+import { HeroSection } from "@/components/marketing/sections/HeroSection"
+import { InnovationBar } from "@/components/marketing/sections/InnovationBar"
+import { ProblemSolution } from "@/components/marketing/sections/ProblemSolution"
+import { Arguments } from "@/components/marketing/sections/Arguments"
+import { Features } from "@/components/marketing/sections/Features"
+import { Testimonials } from "@/components/marketing/sections/Testimonials"
+import { PourQui } from "@/components/marketing/sections/PourQui"
+import { OutreMer } from "@/components/marketing/sections/OutreMer"
+import { Pricing } from "@/components/marketing/sections/Pricing"
+import { FAQ } from "@/components/marketing/sections/FAQ"
+import { FinalCTA, StickyMobileCTA } from "@/components/marketing/sections/FinalCTA"
+
+interface Props {
+  images: Record<string, string>;
+}
+
+export function LandingPageClient({ images }: Props) {
+  return (
+    <>
+      <ScrollProgressBar />
+      <MarketingNavbar />
+      <div className="scroll-smooth">
+        <HeroSection />
+        <InnovationBar />
+        <ProblemSolution images={images} />
+        <Arguments images={images} />
+        <Features />
+        <Testimonials />
+        <PourQui images={images} />
+        <OutreMer />
+        <Pricing />
+        <FAQ />
+        <FinalCTA />
+      </div>
+      <StickyMobileCTA />
+    </>
+  )
+}

--- a/components/marketing/sections/Arguments.tsx
+++ b/components/marketing/sections/Arguments.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Image from "next/image"
 import { motion } from "framer-motion"
 import { fadeUp, staggerContainer } from "@/components/marketing/AnimatedSection"
 import { bounceIn, blurUp, use3DTilt, useCountUp } from "@/components/marketing/hooks"
@@ -14,6 +15,7 @@ function CountUpValue({ target, suffix }: { target: number; suffix: string }) {
 const cards = [
   {
     emoji: "⏱️",
+    imageKey: "landing_arg_time_img",
     title: "Gagnez 3h par semaine",
     body: "Loyers encaissés, reçus envoyés, relances faites — tout automatiquement. Vous vous occupez du reste.",
     badge: "3h économisées par semaine",
@@ -23,6 +25,7 @@ const cards = [
   },
   {
     emoji: "💶",
+    imageKey: "landing_arg_money_img",
     title: "Économisez jusqu\u2019à 2\u00A0000\u00A0€/an",
     body: "Une agence prend 7 à 8\u00A0% de vos loyers. TALOK vous coûte 35\u00A0€/mois. Sans intermédiaire.",
     badge: "Vs une agence classique",
@@ -32,6 +35,7 @@ const cards = [
   },
   {
     emoji: "📋",
+    imageKey: "landing_arg_contract_img",
     title: "Contrats signés en 5 minutes",
     body: "Votre locataire signe depuis son téléphone. Pas d\u2019imprimante, pas de déplacement. La signature a la même valeur légale qu\u2019un original papier.",
     badge: "Valeur légale garantie",
@@ -41,6 +45,7 @@ const cards = [
   },
   {
     emoji: "🛡️",
+    imageKey: "landing_arg_sleep_img",
     title: "Dormez tranquille",
     body: "La loi change souvent. TALOK se met à jour automatiquement. Vos contrats sont toujours dans les règles. Zéro risque juridique.",
     badge: "Mis à jour à chaque nouvelle loi",
@@ -65,7 +70,7 @@ function TiltCard({ children, className }: { children: React.ReactNode; classNam
   )
 }
 
-export function Arguments() {
+export function Arguments({ images }: { images?: Record<string, string> }) {
   return (
     <section className="bg-slate-50 py-16 md:py-24">
       <motion.div
@@ -78,16 +83,34 @@ export function Arguments() {
         {cards.map((card) => (
           <motion.div key={card.title} variants={fadeUp}>
             <TiltCard className="h-full rounded-2xl border border-slate-200 bg-white p-7 shadow-sm transition-shadow hover:shadow-lg md:p-8">
-              {/* Emoji with bounce */}
-              <motion.span
-                variants={bounceIn}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true }}
-                className="inline-block text-3xl"
-              >
-                {card.emoji}
-              </motion.span>
+              {/* Image or emoji fallback */}
+              {images?.[card.imageKey] ? (
+                <motion.div
+                  variants={bounceIn}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={{ once: true }}
+                  className="relative h-32 w-full overflow-hidden rounded-xl"
+                >
+                  <Image
+                    src={images[card.imageKey]}
+                    alt={card.title}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 640px) 100vw, 50vw"
+                  />
+                </motion.div>
+              ) : (
+                <motion.span
+                  variants={bounceIn}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={{ once: true }}
+                  className="inline-block text-3xl"
+                >
+                  {card.emoji}
+                </motion.span>
+              )}
               <h3 className="mt-4 font-display text-[18px] font-semibold text-[#1B2A6B]">
                 {card.title}
               </h3>

--- a/components/marketing/sections/PourQui.tsx
+++ b/components/marketing/sections/PourQui.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Image from "next/image"
 import { motion } from "framer-motion"
 import { fadeUp } from "@/components/marketing/AnimatedSection"
 import { bounceIn, blurUp } from "@/components/marketing/hooks"
@@ -9,6 +10,7 @@ const ease = [0.22, 1, 0.36, 1] as const
 const personas = [
   {
     emoji: "🏡",
+    imageKey: "landing_profile_owner_img",
     title: "Propriétaire particulier",
     subtitle: "1 à 10 logements",
     body: "Vous voulez gérer vous-même, sans agence, sans vous tromper juridiquement. TALOK vous guide pas à pas.",
@@ -17,6 +19,7 @@ const personas = [
   },
   {
     emoji: "📈",
+    imageKey: "landing_profile_investor_img",
     title: "Investisseur / SCI",
     subtitle: "Plusieurs biens & entités",
     body: "Vision patrimoniale globale, comptabilité pour votre expert-comptable, gestion multi-entités. TALOK s\u2019adapte à votre complexité.",
@@ -25,6 +28,7 @@ const personas = [
   },
   {
     emoji: "🏢",
+    imageKey: "landing_profile_agency_img",
     title: "Agence / Gestionnaire",
     subtitle: "Portefeuille multi-propriétaires",
     body: "Votre propre marque, vos propres couleurs, API complète. Gérez des centaines de biens sous votre identité.",
@@ -45,7 +49,7 @@ const glowPulse = {
   },
 }
 
-export function PourQui() {
+export function PourQui({ images }: { images?: Record<string, string> }) {
   return (
     <section className="py-16 md:py-24">
       <div className="mx-auto max-w-[1100px] px-4">
@@ -98,15 +102,34 @@ export function PourQui() {
                   Le plus populaire
                 </span>
               )}
-              <motion.span
-                variants={bounceIn}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true }}
-                className="inline-block text-3xl"
-              >
-                {p.emoji}
-              </motion.span>
+              {/* Image or emoji fallback */}
+              {images?.[p.imageKey] ? (
+                <motion.div
+                  variants={bounceIn}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={{ once: true }}
+                  className="relative h-40 w-full overflow-hidden rounded-xl"
+                >
+                  <Image
+                    src={images[p.imageKey]}
+                    alt={p.title}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 100vw, 33vw"
+                  />
+                </motion.div>
+              ) : (
+                <motion.span
+                  variants={bounceIn}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={{ once: true }}
+                  className="inline-block text-3xl"
+                >
+                  {p.emoji}
+                </motion.span>
+              )}
               <h3 className="mt-3 font-display text-lg font-bold text-[#1B2A6B]">{p.title}</h3>
               <p className="text-xs text-slate-400">{p.subtitle}</p>
               <p className="mt-3 text-sm leading-relaxed text-slate-500">{p.body}</p>

--- a/components/marketing/sections/ProblemSolution.tsx
+++ b/components/marketing/sections/ProblemSolution.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Image from "next/image"
 import { motion } from "framer-motion"
 import { fadeUp, staggerContainer } from "@/components/marketing/AnimatedSection"
 import { blurUp, drawPath } from "@/components/marketing/hooks"
@@ -50,9 +51,20 @@ const strikeLine = {
   },
 }
 
-export function ProblemSolution() {
+export function ProblemSolution({ images }: { images?: Record<string, string> }) {
   return (
-    <section className="py-16 md:py-24">
+    <section className="relative overflow-hidden py-16 md:py-24">
+      {images?.landing_beforeafter_img && (
+        <div className="absolute inset-0 -z-10">
+          <Image
+            src={images.landing_beforeafter_img}
+            alt=""
+            fill
+            className="object-cover opacity-[0.04]"
+            sizes="100vw"
+          />
+        </div>
+      )}
       <div className="mx-auto max-w-[1100px] px-4">
         {/* Header */}
         <motion.div

--- a/lib/config/storage-buckets.ts
+++ b/lib/config/storage-buckets.ts
@@ -16,6 +16,8 @@ export const STORAGE_BUCKETS = {
   IDENTITY: "identity",
   /** Documents d'assemblée de copropriété */
   ASSEMBLY_DOCUMENTS: "assembly-documents",
+  /** Images éditables de la landing page (public) */
+  LANDING_IMAGES: "landing-images",
 } as const;
 
 export type StorageBucket = (typeof STORAGE_BUCKETS)[keyof typeof STORAGE_BUCKETS];

--- a/lib/queries/site-config.ts
+++ b/lib/queries/site-config.ts
@@ -1,0 +1,43 @@
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Récupère toutes les entrées site_config sous forme de map clé → valeur.
+ */
+export async function getSiteConfigMap(): Promise<Record<string, string>> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("site_config")
+    .select("key, value");
+
+  if (!data) return {};
+  return Object.fromEntries(
+    data.filter((r) => r.value).map((r) => [r.key, r.value as string])
+  );
+}
+
+/**
+ * Récupère les entrées site_config filtrées par section.
+ */
+export async function getSiteConfigBySection(section: string) {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("site_config")
+    .select("key, value, label, section, updated_at")
+    .eq("section", section);
+
+  return data ?? [];
+}
+
+/**
+ * Récupère toutes les entrées site_config avec métadonnées (pour l'admin).
+ */
+export async function getAllSiteConfigs() {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("site_config")
+    .select("key, value, label, section, updated_at")
+    .order("section")
+    .order("key");
+
+  return data ?? [];
+}

--- a/supabase/migrations/20260327143000_add_site_config.sql
+++ b/supabase/migrations/20260327143000_add_site_config.sql
@@ -1,0 +1,109 @@
+-- Table de configuration du site vitrine
+CREATE TABLE IF NOT EXISTS site_config (
+  key TEXT PRIMARY KEY,
+  value TEXT,
+  label TEXT,           -- Label lisible pour l'admin
+  section TEXT,         -- Groupe dans l'UI admin
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- RLS : lecture publique, écriture admin uniquement
+ALTER TABLE site_config ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read" ON site_config FOR SELECT USING (true);
+CREATE POLICY "Admin write" ON site_config FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.user_id = auth.uid()
+      AND profiles.role IN ('admin', 'platform_admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.user_id = auth.uid()
+      AND profiles.role IN ('admin', 'platform_admin')
+    )
+  );
+
+-- Valeurs initiales (images Unsplash par défaut)
+INSERT INTO site_config (key, label, section, value) VALUES
+  -- Section "Arguments" (4 cartes)
+  ('landing_arg_time_img',
+   'Argument — Gagnez 3h (illustration)',
+   'Arguments',
+   'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?w=600&q=80'),
+
+  ('landing_arg_money_img',
+   'Argument — Économisez 2000€ (illustration)',
+   'Arguments',
+   'https://images.unsplash.com/photo-1554224155-6726b3ff858f?w=600&q=80'),
+
+  ('landing_arg_contract_img',
+   'Argument — Contrats 5 min (illustration)',
+   'Arguments',
+   'https://images.unsplash.com/photo-1586281380349-632531db7ed4?w=600&q=80'),
+
+  ('landing_arg_sleep_img',
+   'Argument — Dormez tranquille (illustration)',
+   'Arguments',
+   'https://images.unsplash.com/photo-1541480601022-2308c0f02487?w=600&q=80'),
+
+  -- Section "Profils"
+  ('landing_profile_owner_img',
+   'Profil — Propriétaire particulier',
+   'Profils',
+   'https://images.unsplash.com/photo-1560250097-0b93528c311a?w=600&q=80'),
+
+  ('landing_profile_investor_img',
+   'Profil — Investisseur / SCI',
+   'Profils',
+   'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=600&q=80'),
+
+  ('landing_profile_agency_img',
+   'Profil — Agence / Gestionnaire',
+   'Profils',
+   'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=600&q=80'),
+
+  -- Section "Avant / Après"
+  ('landing_beforeafter_img',
+   'Avant/Après — Photo de fond',
+   'Avant-Après',
+   'https://images.unsplash.com/photo-1484154218962-a197022b5858?w=1200&q=80')
+
+ON CONFLICT (key) DO NOTHING;
+
+-- Bucket public pour les images landing
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('landing-images', 'landing-images', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Politique de lecture publique sur le bucket
+CREATE POLICY "Public read landing images"
+ON storage.objects FOR SELECT
+USING (bucket_id = 'landing-images');
+
+-- Politique d'upload admin
+CREATE POLICY "Admin upload landing images"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'landing-images'
+  AND EXISTS (
+    SELECT 1 FROM profiles
+    WHERE profiles.user_id = auth.uid()
+    AND profiles.role IN ('admin', 'platform_admin')
+  )
+);
+
+-- Politique de suppression admin
+CREATE POLICY "Admin delete landing images"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'landing-images'
+  AND EXISTS (
+    SELECT 1 FROM profiles
+    WHERE profiles.user_id = auth.uid()
+    AND profiles.role IN ('admin', 'platform_admin')
+  )
+);


### PR DESCRIPTION
Add site_config table (key/value) with Supabase migration, landing-images
storage bucket, admin page at /admin/landing-images with upload + URL input,
and modify Arguments/PourQui/ProblemSolution sections to display configurable
images with emoji fallback. Convert marketing page to SSR (revalidate: 3600).

https://claude.ai/code/session_01P6DEnPMHMiDXNhvAi2NTJD