### PR TITLE
fix: buildings.site_id nullable + building-units error logging

### DIFF
--- a/app/api/properties/[id]/building-units/route.ts
+++ b/app/api/properties/[id]/building-units/route.ts
@@ -50,6 +50,7 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  let rawBody: unknown;
   try {
     const rateLimitResponse = applyRateLimit(request, "property");
     if (rateLimitResponse) return rateLimitResponse;
@@ -84,6 +85,7 @@ export async function POST(
     }
 
     const body = await request.json();
+    rawBody = body;
     const parsed = bodySchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
@@ -280,7 +282,9 @@ export async function POST(
       lot_property_ids: unitRows.map((r) => r.property_id),
     });
   } catch (e) {
-    console.error("[building-units]", e);
+    const errObj = e instanceof Error ? { message: e.message, stack: e.stack, name: e.name } : e;
+    console.error("[building-units] Full error:", JSON.stringify(errObj, null, 2));
+    console.error("[building-units] Payload received:", JSON.stringify(rawBody, null, 2));
     return NextResponse.json({ error: "Erreur serveur" }, { status: 500 });
   }
 }

--- a/supabase/migrations/20260409180000_buildings_site_id_nullable.sql
+++ b/supabase/migrations/20260409180000_buildings_site_id_nullable.sql
@@ -1,0 +1,10 @@
+-- ============================================
+-- Migration : Rendre site_id nullable sur buildings
+--
+-- La colonne site_id (FK vers sites) a été créée NOT NULL par la
+-- migration copropriété (20251208). Pour les immeubles locatifs
+-- gérés par un propriétaire, il n'y a pas de site de copropriété :
+-- site_id doit être nullable.
+-- ============================================
+
+ALTER TABLE buildings ALTER COLUMN site_id DROP NOT NULL;


### PR DESCRIPTION
## Summary
- **Fix 500 on POST building-units**: `buildings.site_id` was NOT NULL (copro migration) but owner immeubles have no site — migration rends it nullable
- **Enhanced error logging**: catch block now logs full error object + payload for future debugging

## Migration
```sql
ALTER TABLE buildings ALTER COLUMN site_id DROP NOT NULL;
```
Already applied on Supabase.

## Test plan
- [x] Migration applied — "Success. No rows returned"
- [ ] Retester POST `/api/properties/[id]/building-units` — should return 200

https://claude.ai/code/session_01JWB9U6AKWu6KQ3yQJpAL5v