### PR TITLE
fix: image defaults fallback + duplicate navbar

### DIFF
--- a/components/marketing/LandingPageClient.tsx
+++ b/components/marketing/LandingPageClient.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { ScrollProgressBar } from "@/components/marketing/ScrollProgressBar"
-import { MarketingNavbar } from "@/components/marketing/Navbar"
 import { HeroSection } from "@/components/marketing/sections/HeroSection"
 import { InnovationBar } from "@/components/marketing/sections/InnovationBar"
 import { ProblemSolution } from "@/components/marketing/sections/ProblemSolution"
@@ -21,8 +19,6 @@ interface Props {
 export function LandingPageClient({ images }: Props) {
   return (
     <>
-      <ScrollProgressBar />
-      <MarketingNavbar />
       <div className="scroll-smooth">
         <HeroSection />
         <InnovationBar />

--- a/lib/config/landing-image-defaults.ts
+++ b/lib/config/landing-image-defaults.ts
@@ -1,0 +1,26 @@
+/**
+ * URLs par défaut des images landing — utilisées comme fallback
+ * si site_config n'est pas encore renseigné (ou table absente).
+ * L'admin peut les remplacer via /admin/landing-images.
+ */
+export const LANDING_IMAGE_DEFAULTS: Record<string, string> = {
+  // Arguments
+  landing_arg_time_img:
+    "https://images.unsplash.com/photo-1450101499163-c8848c66ca85?w=600&q=80",
+  landing_arg_money_img:
+    "https://images.unsplash.com/photo-1554224155-6726b3ff858f?w=600&q=80",
+  landing_arg_contract_img:
+    "https://images.unsplash.com/photo-1586281380349-632531db7ed4?w=600&q=80",
+  landing_arg_sleep_img:
+    "https://images.unsplash.com/photo-1541480601022-2308c0f02487?w=600&q=80",
+  // Profils
+  landing_profile_owner_img:
+    "https://images.unsplash.com/photo-1560250097-0b93528c311a?w=600&q=80",
+  landing_profile_investor_img:
+    "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=600&q=80",
+  landing_profile_agency_img:
+    "https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=600&q=80",
+  // Avant / Après
+  landing_beforeafter_img:
+    "https://images.unsplash.com/photo-1484154218962-a197022b5858?w=1200&q=80",
+};

--- a/lib/queries/site-config.ts
+++ b/lib/queries/site-config.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { LANDING_IMAGE_DEFAULTS } from "@/lib/config/landing-image-defaults";
 
 export type SiteConfigKey =
   | "landing_arg_time_img"
@@ -12,20 +13,34 @@ export type SiteConfigKey =
 
 /**
  * Récupère un sous-ensemble typé de clés site_config.
+ * Merge avec les defaults pour garantir un affichage même
+ * si la table n'existe pas encore.
  */
 export async function getSiteConfig(
   keys: SiteConfigKey[]
 ): Promise<Record<SiteConfigKey, string>> {
-  const supabase = await createClient();
-  const { data } = await supabase
-    .from("site_config")
-    .select("key, value")
-    .in("key", keys);
-
+  // Start with defaults for requested keys
   const result = {} as Record<SiteConfigKey, string>;
-  for (const row of data ?? []) {
-    result[row.key as SiteConfigKey] = row.value ?? "";
+  for (const k of keys) {
+    result[k] = LANDING_IMAGE_DEFAULTS[k] ?? "";
   }
+
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("site_config")
+      .select("key, value")
+      .in("key", keys);
+
+    for (const row of data ?? []) {
+      if (row.value) {
+        result[row.key as SiteConfigKey] = row.value;
+      }
+    }
+  } catch {
+    // Table doesn't exist yet — defaults already in result
+  }
+
   return result;
 }
 
@@ -33,15 +48,21 @@ export async function getSiteConfig(
  * Récupère toutes les entrées site_config sous forme de map clé → valeur.
  */
 export async function getSiteConfigMap(): Promise<Record<string, string>> {
-  const supabase = await createClient();
-  const { data } = await supabase
-    .from("site_config")
-    .select("key, value");
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("site_config")
+      .select("key, value");
 
-  if (!data) return {};
-  return Object.fromEntries(
-    data.filter((r) => r.value).map((r) => [r.key, r.value as string])
-  );
+    if (!data) return { ...LANDING_IMAGE_DEFAULTS };
+
+    const dbValues = Object.fromEntries(
+      data.filter((r) => r.value).map((r) => [r.key, r.value as string])
+    );
+    return { ...LANDING_IMAGE_DEFAULTS, ...dbValues };
+  } catch {
+    return { ...LANDING_IMAGE_DEFAULTS };
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Ajoute `landing-image-defaults.ts` avec les 8 URLs Unsplash par défaut hardcodées — les images s'affichent même si la migration `site_config` n'est pas encore appliquée
- `getSiteConfig()` / `getSiteConfigMap()` mergent les valeurs DB sur les defaults avec try/catch
- Supprime le `ScrollProgressBar` et `MarketingNavbar` dupliqués dans `LandingPageClient` (déjà rendus par le layout marketing)

## Test plan
- [ ] Vérifier que les images Unsplash s'affichent dans les 3 sections (Arguments, Profils, Avant/Après)
- [ ] Vérifier qu'il n'y a plus de double navbar
- [ ] Vérifier que le build Netlify passe

https://claude.ai/code/session_01P6DEnPMHMiDXNhvAi2NTJD