### PR TITLE
fix: building-units 500 error logging + diagnostic

### DIFF
--- a/app/api/properties/[id]/building-units/route.ts
+++ b/app/api/properties/[id]/building-units/route.ts
@@ -50,6 +50,7 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  let rawBody: unknown;
   try {
     const rateLimitResponse = applyRateLimit(request, "property");
     if (rateLimitResponse) return rateLimitResponse;
@@ -84,6 +85,7 @@ export async function POST(
     }
 
     const body = await request.json();
+    rawBody = body;
     const parsed = bodySchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
@@ -280,7 +282,9 @@ export async function POST(
       lot_property_ids: unitRows.map((r) => r.property_id),
     });
   } catch (e) {
-    console.error("[building-units]", e);
+    const errObj = e instanceof Error ? { message: e.message, stack: e.stack, name: e.name } : e;
+    console.error("[building-units] Full error:", JSON.stringify(errObj, null, 2));
+    console.error("[building-units] Payload received:", JSON.stringify(rawBody, null, 2));
     return NextResponse.json({ error: "Erreur serveur" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- Ajout de logs détaillés dans le catch de `POST /api/properties/[id]/building-units` pour diagnostiquer le 500 : erreur complète (message, stack, name) + payload reçu.

## Test plan
- [ ] Reproduire le POST building-units qui retourne 500
- [ ] Vérifier que les logs Netlify affichent le payload et l'erreur structurée

https://claude.ai/code/session_01JWB9U6AKWu6KQ3yQJpAL5v