### PR TITLE
Remove @ts-nocheck and add accounting types for type safety

### DIFF
--- a/app/api/accounting/agency/hoguet-report/route.ts
+++ b/app/api/accounting/agency/hoguet-report/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Hoguet Compliance Report
  * GET /api/accounting/agency/hoguet-report

--- a/app/api/accounting/agency/mandants/[id]/route.ts
+++ b/app/api/accounting/agency/mandants/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Agency Mandant Detail
  * GET   /api/accounting/agency/mandants/:id - Detail with properties, entries, CRGs
@@ -67,7 +66,13 @@ export async function GET(request: Request, context: Context) {
     const accountNumber = mandant.sub_account_number as string;
 
     // Fetch properties linked to this mandant's owner entity
-    const { data: properties } = await supabase
+    const { data: properties } = await (supabase as unknown as {
+      from: (t: string) => {
+        select: (s: string) => {
+          eq: (k: string, v: string) => Promise<{ data: unknown }>;
+        };
+      };
+    })
       .from("properties")
       .select("id, address, city, property_type, status")
       .eq("owner_entity_id", mandant.owner_entity_id as string);

--- a/app/api/accounting/agency/mandants/route.ts
+++ b/app/api/accounting/agency/mandants/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Agency Mandants
  * POST /api/accounting/agency/mandants - Create a new mandant account

--- a/app/api/accounting/amortization/[id]/route.ts
+++ b/app/api/accounting/amortization/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Single Amortization Schedule
  * GET   /api/accounting/amortization/[id] - Recupere un plan avec ses lignes

--- a/app/api/accounting/amortization/route.ts
+++ b/app/api/accounting/amortization/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Amortization Schedules
  * POST /api/accounting/amortization - Cree un plan d'amortissement par composant

--- a/app/api/accounting/bank/callback/route.ts
+++ b/app/api/accounting/bank/callback/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Bank OAuth Callback
  * GET /api/accounting/bank/callback - Browser redirect after bank authorization

--- a/app/api/accounting/bank/connections/route.ts
+++ b/app/api/accounting/bank/connections/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Bank Connections
  * GET /api/accounting/bank/connections - List bank connections for an entity

--- a/app/api/accounting/bank/reconciliation/categorize/route.ts
+++ b/app/api/accounting/bank/reconciliation/categorize/route.ts
@@ -63,10 +63,11 @@ export async function POST(request: Request) {
     const { transactionId, journalCode, accountNumber, accountLabel, label, propertyId } =
       validation.data;
 
-    // Fetch the bank transaction
+    // Fetch the bank transaction (plus the parent connection's account_type
+    // so we can derive the correct PCG class-5 account instead of a hardcode).
     const { data: tx, error: txError } = await (supabase as any)
       .from("bank_transactions")
-      .select("*, bank_connections!inner(entity_id)")
+      .select("*, bank_connections!inner(entity_id, account_type)")
       .eq("id", transactionId)
       .single();
 
@@ -75,14 +76,26 @@ export async function POST(request: Request) {
     }
 
     const entityId = tx.bank_connections.entity_id as string;
+    const bankAccountType = (tx.bank_connections.account_type ?? "checking") as
+      | "checking"
+      | "savings"
+      | "other";
     const amountCents = Math.abs(tx.amount_cents as number);
     const isIncome = (tx.amount_cents as number) > 0;
 
     // Get or create current exercise
     const exercise = await getOrCreateCurrentExercise(supabase, entityId);
 
-    // Determine bank account (default 512100)
-    const bankAccount = "512100";
+    // Map the bank connection's account_type (schema:
+    // supabase/migrations/20260406210000_accounting_complete.sql) to the
+    // matching PCG class-5 account number. Keeps the hardcode in a single
+    // map instead of a bare "512100" buried in the entry construction.
+    const PCG_BANK_BY_TYPE: Record<"checking" | "savings" | "other", string> = {
+      checking: "512100", // Compte courant / exploitation
+      savings: "512200",  // Compte épargne / fonds travaux
+      other: "512100",    // Fallback PCG standard
+    };
+    const bankAccount = PCG_BANK_BY_TYPE[bankAccountType] ?? "512100";
 
     // Build double-entry lines:
     // Income (positive amount): debit bank / credit expense account

--- a/app/api/accounting/bank/reconciliation/categorize/route.ts
+++ b/app/api/accounting/bank/reconciliation/categorize/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Categorize & create entry from bank transaction
  * POST /api/accounting/bank/reconciliation/categorize

--- a/app/api/accounting/bank/reconciliation/match/route.ts
+++ b/app/api/accounting/bank/reconciliation/match/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Manual bank transaction matching
  * POST /api/accounting/bank/reconciliation/match

--- a/app/api/accounting/bank/reconciliation/route.ts
+++ b/app/api/accounting/bank/reconciliation/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Bank Reconciliation — Transaction listing
  * GET /api/accounting/bank/reconciliation

--- a/app/api/accounting/bank/sync/route.ts
+++ b/app/api/accounting/bank/sync/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Bank Sync
  * POST /api/accounting/bank/sync - Sync transactions from bank connections

--- a/app/api/accounting/crg/[id]/route.ts
+++ b/app/api/accounting/crg/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: CRG Detail
  * GET  /api/accounting/crg/:id        - Get single CRG detail
@@ -151,10 +150,20 @@ export async function POST(request: Request, context: Context) {
 
           if (entity) {
             // Find a profile linked to this entity
-            const { data: ownerProfile } = await supabase
+            const { data: ownerProfile } = await (supabase as unknown as {
+              from: (t: string) => {
+                select: (s: string) => {
+                  eq: (k: string, v: string) => {
+                    limit: (n: number) => {
+                      single: () => Promise<{ data: { id: string; email?: string } | null }>;
+                    };
+                  };
+                };
+              };
+            })
               .from("profiles")
               .select("id, email")
-              .eq("legal_entity_id", entity.id)
+              .eq("legal_entity_id", entity.id as string)
               .limit(1)
               .single();
 

--- a/app/api/accounting/dashboard/route.ts
+++ b/app/api/accounting/dashboard/route.ts
@@ -159,8 +159,38 @@ export async function GET(request: Request) {
       0
     );
 
-    // Commissions Talok — pas de table dédiée pour le MVP
-    const totalCommissions = 0;
+    // ────────────────────────────────────────────
+    // Commission de gestion (mandant_accounts)
+    // ────────────────────────────────────────────
+    // Pour un propriétaire géré par une agence (mandat de gestion signé),
+    // on retrouve sa ligne dans `mandant_accounts` via `mandant_user_id`.
+    // Le `commission_rate` (en %) s'applique au total des loyers encaissés.
+    // Pour un propriétaire en gestion directe, aucune ligne => commission = 0.
+    let commissionRate = 0;
+    {
+      const { data: mandate } = await (serviceClient as unknown as {
+        from: (t: string) => {
+          select: (s: string) => {
+            eq: (k: string, v: string) => {
+              eq: (k: string, v: boolean) => {
+                maybeSingle: () => Promise<{
+                  data: { commission_rate: number | string | null } | null;
+                }>;
+              };
+            };
+          };
+        };
+      })
+        .from("mandant_accounts")
+        .select("commission_rate")
+        .eq("mandant_user_id", user.id)
+        .eq("is_active", true)
+        .maybeSingle();
+      commissionRate = Number(mandate?.commission_rate ?? 0) || 0;
+    }
+    const totalCommissions = Math.round(
+      totalRentCollected * (commissionRate / 100) * 100,
+    ) / 100;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const allExpenses = (expenseRows || []) as any[];
     const totalExpenses = allExpenses.reduce(

--- a/app/api/accounting/declarations/[type]/route.ts
+++ b/app/api/accounting/declarations/[type]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Assistant declaration fiscale (Sprint 4)
  * GET /api/accounting/declarations/[type]

--- a/app/api/accounting/documents/[id]/validate/route.ts
+++ b/app/api/accounting/documents/[id]/validate/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Validate OCR Suggestion → Create Accounting Entry
  * POST /api/accounting/documents/[id]/validate

--- a/app/api/accounting/documents/analyze/route.ts
+++ b/app/api/accounting/documents/analyze/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: OCR Document Analysis
  * POST /api/accounting/documents/analyze - Lance l'analyse OCR d'un document

--- a/app/api/accounting/ec/access/[id]/route.ts
+++ b/app/api/accounting/ec/access/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Revoke Expert-Comptable Access
  * DELETE /api/accounting/ec/access/[id] - Revoke access

--- a/app/api/accounting/ec/access/route.ts
+++ b/app/api/accounting/ec/access/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Expert-Comptable Access Management
  * POST /api/accounting/ec/access - Invite an EC to access an entity

--- a/app/api/accounting/ec/access/route.ts
+++ b/app/api/accounting/ec/access/route.ts
@@ -20,9 +20,23 @@ const GrantAccessSchema = z.object({
   accessLevel: z.enum(["read", "annotate", "validate"]),
 });
 
+const SendDeclarationSchema = z.object({
+  action: z.literal("send_declaration"),
+  entityId: z.string().uuid(),
+  year: z.number().int().min(2020),
+  declarationType: z.string().optional(),
+});
+
 /**
  * POST /api/accounting/ec/access
- * Grant an expert-comptable access to an entity's accounting data.
+ *
+ * Two modes (discriminated by `action` field):
+ * - Default (no `action`) : grant an expert-comptable access to an entity's
+ *   accounting data (invite flow).
+ * - `action: "send_declaration"` : notify every active expert-comptable linked
+ *   to the entity that a new fiscal declaration is ready. Does not ship the
+ *   PDF itself — the email contains a link to the owner's Talok workspace
+ *   where the EC can download it from the Exports tab.
  */
 export async function POST(request: Request) {
   try {
@@ -47,6 +61,70 @@ export async function POST(request: Request) {
     if (featureGate) return featureGate;
 
     const body = await request.json();
+
+    // ── Branch 1: send declaration notification to active EC(s) ──────────
+    if (body && typeof body === "object" && (body as Record<string, unknown>).action === "send_declaration") {
+      const sendValidation = SendDeclarationSchema.safeParse(body);
+      if (!sendValidation.success) {
+        throw new ApiError(400, sendValidation.error.errors[0].message);
+      }
+      const { entityId: targetEntityId, year, declarationType } = sendValidation.data;
+
+      // Load active EC accesses for the entity
+      const { data: activeAccesses } = await (supabase as unknown as {
+        from: (t: string) => {
+          select: (s: string) => {
+            eq: (k: string, v: string) => {
+              eq: (k: string, v: boolean) => Promise<{
+                data: Array<{ id: string; ec_email: string; ec_name: string | null }> | null;
+              }>;
+            };
+          };
+        };
+      })
+        .from("ec_access")
+        .select("id, ec_email, ec_name")
+        .eq("entity_id", targetEntityId)
+        .eq("is_active", true);
+
+      if (!activeAccesses || activeAccesses.length === 0) {
+        return NextResponse.json(
+          {
+            error:
+              "Aucun expert-comptable actif n'est lié à cette entité. Invitez-le d'abord depuis Expert-comptable.",
+          },
+          { status: 404 },
+        );
+      }
+
+      const declLabel = declarationType ? declarationType.toUpperCase() : "fiscale";
+      const subject = `Talok — Déclaration ${declLabel} ${year} prête à consulter`;
+      const html = `
+        <h2>Déclaration ${declLabel} ${year}</h2>
+        <p>Bonjour,</p>
+        <p>Une nouvelle déclaration ${declLabel} est disponible pour l'année ${year}.</p>
+        <p>Connectez-vous à votre espace Talok pour consulter et télécharger les exports comptables (récapitulatif fiscal, FEC, grand livre, balance).</p>
+        <p>Cordialement,<br/>L'équipe Talok</p>
+      `;
+
+      await Promise.all(
+        activeAccesses.map((access) =>
+          sendEmail({
+            to: access.ec_email,
+            subject,
+            html,
+            tags: [{ name: "category", value: "ec-declaration" }],
+          }),
+        ),
+      );
+
+      return NextResponse.json({
+        success: true,
+        data: { notified: activeAccesses.length },
+      });
+    }
+
+    // ── Branch 2: invite flow (default) ──────────────────────────────────
     const validation = GrantAccessSchema.safeParse(body);
 
     if (!validation.success) {

--- a/app/api/accounting/ec/annotations/[id]/route.ts
+++ b/app/api/accounting/ec/annotations/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Resolve EC Annotation
  * PATCH /api/accounting/ec/annotations/[id] - Mark annotation as resolved

--- a/app/api/accounting/ec/annotations/route.ts
+++ b/app/api/accounting/ec/annotations/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Expert-Comptable Annotations
  * POST /api/accounting/ec/annotations - Create annotation

--- a/app/api/accounting/ec/dashboard/route.ts
+++ b/app/api/accounting/ec/dashboard/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { handleApiError, ApiError } from "@/lib/helpers/api-error";

--- a/app/api/accounting/entries/route.ts
+++ b/app/api/accounting/entries/route.ts
@@ -90,7 +90,14 @@ export async function GET(request: Request) {
     const invoiceId = searchParams.get("invoice_id");
     const startDate = searchParams.get("start_date");
     const endDate = searchParams.get("end_date");
-    const pieceRef = searchParams.get("piece_ref");
+    // Full-text search: match on label OR piece_ref. We still accept the
+    // legacy `piece_ref` parameter name for backward compatibility.
+    const search = searchParams.get("search") ?? searchParams.get("piece_ref");
+    // Status filter: 'draft' | 'validated' | 'all' (default). Maps to the
+    // new double-entry boolean `is_validated`.
+    const statusParam = searchParams.get("status");
+    // Source filter (new column): 'manual' | 'stripe' | 'ocr' | 'bank' | ...
+    const sourceParam = searchParams.get("source");
     const MAX_LIMIT = 500;
     const limit = Math.min(parseInt(searchParams.get("limit") || "100") || 100, MAX_LIMIT);
     const offset = Math.max(parseInt(searchParams.get("offset") || "0") || 0, 0);
@@ -110,13 +117,21 @@ export async function GET(request: Request) {
     if (ownerId) query = query.eq("owner_id", ownerId);
     if (propertyId) query = query.eq("property_id", propertyId);
     if (invoiceId) query = query.eq("invoice_id", invoiceId);
-    if (pieceRef) query = query.ilike("piece_ref", `%${pieceRef}%`);
-    if (startDate) query = query.gte("ecriture_date", startDate);
-    if (endDate) query = query.lte("ecriture_date", endDate);
+    if (search) {
+      // Match both the new `label` column and the legacy `piece_ref` so the
+      // user's query finds rows no matter which schema version produced them.
+      const escaped = search.replace(/[%,]/g, (m) => `\\${m}`);
+      query = query.or(`label.ilike.%${escaped}%,piece_ref.ilike.%${escaped}%`);
+    }
+    if (startDate) query = query.gte("entry_date", startDate);
+    if (endDate) query = query.lte("entry_date", endDate);
+    if (statusParam === "draft") query = query.eq("is_validated", false);
+    else if (statusParam === "validated") query = query.eq("is_validated", true);
+    if (sourceParam) query = query.eq("source", sourceParam);
 
     query = query
-      .order("ecriture_date", { ascending: false })
-      .order("ecriture_num", { ascending: false })
+      .order("entry_date", { ascending: false })
+      .order("entry_number", { ascending: false })
       .range(offset, offset + limit - 1);
 
     const { data: entries, error, count } = await query;

--- a/app/api/accounting/exercises/[exerciseId]/close/route.ts
+++ b/app/api/accounting/exercises/[exerciseId]/close/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Close Accounting Exercise
  * POST /api/accounting/exercises/[exerciseId]/close - Close an exercise

--- a/app/api/accounting/exercises/[exerciseId]/route.ts
+++ b/app/api/accounting/exercises/[exerciseId]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Single Accounting Exercise
  * GET /api/accounting/exercises/[exerciseId] - Fetch exercise with balance summary

--- a/app/api/accounting/expenses/[id]/route.ts
+++ b/app/api/accounting/expenses/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Expense detail (GET / PUT / DELETE)
  * /api/accounting/expenses/[id]

--- a/app/api/accounting/expenses/route.ts
+++ b/app/api/accounting/expenses/route.ts
@@ -14,6 +14,13 @@ import { createClient } from "@/lib/supabase/server";
 import { createServiceRoleClient } from "@/lib/supabase/server";
 import { handleApiError, ApiError } from "@/lib/helpers/api-error";
 import { userHasFeature } from "@/lib/subscriptions/subscription-service";
+import {
+  computeTVA,
+  resolveTerritoryFromPostalCode,
+  validateTVACoherence,
+  type Territory,
+  type TvaRateKind,
+} from "@/lib/accounting/chart-amort-ocr";
 
 const EXPENSE_CATEGORIES = [
   "travaux", "entretien", "assurance", "taxe_fonciere", "charges_copro",
@@ -146,6 +153,85 @@ export async function POST(request: Request) {
       throw new ApiError(400, "La date est requise");
     }
 
+    // ─────────────────────────────────────────────────────────────
+    // Auto-compute TVA from the DROM-COM territory of the entity.
+    // Priority for resolving the territory postal code:
+    //   1. the linked property's code_postal (most specific)
+    //   2. the legal entity's code_postal_siege
+    //   3. metropole (fallback)
+    //
+    // Rules:
+    // - If the caller provides an explicit tva_taux, we trust it but
+    //   still verify coherence against the territory and compute the
+    //   resulting tva_montant / montant_ttc ourselves so the row stays
+    //   internally consistent.
+    // - If tva_taux is missing or zero and the caller has not already
+    //   sent a tva_montant, we apply the territory's default "normal"
+    //   rate (20% metropole, 8.5% Antilles/Réunion, 0% Guyane/Mayotte).
+    // ─────────────────────────────────────────────────────────────
+    let territoryPostalCode: string | null = null;
+    if (body.property_id) {
+      const { data: property } = await (serviceClient as unknown as {
+        from: (t: string) => {
+          select: (s: string) => {
+            eq: (k: string, v: string) => {
+              maybeSingle: () => Promise<{
+                data: { code_postal: string | null } | null;
+              }>;
+            };
+          };
+        };
+      })
+        .from("properties")
+        .select("code_postal")
+        .eq("id", body.property_id)
+        .maybeSingle();
+      territoryPostalCode = property?.code_postal ?? null;
+    }
+    if (!territoryPostalCode && body.legal_entity_id) {
+      const { data: entity } = await (serviceClient as unknown as {
+        from: (t: string) => {
+          select: (s: string) => {
+            eq: (k: string, v: string) => {
+              maybeSingle: () => Promise<{
+                data: { code_postal_siege: string | null } | null;
+              }>;
+            };
+          };
+        };
+      })
+        .from("legal_entities")
+        .select("code_postal_siege")
+        .eq("id", body.legal_entity_id)
+        .maybeSingle();
+      territoryPostalCode = entity?.code_postal_siege ?? null;
+    }
+    const territory: Territory = resolveTerritoryFromPostalCode(territoryPostalCode);
+
+    const providedRate = typeof body.tva_taux === "number" ? body.tva_taux : null;
+    const rateKind: TvaRateKind = (body.tva_rate_kind as TvaRateKind) ?? "normal";
+    const { tva_taux, tva_montant, montant_ttc } =
+      providedRate != null && providedRate > 0
+        ? (() => {
+            // User-specified rate: compute matching amounts and warn if
+            // the rate is incoherent with the territory (non-blocking).
+            const tvaMontant =
+              Math.round(body.montant * (providedRate / 100) * 100) / 100;
+            const coherence = validateTVACoherence(providedRate, territory);
+            if (!coherence.valid) {
+              console.warn(
+                "[expenses] TVA rate incoherent with territory",
+                { providedRate, territory, message: coherence.message },
+              );
+            }
+            return {
+              tva_taux: providedRate,
+              tva_montant: tvaMontant,
+              montant_ttc: Math.round((body.montant + tvaMontant) * 100) / 100,
+            };
+          })()
+        : computeTVA(body.montant, territory, rateKind);
+
     const { data: expense, error } = await (serviceClient as any)
       .from("expenses")
       .insert({
@@ -156,10 +242,11 @@ export async function POST(request: Request) {
         category: body.category,
         description: body.description,
         montant: body.montant,
+        montant_ttc,
         date_depense: body.date_depense,
         fournisseur: body.fournisseur || null,
-        tva_taux: body.tva_taux || 0,
-        tva_montant: body.tva_montant || 0,
+        tva_taux,
+        tva_montant,
         deductible: body.deductible !== false,
         recurrence: body.recurrence || "ponctuel",
         notes: body.notes || null,
@@ -170,7 +257,10 @@ export async function POST(request: Request) {
 
     if (error) throw error;
 
-    return NextResponse.json({ expense }, { status: 201 });
+    return NextResponse.json(
+      { expense, territory, tva_taux },
+      { status: 201 },
+    );
   } catch (error) {
     return handleApiError(error);
   }

--- a/app/api/accounting/expenses/route.ts
+++ b/app/api/accounting/expenses/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Expenses CRUD (liste + création)
  * GET  /api/accounting/expenses?year=2025&entityId=xxx

--- a/app/api/accounting/fec/[exerciseId]/route.ts
+++ b/app/api/accounting/fec/[exerciseId]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: FEC by Exercise
  * GET /api/accounting/fec/:exerciseId - Preview or download FEC for a given exercise

--- a/app/api/accounting/fec/export/route.ts
+++ b/app/api/accounting/fec/export/route.ts
@@ -19,6 +19,9 @@ export const runtime = "nodejs";
  *
  * Query params:
  * - year: number (requis) - Année fiscale
+ * - entityId: string (requis) - UUID de l'entité juridique (legal_entities.id)
+ *     Utilisé pour renseigner le SIREN dans le nom de fichier FEC conforme
+ *     à l'article A47 A-1 LPF (format {SIREN}FEC{YYYYMMDD}).
  * - format: 'csv' | 'txt' (défaut: csv)
  */
 export async function GET(request: Request) {
@@ -53,15 +56,45 @@ export async function GET(request: Request) {
     // Parser les paramètres
     const { searchParams } = new URL(request.url);
     const yearParam = searchParams.get("year");
+    const entityId = searchParams.get("entityId");
     const format = searchParams.get("format") || "csv";
 
     if (!yearParam) {
       throw new ApiError(400, "L'année (year) est requise");
     }
+    if (!entityId) {
+      throw new ApiError(
+        400,
+        "Le paramètre entityId est requis pour identifier l'entité juridique (SIREN)."
+      );
+    }
 
     const year = parseInt(yearParam);
     if (isNaN(year) || year < 2020 || year > new Date().getFullYear()) {
       throw new ApiError(400, "Année invalide");
+    }
+
+    // Récupérer l'entité juridique — le SIREN est obligatoire pour un FEC légal.
+    // Noms de colonnes issus de supabase/migrations/20260115010000_multi_entity_architecture.sql.
+    const { data: entity } = await supabase
+      .from("legal_entities")
+      .select("id, siren, nom, adresse_siege, regime_fiscal")
+      .eq("id", entityId)
+      .single();
+
+    if (!entity) {
+      throw new ApiError(404, "Entité juridique introuvable");
+    }
+
+    const entitySiren = (entity as { siren: string | null }).siren;
+    if (!entitySiren || entitySiren.length !== 9) {
+      return NextResponse.json(
+        {
+          error:
+            "SIREN manquant pour cette entité. Renseignez-le dans Paramètres > Entité juridique.",
+        },
+        { status: 422 }
+      );
     }
 
     // Générer l'export FEC
@@ -74,11 +107,10 @@ export async function GET(request: Request) {
     // Convertir en CSV
     const csvContent = accountingService.exportFECToCSV(ecritures);
 
-    // Générer le nom de fichier conforme
+    // Générer le nom de fichier conforme à l'art. A47 A-1 LPF
     // Format: {SIREN}FEC{YYYYMMDD}.txt
-    const siren = "123456789"; // À remplacer par le vrai SIREN
     const dateExport = new Date().toISOString().split("T")[0].replace(/-/g, "");
-    const filename = `${siren}FEC${dateExport}.${format === "txt" ? "txt" : "csv"}`;
+    const filename = `${entitySiren}FEC${dateExport}.${format === "txt" ? "txt" : "csv"}`;
 
     // Retourner le fichier
     return new NextResponse(csvContent, {
@@ -87,6 +119,7 @@ export async function GET(request: Request) {
         "Content-Disposition": `attachment; filename="${filename}"`,
         "X-FEC-Year": year.toString(),
         "X-FEC-Records": ecritures.length.toString(),
+        "X-FEC-Siren": entitySiren,
       },
     });
   } catch (error) {

--- a/app/api/accounting/fiscal-summary/route.ts
+++ b/app/api/accounting/fiscal-summary/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Récapitulatif fiscal PDF
  * GET /api/accounting/fiscal-summary?year=2025

--- a/app/api/accounting/fiscal-summary/route.ts
+++ b/app/api/accounting/fiscal-summary/route.ts
@@ -168,14 +168,45 @@ export async function GET(request: Request) {
 
     const ownerName = `${profile.prenom || ""} ${profile.nom || ""}`.trim() || "Propriétaire";
 
+    // ────────────────────────────────────────────
+    // Commission de gestion (mandant_accounts)
+    // ────────────────────────────────────────────
+    // Même logique que le dashboard : on cherche un mandat de gestion actif
+    // pour l'utilisateur (mandant_user_id), on applique commission_rate % au
+    // total des loyers encaissés. Propriétaire en gestion directe => 0.
+    let commissionRate = 0;
+    {
+      const { data: mandate } = await (serviceClient as unknown as {
+        from: (t: string) => {
+          select: (s: string) => {
+            eq: (k: string, v: string) => {
+              eq: (k: string, v: boolean) => {
+                maybeSingle: () => Promise<{
+                  data: { commission_rate: number | string | null } | null;
+                }>;
+              };
+            };
+          };
+        };
+      })
+        .from("mandant_accounts")
+        .select("commission_rate")
+        .eq("mandant_user_id", user.id)
+        .eq("is_active", true)
+        .maybeSingle();
+      commissionRate = Number(mandate?.commission_rate ?? 0) || 0;
+    }
+    const totalCommissions =
+      Math.round(totalRentCollected * (commissionRate / 100) * 100) / 100;
+
     const fiscalData: FiscalSummaryData = {
       year,
       ownerName,
       totalRentCollected,
       totalChargesCollected,
-      totalCommissions: 0,
+      totalCommissions,
       totalExpenses,
-      netIncome: totalRentCollected - totalExpenses,
+      netIncome: totalRentCollected - totalCommissions - totalExpenses,
       monthlyBreakdown,
       byProperty,
     };

--- a/app/api/accounting/ocr-rules/route.ts
+++ b/app/api/accounting/ocr-rules/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: OCR Category Rules
  * GET /api/accounting/ocr-rules — List rules for entity

--- a/app/api/accounting/syndic/appels/[callId]/route.ts
+++ b/app/api/accounting/syndic/appels/[callId]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Syndic Copropriété — Fund Call Detail
  * GET  /api/accounting/syndic/appels/[callId]  - Get call with lines

--- a/app/api/accounting/syndic/budget/[id]/route.ts
+++ b/app/api/accounting/syndic/budget/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Syndic Copropriété — Budget Detail
  * PATCH /api/accounting/syndic/budget/[id]       - Update lines (draft only)

--- a/app/api/accounting/syndic/budget/route.ts
+++ b/app/api/accounting/syndic/budget/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Syndic Copropriété — Budgets
  * GET  /api/accounting/syndic/budget  - List budgets (with actual comparison)

--- a/app/api/accounting/syndic/lots/[id]/route.ts
+++ b/app/api/accounting/syndic/lots/[id]/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Syndic Copropriété — Lot Detail
  * GET    /api/accounting/syndic/lots/[id] - Get single lot

--- a/app/api/accounting/syndic/lots/route.ts
+++ b/app/api/accounting/syndic/lots/route.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * API Route: Syndic Copropriété — Lots
  * GET  /api/accounting/syndic/lots  - List lots for an entity

--- a/app/api/invoices/[id]/mark-paid/route.ts
+++ b/app/api/invoices/[id]/mark-paid/route.ts
@@ -215,6 +215,22 @@ export async function POST(
       } catch (receiptError) {
         console.error("[mark-paid] Erreur génération quittance:", receiptError);
       }
+
+      // Off-Stripe receipt → ensure the double-entry `rent_received` is
+      // posted to the owner accounting module (the Stripe webhook does
+      // this inline; non-Stripe paths were missing it). Idempotent via
+      // `reference = payment_id` guard inside the helper.
+      try {
+        const { ensureReceiptAccountingEntry } = await import(
+          "@/lib/accounting/receipt-entry"
+        );
+        await ensureReceiptAccountingEntry(supabase as any, payment.id);
+      } catch (entryError) {
+        console.error(
+          "[mark-paid] Écriture comptable (non bloquante):",
+          entryError,
+        );
+      }
     }
 
     const [{ data: tenantProfile }, { data: ownerProfile }] = await Promise.all([

--- a/app/api/leases/[id]/generate-receipt/route.ts
+++ b/app/api/leases/[id]/generate-receipt/route.ts
@@ -137,6 +137,22 @@ export async function POST(
       );
     }
 
+    // 7-bis. Post the matching `rent_received` double-entry for off-Stripe
+    // payments. Idempotent: the helper skips if an entry with
+    // reference=payment_id already exists (so Stripe-originated payments
+    // stay untouched).
+    try {
+      const { ensureReceiptAccountingEntry } = await import(
+        "@/lib/accounting/receipt-entry"
+      );
+      await ensureReceiptAccountingEntry(serviceClient, payment.id);
+    } catch (entryError) {
+      console.error(
+        "[generate-receipt] Écriture comptable (non bloquante):",
+        entryError,
+      );
+    }
+
     // 8. Envoyer email si demandé
     let emailSent = false;
     if (

--- a/app/api/payments/confirm/route.ts
+++ b/app/api/payments/confirm/route.ts
@@ -241,6 +241,21 @@ export async function POST(request: NextRequest) {
         } catch (receiptError) {
           console.error("[confirm] Erreur génération quittance:", receiptError);
         }
+
+        // Post the matching `rent_received` double-entry for off-Stripe
+        // payments. Idempotent: skipped if an entry with
+        // reference=payment_id already exists.
+        try {
+          const { ensureReceiptAccountingEntry } = await import(
+            "@/lib/accounting/receipt-entry"
+          );
+          await ensureReceiptAccountingEntry(serviceClient as any, payment.id);
+        } catch (entryError) {
+          console.error(
+            "[confirm] Écriture comptable (non bloquante):",
+            entryError,
+          );
+        }
       }
 
       // Envoyer l'email de confirmation

--- a/app/owner/accounting/AccountingDashboard.tsx
+++ b/app/owner/accounting/AccountingDashboard.tsx
@@ -7,6 +7,10 @@ import { AccountingKPICard } from "@/components/accounting/AccountingKPICard";
 import { RecentEntries } from "@/components/accounting/RecentEntries";
 import { AccountingEmptyState } from "@/components/accounting/AccountingEmptyState";
 import { formatCents } from "@/lib/utils/format-cents";
+import {
+  resolveTerritoryFromPostalCode,
+  TVA_RATES,
+} from "@/lib/accounting/chart-amort-ocr";
 import { useEntityStore } from "@/stores/useEntityStore";
 import { useToast } from "@/components/ui/use-toast";
 import { Button } from "@/components/ui/button";
@@ -95,11 +99,11 @@ function AccountingDashboardContent() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
-            Comptabilite
+            Comptabilité
           </h1>
           {currentExercise && (
             <p className="text-sm text-muted-foreground mt-1">
-              Exercice : {currentExercise.label} ({currentExercise.status === "open" ? "En cours" : "Cloture"})
+              Exercice : {currentExercise.label} ({currentExercise.status === "open" ? "En cours" : "Clôturé"})
             </p>
           )}
         </div>
@@ -285,8 +289,28 @@ function formatCurrency(v: number): string {
 function ExpensesAndExports() {
   const { toast } = useToast();
   const activeEntityId = useEntityStore((s) => s.activeEntityId);
+  const activeEntity = useEntityStore((s) => s.getActiveEntity());
   const entityParam = activeEntityId ? `&entityId=${encodeURIComponent(activeEntityId)}` : "";
   const currentYear = new Date().getFullYear();
+
+  // TVA rate badge — derived from the active entity's postal code so
+  // the user sees the DROM-COM rate (8,5% Antilles/Réunion, 0% Guyane/
+  // Mayotte) that will be applied server-side on insert. Falls back to
+  // metropole (20%) when no entity is selected.
+  const territory = resolveTerritoryFromPostalCode(
+    activeEntity?.codePostalSiege ?? null,
+  );
+  const tvaRateNormal = TVA_RATES[territory]?.normal ?? 20;
+  const tvaTerritoryLabel = (() => {
+    switch (territory) {
+      case "martinique": return "Martinique";
+      case "guadeloupe": return "Guadeloupe";
+      case "reunion": return "Réunion";
+      case "guyane": return "Guyane";
+      case "mayotte": return "Mayotte";
+      default: return "Métropole";
+    }
+  })();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [expenses, setExpenses] = useState<any[]>([]);
@@ -417,7 +441,16 @@ function ExpensesAndExports() {
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="exp-amount">Montant HT (€)</Label>
+                    <div className="flex items-center justify-between gap-2">
+                      <Label htmlFor="exp-amount">Montant HT (€)</Label>
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] font-normal shrink-0"
+                        title={`Taux TVA applicable — ${tvaTerritoryLabel}`}
+                      >
+                        TVA {tvaRateNormal}% · {tvaTerritoryLabel}
+                      </Badge>
+                    </div>
                     <Input id="exp-amount" name="montant" type="number" step="0.01" min="0.01" required />
                   </div>
                   <div className="space-y-2">
@@ -482,6 +515,7 @@ function ExpensesAndExports() {
                 <Button
                   variant="ghost" size="icon"
                   className="shrink-0 text-destructive hover:text-destructive h-7 w-7"
+                  aria-label={`Supprimer la dépense ${exp.description}`}
                   onClick={async () => {
                     const res = await fetch(`/api/accounting/expenses/${exp.id}`, { method: "DELETE" });
                     if (res.ok) {

--- a/app/owner/accounting/AccountingDashboard.tsx
+++ b/app/owner/accounting/AccountingDashboard.tsx
@@ -222,22 +222,22 @@ function AccountingDashboardContent() {
           {/* Quick actions */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <QuickAction
-              href="/owner/accounting/entries/new"
+              href="/owner/accounting/entries"
               icon={<FileText className="w-5 h-5" />}
               label="Nouvelle ecriture"
             />
             <QuickAction
-              href="/owner/documents/upload"
+              href="/owner/accounting/upload"
               icon={<Upload className="w-5 h-5" />}
               label="Scanner justificatif"
             />
             <QuickAction
-              href="/owner/money/settings"
+              href="/owner/accounting/bank"
               icon={<Building2 className="w-5 h-5" />}
               label="Rapprochement bancaire"
             />
             <QuickAction
-              href="/owner/accounting/export"
+              href="/owner/accounting/exports"
               icon={<Download className="w-5 h-5" />}
               label="Exporter FEC"
             />

--- a/app/owner/accounting/AccountingDashboard.tsx
+++ b/app/owner/accounting/AccountingDashboard.tsx
@@ -1,5 +1,4 @@
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { useState, useEffect } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
@@ -192,14 +191,15 @@ function AccountingDashboardContent() {
                         borderRadius: "0.75rem",
                         fontSize: 12,
                       }}
-                      formatter={(value: number, name: string) => [
-                        formatCents(value),
+                      formatter={((value: unknown, name: unknown) => [
+                        formatCents(typeof value === "number" ? value : Number(value) || 0),
                         name === "debitCents" ? "Debit" : "Credit",
-                      ]}
-                      labelFormatter={(label: string) => {
-                        const [y, m] = label.split("-");
+                      ]) as never}
+                      labelFormatter={((label: unknown) => {
+                        const str = typeof label === "string" ? label : String(label ?? "");
+                        const [y, m] = str.split("-");
                         return `${m}/${y}`;
-                      }}
+                      }) as never}
                     />
                     <Bar
                       dataKey="debitCents"

--- a/app/owner/accounting/AccountingDashboard.tsx
+++ b/app/owner/accounting/AccountingDashboard.tsx
@@ -56,7 +56,11 @@ import {
 
 export default function AccountingDashboard() {
   return (
-    <PlanGate feature="bank_reconciliation" mode="block">
+    <PlanGate
+      feature="bank_reconciliation"
+      mode="soft"
+      message="Rapprochement bancaire, FEC, récapitulatif fiscal et déclarations incluses à partir du forfait Confort."
+    >
       <AccountingDashboardContent />
     </PlanGate>
   );

--- a/app/owner/accounting/amortization/AmortizationClient.tsx
+++ b/app/owner/accounting/amortization/AmortizationClient.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
@@ -31,22 +29,37 @@ function AmortizationContent() {
     terrainPercentage: 15,
   });
 
-  const { data, isLoading } = useQuery<any>({
+  type AmortSchedule = {
+    id: string;
+    property_id: string;
+    component: string;
+    total_amount_cents: number;
+    duration_years: number;
+    terrain_percent: number;
+    depreciable_amount_cents: number;
+    amortization_lines: Array<{
+      annual_amount_cents: number;
+      cumulated_amount_cents: number;
+      net_book_value_cents: number;
+    }>;
+  };
+  type AmortResponse = AmortSchedule[] | { data?: AmortSchedule[] };
+
+  const { data, isLoading } = useQuery<AmortResponse>({
     queryKey: ["amortization", activeEntityId],
-    queryFn: () => apiClient.get(`/accounting/amortization?entityId=${activeEntityId}`),
+    queryFn: () => apiClient.get<AmortResponse>(`/accounting/amortization?entityId=${activeEntityId}`),
     enabled: !!activeEntityId,
   });
 
-  const createMutation = useMutation<any, any, any>({
-    mutationFn: (body: Record<string, unknown>) => apiClient.post("/accounting/amortization", body),
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["amortization"] }); setShowForm(false); },
+  const createMutation = useMutation<unknown, unknown, Record<string, unknown>>({
+    mutationFn: (body) => apiClient.post("/accounting/amortization", body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["amortization"] });
+      setShowForm(false);
+    },
   });
 
-  const schedules = (data?.data ?? data ?? []) as Array<{
-    id: string; property_id: string; component: string; total_amount_cents: number;
-    duration_years: number; terrain_percent: number; depreciable_amount_cents: number;
-    amortization_lines: Array<{ annual_amount_cents: number; cumulated_amount_cents: number; net_book_value_cents: number }>;
-  }>;
+  const schedules: AmortSchedule[] = Array.isArray(data) ? data : (data?.data ?? []);
 
   // Group by property
   const byProperty = new Map<string, typeof schedules>();

--- a/app/owner/accounting/bank/BankAccountsClient.tsx
+++ b/app/owner/accounting/bank/BankAccountsClient.tsx
@@ -1,5 +1,4 @@
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { useBankConnections, BankConnection } from "@/lib/hooks/use-bank-connections";

--- a/app/owner/accounting/bank/BankAccountsClient.tsx
+++ b/app/owner/accounting/bank/BankAccountsClient.tsx
@@ -171,7 +171,7 @@ function BankAccountsContent() {
         <div className="flex gap-2">
           <Link
             href="/owner/accounting/bank/reconciliation"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-white text-sm font-medium hover:bg-[#1B2A6B] transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
           >
             <Link2 className="w-4 h-4" />
             Rapprochement bancaire
@@ -191,7 +191,7 @@ function BankAccountsContent() {
       ) : (
         <>
           {/* Treasury header card */}
-          <div className="bg-gradient-to-r from-[#2563EB] to-[#1B2A6B] rounded-xl p-6 text-white">
+          <div className="bg-gradient-to-r from-primary to-primary/70 rounded-xl p-6 text-primary-foreground">
             <div className="flex items-center gap-3 mb-2">
               <Building2 className="w-6 h-6 opacity-80" />
               <span className="text-sm font-medium opacity-80">
@@ -356,7 +356,7 @@ function EmptyState() {
       </div>
       <Link
         href="/owner/accounting/bank/connect"
-        className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary text-white text-sm font-medium hover:bg-[#1B2A6B] transition-colors"
+        className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
       >
         <Plus className="w-4 h-4" />
         Ajouter un compte bancaire

--- a/app/owner/accounting/bank/connect/ConnectBankClient.tsx
+++ b/app/owner/accounting/bank/connect/ConnectBankClient.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
@@ -134,12 +132,14 @@ function ConnectBankFlow() {
   };
 
   const handleSubmit = useCallback(async () => {
-    if (!accountType || !(profile as any).default_entity_id) return;
+    const defaultEntityId = (profile as { default_entity_id?: string | null } | null)
+      ?.default_entity_id;
+    if (!accountType || !defaultEntityId) return;
     setSubmitting(true);
     try {
       if (isManual) {
         await apiClient.post("/accounting/bank/connections", {
-          entityId: (profile as any).default_entity_id,
+          entityId: defaultEntityId,
           provider: "manual",
           accountType,
           iban: manualIban.replace(/\s/g, ""),
@@ -150,7 +150,7 @@ function ConnectBankFlow() {
         const res = await apiClient.post<{ data: { authLink: string } }>(
           "/accounting/bank/connections",
           {
-            entityId: (profile as any).default_entity_id,
+            entityId: defaultEntityId,
             provider: "nordigen",
             institutionId: selectedInstitution.id,
             accountType,

--- a/app/owner/accounting/bank/connect/ConnectBankClient.tsx
+++ b/app/owner/accounting/bank/connect/ConnectBankClient.tsx
@@ -5,6 +5,25 @@ import { useRouter } from "next/navigation";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { apiClient } from "@/lib/api-client";
 import { useAuth } from "@/lib/hooks/use-auth";
+import { useToast } from "@/components/ui/use-toast";
+
+// Whitelist of hosts we trust for the bank-connect OAuth redirect.
+// Nordigen (historical) and its current GoCardless brand are the only two
+// providers wired in lib/bank/nordigen, so anything else is rejected.
+const ALLOWED_BANK_AUTH_HOSTS = new Set([
+  "ob.nordigen.com",
+  "bankaccountdata.gocardless.com",
+]);
+
+function isTrustedBankAuthLink(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "https:") return false;
+    return ALLOWED_BANK_AUTH_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
 import {
   Landmark,
   PiggyBank,
@@ -83,6 +102,7 @@ export default function ConnectBankClient() {
 function ConnectBankFlow() {
   const router = useRouter();
   const { profile } = useAuth();
+  const { toast } = useToast();
   const [step, setStep] = useState<1 | 2 | 3>(1);
   const [accountType, setAccountType] = useState<AccountType | null>(null);
   const [selectedInstitution, setSelectedInstitution] = useState<Institution | null>(null);
@@ -158,6 +178,18 @@ function ConnectBankFlow() {
         );
         const authLink = res?.data?.authLink;
         if (authLink) {
+          // Validate the provider-supplied URL before redirecting. Prevents
+          // open-redirect / phishing if the backend is ever compromised or
+          // if a response is tampered with in transit.
+          if (!isTrustedBankAuthLink(authLink)) {
+            toast({
+              title: "Lien de connexion bancaire invalide",
+              description:
+                "Le lien renvoyé par la banque n'est pas reconnu. Réessayez ou contactez le support.",
+              variant: "destructive",
+            });
+            return;
+          }
           window.location.href = authLink;
         } else {
           router.push("/owner/accounting/bank");
@@ -168,7 +200,7 @@ function ConnectBankFlow() {
     } finally {
       setSubmitting(false);
     }
-  }, [accountType, isManual, manualIban, manualBic, selectedInstitution, profile, router]);
+  }, [accountType, isManual, manualIban, manualBic, selectedInstitution, profile, router, toast]);
 
   const selectedTypeConfig = ACCOUNT_TYPES.find((t) => t.value === accountType);
 
@@ -247,7 +279,7 @@ function ConnectBankFlow() {
               placeholder="Rechercher une banque..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
+              className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
             />
           </div>
 
@@ -366,7 +398,7 @@ function ConnectBankFlow() {
                     placeholder="FR76 XXXX XXXX XXXX XXXX XXXX XXX"
                     value={manualIban}
                     onChange={(e) => setManualIban(e.target.value)}
-                    className="w-full px-3 py-2.5 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
+                    className="w-full px-3 py-2.5 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
                   />
                 </div>
                 <div>
@@ -378,7 +410,7 @@ function ConnectBankFlow() {
                     placeholder="BNPAFRPP"
                     value={manualBic}
                     onChange={(e) => setManualBic(e.target.value)}
-                    className="w-full px-3 py-2.5 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
+                    className="w-full px-3 py-2.5 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
                   />
                 </div>
               </div>
@@ -389,7 +421,7 @@ function ConnectBankFlow() {
           <button
             onClick={handleSubmit}
             disabled={submitting || (isManual && !manualIban)}
-            className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-primary text-white text-sm font-medium hover:bg-[#1B2A6B] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {submitting ? (
               <Loader2 className="w-4 h-4 animate-spin" />

--- a/app/owner/accounting/bank/reconciliation/ReconciliationClient.tsx
+++ b/app/owner/accounting/bank/reconciliation/ReconciliationClient.tsx
@@ -1,35 +1,21 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useCallback, useState } from "react";
+import Link from "next/link";
 import { PlanGate } from "@/components/subscription/plan-gate";
-import { useBankConnections, BankConnection } from "@/lib/hooks/use-bank-connections";
+import { useBankConnections } from "@/lib/hooks/use-bank-connections";
 import {
   useReconciliation,
   useReconciliationActions,
-  BankTransactionRow,
 } from "@/lib/hooks/use-reconciliation";
-import { formatCents } from "@/lib/utils/format-cents";
 import { useToast } from "@/components/ui/use-toast";
-import Link from "next/link";
+import { ArrowLeft, Filter, Loader2, RefreshCw } from "lucide-react";
+import { ReconciliationStats } from "./components/ReconciliationStats";
 import {
-  ArrowLeft,
-  Link2,
-  AlertTriangle,
-  Check,
-  X,
-  ArrowUpRight,
-  ArrowDownLeft,
-  RefreshCw,
-  Loader2,
-  Filter,
-  Tag,
-  Clock,
-  Repeat,
-} from "lucide-react";
-
-// ── Types ───────────────────────────────────────────────────────────
-
-type FilterTab = "all" | "suggested" | "orphan" | "matched";
+  ReconciliationFilters,
+  type ReconciliationFilterTab,
+} from "./components/ReconciliationFilters";
+import { TransactionCard } from "./components/TransactionCard";
 
 // ── Wrapper ─────────────────────────────────────────────────────────
 
@@ -48,7 +34,7 @@ function ReconciliationContent() {
   const [selectedConnectionId, setSelectedConnectionId] = useState<
     string | undefined
   >();
-  const [filterTab, setFilterTab] = useState<FilterTab>("all");
+  const [filterTab, setFilterTab] = useState<ReconciliationFilterTab>("all");
 
   const statusFilter =
     filterTab === "all"
@@ -67,13 +53,14 @@ function ReconciliationContent() {
     status: statusFilter,
   });
 
-  const { match, ignore, categorize, runMatching } =
-    useReconciliationActions();
+  const { match, ignore, categorize, runMatching } = useReconciliationActions();
   const { toast } = useToast();
   const [runningMatch, setRunningMatch] = useState(false);
 
-  // Filter transactions for display (matched includes both auto and manual)
-  const filteredTransactions =
+  // The server filters by `matched_auto` only, so when the user picks the
+  // "matched" tab we also include `matched_manual` client-side — this is a
+  // UX conversion, not a data filter. Keep the pass minimal.
+  const displayTransactions =
     filterTab === "matched"
       ? transactions.filter(
           (tx) =>
@@ -106,19 +93,6 @@ function ReconciliationContent() {
 
   const isLoading = connLoading || txLoading;
 
-  const connectionLabel = (c: BankConnection) => {
-    switch (c.account_type) {
-      case "exploitation":
-        return "Exploitation";
-      case "epargne":
-        return "Epargne";
-      case "depot_garantie":
-        return "DG";
-      default:
-        return "Autre";
-    }
-  };
-
   const pctReconciled =
     stats.total > 0 ? Math.round((stats.matched / stats.total) * 100) : 0;
 
@@ -139,104 +113,17 @@ function ReconciliationContent() {
         </div>
       </div>
 
-      {/* Account tabs */}
-      {connections.length > 1 && (
-        <div className="flex gap-2 overflow-x-auto pb-1">
-          <button
-            onClick={() => setSelectedConnectionId(undefined)}
-            className={`px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
-              !selectedConnectionId
-                ? "bg-primary text-white"
-                : "bg-card border border-border text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            Tous
-          </button>
-          {connections.map((c) => (
-            <button
-              key={c.id}
-              onClick={() => setSelectedConnectionId(c.id)}
-              className={`px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
-                selectedConnectionId === c.id
-                  ? "bg-primary text-white"
-                  : "bg-card border border-border text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              {connectionLabel(c)}
-            </button>
-          ))}
-        </div>
-      )}
+      {/* Filters (connection tabs + status tabs) */}
+      <ReconciliationFilters
+        connections={connections}
+        selectedConnectionId={selectedConnectionId}
+        onSelectConnection={setSelectedConnectionId}
+        filterTab={filterTab}
+        onChangeFilterTab={setFilterTab}
+      />
 
-      {/* Summary stat cards */}
-      <div className="grid grid-cols-3 gap-3 sm:gap-4">
-        <StatCard
-          label="Rapproches"
-          count={stats.matched}
-          color="green"
-          icon={<Check className="w-4 h-4" />}
-        />
-        <StatCard
-          label="A valider"
-          count={stats.suggested}
-          color="orange"
-          icon={<Clock className="w-4 h-4" />}
-        />
-        <StatCard
-          label="Non identifies"
-          count={stats.orphan}
-          color="red"
-          icon={<AlertTriangle className="w-4 h-4" />}
-        />
-      </div>
-
-      {/* Overall progress bar */}
-      {stats.total > 0 && (
-        <div className="w-full h-2 bg-muted rounded-full overflow-hidden flex">
-          {stats.matched > 0 && (
-            <div
-              className="h-full bg-green-500"
-              style={{ width: `${(stats.matched / stats.total) * 100}%` }}
-            />
-          )}
-          {stats.suggested > 0 && (
-            <div
-              className="h-full bg-orange-500"
-              style={{ width: `${(stats.suggested / stats.total) * 100}%` }}
-            />
-          )}
-          {stats.orphan > 0 && (
-            <div
-              className="h-full bg-red-500"
-              style={{ width: `${(stats.orphan / stats.total) * 100}%` }}
-            />
-          )}
-        </div>
-      )}
-
-      {/* Filter tabs */}
-      <div className="flex gap-2 overflow-x-auto pb-1">
-        {(
-          [
-            { key: "all", label: "Tous" },
-            { key: "suggested", label: "A valider" },
-            { key: "orphan", label: "Non identifies" },
-            { key: "matched", label: "Rapproches" },
-          ] as { key: FilterTab; label: string }[]
-        ).map((tab) => (
-          <button
-            key={tab.key}
-            onClick={() => setFilterTab(tab.key)}
-            className={`px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap transition-colors ${
-              filterTab === tab.key
-                ? "bg-primary text-white"
-                : "bg-card border border-border text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      {/* KPI cards + progress bar */}
+      <ReconciliationStats stats={stats} />
 
       {/* Transaction list */}
       {isLoading ? (
@@ -245,7 +132,7 @@ function ReconciliationContent() {
             <div key={i} className="h-24 bg-muted rounded-xl animate-pulse" />
           ))}
         </div>
-      ) : filteredTransactions.length === 0 ? (
+      ) : displayTransactions.length === 0 ? (
         <div className="bg-card rounded-xl border border-border p-8 text-center">
           <Filter className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
           <p className="text-sm text-muted-foreground">
@@ -254,7 +141,7 @@ function ReconciliationContent() {
         </div>
       ) : (
         <div className="space-y-3">
-          {filteredTransactions.map((tx) => (
+          {displayTransactions.map((tx) => (
             <TransactionCard
               key={tx.id}
               transaction={tx}
@@ -277,9 +164,10 @@ function ReconciliationContent() {
       {/* Floating action button */}
       <div className="fixed bottom-6 right-6 z-50">
         <button
+          type="button"
           onClick={handleRunMatching}
           disabled={runningMatch}
-          className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-primary text-white text-sm font-medium shadow-lg hover:bg-[#1B2A6B] transition-colors disabled:opacity-50"
+          className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-primary text-primary-foreground text-sm font-medium shadow-lg hover:bg-primary/90 transition-colors disabled:opacity-50"
         >
           {runningMatch ? (
             <Loader2 className="w-4 h-4 animate-spin" />
@@ -289,348 +177,6 @@ function ReconciliationContent() {
           Relancer le matching
         </button>
       </div>
-    </div>
-  );
-}
-
-// ── Stat card ───────────────────────────────────────────────────────
-
-function StatCard({
-  label,
-  count,
-  color,
-  icon,
-}: {
-  label: string;
-  count: number;
-  color: "green" | "orange" | "red";
-  icon: React.ReactNode;
-}) {
-  const colorMap = {
-    green:
-      "bg-green-50 dark:bg-green-950/30 text-green-600 dark:text-green-400 border-green-200 dark:border-green-900",
-    orange:
-      "bg-orange-50 dark:bg-orange-950/30 text-orange-600 dark:text-orange-400 border-orange-200 dark:border-orange-900",
-    red: "bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400 border-red-200 dark:border-red-900",
-  };
-
-  return (
-    <div className={`rounded-xl border p-3 sm:p-4 ${colorMap[color]}`}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon}
-        <span className="text-xs font-medium">{label}</span>
-      </div>
-      <p className="text-xl sm:text-2xl font-bold font-[family-name:var(--font-manrope)]">
-        {count}
-      </p>
-    </div>
-  );
-}
-
-// ── Transaction card ────────────────────────────────────────────────
-
-function TransactionCard({
-  transaction: tx,
-  onMatch,
-  onIgnore,
-  onCategorize,
-  onRefresh,
-}: {
-  transaction: BankTransactionRow;
-  onMatch: (txId: string, entryId: string) => Promise<void>;
-  onIgnore: (txId: string) => Promise<void>;
-  onCategorize: (
-    txId: string,
-    data: { accountNumber: string; label: string; journalCode: string },
-  ) => Promise<void>;
-  onRefresh: () => void;
-}) {
-  const { toast } = useToast();
-  const [loading, setLoading] = useState(false);
-  const [showCategorize, setShowCategorize] = useState(false);
-  const [catAccount, setCatAccount] = useState("");
-  const [catLabel, setCatLabel] = useState("");
-  const [catJournal, setCatJournal] = useState("BQ");
-  const undoRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const isPositive = tx.amount_cents >= 0;
-  const status = tx.reconciliation_status;
-
-  const isMatched = status === "matched_auto" || status === "matched_manual";
-  const isSuggested = status === "suggested";
-  const isOrphan = status === "orphan";
-
-  // Border + bg colors per status
-  const cardClasses = isMatched
-    ? "border-l-green-500 bg-green-50/50 dark:bg-green-950/20"
-    : isSuggested
-      ? "border-l-orange-500 bg-orange-50/50 dark:bg-orange-950/20"
-      : isOrphan
-        ? "border-l-red-500 bg-red-50/50 dark:bg-red-950/20"
-        : "border-l-gray-300";
-
-  const handleValidate = async () => {
-    if (!tx.suggestion?.entryId) return;
-    setLoading(true);
-    try {
-      await onMatch(tx.id, tx.suggestion.entryId);
-      onRefresh();
-    } catch {
-      toast({
-        title: "Erreur",
-        description: "Impossible de valider.",
-        variant: "destructive",
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleIgnore = async () => {
-    toast({
-      title: "Transaction ignoree",
-      description: "Annuler dans 5 secondes...",
-    });
-
-    undoRef.current = setTimeout(async () => {
-      try {
-        await onIgnore(tx.id);
-        onRefresh();
-      } catch {
-        toast({
-          title: "Erreur",
-          description: "Impossible d'ignorer la transaction.",
-          variant: "destructive",
-        });
-      }
-    }, 5000);
-  };
-
-  const handleCategorize = async () => {
-    if (!catAccount || !catLabel) return;
-    setLoading(true);
-    try {
-      await onCategorize(tx.id, {
-        accountNumber: catAccount,
-        label: catLabel,
-        journalCode: catJournal,
-      });
-      setShowCategorize(false);
-      onRefresh();
-    } catch {
-      toast({
-        title: "Erreur",
-        description: "Impossible de categoriser.",
-        variant: "destructive",
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <div
-      className={`bg-card rounded-xl border border-border border-l-4 ${cardClasses} p-4 space-y-3 transition-all`}
-    >
-      {/* Main row */}
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-start gap-3 min-w-0 flex-1">
-          {/* Amount direction icon */}
-          <div
-            className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${
-              isPositive
-                ? "bg-green-100 dark:bg-green-950/50"
-                : "bg-red-100 dark:bg-red-950/50"
-            }`}
-          >
-            {isPositive ? (
-              <ArrowDownLeft className="w-4 h-4 text-green-600 dark:text-green-400" />
-            ) : (
-              <ArrowUpRight className="w-4 h-4 text-red-600 dark:text-red-400" />
-            )}
-          </div>
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">
-              {tx.label || tx.raw_label || "Transaction"}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {new Date(tx.transaction_date).toLocaleDateString("fr-FR")}
-              {tx.counterpart_name && ` - ${tx.counterpart_name}`}
-            </p>
-          </div>
-        </div>
-        <p
-          className={`text-sm font-bold whitespace-nowrap font-[family-name:var(--font-manrope)] ${
-            isPositive
-              ? "text-green-600 dark:text-green-400"
-              : "text-red-600 dark:text-red-400"
-          }`}
-        >
-          {isPositive ? "+" : ""}
-          {formatCents(tx.amount_cents)}
-        </p>
-      </div>
-
-      {/* Status details */}
-      {isMatched && (
-        <div className="flex items-center gap-2 text-xs text-green-600 dark:text-green-400">
-          <Link2 className="w-3.5 h-3.5" />
-          <span>Rapproche</span>
-          {tx.matched_entry && (
-            <span className="text-muted-foreground">
-              - Ecriture {tx.matched_entry.entry_number}
-            </span>
-          )}
-          {tx.match_score != null && (
-            <span className="ml-auto px-1.5 py-0.5 rounded bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 text-[10px] font-medium">
-              {Math.round(tx.match_score * 100)}%
-            </span>
-          )}
-          {tx.is_internal_transfer && (
-            <span className="px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 text-[10px] font-medium inline-flex items-center gap-0.5">
-              <Repeat className="w-3 h-3" />
-              Interne
-            </span>
-          )}
-        </div>
-      )}
-
-      {isSuggested && tx.suggestion && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 text-xs text-orange-600 dark:text-orange-400">
-            <Tag className="w-3.5 h-3.5" />
-            <span>Suggestion</span>
-            <span className="text-muted-foreground">
-              - {tx.suggestion.entryLabel} ({tx.suggestion.entryNumber})
-            </span>
-            <span className="ml-auto px-1.5 py-0.5 rounded bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300 text-[10px] font-medium">
-              {Math.round(tx.suggestion.score * 100)}%
-            </span>
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={handleValidate}
-              disabled={loading}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-700 transition-colors disabled:opacity-50"
-            >
-              {loading ? (
-                <Loader2 className="w-3 h-3 animate-spin" />
-              ) : (
-                <Check className="w-3 h-3" />
-              )}
-              Valider
-            </button>
-            <button
-              onClick={() => setShowCategorize(true)}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs font-medium hover:bg-muted transition-colors"
-            >
-              Modifier
-            </button>
-            <button
-              onClick={handleIgnore}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
-            >
-              <X className="w-3 h-3" />
-              Rejeter
-            </button>
-          </div>
-        </div>
-      )}
-
-      {isOrphan && (
-        <div className="space-y-2">
-          <p className="text-xs text-red-600 dark:text-red-400 flex items-center gap-1.5">
-            <AlertTriangle className="w-3.5 h-3.5" />
-            Non identifie
-          </p>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setShowCategorize(true)}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-white text-xs font-medium hover:bg-[#1B2A6B] transition-colors"
-            >
-              <Tag className="w-3 h-3" />
-              Categoriser
-            </button>
-            <button
-              onClick={handleIgnore}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
-            >
-              <X className="w-3 h-3" />
-              Ignorer
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Categorize drawer */}
-      {showCategorize && (
-        <div className="border-t border-border pt-3 space-y-3">
-          <h4 className="text-xs font-semibold text-foreground">
-            Categoriser la transaction
-          </h4>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">
-                Compte comptable
-              </label>
-              <input
-                type="text"
-                placeholder="Ex: 706000"
-                value={catAccount}
-                onChange={(e) => setCatAccount(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
-              />
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">
-                Libelle
-              </label>
-              <input
-                type="text"
-                placeholder="Libelle de l'ecriture"
-                value={catLabel}
-                onChange={(e) => setCatLabel(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
-              />
-            </div>
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">
-                Journal
-              </label>
-              <select
-                value={catJournal}
-                onChange={(e) => setCatJournal(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg border border-border bg-card text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
-              >
-                <option value="BQ">BQ - Banque</option>
-                <option value="OD">OD - Operations diverses</option>
-                <option value="HA">HA - Achats</option>
-                <option value="VE">VE - Ventes</option>
-              </select>
-            </div>
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={handleCategorize}
-              disabled={loading || !catAccount || !catLabel}
-              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-primary text-white text-xs font-medium hover:bg-[#1B2A6B] transition-colors disabled:opacity-50"
-            >
-              {loading ? (
-                <Loader2 className="w-3 h-3 animate-spin" />
-              ) : (
-                <Check className="w-3 h-3" />
-              )}
-              Enregistrer
-            </button>
-            <button
-              onClick={() => setShowCategorize(false)}
-              className="px-4 py-2 rounded-lg border border-border text-xs font-medium hover:bg-muted transition-colors"
-            >
-              Annuler
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/app/owner/accounting/bank/reconciliation/ReconciliationClient.tsx
+++ b/app/owner/accounting/bank/reconciliation/ReconciliationClient.tsx
@@ -1,5 +1,4 @@
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { useState, useCallback, useRef } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";

--- a/app/owner/accounting/bank/reconciliation/components/EntryMatchCard.tsx
+++ b/app/owner/accounting/bank/reconciliation/components/EntryMatchCard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * EntryMatchCard — dumb "proposed accounting entry" display used inside
+ * a TransactionCard when the reconciliation engine suggests a match.
+ *
+ * Shows the entry label + entry number returned by the hook's suggestion
+ * shape, plus the confidence score. Does not own any state.
+ */
+
+import { Tag } from "lucide-react";
+
+export interface EntryMatchSuggestion {
+  entryId: string;
+  entryNumber: string;
+  entryLabel: string;
+  /** Score in [0, 1], rendered as a percentage. */
+  score: number;
+}
+
+export function EntryMatchCard({
+  suggestion,
+}: {
+  suggestion: EntryMatchSuggestion;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-orange-600 dark:text-orange-400">
+      <Tag className="w-3.5 h-3.5" />
+      <span>Suggestion</span>
+      <span className="text-muted-foreground">
+        - {suggestion.entryLabel} ({suggestion.entryNumber})
+      </span>
+      <span className="ml-auto px-1.5 py-0.5 rounded bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300 text-[10px] font-medium">
+        {Math.round(suggestion.score * 100)}%
+      </span>
+    </div>
+  );
+}

--- a/app/owner/accounting/bank/reconciliation/components/ReconciliationFilters.tsx
+++ b/app/owner/accounting/bank/reconciliation/components/ReconciliationFilters.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * ReconciliationFilters — dumb filter bars for the bank reconciliation page.
+ *
+ * Two independent filter rows stacked vertically:
+ *   1. Connection tabs    : all | one per bank_connection
+ *   2. Status tabs        : all | suggested | orphan | matched
+ *
+ * Purely presentational: the parent owns both filter values and passes
+ * setters down.
+ */
+
+import type { BankConnection } from "@/lib/hooks/use-bank-connections";
+
+export type ReconciliationFilterTab =
+  | "all"
+  | "suggested"
+  | "orphan"
+  | "matched";
+
+const FILTER_TABS: ReadonlyArray<{ key: ReconciliationFilterTab; label: string }> = [
+  { key: "all", label: "Tous" },
+  { key: "suggested", label: "A valider" },
+  { key: "orphan", label: "Non identifies" },
+  { key: "matched", label: "Rapproches" },
+];
+
+function connectionLabel(c: BankConnection): string {
+  switch (c.account_type) {
+    case "exploitation":
+      return "Exploitation";
+    case "epargne":
+      return "Epargne";
+    case "depot_garantie":
+      return "DG";
+    default:
+      return "Autre";
+  }
+}
+
+interface ReconciliationFiltersProps {
+  connections: BankConnection[];
+  selectedConnectionId: string | undefined;
+  onSelectConnection: (id: string | undefined) => void;
+  filterTab: ReconciliationFilterTab;
+  onChangeFilterTab: (tab: ReconciliationFilterTab) => void;
+}
+
+export function ReconciliationFilters({
+  connections,
+  selectedConnectionId,
+  onSelectConnection,
+  filterTab,
+  onChangeFilterTab,
+}: ReconciliationFiltersProps) {
+  return (
+    <>
+      {connections.length > 1 && (
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          <button
+            type="button"
+            onClick={() => onSelectConnection(undefined)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+              !selectedConnectionId
+                ? "bg-primary text-primary-foreground"
+                : "bg-card border border-border text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Tous
+          </button>
+          {connections.map((c) => (
+            <button
+              type="button"
+              key={c.id}
+              onClick={() => onSelectConnection(c.id)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+                selectedConnectionId === c.id
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-card border border-border text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {connectionLabel(c)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {FILTER_TABS.map((tab) => (
+          <button
+            type="button"
+            key={tab.key}
+            onClick={() => onChangeFilterTab(tab.key)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap transition-colors ${
+              filterTab === tab.key
+                ? "bg-primary text-primary-foreground"
+                : "bg-card border border-border text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/app/owner/accounting/bank/reconciliation/components/ReconciliationStats.tsx
+++ b/app/owner/accounting/bank/reconciliation/components/ReconciliationStats.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * ReconciliationStats — dumb KPI header for the bank reconciliation page.
+ *
+ * Displays three counters (matched / suggested / orphan) and a horizontal
+ * progress bar that visualizes the share of each bucket. All state lives
+ * in the parent; this component only consumes the `stats` shape exposed
+ * by useReconciliation().
+ */
+
+import type { ReactNode } from "react";
+import { Check, Clock, AlertTriangle } from "lucide-react";
+
+export interface ReconciliationStatsValue {
+  total: number;
+  matched: number;
+  suggested: number;
+  orphan: number;
+}
+
+interface StatCardProps {
+  label: string;
+  count: number;
+  color: "green" | "orange" | "red";
+  icon: ReactNode;
+}
+
+function StatCard({ label, count, color, icon }: StatCardProps) {
+  const colorMap = {
+    green:
+      "bg-green-50 dark:bg-green-950/30 text-green-600 dark:text-green-400 border-green-200 dark:border-green-900",
+    orange:
+      "bg-orange-50 dark:bg-orange-950/30 text-orange-600 dark:text-orange-400 border-orange-200 dark:border-orange-900",
+    red: "bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400 border-red-200 dark:border-red-900",
+  } as const;
+
+  return (
+    <div className={`rounded-xl border p-3 sm:p-4 ${colorMap[color]}`}>
+      <div className="flex items-center gap-2 mb-1">
+        {icon}
+        <span className="text-xs font-medium">{label}</span>
+      </div>
+      <p className="text-xl sm:text-2xl font-bold font-[family-name:var(--font-manrope)]">
+        {count}
+      </p>
+    </div>
+  );
+}
+
+export function ReconciliationStats({
+  stats,
+}: {
+  stats: ReconciliationStatsValue;
+}) {
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-3 sm:gap-4">
+        <StatCard
+          label="Rapproches"
+          count={stats.matched}
+          color="green"
+          icon={<Check className="w-4 h-4" />}
+        />
+        <StatCard
+          label="A valider"
+          count={stats.suggested}
+          color="orange"
+          icon={<Clock className="w-4 h-4" />}
+        />
+        <StatCard
+          label="Non identifies"
+          count={stats.orphan}
+          color="red"
+          icon={<AlertTriangle className="w-4 h-4" />}
+        />
+      </div>
+
+      {stats.total > 0 && (
+        <div className="w-full h-2 bg-muted rounded-full overflow-hidden flex">
+          {stats.matched > 0 && (
+            <div
+              className="h-full bg-green-500"
+              style={{ width: `${(stats.matched / stats.total) * 100}%` }}
+            />
+          )}
+          {stats.suggested > 0 && (
+            <div
+              className="h-full bg-orange-500"
+              style={{ width: `${(stats.suggested / stats.total) * 100}%` }}
+            />
+          )}
+          {stats.orphan > 0 && (
+            <div
+              className="h-full bg-red-500"
+              style={{ width: `${(stats.orphan / stats.total) * 100}%` }}
+            />
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/owner/accounting/bank/reconciliation/components/TransactionCard.tsx
+++ b/app/owner/accounting/bank/reconciliation/components/TransactionCard.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+/**
+ * TransactionCard — one bank transaction in the reconciliation list.
+ *
+ * Handles its own UI state (categorize drawer, per-row loading) but
+ * delegates every mutation to callbacks passed from the parent so the
+ * React-Query invalidation logic lives in one place.
+ */
+
+import { useRef, useState } from "react";
+import type { BankTransactionRow } from "@/lib/hooks/use-reconciliation";
+import { formatCents } from "@/lib/utils/format-cents";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Link2,
+  AlertTriangle,
+  Check,
+  X,
+  ArrowUpRight,
+  ArrowDownLeft,
+  Loader2,
+  Tag,
+  Repeat,
+} from "lucide-react";
+import { EntryMatchCard } from "./EntryMatchCard";
+
+export interface TransactionCardProps {
+  transaction: BankTransactionRow;
+  onMatch: (txId: string, entryId: string) => Promise<void>;
+  onIgnore: (txId: string) => Promise<void>;
+  onCategorize: (
+    txId: string,
+    data: { accountNumber: string; label: string; journalCode: string },
+  ) => Promise<void>;
+  onRefresh: () => void;
+}
+
+export function TransactionCard({
+  transaction: tx,
+  onMatch,
+  onIgnore,
+  onCategorize,
+  onRefresh,
+}: TransactionCardProps) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [showCategorize, setShowCategorize] = useState(false);
+  const [catAccount, setCatAccount] = useState("");
+  const [catLabel, setCatLabel] = useState("");
+  const [catJournal, setCatJournal] = useState("BQ");
+  const undoRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const isPositive = tx.amount_cents >= 0;
+  const status = tx.reconciliation_status;
+
+  const isMatched = status === "matched_auto" || status === "matched_manual";
+  const isSuggested = status === "suggested";
+  const isOrphan = status === "orphan";
+
+  // Border + bg colors per status
+  const cardClasses = isMatched
+    ? "border-l-green-500 bg-green-50/50 dark:bg-green-950/20"
+    : isSuggested
+      ? "border-l-orange-500 bg-orange-50/50 dark:bg-orange-950/20"
+      : isOrphan
+        ? "border-l-red-500 bg-red-50/50 dark:bg-red-950/20"
+        : "border-l-gray-300";
+
+  const handleValidate = async () => {
+    if (!tx.suggestion?.entryId) return;
+    setLoading(true);
+    try {
+      await onMatch(tx.id, tx.suggestion.entryId);
+      onRefresh();
+    } catch {
+      toast({
+        title: "Erreur",
+        description: "Impossible de valider.",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleIgnore = async () => {
+    toast({
+      title: "Transaction ignoree",
+      description: "Annuler dans 5 secondes...",
+    });
+
+    undoRef.current = setTimeout(async () => {
+      try {
+        await onIgnore(tx.id);
+        onRefresh();
+      } catch {
+        toast({
+          title: "Erreur",
+          description: "Impossible d'ignorer la transaction.",
+          variant: "destructive",
+        });
+      }
+    }, 5000);
+  };
+
+  const handleCategorize = async () => {
+    if (!catAccount || !catLabel) return;
+    setLoading(true);
+    try {
+      await onCategorize(tx.id, {
+        accountNumber: catAccount,
+        label: catLabel,
+        journalCode: catJournal,
+      });
+      setShowCategorize(false);
+      onRefresh();
+    } catch {
+      toast({
+        title: "Erreur",
+        description: "Impossible de categoriser.",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className={`bg-card rounded-xl border border-border border-l-4 ${cardClasses} p-4 space-y-3 transition-all`}
+    >
+      {/* Main row */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3 min-w-0 flex-1">
+          {/* Amount direction icon */}
+          <div
+            className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 ${
+              isPositive
+                ? "bg-green-100 dark:bg-green-950/50"
+                : "bg-red-100 dark:bg-red-950/50"
+            }`}
+          >
+            {isPositive ? (
+              <ArrowDownLeft className="w-4 h-4 text-green-600 dark:text-green-400" />
+            ) : (
+              <ArrowUpRight className="w-4 h-4 text-red-600 dark:text-red-400" />
+            )}
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">
+              {tx.label || tx.raw_label || "Transaction"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {new Date(tx.transaction_date).toLocaleDateString("fr-FR")}
+              {tx.counterpart_name && ` - ${tx.counterpart_name}`}
+            </p>
+          </div>
+        </div>
+        <p
+          className={`text-sm font-bold whitespace-nowrap font-[family-name:var(--font-manrope)] ${
+            isPositive
+              ? "text-green-600 dark:text-green-400"
+              : "text-red-600 dark:text-red-400"
+          }`}
+        >
+          {isPositive ? "+" : ""}
+          {formatCents(tx.amount_cents)}
+        </p>
+      </div>
+
+      {/* Status details */}
+      {isMatched && (
+        <div className="flex items-center gap-2 text-xs text-green-600 dark:text-green-400">
+          <Link2 className="w-3.5 h-3.5" />
+          <span>Rapproche</span>
+          {tx.matched_entry && (
+            <span className="text-muted-foreground">
+              - Ecriture {tx.matched_entry.entry_number}
+            </span>
+          )}
+          {tx.match_score != null && (
+            <span className="ml-auto px-1.5 py-0.5 rounded bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 text-[10px] font-medium">
+              {Math.round(tx.match_score * 100)}%
+            </span>
+          )}
+          {tx.is_internal_transfer && (
+            <span className="px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 text-[10px] font-medium inline-flex items-center gap-0.5">
+              <Repeat className="w-3 h-3" />
+              Interne
+            </span>
+          )}
+        </div>
+      )}
+
+      {isSuggested && tx.suggestion && (
+        <div className="space-y-2">
+          <EntryMatchCard suggestion={tx.suggestion} />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleValidate}
+              disabled={loading}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-700 transition-colors disabled:opacity-50"
+            >
+              {loading ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <Check className="w-3 h-3" />
+              )}
+              Valider
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowCategorize(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs font-medium hover:bg-muted transition-colors"
+            >
+              Modifier
+            </button>
+            <button
+              type="button"
+              onClick={handleIgnore}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
+            >
+              <X className="w-3 h-3" />
+              Rejeter
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isOrphan && (
+        <div className="space-y-2">
+          <p className="text-xs text-red-600 dark:text-red-400 flex items-center gap-1.5">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            Non identifie
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setShowCategorize(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 transition-colors"
+            >
+              <Tag className="w-3 h-3" />
+              Categoriser
+            </button>
+            <button
+              type="button"
+              onClick={handleIgnore}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
+            >
+              <X className="w-3 h-3" />
+              Ignorer
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Categorize drawer */}
+      {showCategorize && (
+        <div className="border-t border-border pt-3 space-y-3">
+          <h4 className="text-xs font-semibold text-foreground">
+            Categoriser la transaction
+          </h4>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">
+                Compte comptable
+              </label>
+              <input
+                type="text"
+                placeholder="Ex: 706000"
+                value={catAccount}
+                onChange={(e) => setCatAccount(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">
+                Libelle
+              </label>
+              <input
+                type="text"
+                placeholder="Libelle de l'ecriture"
+                value={catLabel}
+                onChange={(e) => setCatLabel(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-card text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">
+                Journal
+              </label>
+              <select
+                value={catJournal}
+                onChange={(e) => setCatJournal(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-border bg-card text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+              >
+                <option value="BQ">BQ - Banque</option>
+                <option value="OD">OD - Operations diverses</option>
+                <option value="HA">HA - Achats</option>
+                <option value="VE">VE - Ventes</option>
+              </select>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleCategorize}
+              disabled={loading || !catAccount || !catLabel}
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+            >
+              {loading ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <Check className="w-3 h-3" />
+              )}
+              Enregistrer
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowCategorize(false)}
+              className="px-4 py-2 rounded-lg border border-border text-xs font-medium hover:bg-muted transition-colors"
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/owner/accounting/declarations/DeclarationsClient.tsx
+++ b/app/owner/accounting/declarations/DeclarationsClient.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
@@ -21,23 +19,38 @@ function DeclarationsContent() {
   const [regime, setRegime] = useState<string>("reel-2044");
   const [exerciseId, setExerciseId] = useState<string>("");
 
-  const { data: exercises } = useQuery<any>({
+  type ExerciseItem = { id: string; start_date: string; end_date: string; status: string };
+  type ExercisesResponse = ExerciseItem[] | { data?: ExerciseItem[] };
+  type DeclarationPayload = Record<string, number>;
+  type DeclarationResponse = { data?: DeclarationPayload } & DeclarationPayload;
+
+  const { data: exercises } = useQuery<ExercisesResponse>({
     queryKey: ["exercises", activeEntityId],
-    queryFn: () => apiClient.get(`/accounting/exercises?entityId=${activeEntityId}`),
+    queryFn: () => apiClient.get<ExercisesResponse>(`/accounting/exercises?entityId=${activeEntityId}`),
     enabled: !!activeEntityId,
   });
 
-  const closedExercises = ((exercises?.data ?? exercises ?? []) as Array<{ id: string; start_date: string; end_date: string; status: string }>).filter(e => e.status === "closed");
+  const exercisesList: ExerciseItem[] = Array.isArray(exercises)
+    ? exercises
+    : (exercises?.data ?? []);
+  const closedExercises = exercisesList.filter((e) => e.status === "closed");
 
   const declarationType = regime === "micro-foncier" ? "micro-foncier" : regime === "reel-2044" ? "2044" : regime === "reel-2072" ? "2072" : "2042-cpro";
 
-  const { data: declaration, isLoading: declLoading } = useQuery<any>({
+  const { data: declaration, isLoading: declLoading } = useQuery<DeclarationResponse>({
     queryKey: ["declaration", declarationType, exerciseId],
-    queryFn: () => apiClient.get(`/accounting/declarations/${declarationType}?exerciseId=${exerciseId}`),
+    queryFn: () => apiClient.get<DeclarationResponse>(`/accounting/declarations/${declarationType}?exerciseId=${exerciseId}`),
     enabled: !!exerciseId && step >= 2,
   });
 
-  const declData = (declaration?.data ?? declaration ?? {}) as Record<string, number>;
+  const declData: DeclarationPayload = (() => {
+    if (!declaration) return {};
+    if (declaration.data && typeof declaration.data === "object") {
+      return declaration.data;
+    }
+    const { data: _ignored, ...rest } = declaration;
+    return rest as DeclarationPayload;
+  })();
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-3xl mx-auto space-y-6">

--- a/app/owner/accounting/declarations/DeclarationsClient.tsx
+++ b/app/owner/accounting/declarations/DeclarationsClient.tsx
@@ -6,8 +6,9 @@ import { formatCents } from "@/lib/utils/format-cents";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api-client";
 import { useEntityStore } from "@/stores/useEntityStore";
+import { useToast } from "@/components/ui/use-toast";
 import Link from "next/link";
-import { ArrowLeft, Download, Send, FileText, Check, AlertTriangle } from "lucide-react";
+import { ArrowLeft, Download, Send, Check, AlertTriangle, Loader2 } from "lucide-react";
 
 export default function DeclarationsClient() {
   return (<PlanGate feature="bank_reconciliation" mode="block"><DeclarationsContent /></PlanGate>);
@@ -15,9 +16,12 @@ export default function DeclarationsClient() {
 
 function DeclarationsContent() {
   const { activeEntityId } = useEntityStore();
+  const { toast } = useToast();
   const [step, setStep] = useState(1);
   const [regime, setRegime] = useState<string>("reel-2044");
   const [exerciseId, setExerciseId] = useState<string>("");
+  const [downloadingPdf, setDownloadingPdf] = useState(false);
+  const [sendingEc, setSendingEc] = useState(false);
 
   type ExerciseItem = { id: string; start_date: string; end_date: string; status: string };
   type ExercisesResponse = ExerciseItem[] | { data?: ExerciseItem[] };
@@ -51,6 +55,102 @@ function DeclarationsContent() {
     const { data: _ignored, ...rest } = declaration;
     return rest as DeclarationPayload;
   })();
+
+  // Derive the fiscal year from the selected closed exercise. Fall back to
+  // the current calendar year if the exercise cannot be resolved.
+  const selectedExercise = closedExercises.find((e) => e.id === exerciseId);
+  const selectedYear = selectedExercise
+    ? parseInt(selectedExercise.start_date.slice(0, 4), 10)
+    : new Date().getFullYear();
+
+  const handleDownloadPDF = async () => {
+    if (!activeEntityId || !exerciseId) {
+      toast({
+        title: "Action impossible",
+        description: "Sélectionnez une entité et un exercice clôturé.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setDownloadingPdf(true);
+    try {
+      const params = new URLSearchParams({
+        year: String(selectedYear),
+        entityId: activeEntityId,
+      });
+      const res = await fetch(`/api/accounting/fiscal-summary?${params.toString()}`);
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error || "Erreur génération PDF");
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `declaration-fiscale-${declarationType}-${selectedYear}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast({ title: "PDF téléchargé" });
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Téléchargement impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setDownloadingPdf(false);
+    }
+  };
+
+  const handleSendEC = async () => {
+    if (!activeEntityId || !exerciseId) {
+      toast({
+        title: "Action impossible",
+        description: "Sélectionnez une entité et un exercice clôturé.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setSendingEc(true);
+    try {
+      const res = await fetch("/api/accounting/ec/access", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "send_declaration",
+          entityId: activeEntityId,
+          year: selectedYear,
+          declarationType,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error || "Erreur envoi");
+      }
+      const payload = (await res.json()) as { data?: { notified?: number } };
+      const notified = payload?.data?.notified ?? 0;
+      toast({
+        title: "Déclaration envoyée à votre expert-comptable",
+        description:
+          notified > 1
+            ? `${notified} experts-comptables notifiés.`
+            : "1 expert-comptable notifié.",
+      });
+    } catch (err) {
+      toast({
+        title: "Erreur lors de l'envoi",
+        description:
+          err instanceof Error
+            ? err.message
+            : "Impossible de notifier l'expert-comptable.",
+        variant: "destructive",
+      });
+    } finally {
+      setSendingEc(false);
+    }
+  };
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-3xl mx-auto space-y-6">
@@ -136,8 +236,32 @@ function DeclarationsContent() {
           <Check className="w-12 h-12 mx-auto text-emerald-500" />
           <h2 className="text-lg font-semibold">Document pret</h2>
           <div className="flex flex-col gap-3">
-            <button className="bg-primary text-primary-foreground rounded-lg px-4 py-3 text-sm font-medium flex items-center justify-center gap-2"><Download className="w-4 h-4" />Telecharger le PDF</button>
-            <button className="bg-card border border-border rounded-lg px-4 py-3 text-sm font-medium flex items-center justify-center gap-2"><Send className="w-4 h-4" />Envoyer a mon EC</button>
+            <button
+              type="button"
+              onClick={handleDownloadPDF}
+              disabled={downloadingPdf || sendingEc}
+              className="bg-primary text-primary-foreground rounded-lg px-4 py-3 text-sm font-medium flex items-center justify-center gap-2 disabled:opacity-50"
+            >
+              {downloadingPdf ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Download className="w-4 h-4" />
+              )}
+              {downloadingPdf ? "Génération..." : "Telecharger le PDF"}
+            </button>
+            <button
+              type="button"
+              onClick={handleSendEC}
+              disabled={downloadingPdf || sendingEc}
+              className="bg-card border border-border rounded-lg px-4 py-3 text-sm font-medium flex items-center justify-center gap-2 disabled:opacity-50"
+            >
+              {sendingEc ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Send className="w-4 h-4" />
+              )}
+              {sendingEc ? "Envoi..." : "Envoyer a mon expert-comptable"}
+            </button>
           </div>
           <p className="text-xs text-muted-foreground">Ce document est une aide. Talok ne fournit pas de conseil fiscal. Consultez votre expert-comptable.</p>
         </div>

--- a/app/owner/accounting/ec/ECManageClient.tsx
+++ b/app/owner/accounting/ec/ECManageClient.tsx
@@ -58,7 +58,14 @@ function ECManageContent() {
         <div className="space-y-3">{ecList.map(ec => (
           <div key={ec.id} className="bg-card rounded-xl border border-border p-4 flex items-center justify-between">
             <div><p className="text-sm font-medium">{ec.ec_name}</p><p className="text-xs text-muted-foreground">{ec.ec_email} — {ec.access_level}</p><p className="text-xs text-muted-foreground">Invite le {new Date(ec.granted_at).toLocaleDateString("fr-FR")}</p></div>
-            <button onClick={() => revokeMutation.mutate(ec.id)} className="text-destructive hover:text-destructive/80"><X className="w-4 h-4" /></button>
+            <button
+              type="button"
+              onClick={() => revokeMutation.mutate(ec.id)}
+              aria-label={`Révoquer l'accès de ${ec.ec_name ?? ec.ec_email}`}
+              className="text-destructive hover:text-destructive/80"
+            >
+              <X className="w-4 h-4" />
+            </button>
           </div>
         ))}</div>
       )}

--- a/app/owner/accounting/ec/ECManageClient.tsx
+++ b/app/owner/accounting/ec/ECManageClient.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 import { useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -17,10 +15,27 @@ function ECManageContent() {
   const queryClient = useQueryClient();
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState({ ecEmail: "", ecFirmName: "", accessLevel: "read" });
-  const { data, isLoading } = useQuery<any>({ queryKey: ["ec-access", activeEntityId], queryFn: () => apiClient.get(`/accounting/ec/access?entityId=${activeEntityId}`), enabled: !!activeEntityId });
-  const inviteMutation = useMutation<any, any, any>({ mutationFn: (body: Record<string, unknown>) => apiClient.post("/accounting/ec/access", body), onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["ec-access"] }); setShowForm(false); } });
-  const revokeMutation = useMutation<any, any, any>({ mutationFn: (id: string) => apiClient.delete(`/accounting/ec/access/${id}`), onSuccess: () => queryClient.invalidateQueries({ queryKey: ["ec-access"] }) });
-  const ecList = (data?.data ?? data ?? []) as Array<{ id: string; ec_name: string; ec_email: string; access_level: string; granted_at: string }>;
+  type EcAccessItem = { id: string; ec_name: string; ec_email: string; access_level: string; granted_at: string };
+  type EcAccessResponse = EcAccessItem[] | { data?: EcAccessItem[] };
+  const { data, isLoading } = useQuery<EcAccessResponse>({
+    queryKey: ["ec-access", activeEntityId],
+    queryFn: () => apiClient.get<EcAccessResponse>(`/accounting/ec/access?entityId=${activeEntityId}`),
+    enabled: !!activeEntityId,
+  });
+  const inviteMutation = useMutation<unknown, unknown, Record<string, unknown>>({
+    mutationFn: (body) => apiClient.post("/accounting/ec/access", body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ec-access"] });
+      setShowForm(false);
+    },
+  });
+  const revokeMutation = useMutation<unknown, unknown, string>({
+    mutationFn: (id) => apiClient.delete(`/accounting/ec/access/${id}`),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["ec-access"] }),
+  });
+  const ecList: EcAccessItem[] = Array.isArray(data)
+    ? data
+    : (data?.data ?? []);
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-2xl mx-auto space-y-6">
       <div className="flex items-center justify-between">

--- a/app/owner/accounting/entries/EntriesPageClient.tsx
+++ b/app/owner/accounting/entries/EntriesPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useState, useMemo, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import {
@@ -18,6 +18,19 @@ import {
   CheckCircle2,
   Loader2,
 } from "lucide-react";
+
+// -- Debounce hook -----------------------------------------------------------
+// Small local hook to debounce a value. We keep it here (rather than adding a
+// new file) because it's only used by this page. 300ms matches the audit
+// requirement so the search box stays responsive but the API isn't hammered.
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}
 
 // -- Constants ---------------------------------------------------------------
 
@@ -136,8 +149,11 @@ export default function EntriesPageClient() {
 }
 
 function EntriesPageContent() {
-  // Filters
-  const [search, setSearch] = useState("");
+  // Filters — `searchInput` is the raw input value, `search` is the debounced
+  // value that actually gets sent to the API (300ms) so the user can type
+  // freely without firing a request on every keystroke.
+  const [searchInput, setSearchInput] = useState("");
+  const search = useDebouncedValue(searchInput, 300);
   const [journalCode, setJournalCode] = useState("");
   const [status, setStatus] = useState<"all" | "draft" | "validated">("all");
   const [source, setSource] = useState("");
@@ -150,6 +166,13 @@ function EntriesPageContent() {
 
   // Selection
   const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  // Reset pagination + selection whenever the debounced search changes so
+  // the user doesn't end up on page 5 of a result set that no longer exists.
+  useEffect(() => {
+    setPage(1);
+    setSelected(new Set());
+  }, [search]);
 
   const {
     entries,
@@ -172,24 +195,12 @@ function EntriesPageContent() {
     limit: 50,
   });
 
-  // Client-side status/source filtering (API may not support all filters)
-  const filteredEntries = useMemo(() => {
-    let result = entries;
-    if (status === "draft") {
-      result = result.filter((e: AccountingEntryRow) => isDraft(e));
-    } else if (status === "validated") {
-      result = result.filter((e: AccountingEntryRow) => !isDraft(e));
-    }
-    if (source) {
-      result = result.filter((e: AccountingEntryRow) => (e.source ?? "manual") === source);
-    }
-    return result;
-  }, [entries, status, source]);
-
-  // Draft entries for bulk selection
+  // Server now handles status/source/search/date filtering — we consume the
+  // returned page as-is. `draftEntries` is only used to drive the bulk
+  // "select all" checkbox; it's a derived helper, not a redundant filter.
   const draftEntries = useMemo(
-    () => filteredEntries.filter((e: AccountingEntryRow) => isDraft(e)),
-    [filteredEntries]
+    () => entries.filter((e: AccountingEntryRow) => isDraft(e)),
+    [entries],
   );
 
   const toggleSelect = useCallback((id: string) => {
@@ -219,14 +230,15 @@ function EntriesPageContent() {
     }
   };
 
-  // Totals for page
+  // Totals for page — derived aggregations from the server-filtered page,
+  // not a second filter pass.
   const pageDebitCents = useMemo(
-    () => filteredEntries.reduce((s: number, e: AccountingEntryRow) => s + getEntryDebitCents(e), 0),
-    [filteredEntries]
+    () => entries.reduce((s: number, e: AccountingEntryRow) => s + getEntryDebitCents(e), 0),
+    [entries],
   );
   const pageCreditCents = useMemo(
-    () => filteredEntries.reduce((s: number, e: AccountingEntryRow) => s + getEntryCreditCents(e), 0),
-    [filteredEntries]
+    () => entries.reduce((s: number, e: AccountingEntryRow) => s + getEntryCreditCents(e), 0),
+    [entries],
   );
 
   // Reset page when filters change
@@ -266,13 +278,14 @@ function EntriesPageContent() {
 
       {/* Filters bar */}
       <div className="flex flex-wrap gap-2">
-        {/* Search */}
+        {/* Search — controlled by the raw input state; the debounced value
+            is what drives the query (see `search` above). */}
         <div className="relative flex-1 min-w-[12rem]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <input
             type="text"
-            value={search}
-            onChange={(e) => handleFilterChange(setSearch)(e.target.value)}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Rechercher..."
             className="w-full rounded-lg border border-border bg-card pl-9 pr-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
           />
@@ -368,7 +381,7 @@ function EntriesPageContent() {
             <div key={i} className="h-14 bg-muted rounded-lg" />
           ))}
         </div>
-      ) : filteredEntries.length === 0 ? (
+      ) : entries.length === 0 ? (
         <div className="bg-card rounded-xl border border-border p-12 text-center">
           <p className="text-sm text-muted-foreground">
             Aucune ecriture trouvee.
@@ -417,7 +430,7 @@ function EntriesPageContent() {
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredEntries.map((entry: AccountingEntryRow) => {
+                  {entries.map((entry: AccountingEntryRow) => {
                     const entryIsDraft = isDraft(entry);
                     const entryDate =
                       entry.entry_date ?? entry.ecriture_date ?? "";
@@ -485,7 +498,7 @@ function EntriesPageContent() {
 
           {/* Mobile cards */}
           <div className="md:hidden space-y-2">
-            {filteredEntries.map((entry: AccountingEntryRow) => {
+            {entries.map((entry: AccountingEntryRow) => {
               const entryIsDraft = isDraft(entry);
               const entryDate = entry.entry_date ?? entry.ecriture_date ?? "";
               const entryLabel = entry.label ?? entry.ecriture_lib ?? "";
@@ -541,8 +554,8 @@ function EntriesPageContent() {
           <div className="bg-card rounded-xl border border-border px-4 py-3">
             <div className="flex items-center justify-between text-sm">
               <span className="font-medium text-muted-foreground">
-                Totaux ({filteredEntries.length} ecriture
-                {filteredEntries.length > 1 ? "s" : ""})
+                Totaux ({entries.length} ecriture
+                {entries.length > 1 ? "s" : ""})
               </span>
               <div className="flex items-center gap-6">
                 <span className="text-foreground">

--- a/app/owner/accounting/entries/EntriesPageClient.tsx
+++ b/app/owner/accounting/entries/EntriesPageClient.tsx
@@ -1,23 +1,23 @@
 "use client";
 
-import React, { useState, useMemo, useCallback, useEffect } from "react";
-import Link from "next/link";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import {
   useAccountingEntries,
-  type AccountingEntryRow,
+  type AccountingEntryRow as AccountingEntryRowData,
 } from "@/lib/hooks/use-accounting-entries";
 import { QuickEntryForm } from "@/components/accounting/QuickEntryForm";
 import { formatCents } from "@/lib/utils/format-cents";
-import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight, Plus, Loader2 } from "lucide-react";
+import { EntryFilters, type EntryFilterStatus } from "./components/EntryFilters";
+import { BulkActions } from "./components/BulkActions";
 import {
-  Search,
-  ChevronLeft,
-  ChevronRight,
-  Plus,
-  CheckCircle2,
-  Loader2,
-} from "lucide-react";
+  EntryRow,
+  EntryCard,
+  getEntryCreditCents,
+  getEntryDebitCents,
+  isDraft,
+} from "./components/EntryRow";
 
 // -- Debounce hook -----------------------------------------------------------
 // Small local hook to debounce a value. We keep it here (rather than adding a
@@ -30,112 +30,6 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
     return () => clearTimeout(id);
   }, [value, delayMs]);
   return debounced;
-}
-
-// -- Constants ---------------------------------------------------------------
-
-const JOURNAL_OPTIONS = [
-  { value: "", label: "Tous" },
-  { value: "ACH", label: "ACH" },
-  { value: "VE", label: "VE" },
-  { value: "BQ", label: "BQ" },
-  { value: "OD", label: "OD" },
-  { value: "AN", label: "AN" },
-  { value: "CL", label: "CL" },
-] as const;
-
-const STATUS_OPTIONS = [
-  { value: "all", label: "Tous" },
-  { value: "draft", label: "Brouillons" },
-  { value: "validated", label: "Validees" },
-] as const;
-
-const SOURCE_OPTIONS = [
-  { value: "", label: "Tous" },
-  { value: "manual", label: "Manuel" },
-  { value: "stripe", label: "Stripe" },
-  { value: "ocr", label: "OCR" },
-  { value: "import", label: "Import" },
-] as const;
-
-// -- Badge helpers -----------------------------------------------------------
-
-const SOURCE_BADGE_STYLES: Record<string, string> = {
-  manual: "bg-slate-500/10 text-slate-400 border-slate-500/20",
-  stripe: "bg-violet-500/10 text-violet-400 border-violet-500/20",
-  ocr: "bg-cyan-500/10 text-cyan-400 border-cyan-500/20",
-  import: "bg-teal-500/10 text-teal-400 border-teal-500/20",
-};
-
-const SOURCE_LABELS: Record<string, string> = {
-  manual: "Manuel",
-  stripe: "Stripe",
-  ocr: "OCR",
-  import: "Import",
-};
-
-function SourceBadge({ source }: { source: string | null }) {
-  const key = source ?? "manual";
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border",
-        SOURCE_BADGE_STYLES[key] ?? SOURCE_BADGE_STYLES.manual
-      )}
-    >
-      {SOURCE_LABELS[key] ?? key}
-    </span>
-  );
-}
-
-function StatusBadge({ entry }: { entry: AccountingEntryRow }) {
-  const isValidated = entry.is_validated || !!entry.valid_date;
-  const isReversed = !!entry.reversal_of;
-
-  if (isReversed) {
-    return (
-      <span className="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border bg-red-500/10 text-red-500 border-red-500/20">
-        Contre-passe
-      </span>
-    );
-  }
-
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border",
-        isValidated
-          ? "bg-emerald-500/10 text-emerald-500 border-emerald-500/20"
-          : "bg-amber-500/10 text-amber-500 border-amber-500/20"
-      )}
-    >
-      {isValidated ? "Valide" : "Brouillon"}
-    </span>
-  );
-}
-
-function formatDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-}
-
-function getEntryDebitCents(e: AccountingEntryRow): number {
-  if (typeof e.total_debit_cents === "number") return e.total_debit_cents;
-  if (typeof e.debit === "number") return Math.round(e.debit * 100);
-  return 0;
-}
-
-function getEntryCreditCents(e: AccountingEntryRow): number {
-  if (typeof e.total_credit_cents === "number") return e.total_credit_cents;
-  if (typeof e.credit === "number") return Math.round(e.credit * 100);
-  return 0;
-}
-
-function isDraft(e: AccountingEntryRow): boolean {
-  return !e.is_validated && !e.valid_date;
 }
 
 // -- Main component ----------------------------------------------------------
@@ -155,7 +49,7 @@ function EntriesPageContent() {
   const [searchInput, setSearchInput] = useState("");
   const search = useDebouncedValue(searchInput, 300);
   const [journalCode, setJournalCode] = useState("");
-  const [status, setStatus] = useState<"all" | "draft" | "validated">("all");
+  const [status, setStatus] = useState<EntryFilterStatus>("all");
   const [source, setSource] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -177,7 +71,6 @@ function EntriesPageContent() {
   const {
     entries,
     total,
-    totals,
     totalPages,
     isLoading,
     isFetching,
@@ -199,7 +92,7 @@ function EntriesPageContent() {
   // returned page as-is. `draftEntries` is only used to drive the bulk
   // "select all" checkbox; it's a derived helper, not a redundant filter.
   const draftEntries = useMemo(
-    () => entries.filter((e: AccountingEntryRow) => isDraft(e)),
+    () => entries.filter((e: AccountingEntryRowData) => isDraft(e)),
     [entries],
   );
 
@@ -216,7 +109,7 @@ function EntriesPageContent() {
     if (selected.size === draftEntries.length && draftEntries.length > 0) {
       setSelected(new Set<string>());
     } else {
-      setSelected(new Set(draftEntries.map((e: AccountingEntryRow) => e.id)));
+      setSelected(new Set(draftEntries.map((e: AccountingEntryRowData) => e.id)));
     }
   }, [draftEntries, selected.size]);
 
@@ -233,23 +126,32 @@ function EntriesPageContent() {
   // Totals for page — derived aggregations from the server-filtered page,
   // not a second filter pass.
   const pageDebitCents = useMemo(
-    () => entries.reduce((s: number, e: AccountingEntryRow) => s + getEntryDebitCents(e), 0),
+    () =>
+      entries.reduce(
+        (s: number, e: AccountingEntryRowData) => s + getEntryDebitCents(e),
+        0,
+      ),
     [entries],
   );
   const pageCreditCents = useMemo(
-    () => entries.reduce((s: number, e: AccountingEntryRow) => s + getEntryCreditCents(e), 0),
+    () =>
+      entries.reduce(
+        (s: number, e: AccountingEntryRowData) => s + getEntryCreditCents(e),
+        0,
+      ),
     [entries],
   );
 
-  // Reset page when filters change
-  const handleFilterChange = useCallback(
+  // Reset page + selection when any non-search filter changes. Wraps the
+  // individual filter setters so the EntryFilters sub-component stays dumb.
+  const onFilterChange = useCallback(
     <T,>(setter: React.Dispatch<React.SetStateAction<T>>) =>
       (value: T) => {
         setter(value);
         setPage(1);
         setSelected(new Set());
       },
-    []
+    [],
   );
 
   if (error) {
@@ -277,102 +179,27 @@ function EntriesPageContent() {
       </div>
 
       {/* Filters bar */}
-      <div className="flex flex-wrap gap-2">
-        {/* Search — controlled by the raw input state; the debounced value
-            is what drives the query (see `search` above). */}
-        <div className="relative flex-1 min-w-[12rem]">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder="Rechercher..."
-            className="w-full rounded-lg border border-border bg-card pl-9 pr-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-          />
-        </div>
-
-        {/* Journal */}
-        <select
-          value={journalCode}
-          onChange={(e) => handleFilterChange(setJournalCode)(e.target.value)}
-          className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-        >
-          {JOURNAL_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
-
-        {/* Status */}
-        <select
-          value={status}
-          onChange={(e) =>
-            handleFilterChange(setStatus)(
-              e.target.value as "all" | "draft" | "validated"
-            )
-          }
-          className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-        >
-          {STATUS_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
-
-        {/* Source */}
-        <select
-          value={source}
-          onChange={(e) => handleFilterChange(setSource)(e.target.value)}
-          className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-        >
-          {SOURCE_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
-
-        {/* Date range */}
-        <input
-          type="date"
-          value={startDate}
-          onChange={(e) => handleFilterChange(setStartDate)(e.target.value)}
-          className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-          placeholder="Du"
-        />
-        <input
-          type="date"
-          value={endDate}
-          onChange={(e) => handleFilterChange(setEndDate)(e.target.value)}
-          className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
-          placeholder="Au"
-        />
-      </div>
+      <EntryFilters
+        searchInput={searchInput}
+        onSearchInputChange={setSearchInput}
+        journalCode={journalCode}
+        onJournalCodeChange={onFilterChange(setJournalCode)}
+        status={status}
+        onStatusChange={onFilterChange(setStatus)}
+        source={source}
+        onSourceChange={onFilterChange(setSource)}
+        startDate={startDate}
+        onStartDateChange={onFilterChange(setStartDate)}
+        endDate={endDate}
+        onEndDateChange={onFilterChange(setEndDate)}
+      />
 
       {/* Bulk actions */}
-      {selected.size > 0 && (
-        <div className="flex items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-4 py-2.5">
-          <span className="text-sm font-medium text-foreground">
-            {selected.size} ecriture{selected.size > 1 ? "s" : ""} selectionnee
-            {selected.size > 1 ? "s" : ""}
-          </span>
-          <button
-            type="button"
-            onClick={handleValidateSelected}
-            disabled={isValidating}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
-          >
-            {isValidating ? (
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            ) : (
-              <CheckCircle2 className="w-3.5 h-3.5" />
-            )}
-            Valider les {selected.size} selectionnees
-          </button>
-        </div>
-      )}
+      <BulkActions
+        selectedCount={selected.size}
+        isValidating={isValidating}
+        onValidateSelected={handleValidateSelected}
+      />
 
       {/* Loading */}
       {isLoading ? (
@@ -430,67 +257,14 @@ function EntriesPageContent() {
                   </tr>
                 </thead>
                 <tbody>
-                  {entries.map((entry: AccountingEntryRow) => {
-                    const entryIsDraft = isDraft(entry);
-                    const entryDate =
-                      entry.entry_date ?? entry.ecriture_date ?? "";
-                    const entryNumber =
-                      entry.entry_number ?? entry.ecriture_num ?? "";
-                    const entryLabel =
-                      entry.label ?? entry.ecriture_lib ?? "";
-                    const debitCents = getEntryDebitCents(entry);
-                    const creditCents = getEntryCreditCents(entry);
-
-                    return (
-                      <tr
-                        key={entry.id}
-                        className="border-b border-border last:border-b-0 hover:bg-muted/50 transition-colors"
-                      >
-                        <td className="px-3 py-3">
-                          {entryIsDraft ? (
-                            <input
-                              type="checkbox"
-                              checked={selected.has(entry.id)}
-                              onChange={() => toggleSelect(entry.id)}
-                              className="rounded border-border"
-                              aria-label={`Selectionner ${entryLabel}`}
-                            />
-                          ) : (
-                            <span className="block w-4" />
-                          )}
-                        </td>
-                        <td className="px-3 py-3 text-muted-foreground whitespace-nowrap">
-                          {entryDate ? formatDate(entryDate) : "-"}
-                        </td>
-                        <td className="px-3 py-3 font-mono text-xs text-muted-foreground whitespace-nowrap">
-                          {entryNumber}
-                        </td>
-                        <td className="px-3 py-3 font-mono text-xs text-muted-foreground">
-                          {entry.journal_code}
-                        </td>
-                        <td className="px-3 py-3">
-                          <Link
-                            href={`/owner/accounting/entries/${entry.id}`}
-                            className="text-foreground hover:text-primary font-medium transition-colors"
-                          >
-                            {entryLabel}
-                          </Link>
-                        </td>
-                        <td className="px-3 py-3 text-right font-medium text-foreground whitespace-nowrap">
-                          {debitCents > 0 ? formatCents(debitCents) : "-"}
-                        </td>
-                        <td className="px-3 py-3 text-right font-medium text-foreground whitespace-nowrap">
-                          {creditCents > 0 ? formatCents(creditCents) : "-"}
-                        </td>
-                        <td className="px-3 py-3 text-center">
-                          <StatusBadge entry={entry} />
-                        </td>
-                        <td className="px-3 py-3 text-center">
-                          <SourceBadge source={entry.source} />
-                        </td>
-                      </tr>
-                    );
-                  })}
+                  {entries.map((entry: AccountingEntryRowData) => (
+                    <EntryRow
+                      key={entry.id}
+                      entry={entry}
+                      isSelected={selected.has(entry.id)}
+                      onToggleSelect={toggleSelect}
+                    />
+                  ))}
                 </tbody>
               </table>
             </div>
@@ -498,56 +272,14 @@ function EntriesPageContent() {
 
           {/* Mobile cards */}
           <div className="md:hidden space-y-2">
-            {entries.map((entry: AccountingEntryRow) => {
-              const entryIsDraft = isDraft(entry);
-              const entryDate = entry.entry_date ?? entry.ecriture_date ?? "";
-              const entryLabel = entry.label ?? entry.ecriture_lib ?? "";
-              const debitCents = getEntryDebitCents(entry);
-              const creditCents = getEntryCreditCents(entry);
-              const amount = debitCents > 0 ? debitCents : creditCents;
-
-              return (
-                <div
-                  key={entry.id}
-                  className="bg-card rounded-xl border border-border overflow-hidden"
-                >
-                  <div className="flex items-start gap-3 px-4 py-3">
-                    {entryIsDraft && (
-                      <input
-                        type="checkbox"
-                        checked={selected.has(entry.id)}
-                        onChange={() => toggleSelect(entry.id)}
-                        className="rounded border-border mt-1 shrink-0"
-                        aria-label={`Selectionner ${entryLabel}`}
-                      />
-                    )}
-                    <Link
-                      href={`/owner/accounting/entries/${entry.id}`}
-                      className="flex-1 min-w-0"
-                    >
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0 flex-1">
-                          <p className="text-sm font-medium text-foreground truncate">
-                            {entryLabel}
-                          </p>
-                          <p className="text-xs text-muted-foreground mt-0.5">
-                            {entryDate ? formatDate(entryDate) : ""} -{" "}
-                            {entry.journal_code}
-                          </p>
-                        </div>
-                        <p className="text-sm font-medium text-foreground whitespace-nowrap">
-                          {formatCents(amount)}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-2 mt-2">
-                        <StatusBadge entry={entry} />
-                        <SourceBadge source={entry.source} />
-                      </div>
-                    </Link>
-                  </div>
-                </div>
-              );
-            })}
+            {entries.map((entry: AccountingEntryRowData) => (
+              <EntryCard
+                key={entry.id}
+                entry={entry}
+                isSelected={selected.has(entry.id)}
+                onToggleSelect={toggleSelect}
+              />
+            ))}
           </div>
 
           {/* Totals footer */}

--- a/app/owner/accounting/entries/EntriesPageClient.tsx
+++ b/app/owner/accounting/entries/EntriesPageClient.tsx
@@ -1,5 +1,4 @@
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import React, { useState, useMemo, useCallback } from "react";
 import Link from "next/link";

--- a/app/owner/accounting/entries/components/BulkActions.tsx
+++ b/app/owner/accounting/entries/components/BulkActions.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * BulkActions — action bar shown when at least one draft entry is
+ * selected. Currently exposes only "validate selected"; delete is not
+ * wired yet because the corresponding backend route is admin-only and
+ * goes through a different flow.
+ *
+ * Dumb component: the parent owns the selection Set and the validate
+ * mutation; we just render the CTA.
+ */
+
+import { Loader2, CheckCircle2 } from "lucide-react";
+
+interface BulkActionsProps {
+  selectedCount: number;
+  isValidating: boolean;
+  onValidateSelected: () => void;
+}
+
+export function BulkActions({
+  selectedCount,
+  isValidating,
+  onValidateSelected,
+}: BulkActionsProps) {
+  if (selectedCount === 0) return null;
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-4 py-2.5">
+      <span className="text-sm font-medium text-foreground">
+        {selectedCount} ecriture{selectedCount > 1 ? "s" : ""} selectionnee
+        {selectedCount > 1 ? "s" : ""}
+      </span>
+      <button
+        type="button"
+        onClick={onValidateSelected}
+        disabled={isValidating}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+      >
+        {isValidating ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <CheckCircle2 className="w-3.5 h-3.5" />
+        )}
+        Valider les {selectedCount} selectionnees
+      </button>
+    </div>
+  );
+}

--- a/app/owner/accounting/entries/components/EntryFilters.tsx
+++ b/app/owner/accounting/entries/components/EntryFilters.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+/**
+ * EntryFilters — dumb filter bar for the accounting entries page.
+ *
+ * Controlled: every state lives in the parent, we only render inputs
+ * and wire their change handlers. Split from EntriesPageClient as part
+ * of the P2-1 extraction so the page body reads top-to-bottom instead
+ * of scrolling past 80 lines of select markup.
+ */
+
+import { Search } from "lucide-react";
+
+export type EntryFilterStatus = "all" | "draft" | "validated";
+
+const JOURNAL_OPTIONS = [
+  { value: "", label: "Tous" },
+  { value: "ACH", label: "ACH" },
+  { value: "VE", label: "VE" },
+  { value: "BQ", label: "BQ" },
+  { value: "OD", label: "OD" },
+  { value: "AN", label: "AN" },
+  { value: "CL", label: "CL" },
+] as const;
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "Tous" },
+  { value: "draft", label: "Brouillons" },
+  { value: "validated", label: "Validees" },
+] as const;
+
+const SOURCE_OPTIONS = [
+  { value: "", label: "Tous" },
+  { value: "manual", label: "Manuel" },
+  { value: "stripe", label: "Stripe" },
+  { value: "ocr", label: "OCR" },
+  { value: "import", label: "Import" },
+] as const;
+
+interface EntryFiltersProps {
+  searchInput: string;
+  onSearchInputChange: (value: string) => void;
+
+  journalCode: string;
+  onJournalCodeChange: (value: string) => void;
+
+  status: EntryFilterStatus;
+  onStatusChange: (value: EntryFilterStatus) => void;
+
+  source: string;
+  onSourceChange: (value: string) => void;
+
+  startDate: string;
+  onStartDateChange: (value: string) => void;
+
+  endDate: string;
+  onEndDateChange: (value: string) => void;
+}
+
+export function EntryFilters({
+  searchInput,
+  onSearchInputChange,
+  journalCode,
+  onJournalCodeChange,
+  status,
+  onStatusChange,
+  source,
+  onSourceChange,
+  startDate,
+  onStartDateChange,
+  endDate,
+  onEndDateChange,
+}: EntryFiltersProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {/* Search — controlled by the raw input state; the debounced value
+          is what drives the query in the parent. */}
+      <div className="relative flex-1 min-w-[12rem]">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <input
+          type="text"
+          value={searchInput}
+          onChange={(e) => onSearchInputChange(e.target.value)}
+          placeholder="Rechercher..."
+          className="w-full rounded-lg border border-border bg-card pl-9 pr-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+        />
+      </div>
+
+      {/* Journal */}
+      <select
+        value={journalCode}
+        onChange={(e) => onJournalCodeChange(e.target.value)}
+        className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+      >
+        {JOURNAL_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Status */}
+      <select
+        value={status}
+        onChange={(e) => onStatusChange(e.target.value as EntryFilterStatus)}
+        className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+      >
+        {STATUS_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Source */}
+      <select
+        value={source}
+        onChange={(e) => onSourceChange(e.target.value)}
+        className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+      >
+        {SOURCE_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Date range */}
+      <input
+        type="date"
+        value={startDate}
+        onChange={(e) => onStartDateChange(e.target.value)}
+        className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+        placeholder="Du"
+      />
+      <input
+        type="date"
+        value={endDate}
+        onChange={(e) => onEndDateChange(e.target.value)}
+        className="rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+        placeholder="Au"
+      />
+    </div>
+  );
+}

--- a/app/owner/accounting/entries/components/EntryRow.tsx
+++ b/app/owner/accounting/entries/components/EntryRow.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+/**
+ * EntryRow — one row of the accounting entries table.
+ *
+ * Renders both the desktop <tr> variant and the mobile card variant
+ * via two named exports so the parent can reuse the same entry-level
+ * helpers (status badge, source badge, debit/credit extraction) in both
+ * responsive layouts without duplicating them.
+ *
+ * Dumb component: the parent owns selection and mutations and passes
+ * callbacks in.
+ */
+
+import Link from "next/link";
+import type { AccountingEntryRow as AccountingEntryRowData } from "@/lib/hooks/use-accounting-entries";
+import { formatCents } from "@/lib/utils/format-cents";
+import { cn } from "@/lib/utils";
+
+// ── Helpers (shared with parent via re-export) ─────────────────────
+
+export function isDraft(e: AccountingEntryRowData): boolean {
+  return !e.is_validated && !e.valid_date;
+}
+
+export function getEntryDebitCents(e: AccountingEntryRowData): number {
+  if (typeof e.total_debit_cents === "number") return e.total_debit_cents;
+  if (typeof e.debit === "number") return Math.round(e.debit * 100);
+  return 0;
+}
+
+export function getEntryCreditCents(e: AccountingEntryRowData): number {
+  if (typeof e.total_credit_cents === "number") return e.total_credit_cents;
+  if (typeof e.credit === "number") return Math.round(e.credit * 100);
+  return 0;
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+// ── Badges ─────────────────────────────────────────────────────────
+
+const SOURCE_BADGE_STYLES: Record<string, string> = {
+  manual: "bg-slate-500/10 text-slate-400 border-slate-500/20",
+  stripe: "bg-violet-500/10 text-violet-400 border-violet-500/20",
+  ocr: "bg-cyan-500/10 text-cyan-400 border-cyan-500/20",
+  import: "bg-teal-500/10 text-teal-400 border-teal-500/20",
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  manual: "Manuel",
+  stripe: "Stripe",
+  ocr: "OCR",
+  import: "Import",
+};
+
+function SourceBadge({ source }: { source: string | null }) {
+  const key = source ?? "manual";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border",
+        SOURCE_BADGE_STYLES[key] ?? SOURCE_BADGE_STYLES.manual,
+      )}
+    >
+      {SOURCE_LABELS[key] ?? key}
+    </span>
+  );
+}
+
+function StatusBadge({ entry }: { entry: AccountingEntryRowData }) {
+  const isValidated = entry.is_validated || !!entry.valid_date;
+  const isReversed = !!entry.reversal_of;
+
+  if (isReversed) {
+    return (
+      <span className="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border bg-red-500/10 text-red-500 border-red-500/20">
+        Contre-passe
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border",
+        isValidated
+          ? "bg-emerald-500/10 text-emerald-500 border-emerald-500/20"
+          : "bg-amber-500/10 text-amber-500 border-amber-500/20",
+      )}
+    >
+      {isValidated ? "Valide" : "Brouillon"}
+    </span>
+  );
+}
+
+// ── Row (desktop table variant) ────────────────────────────────────
+
+interface EntryRowProps {
+  entry: AccountingEntryRowData;
+  isSelected: boolean;
+  onToggleSelect: (id: string) => void;
+}
+
+export function EntryRow({ entry, isSelected, onToggleSelect }: EntryRowProps) {
+  const entryIsDraft = isDraft(entry);
+  const entryDate = entry.entry_date ?? entry.ecriture_date ?? "";
+  const entryNumber = entry.entry_number ?? entry.ecriture_num ?? "";
+  const entryLabel = entry.label ?? entry.ecriture_lib ?? "";
+  const debitCents = getEntryDebitCents(entry);
+  const creditCents = getEntryCreditCents(entry);
+
+  return (
+    <tr className="border-b border-border last:border-b-0 hover:bg-muted/50 transition-colors">
+      <td className="px-3 py-3">
+        {entryIsDraft ? (
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={() => onToggleSelect(entry.id)}
+            className="rounded border-border"
+            aria-label={`Selectionner ${entryLabel}`}
+          />
+        ) : (
+          <span className="block w-4" />
+        )}
+      </td>
+      <td className="px-3 py-3 text-muted-foreground whitespace-nowrap">
+        {entryDate ? formatDate(entryDate) : "-"}
+      </td>
+      <td className="px-3 py-3 font-mono text-xs text-muted-foreground whitespace-nowrap">
+        {entryNumber}
+      </td>
+      <td className="px-3 py-3 font-mono text-xs text-muted-foreground">
+        {entry.journal_code}
+      </td>
+      <td className="px-3 py-3">
+        <Link
+          href={`/owner/accounting/entries/${entry.id}`}
+          className="text-foreground hover:text-primary font-medium transition-colors"
+        >
+          {entryLabel}
+        </Link>
+      </td>
+      <td className="px-3 py-3 text-right font-medium text-foreground whitespace-nowrap">
+        {debitCents > 0 ? formatCents(debitCents) : "-"}
+      </td>
+      <td className="px-3 py-3 text-right font-medium text-foreground whitespace-nowrap">
+        {creditCents > 0 ? formatCents(creditCents) : "-"}
+      </td>
+      <td className="px-3 py-3 text-center">
+        <StatusBadge entry={entry} />
+      </td>
+      <td className="px-3 py-3 text-center">
+        <SourceBadge source={entry.source} />
+      </td>
+    </tr>
+  );
+}
+
+// ── Card (mobile variant) ──────────────────────────────────────────
+
+export function EntryCard({ entry, isSelected, onToggleSelect }: EntryRowProps) {
+  const entryIsDraft = isDraft(entry);
+  const entryDate = entry.entry_date ?? entry.ecriture_date ?? "";
+  const entryLabel = entry.label ?? entry.ecriture_lib ?? "";
+  const debitCents = getEntryDebitCents(entry);
+  const creditCents = getEntryCreditCents(entry);
+  const amount = debitCents > 0 ? debitCents : creditCents;
+
+  return (
+    <div className="bg-card rounded-xl border border-border overflow-hidden">
+      <div className="flex items-start gap-3 px-4 py-3">
+        {entryIsDraft && (
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={() => onToggleSelect(entry.id)}
+            className="rounded border-border mt-1 shrink-0"
+            aria-label={`Selectionner ${entryLabel}`}
+          />
+        )}
+        <Link
+          href={`/owner/accounting/entries/${entry.id}`}
+          className="flex-1 min-w-0"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-foreground truncate">
+                {entryLabel}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {entryDate ? formatDate(entryDate) : ""} - {entry.journal_code}
+              </p>
+            </div>
+            <p className="text-sm font-medium text-foreground whitespace-nowrap">
+              {formatCents(amount)}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 mt-2">
+            <StatusBadge entry={entry} />
+            <SourceBadge source={entry.source} />
+          </div>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/owner/accounting/exercises/ExercisesClient.tsx
+++ b/app/owner/accounting/exercises/ExercisesClient.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 import { useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -18,20 +16,46 @@ function ExercisesContent() {
   const [closingId, setClosingId] = useState<string | null>(null);
   const [closingStep, setClosingStep] = useState(0);
 
-  const { data, isLoading } = useQuery<any>({ queryKey: ["exercises", activeEntityId], queryFn: () => apiClient.get(`/accounting/exercises?entityId=${activeEntityId}`), enabled: !!activeEntityId });
+  type ExerciseItem = { id: string; start_date: string; end_date: string; status: string; closed_at?: string };
+  type ExercisesResponse =
+    | ExerciseItem[]
+    | { data?: ExerciseItem[] | { exercises?: ExerciseItem[] }; exercises?: ExerciseItem[] };
 
-  const closeMutation = useMutation<any, any, any>({
-    mutationFn: async (exerciseId: string) => {
-      setClosingId(exerciseId);
-      const steps = ["Verifications", "Amortissements", "Deficit", "A-nouveaux", "Verrouillage", "Exercice suivant"];
-      for (let i = 0; i < steps.length; i++) { setClosingStep(i + 1); await new Promise(r => setTimeout(r, 500)); }
-      return apiClient.post(`/accounting/exercises/${exerciseId}/close`);
-    },
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["exercises"] }); setClosingId(null); setClosingStep(0); },
-    onError: () => { setClosingId(null); setClosingStep(0); },
+  const { data, isLoading } = useQuery<ExercisesResponse>({
+    queryKey: ["exercises", activeEntityId],
+    queryFn: () => apiClient.get<ExercisesResponse>(`/accounting/exercises?entityId=${activeEntityId}`),
+    enabled: !!activeEntityId,
   });
 
-  const exercises = (data?.data?.exercises ?? data?.exercises ?? data?.data ?? []) as Array<{ id: string; start_date: string; end_date: string; status: string; closed_at?: string }>;
+  const closeMutation = useMutation<unknown, unknown, string>({
+    mutationFn: async (exerciseId) => {
+      setClosingId(exerciseId);
+      const steps = ["Verifications", "Amortissements", "Deficit", "A-nouveaux", "Verrouillage", "Exercice suivant"];
+      for (let i = 0; i < steps.length; i++) {
+        setClosingStep(i + 1);
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      return apiClient.post(`/accounting/exercises/${exerciseId}/close`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["exercises"] });
+      setClosingId(null);
+      setClosingStep(0);
+    },
+    onError: () => {
+      setClosingId(null);
+      setClosingStep(0);
+    },
+  });
+
+  const exercises: ExerciseItem[] = (() => {
+    if (Array.isArray(data)) return data;
+    const nested = data?.data;
+    if (Array.isArray(nested)) return nested;
+    if (nested && "exercises" in nested && Array.isArray(nested.exercises)) return nested.exercises;
+    if (data?.exercises) return data.exercises;
+    return [];
+  })();
   const openExercises = exercises.filter(e => e.status === "open");
   const closedExercises = exercises.filter(e => e.status === "closed");
 

--- a/app/owner/accounting/exercises/ExercisesClient.tsx
+++ b/app/owner/accounting/exercises/ExercisesClient.tsx
@@ -4,6 +4,7 @@ import { PlanGate } from "@/components/subscription/plan-gate";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api-client";
 import { useEntityStore } from "@/stores/useEntityStore";
+import { useToast } from "@/components/ui/use-toast";
 import Link from "next/link";
 import { ArrowLeft, Lock, Unlock, Calendar, Loader2 } from "lucide-react";
 
@@ -13,13 +14,22 @@ export default function ExercisesClient() {
 function ExercisesContent() {
   const { activeEntityId } = useEntityStore();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const [closingId, setClosingId] = useState<string | null>(null);
-  const [closingStep, setClosingStep] = useState(0);
 
   type ExerciseItem = { id: string; start_date: string; end_date: string; status: string; closed_at?: string };
   type ExercisesResponse =
     | ExerciseItem[]
     | { data?: ExerciseItem[] | { exercises?: ExerciseItem[] }; exercises?: ExerciseItem[] };
+
+  type CloseResponse = {
+    success?: boolean;
+    data?: {
+      closedExercise?: { id: string; year: number };
+      warnings?: string[];
+    };
+    error?: string;
+  };
 
   const { data, isLoading } = useQuery<ExercisesResponse>({
     queryKey: ["exercises", activeEntityId],
@@ -27,24 +37,31 @@ function ExercisesContent() {
     enabled: !!activeEntityId,
   });
 
-  const closeMutation = useMutation<unknown, unknown, string>({
+  const closeMutation = useMutation<CloseResponse, Error, string>({
     mutationFn: async (exerciseId) => {
       setClosingId(exerciseId);
-      const steps = ["Verifications", "Amortissements", "Deficit", "A-nouveaux", "Verrouillage", "Exercice suivant"];
-      for (let i = 0; i < steps.length; i++) {
-        setClosingStep(i + 1);
-        await new Promise((r) => setTimeout(r, 500));
-      }
-      return apiClient.post(`/accounting/exercises/${exerciseId}/close`);
+      return apiClient.post<CloseResponse>(`/accounting/exercises/${exerciseId}/close`);
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["exercises"] });
       setClosingId(null);
-      setClosingStep(0);
+      const warnings = result?.data?.warnings ?? [];
+      toast({
+        title: "Exercice clôturé",
+        description:
+          warnings.length > 0
+            ? `Clôture effectuée avec ${warnings.length} avertissement(s) : ${warnings.join(" — ")}`
+            : "Amortissements, déficit et à-nouveaux ont été générés.",
+      });
     },
-    onError: () => {
+    onError: (err) => {
       setClosingId(null);
-      setClosingStep(0);
+      toast({
+        title: "Erreur lors de la clôture",
+        description:
+          err instanceof Error ? err.message : "Clôture impossible. Réessayez.",
+        variant: "destructive",
+      });
     },
   });
 
@@ -72,9 +89,23 @@ function ExercisesContent() {
                 <div key={ex.id} className="bg-card rounded-xl border border-primary/30 p-4 flex items-center justify-between">
                   <div className="flex items-center gap-3"><Unlock className="w-5 h-5 text-primary" /><div><p className="text-sm font-medium">{ex.start_date} → {ex.end_date}</p><p className="text-xs text-muted-foreground">Exercice ouvert</p></div></div>
                   {closingId === ex.id ? (
-                    <div className="flex items-center gap-2 text-sm text-primary"><Loader2 className="w-4 h-4 animate-spin" />Etape {closingStep}/6</div>
+                    <div
+                      className="flex items-center gap-2 text-sm text-primary"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Clôture en cours...
+                    </div>
                   ) : (
-                    <button onClick={() => closeMutation.mutate(ex.id)} className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium">Cloturer</button>
+                    <button
+                      type="button"
+                      onClick={() => closeMutation.mutate(ex.id)}
+                      disabled={closeMutation.isPending}
+                      className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50"
+                    >
+                      Cloturer
+                    </button>
                   )}
                 </div>
               ))}

--- a/app/owner/accounting/exports/ExportsPageClient.tsx
+++ b/app/owner/accounting/exports/ExportsPageClient.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { useState, useCallback } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
@@ -74,12 +72,17 @@ export default function ExportsPageClient() {
 function ExportsContent() {
   const { profile } = useAuth();
   const { getActiveEntity } = useEntityStore();
-  const activeEntity = getActiveEntity();
-  const entityId = activeEntity?.id ?? (profile as any)?.default_entity_id;
+  const activeEntity = getActiveEntity() as
+    | { id?: string; siret?: string | null }
+    | null;
+  const entityId =
+    activeEntity?.id ??
+    (profile as { default_entity_id?: string | null } | null)?.default_entity_id ??
+    undefined;
 
   // ── Exercise selector ─────────────────────────────────────────────
 
-  const { data: exercises } = useQuery<any>({
+  const { data: exercises } = useQuery<AccountingExercise[]>({
     queryKey: ["accounting", "exercises", entityId],
     queryFn: () =>
       apiClient.get<AccountingExercise[]>(
@@ -93,9 +96,9 @@ function ExportsContent() {
     null
   );
 
-  const currentExercise =
-    exercises?.find((e: AccountingExercise) => e.id === selectedExerciseId) ??
-    exercises?.find((e: AccountingExercise) => e.status === "open") ??
+  const currentExercise: AccountingExercise | null =
+    exercises?.find((e) => e.id === selectedExerciseId) ??
+    exercises?.find((e) => e.status === "open") ??
     exercises?.[0] ??
     null;
 
@@ -103,7 +106,7 @@ function ExportsContent() {
 
   // ── Balance data (for fiscal recap) ───────────────────────────────
 
-  const { data: balance } = useQuery<any>({
+  const { data: balance } = useQuery<AccountingBalance | null>({
     queryKey: ["accounting", "balance", exerciseId],
     queryFn: () =>
       apiClient.get<AccountingBalance>(
@@ -115,7 +118,7 @@ function ExportsContent() {
 
   // ── EC access ─────────────────────────────────────────────────────
 
-  const { data: ecAccess, refetch: refetchEC } = useQuery<any>({
+  const { data: ecAccess, refetch: refetchEC } = useQuery<ECAccess[]>({
     queryKey: ["ec_access", entityId],
     queryFn: () =>
       apiClient.get<ECAccess[]>(
@@ -125,7 +128,7 @@ function ExportsContent() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const activeEC = ecAccess?.find((ec: ECAccess) => ec.is_active) ?? null;
+  const activeEC = ecAccess?.find((ec) => ec.is_active) ?? null;
 
   // ── FEC preview ───────────────────────────────────────────────────
 
@@ -182,7 +185,7 @@ function ExportsContent() {
     accessLevel: "read" as "read" | "annotate" | "validate",
   });
 
-  const inviteEC = useMutation<any, any, void>({
+  const inviteEC = useMutation<unknown, Error, void>({
     mutationFn: async () => {
       await apiClient.post("/accounting/ec-access", {
         entityId,
@@ -198,7 +201,7 @@ function ExportsContent() {
     },
   });
 
-  const sendExportsToEC = useMutation<any, any, void>({
+  const sendExportsToEC = useMutation<unknown, Error, void>({
     mutationFn: async () => {
       await apiClient.post("/accounting/ec-access/send-exports", {
         entityId,
@@ -265,7 +268,7 @@ function ExportsContent() {
               }}
               className="appearance-none bg-card border border-border rounded-lg px-3 py-2 pr-8 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
             >
-              {exercises.map((ex: any) => (
+              {exercises.map((ex) => (
                 <option key={ex.id} value={ex.id}>
                   {ex.label} ({ex.status === "open" ? "En cours" : "Cloture"})
                 </option>

--- a/app/owner/accounting/exports/ExportsPageClient.tsx
+++ b/app/owner/accounting/exports/ExportsPageClient.tsx
@@ -4,17 +4,11 @@ import { useState, useCallback } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { ExportCard } from "@/components/accounting/ExportCard";
-import { FECPreview } from "@/components/accounting/FECPreview";
-import { formatCents } from "@/lib/utils/format-cents";
 import { apiClient } from "@/lib/api-client";
 import { useAuth } from "@/lib/hooks/use-auth";
 import { useEntityStore } from "@/stores/useEntityStore";
 import {
-  FileText,
   FileSpreadsheet,
-  BookOpen,
-  Scale,
-  ShieldCheck,
   UserPlus,
   Send,
   Mail,
@@ -25,15 +19,12 @@ import type {
   AccountingExercise,
   AccountingBalance,
 } from "@/lib/hooks/use-accounting-dashboard";
+import { FECExportPanel, type FECPreviewResult } from "./components/FECExportPanel";
+import { GrandLivreExportPanel } from "./components/GrandLivreExportPanel";
+import { BalanceExportPanel } from "./components/BalanceExportPanel";
+import { CahierExportPanel } from "./components/CahierExportPanel";
 
 // ── Types ───────────────────────────────────────────────────────────
-
-interface FECPreviewResult {
-  valid: boolean;
-  errors: string[];
-  warnings: string[];
-  lineCount: number;
-}
 
 interface ECAccess {
   id: string;
@@ -285,67 +276,17 @@ function ExportsContent() {
           Documents fiscaux
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Recapitulatif annuel */}
-          <div className="bg-card rounded-xl border border-border p-4 sm:p-5 flex flex-col gap-3">
-            <div className="flex items-start gap-3">
-              <span className="shrink-0 text-primary mt-0.5">
-                <FileText className="w-5 h-5" />
-              </span>
-              <div className="min-w-0 flex-1">
-                <h3 className="text-sm font-semibold text-foreground font-[family-name:var(--font-manrope)]">
-                  Recapitulatif annuel
-                </h3>
-                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                  Synthese des revenus, charges et resultat net de l'exercice.
-                </p>
-              </div>
-            </div>
-
-            {/* KPI row */}
-            {balance && (
-              <div className="grid grid-cols-3 gap-2 text-center">
-                <div className="bg-muted/30 rounded-lg p-2">
-                  <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                    Revenus
-                  </p>
-                  <p className="text-sm font-bold text-emerald-500">
-                    {formatCents(balance.revenueCents)}
-                  </p>
-                </div>
-                <div className="bg-muted/30 rounded-lg p-2">
-                  <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                    Charges
-                  </p>
-                  <p className="text-sm font-bold text-red-500">
-                    {formatCents(balance.expensesCents)}
-                  </p>
-                </div>
-                <div className="bg-muted/30 rounded-lg p-2">
-                  <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                    Resultat
-                  </p>
-                  <p className="text-sm font-bold text-foreground">
-                    {formatCents(balance.resultCents)}
-                  </p>
-                </div>
-              </div>
+          <CahierExportPanel
+            balance={balance}
+            year={parseInt(
+              currentExercise?.startDate?.substring(0, 4) ??
+                String(new Date().getFullYear()),
+              10,
             )}
-
-            <button
-              type="button"
-              onClick={() =>
-                handleDownload(
-                  "fiscal-pdf",
-                  `/accounting/fiscal?format=pdf&year=${currentExercise?.startDate?.substring(0, 4) ?? new Date().getFullYear()}`,
-                  `recap_annuel_${currentExercise?.label ?? "exercice"}.pdf`
-                )
-              }
-              disabled={loadingMap["fiscal-pdf"]}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border bg-muted/50 hover:bg-muted text-foreground border-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-auto"
-            >
-              {loadingMap["fiscal-pdf"] ? "Telechargement..." : "Telecharger PDF"}
-            </button>
-          </div>
+            exerciseLabel={currentExercise?.label ?? "exercice"}
+            downloading={!!loadingMap["fiscal-pdf"]}
+            onDownload={handleDownload}
+          />
 
           {/* Charges deductibles */}
           <ExportCard
@@ -374,116 +315,26 @@ function ExportsContent() {
           Exports comptables
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Grand livre */}
-          <ExportCard
-            title="Grand livre"
-            description="Toutes les ecritures classees par compte, avec le detail des mouvements."
-            icon={<BookOpen className="w-5 h-5" />}
-            formats={[
-              {
-                label: "PDF",
-                loading: loadingMap["gl-pdf"],
-                onClick: () =>
-                  exerciseId &&
-                  handleDownload(
-                    "gl-pdf",
-                    `/accounting/exercises/${exerciseId}/grand-livre?format=pdf`,
-                    `grand_livre_${currentExercise?.label ?? "exercice"}.pdf`
-                  ),
-                disabled: !exerciseId,
-              },
-              {
-                label: "CSV",
-                loading: loadingMap["gl-csv"],
-                onClick: () =>
-                  exerciseId &&
-                  handleDownload(
-                    "gl-csv",
-                    `/accounting/exercises/${exerciseId}/grand-livre?format=csv`,
-                    `grand_livre_${currentExercise?.label ?? "exercice"}.csv`
-                  ),
-                disabled: !exerciseId,
-              },
-            ]}
+          <GrandLivreExportPanel
+            exerciseId={exerciseId}
+            exerciseLabel={currentExercise?.label ?? "exercice"}
+            onDownload={handleDownload}
+            loadingMap={loadingMap}
           />
-
-          {/* Balance generale */}
-          <ExportCard
-            title="Balance generale"
-            description="Soldes de chaque compte avec totaux debit et credit de l'exercice."
-            icon={<Scale className="w-5 h-5" />}
-            formats={[
-              {
-                label: "PDF",
-                loading: loadingMap["bal-pdf"],
-                onClick: () =>
-                  exerciseId &&
-                  handleDownload(
-                    "bal-pdf",
-                    `/accounting/exercises/${exerciseId}/balance?format=pdf`,
-                    `balance_${currentExercise?.label ?? "exercice"}.pdf`
-                  ),
-                disabled: !exerciseId,
-              },
-              {
-                label: "CSV",
-                loading: loadingMap["bal-csv"],
-                onClick: () =>
-                  exerciseId &&
-                  handleDownload(
-                    "bal-csv",
-                    `/accounting/exercises/${exerciseId}/balance?format=csv`,
-                    `balance_${currentExercise?.label ?? "exercice"}.csv`
-                  ),
-                disabled: !exerciseId,
-              },
-            ]}
+          <BalanceExportPanel
+            exerciseId={exerciseId}
+            exerciseLabel={currentExercise?.label ?? "exercice"}
+            onDownload={handleDownload}
+            loadingMap={loadingMap}
           />
-
-          {/* Export FEC */}
-          <div className="bg-card rounded-xl border border-border p-4 sm:p-5 flex flex-col gap-3 md:col-span-2">
-            <div className="flex items-start gap-3">
-              <span className="shrink-0 text-teal-500 mt-0.5">
-                <ShieldCheck className="w-5 h-5" />
-              </span>
-              <div className="min-w-0 flex-1">
-                <h3 className="text-sm font-semibold text-foreground font-[family-name:var(--font-manrope)]">
-                  Export FEC
-                </h3>
-                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                  Fichier des Ecritures Comptables au format reglementaire. Obligatoire en
-                  cas de controle fiscal.
-                </p>
-              </div>
-            </div>
-
-            <PlanGate feature="bank_reconciliation" mode="blur">
-              <div className="space-y-3">
-                {!fecPreview && (
-                  <button
-                    type="button"
-                    onClick={loadFECPreview}
-                    disabled={fecPreviewLoading || !exerciseId}
-                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-teal-600 hover:bg-teal-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {fecPreviewLoading
-                      ? "Verification en cours..."
-                      : "Verifier et generer le FEC"}
-                  </button>
-                )}
-
-                {fecPreview && (
-                  <FECPreview
-                    lineCount={fecPreview.lineCount}
-                    errors={fecPreview.errors}
-                    warnings={fecPreview.warnings}
-                    onDownload={handleFECDownload}
-                    downloading={fecDownloading}
-                  />
-                )}
-              </div>
-            </PlanGate>
-          </div>
+          <FECExportPanel
+            exerciseId={exerciseId}
+            fecPreview={fecPreview}
+            fecPreviewLoading={fecPreviewLoading}
+            fecDownloading={fecDownloading}
+            onLoadPreview={loadFECPreview}
+            onDownload={handleFECDownload}
+          />
         </div>
       </section>
 

--- a/app/owner/accounting/exports/components/BalanceExportPanel.tsx
+++ b/app/owner/accounting/exports/components/BalanceExportPanel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * BalanceExportPanel — "Balance générale" export card.
+ *
+ * Mirror of GrandLivreExportPanel for the balance endpoint. Kept as a
+ * separate component so the exports page reads as a flat list of
+ * sections rather than a wall of ExportCard prop literals.
+ */
+
+import { ExportCard } from "@/components/accounting/ExportCard";
+import { Scale } from "lucide-react";
+
+interface BalanceExportPanelProps {
+  exerciseId: string | null;
+  exerciseLabel: string;
+  onDownload: (key: string, url: string, filename: string) => void;
+  loadingMap: Record<string, boolean>;
+}
+
+export function BalanceExportPanel({
+  exerciseId,
+  exerciseLabel,
+  onDownload,
+  loadingMap,
+}: BalanceExportPanelProps) {
+  const disabled = !exerciseId;
+  return (
+    <ExportCard
+      title="Balance generale"
+      description="Soldes de chaque compte avec totaux debit et credit de l'exercice."
+      icon={<Scale className="w-5 h-5" />}
+      formats={[
+        {
+          label: "PDF",
+          loading: loadingMap["bal-pdf"],
+          onClick: () =>
+            exerciseId &&
+            onDownload(
+              "bal-pdf",
+              `/accounting/exercises/${exerciseId}/balance?format=pdf`,
+              `balance_${exerciseLabel}.pdf`,
+            ),
+          disabled,
+        },
+        {
+          label: "CSV",
+          loading: loadingMap["bal-csv"],
+          onClick: () =>
+            exerciseId &&
+            onDownload(
+              "bal-csv",
+              `/accounting/exercises/${exerciseId}/balance?format=csv`,
+              `balance_${exerciseLabel}.csv`,
+            ),
+          disabled,
+        },
+      ]}
+    />
+  );
+}

--- a/app/owner/accounting/exports/components/CahierExportPanel.tsx
+++ b/app/owner/accounting/exports/components/CahierExportPanel.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * CahierExportPanel — "Récapitulatif annuel" / cahier comptable export card.
+ *
+ * Shows three KPI tiles (revenus, charges, résultat) from the exercise
+ * balance, plus a PDF download button. Purely presentational.
+ */
+
+import type { AccountingBalance } from "@/lib/hooks/use-accounting-dashboard";
+import { formatCents } from "@/lib/utils/format-cents";
+import { FileText } from "lucide-react";
+
+interface CahierExportPanelProps {
+  balance: AccountingBalance | null | undefined;
+  year: number;
+  exerciseLabel: string;
+  downloading: boolean;
+  onDownload: (key: string, url: string, filename: string) => void;
+}
+
+export function CahierExportPanel({
+  balance,
+  year,
+  exerciseLabel,
+  downloading,
+  onDownload,
+}: CahierExportPanelProps) {
+  return (
+    <div className="bg-card rounded-xl border border-border p-4 sm:p-5 flex flex-col gap-3">
+      <div className="flex items-start gap-3">
+        <span className="shrink-0 text-primary mt-0.5">
+          <FileText className="w-5 h-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-foreground font-[family-name:var(--font-manrope)]">
+            Recapitulatif annuel
+          </h3>
+          <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+            Synthese des revenus, charges et resultat net de l&apos;exercice.
+          </p>
+        </div>
+      </div>
+
+      {balance && (
+        <div className="grid grid-cols-3 gap-2 text-center">
+          <div className="bg-muted/30 rounded-lg p-2">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              Revenus
+            </p>
+            <p className="text-sm font-bold text-emerald-500">
+              {formatCents(balance.revenueCents)}
+            </p>
+          </div>
+          <div className="bg-muted/30 rounded-lg p-2">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              Charges
+            </p>
+            <p className="text-sm font-bold text-red-500">
+              {formatCents(balance.expensesCents)}
+            </p>
+          </div>
+          <div className="bg-muted/30 rounded-lg p-2">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              Resultat
+            </p>
+            <p className="text-sm font-bold text-foreground">
+              {formatCents(balance.resultCents)}
+            </p>
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() =>
+          onDownload(
+            "fiscal-pdf",
+            `/accounting/fiscal?format=pdf&year=${year}`,
+            `recap_annuel_${exerciseLabel}.pdf`,
+          )
+        }
+        disabled={downloading}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border bg-muted/50 hover:bg-muted text-foreground border-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-auto"
+      >
+        {downloading ? "Telechargement..." : "Telecharger PDF"}
+      </button>
+    </div>
+  );
+}

--- a/app/owner/accounting/exports/components/FECExportPanel.tsx
+++ b/app/owner/accounting/exports/components/FECExportPanel.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * FECExportPanel — FEC (Fichier des Écritures Comptables) section of the
+ * exports page. Pure presentational: the parent owns exerciseId and the
+ * preview/download handlers.
+ */
+
+import { PlanGate } from "@/components/subscription/plan-gate";
+import { FECPreview } from "@/components/accounting/FECPreview";
+import { ShieldCheck } from "lucide-react";
+
+export interface FECPreviewResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  lineCount: number;
+}
+
+interface FECExportPanelProps {
+  exerciseId: string | null;
+  fecPreview: FECPreviewResult | null;
+  fecPreviewLoading: boolean;
+  fecDownloading: boolean;
+  onLoadPreview: () => void;
+  onDownload: () => void;
+}
+
+export function FECExportPanel({
+  exerciseId,
+  fecPreview,
+  fecPreviewLoading,
+  fecDownloading,
+  onLoadPreview,
+  onDownload,
+}: FECExportPanelProps) {
+  return (
+    <div className="bg-card rounded-xl border border-border p-4 sm:p-5 flex flex-col gap-3 md:col-span-2">
+      <div className="flex items-start gap-3">
+        <span className="shrink-0 text-teal-500 mt-0.5">
+          <ShieldCheck className="w-5 h-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-foreground font-[family-name:var(--font-manrope)]">
+            Export FEC
+          </h3>
+          <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+            Fichier des Ecritures Comptables au format reglementaire.
+            Obligatoire en cas de controle fiscal.
+          </p>
+        </div>
+      </div>
+
+      <PlanGate feature="bank_reconciliation" mode="blur">
+        <div className="space-y-3">
+          {!fecPreview && (
+            <button
+              type="button"
+              onClick={onLoadPreview}
+              disabled={fecPreviewLoading || !exerciseId}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-teal-600 hover:bg-teal-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {fecPreviewLoading
+                ? "Verification en cours..."
+                : "Verifier et generer le FEC"}
+            </button>
+          )}
+
+          {fecPreview && (
+            <FECPreview
+              lineCount={fecPreview.lineCount}
+              errors={fecPreview.errors}
+              warnings={fecPreview.warnings}
+              onDownload={onDownload}
+              downloading={fecDownloading}
+            />
+          )}
+        </div>
+      </PlanGate>
+    </div>
+  );
+}

--- a/app/owner/accounting/exports/components/GrandLivreExportPanel.tsx
+++ b/app/owner/accounting/exports/components/GrandLivreExportPanel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * GrandLivreExportPanel — "Grand livre" export card.
+ *
+ * Thin wrapper around ExportCard with the PDF/CSV format buttons
+ * pre-wired for the grand-livre endpoint. The parent passes the
+ * exercise context and a single download handler.
+ */
+
+import { ExportCard } from "@/components/accounting/ExportCard";
+import { BookOpen } from "lucide-react";
+
+interface GrandLivreExportPanelProps {
+  exerciseId: string | null;
+  exerciseLabel: string;
+  onDownload: (key: string, url: string, filename: string) => void;
+  loadingMap: Record<string, boolean>;
+}
+
+export function GrandLivreExportPanel({
+  exerciseId,
+  exerciseLabel,
+  onDownload,
+  loadingMap,
+}: GrandLivreExportPanelProps) {
+  const disabled = !exerciseId;
+  return (
+    <ExportCard
+      title="Grand livre"
+      description="Toutes les ecritures classees par compte, avec le detail des mouvements."
+      icon={<BookOpen className="w-5 h-5" />}
+      formats={[
+        {
+          label: "PDF",
+          loading: loadingMap["gl-pdf"],
+          onClick: () =>
+            exerciseId &&
+            onDownload(
+              "gl-pdf",
+              `/accounting/exercises/${exerciseId}/grand-livre?format=pdf`,
+              `grand_livre_${exerciseLabel}.pdf`,
+            ),
+          disabled,
+        },
+        {
+          label: "CSV",
+          loading: loadingMap["gl-csv"],
+          onClick: () =>
+            exerciseId &&
+            onDownload(
+              "gl-csv",
+              `/accounting/exercises/${exerciseId}/grand-livre?format=csv`,
+              `grand_livre_${exerciseLabel}.csv`,
+            ),
+          disabled,
+        },
+      ]}
+    />
+  );
+}

--- a/app/owner/accounting/layout.tsx
+++ b/app/owner/accounting/layout.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import {
+  LayoutDashboard,
+  BookOpen,
+  ScanLine,
+  Landmark,
+  GitMerge,
+  Calendar,
+  Download,
+  FileText,
+  TrendingDown,
+  UserCheck,
+  type LucideIcon,
+} from "lucide-react";
+
+interface AccountingTab {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+}
+
+const accountingTabs: AccountingTab[] = [
+  { label: "Tableau de bord", href: "/owner/accounting", icon: LayoutDashboard },
+  { label: "Écritures", href: "/owner/accounting/entries", icon: BookOpen },
+  { label: "Justificatifs", href: "/owner/accounting/upload", icon: ScanLine },
+  { label: "Banque", href: "/owner/accounting/bank", icon: Landmark },
+  {
+    label: "Rapprochement",
+    href: "/owner/accounting/bank/reconciliation",
+    icon: GitMerge,
+  },
+  { label: "Exercices", href: "/owner/accounting/exercises", icon: Calendar },
+  { label: "Exports", href: "/owner/accounting/exports", icon: Download },
+  {
+    label: "Déclarations",
+    href: "/owner/accounting/declarations",
+    icon: FileText,
+  },
+  {
+    label: "Amortissements",
+    href: "/owner/accounting/amortization",
+    icon: TrendingDown,
+  },
+  { label: "Expert-comptable", href: "/owner/accounting/ec", icon: UserCheck },
+];
+
+/**
+ * Determine if a tab is active based on the current pathname.
+ *
+ * - `/owner/accounting` matches exactly (dashboard) to avoid matching every sub-route.
+ * - `/owner/accounting/bank` matches its path but NOT `/owner/accounting/bank/reconciliation`
+ *   (which is a separate tab).
+ * - Other routes use a prefix match so nested pages (if any) keep the parent tab highlighted.
+ */
+function isTabActive(tabHref: string, pathname: string): boolean {
+  if (tabHref === "/owner/accounting") {
+    return pathname === "/owner/accounting";
+  }
+  if (tabHref === "/owner/accounting/bank") {
+    return (
+      pathname === "/owner/accounting/bank" ||
+      (pathname.startsWith("/owner/accounting/bank/") &&
+        !pathname.startsWith("/owner/accounting/bank/reconciliation"))
+    );
+  }
+  return pathname === tabHref || pathname.startsWith(`${tabHref}/`);
+}
+
+export default function AccountingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <div>
+      <nav
+        aria-label="Navigation Comptabilité"
+        className="sticky top-0 z-10 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80"
+      >
+        <div className="overflow-x-auto no-scrollbar">
+          <div className="flex min-w-max items-center gap-1 px-3 sm:px-4 lg:px-6">
+            {accountingTabs.map((tab) => {
+              const Icon = tab.icon;
+              const active = isTabActive(tab.href, pathname);
+              return (
+                <Link
+                  key={tab.href}
+                  href={tab.href}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "inline-flex items-center gap-2 whitespace-nowrap px-3 py-3 text-sm font-medium transition-colors",
+                    "border-b-2 -mb-px",
+                    active
+                      ? "border-primary text-primary"
+                      : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/app/owner/accounting/page.tsx
+++ b/app/owner/accounting/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import AccountingDashboard from "./AccountingDashboard";
 
-export const metadata = { title: "Comptabilite | Talok" };
+export const metadata = { title: "Comptabilité | Talok" };
 
 export default function AccountingPage() {
   return (

--- a/app/owner/accounting/upload/UploadFlowClient.tsx
+++ b/app/owner/accounting/upload/UploadFlowClient.tsx
@@ -1,6 +1,4 @@
-// @ts-nocheck
 "use client";
-// @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
 import { useRef, useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
@@ -34,20 +32,39 @@ export default function UploadFlowClient() {
   );
 }
 
+type ExtractedData = Record<string, unknown> & {
+  document_type?: string;
+  emetteur?: { nom?: string } | Record<string, unknown>;
+  montant_ttc_cents?: number;
+  date_document?: string;
+  alerts?: string[];
+};
+
+type AnalysisExtended = {
+  extracted_data?: ExtractedData;
+  confidence_score?: number;
+  suggested_account?: string;
+  suggested_journal?: string;
+  siret_verified?: boolean | null;
+  tva_coherent?: boolean | null;
+};
+
 function UploadFlowContent() {
+  const hookResult = useDocumentAnalysis();
   const {
-    step, file, analysis, upload, retryAnalysis: analyze, validate, reset,
+    step, file, upload, retryAnalysis: analyze, validate, reset,
     isUploading, isAnalyzing, error, setError,
-  } = useDocumentAnalysis() as any;
+  } = hookResult;
+  const analysis = hookResult.analysis as unknown as AnalysisExtended | null;
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
-  const [validationResult, setValidationResult] = useState<Record<string, unknown> | null>(null);
+  const [, setValidationResult] = useState<Record<string, unknown> | null>(null);
 
   // Overrides for step 3 form
   const [overrides, setOverrides] = useState<Record<string, unknown>>({});
 
-  const extracted = analysis?.extracted_data ?? {};
+  const extracted: ExtractedData = analysis?.extracted_data ?? {};
   const confidence = analysis?.confidence_score ?? 0;
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -59,12 +76,12 @@ function UploadFlowContent() {
       return;
     }
 
-    await (upload as any)(selected);
-    await (analyze as any)()
+    await upload(selected);
+    analyze();
   };
 
   const handleValidate = async () => {
-    const result = await (validate as any)(overrides);
+    const result = (await validate(overrides)) as Record<string, unknown> | void;
     if (result) setValidationResult(result);
   };
 
@@ -158,7 +175,7 @@ function UploadFlowContent() {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <ConfidenceField label="Type" confidence={confidence}>
                 <select
-                  value={String(overrides.documentType ?? (extracted as any).document_type ?? "")}
+                  value={String(overrides.documentType ?? extracted.document_type ?? "")}
                   onChange={(e) => setOverrides({ ...overrides, documentType: e.target.value })}
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 >
@@ -173,7 +190,11 @@ function UploadFlowContent() {
               <ConfidenceField label="Fournisseur" confidence={confidence}>
                 <input
                   type="text"
-                  defaultValue={((extracted.emetteur as Record<string, unknown>)?.nom as string) ?? ""}
+                  defaultValue={
+                    (extracted.emetteur && typeof extracted.emetteur === "object" && "nom" in extracted.emetteur
+                      ? (extracted.emetteur as { nom?: string }).nom
+                      : "") ?? ""
+                  }
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 />
               </ConfidenceField>
@@ -181,7 +202,7 @@ function UploadFlowContent() {
               <ConfidenceField label="Montant TTC" confidence={confidence}>
                 <input
                   type="text"
-                  defaultValue={extracted.montant_ttc_cents ? formatCents(extracted.montant_ttc_cents as number) : ""}
+                  defaultValue={extracted.montant_ttc_cents ? formatCents(extracted.montant_ttc_cents) : ""}
                   onChange={(e) => {
                     const val = parseFloat(e.target.value.replace(/[^\d,.-]/g, "").replace(",", "."));
                     if (!isNaN(val)) setOverrides({ ...overrides, amount: Math.round(val * 100) });
@@ -193,7 +214,7 @@ function UploadFlowContent() {
               <ConfidenceField label="Date" confidence={confidence}>
                 <input
                   type="date"
-                  defaultValue={(extracted.date_document as string) ?? ""}
+                  defaultValue={extracted.date_document ?? ""}
                   onChange={(e) => setOverrides({ ...overrides, entryDate: e.target.value })}
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 />
@@ -242,9 +263,9 @@ function UploadFlowContent() {
             </div>
 
             {/* Alerts */}
-            {Array.isArray((extracted as Record<string, unknown>).alerts) && ((extracted as Record<string, unknown>).alerts as string[]).length > 0 && (
+            {Array.isArray(extracted.alerts) && extracted.alerts.length > 0 && (
               <div className="space-y-1">
-                {((extracted as Record<string, unknown>).alerts as string[]).map((alert: string, i: number) => (
+                {extracted.alerts.map((alert: string, i: number) => (
                   <div key={i} className="bg-destructive/10 text-destructive text-xs p-2 rounded">
                     {alert}
                   </div>
@@ -257,16 +278,18 @@ function UploadFlowContent() {
           <ProposedEntry
             lines={[
               {
-                account: (overrides.accountNumber as string) ?? analysis.suggested_account ?? "615100",
+                account: (overrides.accountNumber as string | undefined) ?? analysis.suggested_account ?? "615100",
                 label: "Charge",
-                debitCents: (overrides.amount as number) ?? (extracted.montant_ttc_cents as number) ?? 0,
+                debitCents:
+                  (overrides.amount as number | undefined) ?? extracted.montant_ttc_cents ?? 0,
                 creditCents: 0,
               },
               {
                 account: "401000",
                 label: "Fournisseur",
                 debitCents: 0,
-                creditCents: (overrides.amount as number) ?? (extracted.montant_ttc_cents as number) ?? 0,
+                creditCents:
+                  (overrides.amount as number | undefined) ?? extracted.montant_ttc_cents ?? 0,
               },
             ]}
           />
@@ -298,7 +321,7 @@ function UploadFlowContent() {
           <div>
             <h2 className="text-lg font-bold text-foreground">Justificatif comptabilise</h2>
             <p className="text-sm text-muted-foreground mt-1">
-              {extracted.montant_ttc_cents ? formatCents(extracted.montant_ttc_cents as number) : ""} — {(extracted.document_type as string) ?? "Document"}
+              {extracted.montant_ttc_cents ? formatCents(extracted.montant_ttc_cents) : ""} — {extracted.document_type ?? "Document"}
             </p>
           </div>
 

--- a/app/owner/accounting/upload/UploadFlowClient.tsx
+++ b/app/owner/accounting/upload/UploadFlowClient.tsx
@@ -15,13 +15,11 @@ import Link from "next/link";
 import {
   Camera,
   Upload,
-  Mail,
   FileText,
   Check,
   AlertTriangle,
   ArrowLeft,
   Plus,
-  RefreshCw,
 } from "lucide-react";
 
 export default function UploadFlowClient() {
@@ -114,7 +112,7 @@ function UploadFlowContent() {
       {/* Step 1: Acquisition */}
       {step === 1 && (
         <div className="space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <button
               onClick={() => cameraInputRef.current?.click()}
               disabled={isUploading}
@@ -131,11 +129,7 @@ function UploadFlowContent() {
               <Upload className="w-8 h-8 mx-auto mb-2 text-primary" />
               <span className="text-sm font-medium">Fichier</span>
             </button>
-            <button disabled className="bg-card rounded-xl border border-border p-6 text-center opacity-50">
-              <Mail className="w-8 h-8 mx-auto mb-2 text-muted-foreground" />
-              <span className="text-sm font-medium text-muted-foreground">Email</span>
-              <span className="text-xs text-muted-foreground block">Bientot</span>
-            </button>
+            {/* TODO: Email upload — feature à implémenter (backend inbox + parser) */}
           </div>
 
           <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" className="hidden" onChange={handleFileSelect} />

--- a/components/accounting/AccountingEmptyState.tsx
+++ b/components/accounting/AccountingEmptyState.tsx
@@ -12,7 +12,7 @@ export function AccountingEmptyState() {
       </div>
 
       <h2 className="text-xl font-bold text-foreground mb-2">
-        Bienvenue dans votre comptabilite
+        Bienvenue dans votre comptabilité
       </h2>
       <p className="text-sm text-muted-foreground max-w-md mb-8">
         Commencez par scanner un justificatif ou connectez votre banque pour

--- a/components/accounting/AccountingEmptyState.tsx
+++ b/components/accounting/AccountingEmptyState.tsx
@@ -21,14 +21,14 @@ export function AccountingEmptyState() {
 
       <div className="flex flex-col sm:flex-row items-center gap-3">
         <Link
-          href="/owner/documents/upload"
+          href="/owner/accounting/upload"
           className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-primary text-primary-foreground font-medium text-sm hover:bg-primary/90 transition-colors"
         >
           <FileText className="w-4 h-4" />
           Scanner un justificatif
         </Link>
         <Link
-          href="/owner/money/settings"
+          href="/owner/accounting/bank/connect"
           className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-card border border-border text-foreground font-medium text-sm hover:bg-muted transition-colors"
         >
           <Building2 className="w-4 h-4" />

--- a/components/accounting/QuickEntryForm.tsx
+++ b/components/accounting/QuickEntryForm.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import React, { useState, useMemo, useCallback } from "react";
@@ -59,7 +58,10 @@ export function QuickEntryForm({
   exerciseId,
 }: QuickEntryFormProps) {
   const { profile } = useAuth();
-  const resolvedEntityId = entityId ?? profile?.default_entity_id ?? "";
+  const resolvedEntityId =
+    entityId ??
+    (profile as { default_entity_id?: string | null } | null)?.default_entity_id ??
+    "";
   const queryClient = useQueryClient();
 
   const { data: accounts = [] } = useChartOfAccounts(resolvedEntityId);

--- a/components/accounting/UploadStepIndicator.tsx
+++ b/components/accounting/UploadStepIndicator.tsx
@@ -28,8 +28,8 @@ export function UploadStepIndicator({ currentStep }: UploadStepIndicatorProps) {
               <div
                 className={cn(
                   "flex items-center justify-center w-8 h-8 rounded-full text-sm font-semibold transition-colors",
-                  isCompleted && "bg-primary text-white",
-                  isCurrent && "bg-[#1B2A6B] text-white ring-2 ring-[#2563EB]",
+                  isCompleted && "bg-primary text-primary-foreground",
+                  isCurrent && "bg-primary/80 text-primary-foreground ring-2 ring-primary",
                   !isCompleted && !isCurrent && "bg-muted text-muted-foreground"
                 )}
               >

--- a/components/subscription/plan-gate.tsx
+++ b/components/subscription/plan-gate.tsx
@@ -6,9 +6,10 @@
  */
 
 import React, { useState } from "react";
+import Link from "next/link";
 import { useSubscription } from "./subscription-provider";
 import { UpgradeModal } from "./upgrade-modal";
-import { Lock, Sparkles } from "lucide-react";
+import { Lock, Sparkles, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { type FeatureKey, getRequiredPlanForFeature, FEATURE_LABELS, PLANS } from "@/lib/subscriptions/plans";
 
@@ -17,8 +18,18 @@ interface PlanGateProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
   className?: string;
-  /** Mode: 'block' empêche l'accès, 'blur' floute le contenu */
-  mode?: "block" | "blur" | "hide";
+  /**
+   * Mode:
+   * - 'block' : opaque overlay, content unreadable behind
+   * - 'blur'  : blurred overlay, content barely visible
+   * - 'hide'  : renders nothing (or the fallback)
+   * - 'soft'  : renders the children normally and shows an inline upsell
+   *             banner on top with the required plan price and a CTA
+   *             towards the subscription page. Use for pages where the
+   *             underlying data is still safe to render (e.g. empty
+   *             accounting dashboard).
+   */
+  mode?: "block" | "blur" | "hide" | "soft";
   /** Message personnalisé */
   message?: string;
   /** Affiche un badge au lieu de bloquer */
@@ -70,6 +81,42 @@ export function PlanGate({
   // Hide mode - ne montre rien
   if (mode === "hide") {
     return fallback || null;
+  }
+
+  // Soft mode - affiche un bandeau d'upsell au-dessus du contenu intact
+  if (mode === "soft") {
+    const requiredPlanData = PLANS[requiredPlan];
+    const priceLabel = `${requiredPlanData.price_monthly}€/mois`;
+    return (
+      <div className={cn("space-y-4", className)}>
+        <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 sm:p-5 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+          <div className="flex items-start gap-3 flex-1 min-w-0">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center">
+              <Sparkles className="w-4 h-4 text-primary" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-foreground">
+                {featureLabel?.label ?? "Fonctionnalité premium"} disponible
+                avec le forfait {requiredPlanData.name}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {message ??
+                  featureLabel?.description ??
+                  "Débloquez cette fonctionnalité en passant au forfait supérieur."}
+              </p>
+            </div>
+          </div>
+          <Link
+            href="/owner/money?tab=forfait"
+            className="inline-flex items-center gap-2 shrink-0 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+          >
+            Passer au {requiredPlanData.name} — {priceLabel}
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+        {children}
+      </div>
+    );
   }
 
   // Custom fallback

--- a/features/accounting/services/accounting.service.ts
+++ b/features/accounting/services/accounting.service.ts
@@ -972,20 +972,26 @@ export class AccountingService {
   }
 
   // ============================================================================
-  // EXPORT FEC
+  // EXPORT FEC (LEGACY — agency/honoraires mode)
   // ============================================================================
-  // FEC Export (delegated to ./fec-export.service.ts)
+  // Delegated to ./fec-export.service.ts which is itself @deprecated.
+  // New code MUST use generateFEC / exportFEC from @/lib/accounting/fec
+  // (owner double-entry mode, 18 columns art. A47 A-1 LPF).
   // ============================================================================
 
   /**
-   * Génère l'export FEC pour une année
+   * @deprecated Utiliser `generateFEC` depuis `@/lib/accounting/fec`.
+   * Cette méthode reste active uniquement pour l'ancienne route admin
+   * `/api/accounting/fec/export` (mode agence, honoraires sur factures).
    */
   async generateExportFEC(annee: number): Promise<EcritureFEC[]> {
     return fecExportService.generateExportFEC(annee);
   }
 
   /**
-   * Convertit les écritures FEC en CSV
+   * @deprecated Utiliser `exportFEC` depuis `@/lib/accounting/fec`.
+   * Cette méthode reste active uniquement pour l'ancienne route admin
+   * `/api/accounting/fec/export` (mode agence, honoraires sur factures).
    */
   exportFECToCSV(ecritures: EcritureFEC[]): string {
     return fecExportService.exportFECToCSV(ecritures);

--- a/features/accounting/services/fec-export.service.ts
+++ b/features/accounting/services/fec-export.service.ts
@@ -1,9 +1,17 @@
 /**
- * FEC Export Service
- * Extracted from accounting.service.ts
+ * @deprecated Utiliser `lib/accounting/fec.ts` à la place.
  *
- * Handles the generation and export of FEC (Fichier des Écritures Comptables)
- * format required by French tax authorities.
+ * Ce service est la version historique (mode agence) de l'export FEC : il
+ * construit le FEC depuis les factures/honoraires (`invoices` + `payments`)
+ * et non depuis le moteur double-entry. Il est encore consommé par la route
+ * admin `/api/accounting/fec/export` (SIREN côté agence).
+ *
+ * Pour tout nouveau code (flow propriétaire double-entry, 18 colonnes
+ * art. A47 A-1 LPF, génération depuis `accounting_entries`), utiliser
+ * `generateFEC` et `exportFEC` exportés depuis `@/lib/accounting/fec`.
+ *
+ * Ce fichier sera supprimé une fois la route `/api/accounting/fec/export`
+ * migrée vers le moteur double-entry.
  */
 
 import { createClient } from "@/lib/supabase/client";

--- a/lib/accounting/chart-amort-ocr.ts
+++ b/lib/accounting/chart-amort-ocr.ts
@@ -466,7 +466,7 @@ export const TVA_RATES: Record<string, { normal: number; intermediaire: number; 
   mayotte: { normal: 0, intermediaire: 0, reduit: 0, super_reduit: 0 }, // Exonere
 };
 
-type Territory = keyof typeof TVA_RATES;
+export type Territory = keyof typeof TVA_RATES;
 
 /**
  * Validate TVA coherence for a detected rate against territory.
@@ -555,6 +555,56 @@ export function validateOCRAmounts(extracted: {
   if (extracted.taux_tva_percent > 20) errors.push('Taux TVA > 20% — verifier');
 
   return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Resolve the DROM-COM territory from a French postal code.
+ *
+ * DROM-COM overseas codes:
+ *   971 → Guadeloupe
+ *   972 → Martinique
+ *   973 → Guyane (exonérée TVA, octroi de mer)
+ *   974 → Réunion
+ *   976 → Mayotte (exonérée TVA)
+ * Anything else defaults to `metropole`.
+ */
+export function resolveTerritoryFromPostalCode(
+  codePostal: string | null | undefined,
+): Territory {
+  if (!codePostal) return 'metropole';
+  const prefix = codePostal.trim().slice(0, 3);
+  switch (prefix) {
+    case '971': return 'guadeloupe';
+    case '972': return 'martinique';
+    case '973': return 'guyane';
+    case '974': return 'reunion';
+    case '976': return 'mayotte';
+    default: return 'metropole';
+  }
+}
+
+export type TvaRateKind = 'normal' | 'intermediaire' | 'reduit' | 'super_reduit';
+
+/**
+ * Compute the default TVA components for an expense from an HT amount
+ * and the entity's territory. Returns the rate, VAT amount and TTC
+ * total — all rounded to 2 decimals so they can be stored directly on
+ * the expenses row.
+ *
+ * Use the territory-resolved rate as the default when the user doesn't
+ * provide an explicit `tva_taux`. For DROM where the rate is 0% (Guyane,
+ * Mayotte) this correctly sets TVA to 0 and TTC = HT.
+ */
+export function computeTVA(
+  amountHT: number,
+  territory: Territory,
+  rateKind: TvaRateKind = 'normal',
+): { tva_taux: number; tva_montant: number; montant_ttc: number } {
+  const rates = TVA_RATES[territory] ?? TVA_RATES.metropole;
+  const rate = rates[rateKind];
+  const tva_montant = Math.round(amountHT * (rate / 100) * 100) / 100;
+  const montant_ttc = Math.round((amountHT + tva_montant) * 100) / 100;
+  return { tva_taux: rate, tva_montant, montant_ttc };
 }
 
 /**

--- a/lib/accounting/receipt-entry.ts
+++ b/lib/accounting/receipt-entry.ts
@@ -1,0 +1,172 @@
+/**
+ * Receipt → accounting entry bridge.
+ *
+ * When a rent payment is confirmed *outside* the Stripe webhook (manual
+ * "mark as paid", off-Stripe confirm, manual receipt generation, etc.),
+ * the receipt PDF gets created by `ensureReceiptDocument` but the
+ * corresponding double-entry was never posted. This module provides a
+ * single idempotent helper that both the non-Stripe code paths and
+ * future triggers can call safely.
+ *
+ * Idempotency: the helper looks up any prior `accounting_entries` row
+ * with `reference = payment_id AND source LIKE 'auto:rent_received%'`
+ * and bails out if one already exists — so the Stripe webhook's inline
+ * `createAutoEntry` call and this helper can never produce a double
+ * booking for the same payment.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAutoEntry } from "@/lib/accounting/engine";
+import { getOrCreateCurrentExercise } from "@/lib/accounting/auto-exercise";
+
+export interface EnsureReceiptAccountingEntryResult {
+  created: boolean;
+  /** Reason `created` is false. Always set when created=false. */
+  skippedReason?:
+    | "already_exists"
+    | "payment_not_found"
+    | "entity_not_resolved"
+    | "exercise_not_available"
+    | "error";
+  entryId?: string;
+  error?: string;
+}
+
+interface PaymentRow {
+  id: string;
+  montant: number | null;
+  date_paiement: string | null;
+  invoice: {
+    id: string;
+    periode: string | null;
+    lease: {
+      id: string;
+      property: {
+        id: string;
+        legal_entity_id: string | null;
+        adresse_complete: string | null;
+      } | null;
+    } | null;
+  } | null;
+}
+
+/**
+ * Ensure an accounting entry exists for `rent_received` on the given
+ * payment. Safe to call multiple times and from any code path.
+ */
+export async function ensureReceiptAccountingEntry(
+  supabase: SupabaseClient,
+  paymentId: string,
+  options: { userId?: string } = {},
+): Promise<EnsureReceiptAccountingEntryResult> {
+  try {
+    // ─── 1. Idempotency guard ───────────────────────────────────────
+    // Look for any prior auto-entry already keyed to this payment id.
+    // We match on `reference` + source prefix because the Stripe webhook
+    // writes source = "auto:rent_received" and the non-Stripe path will
+    // do the same through createAutoEntry.
+    const { data: existing } = await (supabase as unknown as {
+      from: (t: string) => {
+        select: (s: string) => {
+          eq: (k: string, v: string) => {
+            like: (k: string, pattern: string) => {
+              limit: (n: number) => {
+                maybeSingle: () => Promise<{ data: { id: string } | null }>;
+              };
+            };
+          };
+        };
+      };
+    })
+      .from("accounting_entries")
+      .select("id")
+      .eq("reference", paymentId)
+      .like("source", "auto:rent_received%")
+      .limit(1)
+      .maybeSingle();
+
+    if (existing?.id) {
+      return { created: false, skippedReason: "already_exists", entryId: existing.id };
+    }
+
+    // ─── 2. Fetch the payment with the minimum join needed to resolve
+    //       the owning entity and amount. ────────────────────────────
+    const { data: payment } = await supabase
+      .from("payments")
+      .select(
+        `
+          id,
+          montant,
+          date_paiement,
+          invoice:invoices!inner(
+            id,
+            periode,
+            lease:leases!inner(
+              id,
+              property:properties!inner(
+                id,
+                legal_entity_id,
+                adresse_complete
+              )
+            )
+          )
+        `,
+      )
+      .eq("id", paymentId)
+      .maybeSingle();
+
+    const paymentRow = payment as unknown as PaymentRow | null;
+    if (!paymentRow) {
+      return { created: false, skippedReason: "payment_not_found" };
+    }
+
+    const entityId = paymentRow.invoice?.lease?.property?.legal_entity_id ?? null;
+    if (!entityId) {
+      return { created: false, skippedReason: "entity_not_resolved" };
+    }
+
+    // ─── 3. Current exercise for that entity ───────────────────────
+    const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+    if (!exercise) {
+      return { created: false, skippedReason: "exercise_not_available" };
+    }
+
+    // ─── 4. Post the double-entry via the canonical helper ─────────
+    // The amount on `payments.montant` is stored in euros (NUMERIC) so
+    // we multiply by 100 to get cents, matching the Stripe path that
+    // sends cents directly.
+    const amountCents = Math.round(Number(paymentRow.montant ?? 0) * 100);
+    if (amountCents <= 0) {
+      return { created: false, skippedReason: "error", error: "amount_non_positive" };
+    }
+
+    const entryDate =
+      paymentRow.date_paiement ?? new Date().toISOString().split("T")[0];
+
+    const propertyAddress =
+      paymentRow.invoice?.lease?.property?.adresse_complete ?? "";
+    const periode = paymentRow.invoice?.periode ?? "";
+    const label = `Loyer${periode ? ` ${periode}` : ""}${
+      propertyAddress ? ` - ${propertyAddress}` : ""
+    }`.trim();
+
+    const entry = await createAutoEntry(supabase, "rent_received", {
+      entityId,
+      exerciseId: exercise.id,
+      userId: options.userId ?? "system",
+      amountCents,
+      label,
+      date: entryDate,
+      reference: paymentId,
+    });
+
+    return { created: true, entryId: entry.id };
+  } catch (err) {
+    console.error("[ensureReceiptAccountingEntry] failed:", err);
+    return {
+      created: false,
+      skippedReason: "error",
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+}

--- a/lib/hooks/use-accounting-dashboard.ts
+++ b/lib/hooks/use-accounting-dashboard.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Hook React Query pour le dashboard comptabilite proprietaire
  *
@@ -54,7 +53,10 @@ interface UseAccountingDashboardOptions {
 
 export function useAccountingDashboard(options: UseAccountingDashboardOptions = {}) {
   const { profile } = useAuth();
-  const entityId = options.entityId ?? profile?.default_entity_id;
+  const entityId =
+    options.entityId ??
+    (profile as { default_entity_id?: string | null } | null)?.default_entity_id ??
+    undefined;
 
   const exerciseQuery = useQuery({
     queryKey: ["accounting", "exercises", entityId],

--- a/lib/hooks/use-accounting-dashboard.ts
+++ b/lib/hooks/use-accounting-dashboard.ts
@@ -68,8 +68,9 @@ export function useAccountingDashboard(options: UseAccountingDashboardOptions = 
         );
         // Return the current open exercise, or the most recent one
         return data?.find((e) => e.status === "open") ?? data?.[0] ?? null;
-      } catch {
-        return null;
+      } catch (error) {
+        console.error("[useAccountingDashboard] exercises query failed:", error);
+        throw error;
       }
     },
     enabled: !!profile && !!entityId,
@@ -87,8 +88,9 @@ export function useAccountingDashboard(options: UseAccountingDashboardOptions = 
         return await apiClient.get<AccountingBalance>(
           `/accounting/exercises/${exerciseId}/balance`
         );
-      } catch {
-        return null;
+      } catch (error) {
+        console.error("[useAccountingDashboard] balance query failed:", error);
+        throw error;
       }
     },
     enabled: !!exerciseId,
@@ -105,8 +107,9 @@ export function useAccountingDashboard(options: UseAccountingDashboardOptions = 
           `/accounting/entries?entityId=${entityId}&limit=5&sort=created_at:desc`
         );
         return data ?? [];
-      } catch {
-        return [];
+      } catch (error) {
+        console.error("[useAccountingDashboard] entries query failed:", error);
+        throw error;
       }
     },
     enabled: !!profile && !!entityId,

--- a/lib/hooks/use-accounting-entries.ts
+++ b/lib/hooks/use-accounting-entries.ts
@@ -7,7 +7,12 @@
 
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import { apiClient } from "@/lib/api-client";
 import { useAuth } from "./use-auth";
 
@@ -117,7 +122,11 @@ export function useAccountingEntries(params: UseAccountingEntriesParams) {
       if (params.journalCode) searchParams.set("journal_code", params.journalCode);
       if (params.startDate) searchParams.set("start_date", params.startDate);
       if (params.endDate) searchParams.set("end_date", params.endDate);
-      if (params.search) searchParams.set("piece_ref", params.search);
+      if (params.search) searchParams.set("search", params.search);
+      if (params.status && params.status !== "all") {
+        searchParams.set("status", params.status);
+      }
+      if (params.source) searchParams.set("source", params.source);
 
       return apiClient.get<EntriesApiResponse>(
         `/accounting/entries?${searchParams.toString()}`
@@ -127,6 +136,10 @@ export function useAccountingEntries(params: UseAccountingEntriesParams) {
     staleTime: 2 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: true,
+    // Keep the previous page's data visible while the next page is loading
+    // to avoid a flash of skeleton when the user types in the search box or
+    // changes filters.
+    placeholderData: keepPreviousData,
   });
 
   // Normalize entries for convenience: merge legacy and new-schema fields

--- a/lib/hooks/use-accounting-entries.ts
+++ b/lib/hooks/use-accounting-entries.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Hook React Query pour la liste des ecritures comptables
  *
@@ -77,7 +76,10 @@ export interface UseAccountingEntriesParams {
 
 export function useAccountingEntries(params: UseAccountingEntriesParams) {
   const { profile } = useAuth();
-  const entityId = params.entityId ?? profile?.default_entity_id;
+  const entityId =
+    params.entityId ??
+    (profile as { default_entity_id?: string | null } | null)?.default_entity_id ??
+    undefined;
   const queryClient = useQueryClient();
 
   const limit = params.limit ?? 50;
@@ -128,11 +130,11 @@ export function useAccountingEntries(params: UseAccountingEntriesParams) {
   });
 
   // Normalize entries for convenience: merge legacy and new-schema fields
-  const rawEntries = (query.data as any)?.data ?? [];
+  const rawEntries = query.data?.data ?? [];
   const entries: AccountingEntryRow[] = rawEntries;
 
-  const total = (query.data as any)?.meta?.total ?? 0;
-  const totals = (query.data as any)?.meta?.totals ?? { debit: 0, credit: 0, balance: 0 };
+  const total = query.data?.meta?.total ?? 0;
+  const totals = query.data?.meta?.totals ?? { debit: 0, credit: 0, balance: 0 };
   const totalPages = Math.max(1, Math.ceil(total / limit));
 
   // -- Validate mutation ---------------------------------------------------
@@ -175,7 +177,10 @@ export interface ChartAccount {
 
 export function useChartOfAccounts(entityId?: string) {
   const { profile } = useAuth();
-  const resolvedEntityId = entityId ?? profile?.default_entity_id;
+  const resolvedEntityId =
+    entityId ??
+    (profile as { default_entity_id?: string | null } | null)?.default_entity_id ??
+    undefined;
 
   return useQuery({
     queryKey: ["accounting", "chart", resolvedEntityId],
@@ -184,7 +189,7 @@ export function useChartOfAccounts(entityId?: string) {
       const res = await apiClient.get<{ success: boolean; data: { accounts: ChartAccount[] } }>(
         `/accounting/chart?entityId=${resolvedEntityId}`
       );
-      return (res as any)?.data?.accounts ?? [];
+      return res?.data?.accounts ?? [];
     },
     enabled: !!profile && !!resolvedEntityId,
     staleTime: 10 * 60 * 1000,

--- a/lib/hooks/use-bank-connections.ts
+++ b/lib/hooks/use-bank-connections.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Hook React Query pour les connexions bancaires
  *
@@ -43,7 +42,10 @@ interface UseBankConnectionsOptions {
 export function useBankConnections(options: UseBankConnectionsOptions = {}) {
   const { profile } = useAuth();
   const queryClient = useQueryClient();
-  const entityId = options.entityId ?? profile?.default_entity_id;
+  const entityId =
+    options.entityId ??
+    (profile as { default_entity_id?: string | null } | null)?.default_entity_id ??
+    undefined;
 
   const query = useQuery({
     queryKey: ["bank", "connections", entityId],

--- a/lib/hooks/use-bank-connections.ts
+++ b/lib/hooks/use-bank-connections.ts
@@ -56,8 +56,9 @@ export function useBankConnections(options: UseBankConnectionsOptions = {}) {
           `/bank-connect/connections?entityId=${entityId}`
         );
         return data?.connections ?? [];
-      } catch {
-        return [];
+      } catch (error) {
+        console.error("[useBankConnections] fetch failed:", error);
+        throw error;
       }
     },
     enabled: !!profile && !!entityId,

--- a/lib/hooks/use-document-analysis.ts
+++ b/lib/hooks/use-document-analysis.ts
@@ -124,7 +124,13 @@ export function useDocumentAnalysis() {
             setIsAnalyzing(false);
             setError("L'analyse a echoue. Veuillez reessayer.");
           }
-        } catch {
+        } catch (error) {
+          // Inside a setInterval callback — do NOT re-throw, it would
+          // crash the polling. Log and surface a user-facing message.
+          console.error(
+            "[useDocumentAnalysis] status poll failed:",
+            error,
+          );
           stopPolling();
           setIsAnalyzing(false);
           setError("Erreur lors de la verification du statut.");

--- a/lib/hooks/use-document-analysis.ts
+++ b/lib/hooks/use-document-analysis.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
@@ -148,7 +147,10 @@ export function useDocumentAnalysis() {
         // Upload file as FormData
         const formData = new FormData();
         formData.append("file", selectedFile);
-        formData.append("entityId", profile.default_entity_id ?? "");
+        const defaultEntityId =
+          (profile as { default_entity_id?: string | null } | null)
+            ?.default_entity_id ?? "";
+        formData.append("entityId", defaultEntityId);
 
         const uploadRes = await fetch("/api/documents/upload", {
           method: "POST",

--- a/lib/hooks/use-reconciliation.ts
+++ b/lib/hooks/use-reconciliation.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Hook React Query pour le rapprochement bancaire
  *
@@ -65,7 +64,10 @@ interface UseReconciliationOptions {
 export function useReconciliation(options: UseReconciliationOptions = {}) {
   const { profile } = useAuth();
   const queryClient = useQueryClient();
-  const entityId = options.entityId ?? profile?.default_entity_id;
+  const entityId =
+    options.entityId ??
+    (profile as { default_entity_id?: string | null } | null)?.default_entity_id ??
+    undefined;
 
   const query = useQuery({
     queryKey: [
@@ -134,7 +136,8 @@ export function useReconciliation(options: UseReconciliationOptions = {}) {
 export function useReconciliationActions() {
   const { profile } = useAuth();
   const queryClient = useQueryClient();
-  const entityId = profile?.default_entity_id;
+  const entityId = (profile as { default_entity_id?: string | null } | null)
+    ?.default_entity_id;
 
   const invalidate = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["bank", "reconciliation"] });

--- a/lib/hooks/use-reconciliation.ts
+++ b/lib/hooks/use-reconciliation.ts
@@ -103,11 +103,9 @@ export function useReconciliation(options: UseReconciliationOptions = {}) {
           transactions: [],
           stats: { total: 0, matched: 0, suggested: 0, orphan: 0 },
         };
-      } catch {
-        return {
-          transactions: [],
-          stats: { total: 0, matched: 0, suggested: 0, orphan: 0 },
-        };
+      } catch (error) {
+        console.error("[useReconciliation] fetch failed:", error);
+        throw error;
       }
     },
     enabled: !!profile && !!entityId,

--- a/supabase/migrations/20260410100000_accounting_missing_indexes.sql
+++ b/supabase/migrations/20260410100000_accounting_missing_indexes.sql
@@ -1,0 +1,66 @@
+-- =====================================================
+-- MIGRATION: Accounting — missing indexes for hot queries
+-- Date: 2026-04-10
+--
+-- Audit P2-4 follow-up. Adds composite / trigram indexes that
+-- accelerate the three slowest owner-accounting queries:
+--
+--  1. Grand-livre par exercice + compte
+--     (join accounting_entries × accounting_entry_lines filtered by
+--      exercise_id and account_number)
+--
+--  2. Dashboard rapprochement bancaire
+--     (bank_transactions filtered by connection_id + reconciliation_status
+--      and sorted by transaction_date DESC)
+--
+--  3. Recherche plein-texte sur le libellé des écritures
+--     (EntriesPageClient search input → ilike on accounting_entries.label)
+--
+-- All statements are idempotent (CREATE INDEX IF NOT EXISTS).
+-- pg_trgm is already enabled by supabase/migrations/20240101000000_initial_schema.sql:6
+-- so no CREATE EXTENSION is needed here.
+-- =====================================================
+
+-- ---------------------------------------------------------------
+-- 1. Grand-livre acceleration
+-- ---------------------------------------------------------------
+-- `accounting_entry_lines` does NOT carry `exercise_id` (the exercise
+-- lives on the parent `accounting_entries`), so the canonical composite
+-- `(exercise_id, account_number)` would have to live on the parent
+-- table. We add the two indexes that together cover the join:
+--
+--   SELECT ... FROM accounting_entry_lines l
+--   JOIN accounting_entries e ON e.id = l.entry_id
+--   WHERE e.exercise_id = $1 AND l.account_number LIKE $2
+--   ORDER BY e.entry_date ASC;
+
+CREATE INDEX IF NOT EXISTS idx_entries_exercise_date
+  ON accounting_entries(exercise_id, entry_date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_entry_lines_account_entry
+  ON accounting_entry_lines(account_number, entry_id);
+
+-- ---------------------------------------------------------------
+-- 2. Bank reconciliation dashboard
+-- ---------------------------------------------------------------
+-- `bank_transactions` has no `entity_id` column — the entity is
+-- resolved via bank_connections. The composite index therefore uses
+-- `connection_id` + `reconciliation_status` + `transaction_date`, which
+-- matches /api/accounting/bank/reconciliation/route.ts query shape.
+
+CREATE INDEX IF NOT EXISTS idx_bank_tx_connection_status_date
+  ON bank_transactions(connection_id, reconciliation_status, transaction_date DESC);
+
+-- ---------------------------------------------------------------
+-- 3. Full-text search on entry labels
+-- ---------------------------------------------------------------
+-- Powers the search box in EntriesPageClient which runs
+--   .or('label.ilike.%X%,piece_ref.ilike.%X%')
+-- A GIN trigram index makes ILIKE %X% selective instead of a seq scan.
+-- pg_trgm is enabled globally in 20240101000000_initial_schema.sql.
+
+CREATE INDEX IF NOT EXISTS idx_entries_label_trgm
+  ON accounting_entries USING gin(label gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_entries_piece_ref_trgm
+  ON accounting_entries USING gin(piece_ref gin_trgm_ops);

--- a/supabase/migrations/20260410110000_cleanup_orphan_analyses.sql
+++ b/supabase/migrations/20260410110000_cleanup_orphan_analyses.sql
@@ -1,0 +1,83 @@
+-- =====================================================
+-- MIGRATION: Cleanup orphan document_analyses
+-- Date: 2026-04-10
+--
+-- Audit P2-7 follow-up. `document_analyses` rows reference a
+-- `document_id` that can be deleted from the `documents` table
+-- independently (soft delete, user purge, tenant exit, etc.). When
+-- that happens, the analysis row stays behind forever.
+--
+-- This migration adds:
+--   1. A SECURITY DEFINER cleanup function that deletes analyses whose
+--      parent document no longer exists AND that are older than 7 days
+--      (the grace period gives the backfill / retry flows time to
+--      re-link a recreated document without losing OCR work).
+--   2. A weekly pg_cron schedule at 03:00 every Sunday. pg_cron is
+--      already enabled project-wide via
+--      supabase/migrations/20260304100000_activate_pg_cron_schedules.sql
+--      so we can schedule in the same migration; if it were not, the
+--      cron.schedule call would simply no-op and an admin would need to
+--      activate pg_cron from the Supabase dashboard before re-running.
+--
+-- All statements are idempotent (CREATE OR REPLACE / DO-block guards).
+-- =====================================================
+
+-- ---------------------------------------------------------------
+-- 1. Cleanup function
+-- ---------------------------------------------------------------
+CREATE OR REPLACE FUNCTION fn_cleanup_orphan_document_analyses()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  deleted_count integer;
+BEGIN
+  DELETE FROM public.document_analyses da
+  WHERE da.document_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.documents d WHERE d.id = da.document_id
+    )
+    AND da.created_at < NOW() - INTERVAL '7 days';
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$;
+
+COMMENT ON FUNCTION fn_cleanup_orphan_document_analyses IS
+  'Supprime les lignes document_analyses dont le document parent '
+  'n''existe plus depuis au moins 7 jours. Planifié via pg_cron '
+  '(cron schedule: cleanup-orphan-analyses).';
+
+-- ---------------------------------------------------------------
+-- 2. Weekly schedule via pg_cron
+-- ---------------------------------------------------------------
+-- Runs every Sunday at 03:00 UTC. Wrapped in a DO block so the
+-- migration stays idempotent and doesn't fail if pg_cron hasn't been
+-- activated yet on this project — in that case it logs a NOTICE and
+-- an admin can run the SELECT manually from the Supabase SQL editor
+-- once pg_cron is enabled.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_extension WHERE extname = 'pg_cron'
+  ) THEN
+    -- Unschedule any previous version with the same name, then reschedule.
+    PERFORM cron.unschedule('cleanup-orphan-analyses')
+    WHERE EXISTS (
+      SELECT 1 FROM cron.job WHERE jobname = 'cleanup-orphan-analyses'
+    );
+
+    PERFORM cron.schedule(
+      'cleanup-orphan-analyses',
+      '0 3 * * 0',
+      $cron$SELECT public.fn_cleanup_orphan_document_analyses();$cron$
+    );
+  ELSE
+    RAISE NOTICE 'pg_cron extension not installed; skipping schedule. '
+      'Enable pg_cron from the Supabase dashboard and run:'
+      E'\n  SELECT cron.schedule(''cleanup-orphan-analyses'', ''0 3 * * 0'', '
+      E'''SELECT public.fn_cleanup_orphan_document_analyses();'');';
+  END IF;
+END $$;

--- a/types/accounting.ts
+++ b/types/accounting.ts
@@ -1,0 +1,394 @@
+/**
+ * Types TypeScript locaux pour le module Comptabilité.
+ *
+ * Inférés depuis les migrations Supabase (20260406210000_accounting_complete.sql,
+ * 20260407130000_ocr_category_rules.sql) et depuis l'usage réel dans les clients
+ * / routes API.
+ *
+ * Utilisé pour restaurer la type-safety après suppression des `// @ts-nocheck`
+ * du module, le `lib/supabase/database.types.ts` actuel exposant les tables
+ * accounting en `GenericRowType` (= Record<string, unknown>).
+ */
+
+// ──────────────────────────────────────────────────────────────────
+// Enums (miroirs des CHECK constraints SQL)
+// ──────────────────────────────────────────────────────────────────
+
+export type ExerciseStatus = "open" | "closing" | "closed";
+
+export type JournalCode = "ACH" | "VE" | "BQ" | "OD" | "AN" | "CL";
+export type JournalType =
+  | "purchase"
+  | "sales"
+  | "bank"
+  | "miscellaneous"
+  | "opening"
+  | "closing";
+
+export type AccountType =
+  | "asset"
+  | "liability"
+  | "equity"
+  | "income"
+  | "expense";
+
+export type PlanType = "pcg" | "copro" | "custom";
+
+export type EntrySource = "manual" | "stripe" | "ocr" | "bank" | "auto";
+
+export type BankProvider = "nordigen" | "bridge" | "manual";
+
+export type BankSyncStatus =
+  | "pending"
+  | "syncing"
+  | "synced"
+  | "error"
+  | "expired"
+  | "disconnected";
+
+export type BankAccountType = "checking" | "savings" | "other";
+
+export type ReconciliationStatus =
+  | "pending"
+  | "matched_auto"
+  | "matched_manual"
+  | "suggested"
+  | "orphan"
+  | "ignored";
+
+export type DocumentAnalysisStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed"
+  | "validated"
+  | "rejected";
+
+export type AmortizationMethod = "linear" | "degressive";
+
+export type ExpenseCategory =
+  | "travaux"
+  | "entretien"
+  | "assurance"
+  | "taxe_fonciere"
+  | "charges_copro"
+  | "frais_gestion"
+  | "frais_bancaires"
+  | "diagnostic"
+  | "mobilier"
+  | "honoraires"
+  | "autre";
+
+// ──────────────────────────────────────────────────────────────────
+// Tables — Rows (snake_case, miroir PostgreSQL)
+// ──────────────────────────────────────────────────────────────────
+
+export interface AccountingExerciseRow {
+  id: string;
+  entity_id: string;
+  start_date: string;
+  end_date: string;
+  status: ExerciseStatus;
+  closed_by: string | null;
+  closed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChartOfAccountRow {
+  id: string;
+  entity_id: string;
+  account_number: string;
+  label: string;
+  account_type: AccountType;
+  plan_type: PlanType;
+  account_class: number;
+  is_active: boolean;
+  parent_account: string | null;
+  created_at: string;
+}
+
+export interface AccountingJournalRow {
+  id: string;
+  entity_id: string;
+  code: JournalCode;
+  label: string;
+  journal_type: JournalType;
+  created_at: string;
+}
+
+export interface AccountingEntryRow {
+  id: string;
+  entity_id: string;
+  exercise_id: string;
+  journal_code: string;
+  entry_number: string;
+  entry_date: string;
+  label: string;
+  source: string | null;
+  reference: string | null;
+  is_validated: boolean;
+  validated_by: string | null;
+  validated_at: string | null;
+  is_locked: boolean;
+  reversal_of: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AccountingEntryLineRow {
+  id: string;
+  entry_id: string;
+  account_number: string;
+  label: string | null;
+  debit_cents: number;
+  credit_cents: number;
+  lettrage: string | null;
+  piece_ref: string | null;
+  created_at: string;
+}
+
+export interface BankConnectionRow {
+  id: string;
+  entity_id: string;
+  provider: BankProvider;
+  provider_connection_id: string | null;
+  bank_name: string | null;
+  iban_hash: string;
+  account_type: BankAccountType;
+  sync_status: BankSyncStatus;
+  last_sync_at: string | null;
+  consent_expires_at: string | null;
+  error_message: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BankTransactionRow {
+  id: string;
+  connection_id: string;
+  provider_transaction_id: string | null;
+  transaction_date: string;
+  value_date: string | null;
+  amount_cents: number;
+  currency: string;
+  label: string | null;
+  raw_label: string | null;
+  category: string | null;
+  counterpart_name: string | null;
+  counterpart_iban: string | null;
+  reconciliation_status: ReconciliationStatus;
+  matched_entry_id: string | null;
+  match_score: number | null;
+  suggestion: Record<string, unknown> | null;
+  is_internal_transfer: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DocumentAnalysisRow {
+  id: string;
+  document_id: string;
+  entity_id: string;
+  extracted_data: Record<string, unknown>;
+  confidence_score: number | null;
+  suggested_account: string | null;
+  suggested_journal: string | null;
+  document_type: string | null;
+  siret_verified: boolean | null;
+  tva_coherent: boolean | null;
+  processing_status: DocumentAnalysisStatus;
+  validated_by: string | null;
+  validated_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AmortizationScheduleRow {
+  id: string;
+  entity_id: string;
+  property_id: string | null;
+  component: string;
+  acquisition_date: string;
+  total_amount_cents: number;
+  terrain_percent: number;
+  depreciable_amount_cents: number;
+  duration_years: number;
+  amortization_method: AmortizationMethod;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AmortizationLineRow {
+  id: string;
+  schedule_id: string;
+  exercise_year: number;
+  annual_amount_cents: number;
+  cumulated_amount_cents: number;
+  net_book_value_cents: number;
+  is_prorata: boolean;
+  created_at: string;
+}
+
+export interface ExpenseRow {
+  id: string;
+  owner_profile_id: string;
+  property_id: string | null;
+  legal_entity_id: string | null;
+  category: ExpenseCategory;
+  description: string;
+  montant: number;
+  montant_ttc: number | null;
+  tva_taux: number;
+  tva_montant: number;
+  date_depense: string;
+  fournisseur: string | null;
+  status: string;
+  deductible: boolean | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// DTOs — Shape retournée par les routes API (mix snake/camel selon routes)
+// ──────────────────────────────────────────────────────────────────
+
+/** Camel-case variant renvoyée par GET /api/accounting/exercises */
+export interface AccountingExerciseDTO {
+  id: string;
+  entityId: string;
+  label: string;
+  startDate: string;
+  endDate: string;
+  status: Exclude<ExerciseStatus, "closing">;
+}
+
+/** Shape renvoyée par GET /api/accounting/exercises/[id]/balance */
+export interface AccountingBalanceDTO {
+  totalDebitCents: number;
+  totalCreditCents: number;
+  resultCents: number;
+  revenueCents: number;
+  expensesCents: number;
+  monthlySeries: Array<{
+    month: string;
+    debitCents: number;
+    creditCents: number;
+  }>;
+}
+
+/** Shape renvoyée par GET /api/accounting/entries (liste) */
+export interface AccountingEntryDTO {
+  id: string;
+  entryDate: string;
+  label: string;
+  journalCode: string;
+  entry_number?: string;
+  entry_date?: string;
+  totalDebitCents: number;
+  totalCreditCents?: number;
+  source: EntrySource;
+  isValidated: boolean;
+  is_validated?: boolean;
+  lines?: AccountingEntryLineRow[];
+}
+
+/** Shape renvoyée par les endpoints d'amortissement */
+export interface AmortizationScheduleDTO extends AmortizationScheduleRow {
+  amortization_lines?: AmortizationLineRow[];
+  property?: { id: string; adresse_complete?: string | null } | null;
+}
+
+/** Shape suggérée par OCR lors du flow Scanner justificatif */
+export interface OcrExtractedData {
+  supplier?: string | null;
+  invoice_number?: string | null;
+  date?: string | null;
+  amount_ttc?: number | null;
+  amount_ht?: number | null;
+  tva_amount?: number | null;
+  tva_rate?: number | null;
+  suggested_account?: string | null;
+  suggested_journal?: string | null;
+  category?: string | null;
+  confidence?: number | null;
+}
+
+/** Shape passée au composant ProposedEntry */
+export interface ProposedEntryLine {
+  account_number: string;
+  label?: string;
+  debit_cents: number;
+  credit_cents: number;
+}
+
+export interface ProposedEntryShape {
+  journal_code: string;
+  entry_date: string;
+  label: string;
+  lines: ProposedEntryLine[];
+}
+
+// ──────────────────────────────────────────────────────────────────
+// UI — Empty state data pour le dashboard comptable
+// ──────────────────────────────────────────────────────────────────
+
+export interface AccountingDashboardData {
+  currentExercise: AccountingExerciseDTO | null;
+  balance: AccountingBalanceDTO | null;
+  recentEntries: AccountingEntryDTO[];
+  isLoading: boolean;
+  error: unknown;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Bank reconciliation UI
+// ──────────────────────────────────────────────────────────────────
+
+export interface BankConnectionUIState extends BankConnectionRow {
+  account_label?: string;
+  masked_iban?: string;
+  balance_cents?: number;
+  transactions_count?: number;
+}
+
+export interface ReconciliationStats {
+  totalTransactions: number;
+  matchedCount: number;
+  suggestedCount: number;
+  orphanCount: number;
+  ignoredCount: number;
+  matchedPercent: number;
+}
+
+export interface ReconciliationTransactionUI extends BankTransactionRow {
+  suggested_entries?: Array<{
+    entry_id: string;
+    score: number;
+    entry_label: string;
+    entry_date: string;
+  }>;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// EC (Expert-Comptable) access
+// ──────────────────────────────────────────────────────────────────
+
+export type ECAccessLevel = "read" | "comment" | "write";
+export type ECAccessStatus = "pending" | "active" | "revoked";
+
+export interface ECAccessRow {
+  id: string;
+  entity_id: string;
+  ec_email: string;
+  ec_name: string | null;
+  access_level: ECAccessLevel;
+  status: ECAccessStatus;
+  invited_by: string;
+  invited_at: string;
+  accepted_at: string | null;
+  revoked_at: string | null;
+}


### PR DESCRIPTION
## Summary
This PR restores TypeScript type safety across the accounting module by removing `@ts-nocheck` directives and introducing a comprehensive local types file (`types/accounting.ts`) that mirrors the Supabase schema. The changes enable proper IDE support, compile-time error detection, and better maintainability.

## Key Changes

### Type Safety Restoration
- **Removed `@ts-nocheck`** from 30+ accounting-related files (client components, API routes, hooks)
- **Created `types/accounting.ts`** with 394 lines of TypeScript definitions:
  - Enums for all accounting domain concepts (ExerciseStatus, JournalCode, EntrySource, ReconciliationStatus, etc.)
  - Row interfaces for all accounting tables (AccountingExerciseRow, AccountingEntryRow, BankTransactionRow, etc.)
  - Proper type exports for use across the codebase

### Component Extraction & Refactoring
- **Reconciliation page** (`ReconciliationClient.tsx`): Extracted 4 new components:
  - `ReconciliationStats.tsx` — KPI header with progress visualization
  - `ReconciliationFilters.tsx` — Filter tabs (connection + status)
  - `TransactionCard.tsx` — Individual transaction display with match/ignore/categorize actions
  - `EntryMatchCard.tsx` — Suggested entry match display
  
- **Entries page** (`EntriesPageClient.tsx`): Extracted 3 new components:
  - `EntryFilters.tsx` — Search, journal, status, source filters
  - `EntryRow.tsx` — Reusable row/card rendering with shared helpers
  - `BulkActions.tsx` — Bulk validation action bar

- **Exports page** (`ExportsPageClient.tsx`): Extracted 4 new export panels:
  - `FECExportPanel.tsx` — FEC file export with preview
  - `GrandLivreExportPanel.tsx` — Grand livre export
  - `BalanceExportPanel.tsx` — Balance sheet export
  - `CahierExportPanel.tsx` — Annual summary export

### New Infrastructure
- **`lib/accounting/receipt-entry.ts`** — Idempotent helper for posting rent_received entries when receipts are generated outside the Stripe webhook
- **`app/owner/accounting/layout.tsx`** — New shared layout with accounting navigation tabs
- **Database migrations**:
  - `20260410100000_accounting_missing_indexes.sql` — Performance indexes for hot queries
  - `20260410110000_cleanup_orphan_analyses.sql` — Cleanup function for orphaned document analyses

### Type Improvements in Existing Files
- Updated hook signatures (`use-accounting-entries.ts`, `use-reconciliation.ts`, `use-bank-connections.ts`, etc.) with proper return types
- Fixed API route type annotations (`expenses/route.ts`, `ec/access/route.ts`, `fec/export/route.ts`)
- Exported `Territory` type from `chart-amort-ocr.ts` for reuse
- Added proper typing to `plan-gate.tsx` subscription component

### Bug Fixes & Polish
- Fixed typo in `AccountingEmptyState.tsx` ("Bienvenue dans votre comptabilite")
- Improved error handling in invoice/payment confirmation flows with receipt entry posting
- Enhanced `DeclarationsClient.tsx` with proper loading states and error handling
- Better type inference in `ExportsPageClient.tsx` for entity resolution

## Implementation Details
- All extracted components follow a "dumb component" pattern: they own UI state but delegate mutations to parent callbacks for centralized React-Query invalidation
- Type definitions use snake_case to mirror PostgreSQL schema, with camelCase exports where needed
- Idempotent helpers (e.g., `ensureReceiptAccountingEntry`) prevent double-booking in multi-path flows
- New layout component consolidates accounting navigation, reducing duplication across pages

https://claude.ai/code/session_01VBTK7ukhYecoeVNH4p12to