### PR TITLE
Add dark mode support to payment and lease management components

### DIFF
--- a/app/owner/invoices/[id]/page.tsx
+++ b/app/owner/invoices/[id]/page.tsx
@@ -37,15 +37,15 @@ import { ManualPaymentDialog } from "@/components/payments";
 
 const statusConfig = {
   draft: { label: "Brouillon", color: "bg-muted text-foreground", icon: FileText },
-  sent: { label: "Envoyée", color: "bg-blue-100 text-blue-700", icon: Send },
-  viewed: { label: "Vue", color: "bg-purple-100 text-purple-700", icon: Eye },
-  pending: { label: "En attente", color: "bg-blue-100 text-blue-700", icon: Clock },
-  paid: { label: "Payée", color: "bg-green-100 text-green-700", icon: CheckCircle2 },
-  late: { label: "En retard", color: "bg-red-100 text-red-700", icon: AlertCircle },
-  overdue: { label: "En retard", color: "bg-red-100 text-red-700", icon: AlertCircle },
-  unpaid: { label: "Impayée", color: "bg-red-100 text-red-700", icon: AlertCircle },
-  partial: { label: "Partielle", color: "bg-amber-100 text-amber-700", icon: Clock },
-  cancelled: { label: "Annulée", color: "bg-gray-100 text-gray-500", icon: XCircle },
+  sent: { label: "Envoyée", color: "bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300", icon: Send },
+  viewed: { label: "Vue", color: "bg-purple-100 text-purple-700 dark:bg-purple-950/40 dark:text-purple-300", icon: Eye },
+  pending: { label: "En attente", color: "bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300", icon: Clock },
+  paid: { label: "Payée", color: "bg-green-100 text-green-700 dark:bg-green-950/40 dark:text-green-300", icon: CheckCircle2 },
+  late: { label: "En retard", color: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300", icon: AlertCircle },
+  overdue: { label: "En retard", color: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300", icon: AlertCircle },
+  unpaid: { label: "Impayée", color: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300", icon: AlertCircle },
+  partial: { label: "Partielle", color: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300", icon: Clock },
+  cancelled: { label: "Annulée", color: "bg-gray-100 text-gray-500 dark:bg-slate-800 dark:text-slate-400", icon: XCircle },
 };
 
 interface Invoice {

--- a/app/owner/leases/[id]/signers/TenantInviteModal.tsx
+++ b/app/owner/leases/[id]/signers/TenantInviteModal.tsx
@@ -139,7 +139,7 @@ export function TenantInviteModal({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <UserPlus className="h-5 w-5 text-blue-600" />
+            <UserPlus className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             Inviter un {ROLE_LABELS[role]}
           </DialogTitle>
           <DialogDescription>
@@ -149,10 +149,10 @@ export function TenantInviteModal({
 
         <form onSubmit={handleSubmit} className="space-y-6 pt-4">
           {/* Info sur le rôle */}
-          <div className="p-3 bg-blue-50 rounded-lg border border-blue-100">
+          <div className="p-3 bg-blue-50 rounded-lg border border-blue-100 dark:bg-blue-950/30 dark:border-blue-900">
             <div className="flex items-start gap-2">
-              <Info className="h-4 w-4 text-blue-600 mt-0.5 shrink-0" />
-              <p className="text-sm text-blue-700">
+              <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
+              <p className="text-sm text-blue-700 dark:text-blue-300">
                 {ROLE_DESCRIPTIONS[role]}
               </p>
             </div>

--- a/app/owner/leases/[id]/tabs/components/DocumentUploadDialog.tsx
+++ b/app/owner/leases/[id]/tabs/components/DocumentUploadDialog.tsx
@@ -170,7 +170,7 @@ export function DocumentUploadDialog({
                   onClick={() => setSelectedType(config.type)}
                   className={`text-left px-3 py-2 rounded-lg border text-xs transition-colors ${
                     selectedType === config.type
-                      ? "border-blue-300 bg-blue-50 text-blue-700 font-semibold"
+                      ? "border-blue-300 bg-blue-50 text-blue-700 font-semibold dark:border-blue-900 dark:bg-blue-950/30 dark:text-blue-300"
                       : "border-border text-muted-foreground hover:border-border hover:bg-muted"
                   }`}
                 >
@@ -199,14 +199,14 @@ export function DocumentUploadDialog({
                 onClick={() => fileInputRef.current?.click()}
                 className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
                   dragOver
-                    ? "border-blue-400 bg-blue-50"
+                    ? "border-blue-400 bg-blue-50 dark:border-blue-500 dark:bg-blue-950/20"
                     : "border-border hover:border-border hover:bg-muted"
                 }`}
               >
                 <Upload className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
                 <p className="text-sm text-muted-foreground">
                   Glissez un fichier ici ou{" "}
-                  <span className="text-blue-600 font-medium">
+                  <span className="text-blue-600 dark:text-blue-400 font-medium">
                     cliquez pour parcourir
                   </span>
                 </p>
@@ -225,8 +225,8 @@ export function DocumentUploadDialog({
                 />
               </div>
             ) : (
-              <div className="flex items-center gap-3 p-3 bg-green-50 border border-green-200 rounded-lg">
-                <CheckCircle className="h-5 w-5 text-green-600 flex-shrink-0" />
+              <div className="flex items-center gap-3 p-3 bg-green-50 border border-green-200 rounded-lg dark:bg-green-950/20 dark:border-green-900">
+                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-foreground truncate">
                     {file.name}

--- a/components/payments/CashReceiptFlow.tsx
+++ b/components/payments/CashReceiptFlow.tsx
@@ -273,7 +273,7 @@ export function CashReceiptFlow({
                   </div>
                 </div>
                 {parseFloat(actualAmount) !== amount && (
-                  <div className="flex items-center gap-2 text-amber-600 text-xs">
+                  <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400 text-xs">
                     <AlertTriangle className="w-3 h-3" />
                     Montant différent du loyer attendu ({amount}€)
                   </div>
@@ -317,12 +317,12 @@ export function CashReceiptFlow({
                   {format(new Date(), "dd/MM HH:mm", { locale: fr })}
                 </div>
                 {geolocation ? (
-                  <div className="flex items-center gap-1 text-green-600">
+                  <div className="flex items-center gap-1 text-green-600 dark:text-green-400">
                     <MapPin className="w-3 h-3" />
                     GPS OK
                   </div>
                 ) : geoError ? (
-                  <div className="flex items-center gap-1 text-amber-600">
+                  <div className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
                     <MapPin className="w-3 h-3" />
                     {geoError}
                   </div>

--- a/components/payments/ManualPaymentDialog.tsx
+++ b/components/payments/ManualPaymentDialog.tsx
@@ -66,24 +66,27 @@ const PAYMENT_METHODS: PaymentMethodOption[] = [
     label: "Espèces",
     description: "Paiement en main propre avec double signature",
     icon: <Banknote className="w-6 h-6" />,
-    color: "text-green-600",
-    bgColor: "bg-green-50 border-green-200 hover:bg-green-100",
+    color: "text-green-600 dark:text-green-400",
+    bgColor:
+      "bg-green-50 border-green-200 hover:bg-green-100 dark:bg-green-950/30 dark:border-green-900 dark:hover:bg-green-900/40",
   },
   {
     id: "cheque",
     label: "Chèque",
     description: "Enregistrer un paiement par chèque reçu",
     icon: <FileText className="w-6 h-6" />,
-    color: "text-blue-600",
-    bgColor: "bg-blue-50 border-blue-200 hover:bg-blue-100",
+    color: "text-blue-600 dark:text-blue-400",
+    bgColor:
+      "bg-blue-50 border-blue-200 hover:bg-blue-100 dark:bg-blue-950/30 dark:border-blue-900 dark:hover:bg-blue-900/40",
   },
   {
     id: "virement",
     label: "Virement bancaire",
     description: "Enregistrer un virement reçu",
     icon: <Building2 className="w-6 h-6" />,
-    color: "text-purple-600",
-    bgColor: "bg-purple-50 border-purple-200 hover:bg-purple-100",
+    color: "text-purple-600 dark:text-purple-400",
+    bgColor:
+      "bg-purple-50 border-purple-200 hover:bg-purple-100 dark:bg-purple-950/30 dark:border-purple-900 dark:hover:bg-purple-900/40",
   },
 ];
 
@@ -229,7 +232,12 @@ export function ManualPaymentDialog({
                     whileHover={{ scale: 1.01 }}
                     whileTap={{ scale: 0.99 }}
                   >
-                    <div className={cn("p-2 rounded-lg bg-white shadow-sm", method.color)}>
+                    <div
+                      className={cn(
+                        "p-2 rounded-lg bg-white dark:bg-slate-900/70 shadow-sm",
+                        method.color
+                      )}
+                    >
                       {method.icon}
                     </div>
                     <div className="flex-1">
@@ -261,9 +269,9 @@ export function ManualPaymentDialog({
               <DialogHeader>
                 <DialogTitle className="flex items-center gap-2">
                   {selectedMethod === "cheque" ? (
-                    <FileText className="w-5 h-5 text-blue-600" />
+                    <FileText className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                   ) : (
-                    <Building2 className="w-5 h-5 text-purple-600" />
+                    <Building2 className="w-5 h-5 text-purple-600 dark:text-purple-400" />
                   )}
                   Enregistrer un {selectedMethod === "cheque" ? "chèque" : "virement"}
                 </DialogTitle>
@@ -293,7 +301,7 @@ export function ManualPaymentDialog({
                     </span>
                   </div>
                   {parseFloat(formData.amount) !== amount && (
-                    <p className="text-xs text-amber-600">
+                    <p className="text-xs text-amber-600 dark:text-amber-400">
                       ⚠️ Montant différent de la facture ({amount.toLocaleString("fr-FR")} €)
                     </p>
                   )}

--- a/features/colocation/components/DepartureModal.tsx
+++ b/features/colocation/components/DepartureModal.tsx
@@ -87,8 +87,8 @@ export function DepartureModal({
           </div>
 
           {solidarityEndDate && (
-            <div className="p-3 rounded-lg bg-amber-50 border border-amber-200">
-              <div className="flex items-center gap-2 text-sm text-amber-700">
+            <div className="p-3 rounded-lg bg-amber-50 border border-amber-200 dark:bg-amber-950/30 dark:border-amber-900">
+              <div className="flex items-center gap-2 text-sm text-amber-700 dark:text-amber-300">
                 <Shield className="h-4 w-4" />
                 <span>
                   Solidarite jusqu&apos;au{" "}
@@ -97,24 +97,24 @@ export function DepartureModal({
                   </strong>
                 </span>
               </div>
-              <p className="text-xs text-amber-600 mt-1">
+              <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
                 La solidarite s&apos;eteint immediatement si un remplacant est nomme au bail
                 (loi ALUR, max 6 mois)
               </p>
             </div>
           )}
 
-          <div className="p-3 rounded-lg bg-blue-50 border border-blue-200">
-            <p className="text-sm text-blue-700">
+          <div className="p-3 rounded-lg bg-blue-50 border border-blue-200 dark:bg-blue-950/30 dark:border-blue-900">
+            <p className="text-sm text-blue-700 dark:text-blue-300">
               <strong>Part loyer :</strong>{" "}
               {(member.rent_share_cents / 100).toFixed(0)}€/mois
             </p>
-            <p className="text-sm text-blue-700">
+            <p className="text-sm text-blue-700 dark:text-blue-300">
               <strong>Depot de garantie :</strong>{" "}
               {(member.deposit_cents / 100).toFixed(0)}€
             </p>
             {member.room && (
-              <p className="text-sm text-blue-700">
+              <p className="text-sm text-blue-700 dark:text-blue-300">
                 <strong>Chambre :</strong> {member.room.room_number}
               </p>
             )}

--- a/features/leases/components/keys-handover-dialog.tsx
+++ b/features/leases/components/keys-handover-dialog.tsx
@@ -40,7 +40,7 @@ export function KeysHandoverDialog({
         variant="outline"
         disabled
         className={cn(
-          "gap-2 border-emerald-200 bg-emerald-50 text-emerald-700 cursor-default",
+          "gap-2 border-emerald-200 bg-emerald-50 text-emerald-700 cursor-default dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300",
           triggerClassName
         )}
       >
@@ -56,7 +56,7 @@ export function KeysHandoverDialog({
         <Button
           variant="outline"
           className={cn(
-            "gap-2 border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 hover:border-indigo-300 font-semibold",
+            "gap-2 border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 hover:border-indigo-300 font-semibold dark:border-indigo-900 dark:bg-indigo-950/30 dark:text-indigo-300 dark:hover:bg-indigo-900/40 dark:hover:border-indigo-800",
             triggerClassName
           )}
         >
@@ -68,8 +68,8 @@ export function KeysHandoverDialog({
       <DialogContent className="max-w-md w-full p-0 overflow-hidden rounded-2xl">
         <DialogHeader className="px-6 pt-6 pb-3">
           <DialogTitle className="flex items-center gap-2 text-lg font-bold">
-            <div className="p-1.5 bg-indigo-100 rounded-lg">
-              <Key className="h-4 w-4 text-indigo-600" />
+            <div className="p-1.5 bg-indigo-100 rounded-lg dark:bg-indigo-900/40">
+              <Key className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
             </div>
             Remise des clés
           </DialogTitle>


### PR DESCRIPTION
## Summary
This PR adds comprehensive dark mode styling support across payment dialogs, invoice status badges, lease management modals, and document upload interfaces. All color-coded UI elements now include appropriate dark mode variants for improved visibility and consistency in dark theme.

## Key Changes
- **Payment dialogs**: Added dark mode classes to payment method options (cash, check, bank transfer) with appropriate background and text color variants
- **Invoice status badges**: Updated all status config colors to include dark mode equivalents (sent, viewed, pending, paid, late, overdue, unpaid, partial, cancelled)
- **Departure modal**: Added dark mode styling to solidarity period and member information alert boxes
- **Document upload dialog**: Updated selected state styling and drag-over states with dark mode support
- **Tenant invite modal**: Added dark mode classes to role information box and icons
- **Keys handover dialog**: Updated button and icon styling with dark mode variants
- **Cash receipt flow**: Added dark mode support to amount warning and geolocation status indicators

## Implementation Details
- Used consistent dark mode color patterns: `dark:bg-{color}-950/30` for backgrounds and `dark:text-{color}-300` or `dark:text-{color}-400` for text
- Maintained visual hierarchy and contrast ratios in dark mode
- Applied changes across all interactive elements including buttons, badges, alerts, and icons
- Ensured dark mode variants match the light mode color semantics (e.g., green for success, red for errors, blue for info)

https://claude.ai/code/session_019MyenQBz5aZoirREGzwr8W