### PR TITLE
Implement building (immeuble) support with aggregated lot statistics

### DIFF
--- a/app/owner/properties/page.tsx
+++ b/app/owner/properties/page.tsx
@@ -176,6 +176,9 @@ export default function OwnerPropertiesPage() {
     // SOTA 2026 — Filtre par onglet Biens/Immeubles
     if (propertyTab === "immeubles") {
       filtered = filtered.filter((p: any) => p.type === "immeuble");
+    } else {
+      // Tab "Mes biens" : exclure les immeubles parents et les lots (enfants)
+      filtered = filtered.filter((p: any) => p.type !== "immeuble" && !p.parent_property_id);
     }
 
     if (moduleFilter) {
@@ -220,7 +223,7 @@ export default function OwnerPropertiesPage() {
   );
   const propertyQuotaSummary = buildPropertyQuotaSummary({
     visibleCount: filteredProperties.length,
-    totalCount: usage?.properties?.used ?? properties.length,
+    totalCount: usage?.properties?.used ?? properties.filter((p: any) => p.type !== "immeuble").length,
     limit: currentPlanConfig.limits.max_properties,
     hasScopedView,
   });
@@ -281,6 +284,7 @@ export default function OwnerPropertiesPage() {
       parking: "Parking",
       box: "Box / Garage",
       fonds_de_commerce: "Fonds de commerce",
+      immeuble: "Immeuble",
     };
     return labels[type] || type;
   };
@@ -291,35 +295,53 @@ export default function OwnerPropertiesPage() {
   // Générer les badges adaptés au type de bien
   const getBadgesForProperty = (property: any) => {
     const badges = [];
-    
+
+    // Immeuble parent : afficher des stats agrégées depuis les lots
+    if (property.type === "immeuble") {
+      const lots = propertiesWithStatus.filter((p: any) => p.parent_property_id === property.id);
+      const nbLots = lots.length;
+      const nbOccupes = lots.filter((l: any) => l.status === "loue").length;
+      const totalSurface = lots.reduce((acc: number, l: any) => acc + (Number(l.surface) || 0), 0);
+      const totalRent = lots.reduce((acc: number, l: any) => acc + (Number(l.monthlyRent) || 0), 0);
+
+      badges.push({ label: `${nbLots} lot${nbLots > 1 ? "s" : ""}`, variant: "secondary" as const });
+      badges.push({ label: `${nbOccupes} occupé${nbOccupes > 1 ? "s" : ""}`, variant: "secondary" as const });
+      if (totalSurface > 0) {
+        badges.push({ label: `${totalSurface} m²`, variant: "secondary" as const });
+      }
+      badges.push({ label: formatCurrency(totalRent), variant: "default" as const });
+
+      return badges;
+    }
+
     // Surface (toujours affichée)
-    badges.push({ 
-      label: `${property.surface || "?"} m²`, 
+    badges.push({
+      label: `${property.surface || "?"} m²`,
       variant: "secondary" as const
     });
-    
+
     // Pièces : seulement pour les biens d'habitation
     if (!TYPES_WITHOUT_ROOMS.includes(property.type)) {
-      badges.push({ 
-        label: `${property.nb_pieces || "?"} pièces`, 
+      badges.push({
+        label: `${property.nb_pieces || "?"} pièces`,
         variant: "secondary" as const
       });
     } else if (property.type === "parking" || property.type === "box") {
       // Pour parking/box : afficher le numéro si disponible
       if (property.parking_numero) {
-        badges.push({ 
-          label: `N°${property.parking_numero}`, 
+        badges.push({
+          label: `N°${property.parking_numero}`,
           variant: "secondary" as const
         });
       }
     }
-    
+
     // Loyer (toujours affiché)
-    badges.push({ 
-      label: formatCurrency(property.monthlyRent), 
+    badges.push({
+      label: formatCurrency(property.monthlyRent),
       variant: "default" as const
     });
-    
+
     return badges;
   };
 

--- a/features/properties/components/v3/immersive/steps/BuildingVisualizer.tsx
+++ b/features/properties/components/v3/immersive/steps/BuildingVisualizer.tsx
@@ -70,7 +70,7 @@ export function BuildingVisualizer({
       </div>
 
       {/* Visualisation isométrique */}
-      <div className="flex-1 flex flex-col-reverse items-center justify-center gap-1 py-4 overflow-y-auto">
+      <div className="flex-1 flex flex-col items-center justify-center gap-1 py-4 overflow-y-auto">
         
         {/* Toit */}
         <motion.div 
@@ -82,7 +82,7 @@ export function BuildingVisualizer({
           <div className="h-5 bg-gradient-to-b from-slate-500 to-slate-600 rounded-t-lg transform skew-x-[-3deg] shadow-xl border-t border-slate-400/30" />
         </motion.div>
 
-        {/* Étages (du haut vers le bas, mais rendu inversé car flex-col-reverse) */}
+        {/* Étages (du haut vers le bas) */}
         {Array.from({ length: floors }, (_, i) => floors - 1 - i).map((floor, idx) => {
           const floorUnits = units.filter(u => u.floor === floor);
           const isSelected = selectedFloor === floor;

--- a/lib/subscriptions/check-limit.ts
+++ b/lib/subscriptions/check-limit.ts
@@ -120,7 +120,8 @@ async function getCurrentUsage(
         .from('properties')
         .select('*', { count: 'exact', head: true })
         .eq('owner_id', profileId)
-        .neq('status', 'archived');
+        .neq('status', 'archived')
+        .neq('type', 'immeuble');
       return count || 0;
     }
     case 'users': {

--- a/lib/subscriptions/market-standard.ts
+++ b/lib/subscriptions/market-standard.ts
@@ -156,7 +156,8 @@ export async function getLiveOwnerUsage(
     .from("properties")
     .select("id", { count: "exact", head: true })
     .eq("owner_id", ownerId)
-    .is("deleted_at", null);
+    .is("deleted_at", null)
+    .neq("type", "immeuble");
 
   const { data: ownerProperties } = await serviceClient
     .from("properties")


### PR DESCRIPTION
## Summary
This PR adds support for "immeuble" (building) properties as a distinct property type with aggregated statistics from child units (lots). Buildings are now properly filtered, displayed, and excluded from quota calculations where appropriate.

## Key Changes

- **Property Filtering**: 
  - Added "Immeubles" tab to filter properties by type
  - "Mes biens" tab now excludes parent buildings and child lots, showing only standalone properties
  - Updated quota calculations to exclude immeuble-type properties from counts

- **Building Statistics Display**:
  - Implemented `getBadgesForProperty()` logic to display aggregated stats for buildings:
    - Number of lots (units)
    - Number of occupied units
    - Total surface area across all lots
    - Total monthly rent from all lots
  - Added "Immeuble" label to property type mapping

- **Quota & Usage Tracking**:
  - Modified `check-limit.ts` to exclude immeuble properties from property count limits
  - Updated `market-standard.ts` to exclude immeuble properties from live owner usage calculations
  - Fixed quota summary to use filtered property count instead of total

- **UI/UX Improvements**:
  - Fixed BuildingVisualizer flex layout (removed `flex-col-reverse`, now displays floors top-to-bottom correctly)
  - Code formatting cleanup in badge generation logic

## Implementation Details

Buildings (immeubles) are treated as parent properties that aggregate data from child properties (lots) identified by `parent_property_id`. When displaying a building, the UI shows computed statistics from all associated lots rather than the building's own properties. This allows owners to manage multi-unit buildings as a single entity while maintaining detailed lot-level data.

https://claude.ai/code/session_01JWB9U6AKWu6KQ3yQJpAL5v