### PR TITLE
fix: building pages 404 + quota RLS recursion

### DIFF
--- a/app/api/subscriptions/usage/route.ts
+++ b/app/api/subscriptions/usage/route.ts
@@ -72,7 +72,7 @@ export async function GET() {
     }
     const limits = PLANS[planSlug]?.limits || PLANS.gratuit.limits;
 
-    const liveUsage = await getLiveOwnerUsage(supabase as any, profile.id);
+    const liveUsage = await getLiveOwnerUsage(adminClient as any, profile.id);
     const propertiesCount = liveUsage.properties;
     const leasesCount = liveUsage.leases;
 

--- a/app/owner/buildings/[id]/page.tsx
+++ b/app/owner/buildings/[id]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import type { Metadata, ResolvingMetadata } from "next";
 import { redirect, notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
@@ -12,24 +14,28 @@ export async function generateMetadata(
   { params }: PageProps,
   parent: ResolvingMetadata
 ): Promise<Metadata> {
-  const { id } = await params;
-  const serviceClient = getServiceClient();
+  try {
+    const { id } = await params;
+    const serviceClient = getServiceClient();
 
-  const { data: building } = await serviceClient
-    .from("properties")
-    .select("adresse_complete, ville")
-    .eq("id", id)
-    .eq("type", "immeuble")
-    .single();
+    const { data: building } = await serviceClient
+      .from("properties")
+      .select("adresse_complete, ville")
+      .eq("id", id)
+      .eq("type", "immeuble")
+      .single();
 
-  if (!building) {
-    return { title: "Immeuble non trouvé | Talok" };
+    if (!building) {
+      return { title: "Immeuble non trouvé | Talok" };
+    }
+
+    return {
+      title: `${building.adresse_complete} | Talok`,
+      description: `Gestion de l'immeuble situé à ${building.ville}`,
+    };
+  } catch {
+    return { title: "Immeuble | Talok" };
   }
-
-  return {
-    title: `${building.adresse_complete} | Talok`,
-    description: `Gestion de l'immeuble situé à ${building.ville}`,
-  };
 }
 
 export default async function BuildingDetailPage({ params }: PageProps) {
@@ -80,6 +86,7 @@ export default async function BuildingDetailPage({ params }: PageProps) {
     .single();
 
   if (error || !building) {
+    console.error("[building-detail] Property query failed:", { id, ownerId: profile.id, error });
     notFound();
   }
 

--- a/app/owner/buildings/[id]/units/page.tsx
+++ b/app/owner/buildings/[id]/units/page.tsx
@@ -1,6 +1,9 @@
+export const dynamic = "force-dynamic";
+
 import type { Metadata } from "next";
 import { redirect, notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { UnitsManagementClient } from "./UnitsManagementClient";
 
 export const metadata: Metadata = {
@@ -26,7 +29,10 @@ export default async function UnitsPage({ params }: PageProps) {
     redirect("/auth/signin");
   }
 
-  const { data: profile } = await supabase
+  // Service client pour bypasser RLS (évite récursion user_profile_id())
+  const serviceClient = getServiceClient();
+
+  const { data: profile } = await serviceClient
     .from("profiles")
     .select("id, role")
     .eq("user_id", user.id)
@@ -37,7 +43,7 @@ export default async function UnitsPage({ params }: PageProps) {
   }
 
   // Verify building ownership
-  const { data: building, error } = await supabase
+  const { data: building, error } = await serviceClient
     .from("properties")
     .select("id, adresse_complete, ville")
     .eq("id", id)
@@ -51,14 +57,14 @@ export default async function UnitsPage({ params }: PageProps) {
   }
 
   // Fetch building metadata (from buildings table linked to this property)
-  const { data: buildingRecord } = await supabase
+  const { data: buildingRecord } = await serviceClient
     .from("buildings")
     .select("floors, has_ascenseur, has_gardien, has_interphone, has_digicode, has_local_velo, has_local_poubelles")
     .eq("property_id", id)
     .single();
 
   // Fetch existing units
-  const { data: units } = await supabase
+  const { data: units } = await serviceClient
     .from("building_units")
     .select("*")
     .eq("property_id", id)


### PR DESCRIPTION
## Summary
- **Fix building detail 404**: RLS recursion on `user_profile_id()` caused silent query failure → `notFound()`. Switched all building pages to `getServiceClient()` + `force-dynamic`.
- **Fix quota 1/50 & 0/50**: `GET /api/subscriptions/usage` called `getLiveOwnerUsage` with user-scoped client → RLS recursion → count=0. Fixed: uses `adminClient`.
- **Fix units page**: same RLS bypass applied to `/owner/buildings/[id]/units`

## Test plan
- [ ] Click immeuble card → building detail loads (no 404)
- [ ] Tab "Mes biens" shows correct quota (e.g. 5/50)
- [ ] Tab "Immeubles" shows same quota (5/50)
- [ ] Units management page loads correctly

https://claude.ai/code/session_01JWB9U6AKWu6KQ3yQJpAL5v