### PR TITLE
fix: resolve 5 critical bugs — entity race condition, profile dedup, …

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function LoginPage() {
+  redirect("/auth/signin");
+}

--- a/app/signout/route.ts
+++ b/app/signout/route.ts
@@ -1,0 +1,11 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  return NextResponse.redirect(new URL("/auth/signin", request.url));
+}

--- a/lib/hooks/use-auth.ts
+++ b/lib/hooks/use-auth.ts
@@ -52,6 +52,10 @@ let _globalProfilePromise: Promise<Profile | null> | null = null;
 let _globalFetchedUserId: string | null = null;
 // Anti-retry guard: prevents infinite profile creation attempts
 let _globalCreateAttempted = false;
+// FIX 2: Cache resolved profile to avoid refetching on every component mount
+let _globalCachedProfile: Profile | null = null;
+let _globalCachedAt = 0;
+const PROFILE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Reset all global guards. Called on sign-out and user change.
@@ -60,6 +64,8 @@ function resetGlobalGuards() {
   _globalFetchedUserId = null;
   _globalProfilePromise = null;
   _globalCreateAttempted = false;
+  _globalCachedProfile = null;
+  _globalCachedAt = 0;
 }
 
 // ======================================================================
@@ -149,6 +155,16 @@ export function useAuth() {
 
   const fetchProfile = useCallback(
     async (userId: string, force = false) => {
+      // FIX 2: Return cached profile if still fresh (avoids 6 fetches per page)
+      if (!force && _globalCachedProfile && _globalFetchedUserId === userId &&
+          Date.now() - _globalCachedAt < PROFILE_CACHE_TTL) {
+        safeSetProfile(_globalCachedProfile);
+        safeSetStatus("authenticated");
+        safeSetProfileError(null);
+        safeSetLoading(false);
+        return;
+      }
+
       // If another instance already fetched this user, reuse the cached promise
       if (!force && _globalFetchedUserId === userId && _globalProfilePromise) {
         try {
@@ -266,6 +282,9 @@ export function useAuth() {
           });
           safeSetStatus("profile_error");
         } else {
+          // FIX 2: Cache the resolved profile
+          _globalCachedProfile = result as Profile;
+          _globalCachedAt = Date.now();
           safeSetProfileError(null);
           safeSetStatus("authenticated");
         }

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,6 +28,8 @@ const publicRoutes = [
   "/auth/reset-password",
   "/recovery/password",
   "/signup",
+  "/login",
+  "/signout",
   "/pricing",
   "/blog",
   "/legal",

--- a/providers/EntityProvider.tsx
+++ b/providers/EntityProvider.tsx
@@ -11,7 +11,7 @@
  * (React strict mode, onglets multiples).
  */
 
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { useEntityStore } from "@/stores/useEntityStore";
 import { useAuth } from "@/lib/hooks/use-auth";
 
@@ -25,12 +25,12 @@ let ensureDefaultPromise: Promise<void> | null = null;
 export function EntityProvider({ children }: EntityProviderProps) {
   const { profile } = useAuth();
   const fetchEntities = useEntityStore((s) => s.fetchEntities);
+  const setActiveEntity = useEntityStore((s) => s.setActiveEntity);
+  const autoSelectDoneRef = useRef(false);
 
   useEffect(() => {
     if (!profile?.id) return;
 
-    // owner_profiles.profile_id === profiles.id === legal_entities.owner_profile_id
-    // No intermediate query needed — profile.id is the owner_profile_id FK value.
     const loadEntities = async () => {
       try {
         const { entities, lastFetchedAt } = useEntityStore.getState();
@@ -43,7 +43,6 @@ export function EntityProvider({ children }: EntityProviderProps) {
         // Si toujours vide après fetch, auto-créer l'entité par défaut
         const currentEntities = useEntityStore.getState().entities;
         if (currentEntities.length === 0) {
-          // Dédupliquer les appels concurrents (strict mode, multi-tab)
           if (ensureDefaultPromise) {
             await ensureDefaultPromise;
           } else {
@@ -63,13 +62,21 @@ export function EntityProvider({ children }: EntityProviderProps) {
             await ensureDefaultPromise;
           }
         }
+
+        // FIX 1: Auto-select first entity if activeEntityId is null
+        const state = useEntityStore.getState();
+        if (!state.activeEntityId && state.entities.length > 0 && !autoSelectDoneRef.current) {
+          autoSelectDoneRef.current = true;
+          const defaultEntity = state.entities.find((e) => e.isDefault);
+          setActiveEntity(defaultEntity?.id ?? state.entities[0].id);
+        }
       } catch (err) {
         console.error("[EntityProvider] Error loading entities:", err);
       }
     };
 
     loadEntities();
-  }, [profile?.id, fetchEntities]);
+  }, [profile?.id, fetchEntities, setActiveEntity]);
 
   return <>{children}</>;
 }

--- a/supabase/migrations/20260328000000_fix_visible_tenant_documents.sql
+++ b/supabase/migrations/20260328000000_fix_visible_tenant_documents.sql
@@ -1,0 +1,9 @@
+-- FIX 4: Ensure mandatory lease documents are visible to tenants
+-- Documents types contrat_bail, edl_entree, assurance_habitation
+-- must have visible_tenant = true so tenants can see them.
+
+UPDATE documents
+SET visible_tenant = true,
+    updated_at = now()
+WHERE type IN ('contrat_bail', 'edl_entree', 'assurance_habitation')
+  AND (visible_tenant IS NULL OR visible_tenant = false);


### PR DESCRIPTION
…auth routes, document visibility

- FIX 1: Auto-select activeEntityId on mount in EntityProvider to prevent dashboard showing 0/0 on first load (race condition with Zustand store)
- FIX 2: Add 5-min profile cache in useAuth to deduplicate /api/me/profile calls (6x per page → 1x)
- FIX 3: Create /login and /signout routes (previously 404) with proper redirects to /auth/signin
- FIX 4: SQL migration to set visible_tenant=true on mandatory lease documents (contrat_bail, edl_entree, assurance_habitation)
- FIX 5: Dashboard KPI inconsistency resolved via FIX 1