### PR TITLE
fix: 7 owner/tenant bugs from prod audit (exports 403, invoice 404, deposits/work_orders 500, blank contract preview, dashboard click, total 0)

### DIFF
--- a/app/api/deposits/route.ts
+++ b/app/api/deposits/route.ts
@@ -71,21 +71,36 @@ export async function GET(request: Request) {
       )
       .order("created_at", { ascending: false });
 
-    // RBAC
+    // RBAC — PostgREST does not support passing a query builder to `.in()`
+    // as a subquery, so we have to resolve the scope in two short hops.
     if (typedProfile.role === "owner") {
-      query = query.in(
-        "lease_id",
-        serviceClient
-          .from("leases")
-          .select("id")
-          .in(
-            "property_id",
-            serviceClient
-              .from("properties")
-              .select("id")
-              .eq("owner_id", typedProfile.id) as any
-          ) as any
-      );
+      const { data: ownedProperties } = await serviceClient
+        .from("properties")
+        .select("id")
+        .eq("owner_id", typedProfile.id);
+
+      const propertyIds = (ownedProperties || []).map((p: any) => p.id);
+      if (propertyIds.length === 0) {
+        return NextResponse.json({
+          deposits: [],
+          pagination: { page, limit, total: 0 },
+        });
+      }
+
+      const { data: ownedLeases } = await serviceClient
+        .from("leases")
+        .select("id")
+        .in("property_id", propertyIds);
+
+      const leaseIds = (ownedLeases || []).map((l: any) => l.id);
+      if (leaseIds.length === 0) {
+        return NextResponse.json({
+          deposits: [],
+          pagination: { page, limit, total: 0 },
+        });
+      }
+
+      query = query.in("lease_id", leaseIds);
     } else if (typedProfile.role === "tenant") {
       query = query.eq("tenant_id", typedProfile.id);
     } else if (typedProfile.role !== "admin") {

--- a/app/api/exports/route.ts
+++ b/app/api/exports/route.ts
@@ -97,24 +97,24 @@ export async function POST(request: Request) {
       const invoiceId = filters?.invoiceId;
       if (!invoiceId) return NextResponse.json({ error: "invoiceId requis" }, { status: 400 });
 
+      // Les colonnes owner_id / tenant_id existent directement sur invoices :
+      // on évite la jointure imbriquée qui peut être tronquée par RLS.
       const { data: invoice, error } = await supabase
         .from("invoices")
-        .select(`
-          id, periode, montant_total, montant_loyer, montant_charges, statut,
-          lease:leases!inner(
-            property:properties!inner(owner_id)
-          )
-        `)
+        .select("id, periode, montant_total, montant_loyer, montant_charges, statut, owner_id, tenant_id")
         .eq("id", invoiceId)
         .single();
 
       if (error || !invoice) return NextResponse.json({ error: "Facture non trouvée" }, { status: 404 });
 
-      const isOwner = invoice.lease?.property?.owner_id === profile.id;
+      const invAny = invoice as any;
+      const isOwner = invAny.owner_id === profile.id;
+      const isTenant = invAny.tenant_id === profile.id;
       const isAdmin = profile.role === "admin";
-      // Manque check tenant ici, mais simplifié pour l'exemple
 
-      if (!isOwner && !isAdmin) return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+      if (!isOwner && !isTenant && !isAdmin) {
+        return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+      }
 
       dataToExport = [{
         id: invoice.id,

--- a/app/api/leases/[id]/html/route.ts
+++ b/app/api/leases/[id]/html/route.ts
@@ -49,17 +49,49 @@ export async function GET(
       return NextResponse.json({ error: "Accès non autorisé à ce bail" }, { status: 403 });
     }
 
-    // Sealed bail — return stored PDF URL
-    if (leaseCheck.sealed_at && leaseCheck.signed_pdf_path && !leaseCheck.signed_pdf_path.startsWith("pending_generation_")) {
-      const { data: signedUrl } = await serviceClient.storage.from("documents").createSignedUrl(leaseCheck.signed_pdf_path, 3600);
-      if (signedUrl?.signedUrl) {
-        return NextResponse.json({
-          sealed: true,
-          pdfUrl: signedUrl.signedUrl,
-          fileName: `Bail_Signe_${(leaseCheck.property as any)?.ville || "document"}.pdf`,
-          html: null,
-        });
+    // Sealed bail — return stored PDF URL only if the file actually
+    // exists in storage. createSignedUrl() happily signs a URL for a
+    // missing object, which then renders as a blank iframe on the
+    // client. List the parent folder and verify the filename is there
+    // before committing to the sealed branch; otherwise fall through
+    // to regenerating the HTML on the fly.
+    if (
+      leaseCheck.sealed_at &&
+      leaseCheck.signed_pdf_path &&
+      !leaseCheck.signed_pdf_path.startsWith("pending_generation_")
+    ) {
+      const signedPath = leaseCheck.signed_pdf_path as string;
+      const lastSlash = signedPath.lastIndexOf("/");
+      const folder = lastSlash >= 0 ? signedPath.slice(0, lastSlash) : "";
+      const fileName = lastSlash >= 0 ? signedPath.slice(lastSlash + 1) : signedPath;
+
+      const { data: files } = await serviceClient
+        .storage
+        .from("documents")
+        .list(folder, { limit: 100, search: fileName });
+
+      const hasNonEmptyFile = (files || []).some(
+        (f: any) => f.name === fileName && (f.metadata?.size ?? 0) > 0
+      );
+
+      if (hasNonEmptyFile) {
+        const { data: signedUrl } = await serviceClient.storage
+          .from("documents")
+          .createSignedUrl(signedPath, 3600);
+        if (signedUrl?.signedUrl) {
+          return NextResponse.json({
+            sealed: true,
+            pdfUrl: signedUrl.signedUrl,
+            fileName: `Bail_Signe_${(leaseCheck.property as any)?.ville || "document"}.pdf`,
+            html: null,
+          });
+        }
       }
+      // File is missing or empty — fall through to HTML regeneration
+      console.warn(
+        "[Lease HTML] sealed_at set but signed_pdf_path missing in storage, falling back to HTML",
+        { leaseId, signed_pdf_path: signedPath }
+      );
     }
 
     // Build bail data via unified builder

--- a/app/api/owner/dashboard/route.ts
+++ b/app/api/owner/dashboard/route.ts
@@ -529,6 +529,7 @@ export async function GET(request: Request) {
     // 12. Activité récente (agrégation des dernières actions)
     const recentActivity: Array<{
       id: string;
+      entityId: string;
       type: "invoice" | "ticket" | "signature" | "lease";
       title: string;
       description: string;
@@ -544,6 +545,7 @@ export async function GET(request: Request) {
       const statusLabel = inv.statut === "paid" ? "Payée" : inv.statut === "sent" ? "Envoyée" : inv.statut === "draft" ? "Brouillon" : inv.statut;
       recentActivity.push({
         id: `inv-${inv.id}`,
+        entityId: inv.id,
         type: "invoice",
         title: `Facture ${inv.periode}`,
         description: `${Number(inv.montant_total || 0).toLocaleString("fr-FR")} € — ${statusLabel}`,
@@ -557,6 +559,7 @@ export async function GET(request: Request) {
       pendingSignatures.forEach((sig: any) => {
         recentActivity.push({
           id: `sig-${sig.id}`,
+          entityId: sig.lease_id || sig.id,
           type: "signature",
           title: `Signature en attente`,
           description: sig.leases?.properties?.adresse_complete || "Bail en cours",

--- a/app/owner/_data/fetchDashboard.ts
+++ b/app/owner/_data/fetchDashboard.ts
@@ -46,6 +46,7 @@ export interface OwnerDashboardData {
     type: string;
     title: string;
     date: string;
+    entityId?: string;
   }>;
 }
 
@@ -171,6 +172,7 @@ async function fetchDashboardDirect(
   const recentActivity = [
     ...recentInvoices.map((inv: { id: string; statut: string; periode: string; created_at: string }) => ({
       type: "invoice" as const,
+      entityId: inv.id,
       title: `Facture ${inv.periode} - ${inv.statut === "paid" ? "payée" : inv.statut === "late" ? "en retard" : "envoyée"}`,
       date: inv.created_at,
     })),
@@ -181,6 +183,7 @@ async function fetchDashboardDirect(
       .slice(0, 3)
       .map((t: any) => ({
         type: "ticket" as const,
+        entityId: t.id,
         title: `Ticket ${t.statut === "open" ? "ouvert" : t.statut === "in_progress" ? "en cours" : "résolu"}`,
         date: t.created_at,
       })),

--- a/app/owner/finances/invoices/[id]/InvoiceDetailClient.tsx
+++ b/app/owner/finances/invoices/[id]/InvoiceDetailClient.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft, Send, FileDown, Loader2 } from "lucide-react";
 
 interface InvoiceDetail {
   id: string;
+  lease_id: string | null;
   periode: string;
   montant_loyer: number;
   montant_charges: number;
@@ -219,12 +220,15 @@ export function InvoiceDetailClient() {
         )}
 
         {(invoice.statut === "paid" || invoice.statut === "receipt_generated") &&
-          !invoice.receipt_generated && (
+          !invoice.receipt_generated &&
+          invoice.lease_id && (
             <Button
               variant="outline"
               onClick={() =>
-                fetch(`/api/invoices/${invoiceId}/generate-receipt`, {
+                fetch(`/api/leases/${invoice.lease_id}/generate-receipt`, {
                   method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ invoice_id: invoice.id }),
                 })
               }
             >

--- a/app/owner/invoices/[id]/page.tsx
+++ b/app/owner/invoices/[id]/page.tsx
@@ -334,11 +334,11 @@ export default function InvoiceDetailPage() {
                     <span className="font-semibold">Total</span>
                     <span className="font-bold text-lg">{invoice.montant_total.toLocaleString("fr-FR")} €</span>
                   </div>
-                  {invoice.montant_paye && invoice.montant_paye > 0 && (
+                  {(invoice.montant_paye ?? 0) > 0 && (
                     <>
                       <div className="flex justify-between items-center py-2 text-green-600">
                         <span>Déjà payé</span>
-                        <span className="font-medium">-{invoice.montant_paye.toLocaleString("fr-FR")} €</span>
+                        <span className="font-medium">-{(invoice.montant_paye ?? 0).toLocaleString("fr-FR")} €</span>
                       </div>
                       <Separator />
                       <div className="flex justify-between items-center py-2">

--- a/components/owner/dashboard/recent-activity.tsx
+++ b/components/owner/dashboard/recent-activity.tsx
@@ -9,9 +9,25 @@ import { fr } from "date-fns/locale";
 import Link from "next/link";
 
 interface Activity {
-  type: "invoice" | "ticket" | "signature";
+  type: "invoice" | "ticket" | "signature" | "lease";
   title: string;
   date: string;
+  entityId?: string;
+}
+
+function getActivityHref(activity: Activity): string | null {
+  if (!activity.entityId) return null;
+  switch (activity.type) {
+    case "invoice":
+      return `/owner/invoices/${activity.entityId}`;
+    case "ticket":
+      return `/owner/tickets/${activity.entityId}`;
+    case "signature":
+    case "lease":
+      return `/owner/leases/${activity.entityId}`;
+    default:
+      return null;
+  }
 }
 
 interface OwnerRecentActivityProps {
@@ -72,15 +88,10 @@ export function OwnerRecentActivity({ activities }: OwnerRecentActivityProps) {
             const timeAgo = activityDate
               ? formatDistanceToNow(activityDate, { addSuffix: true, locale: fr })
               : "—";
+            const href = getActivityHref(activity);
 
-            return (
-              <motion.div
-                key={index}
-                initial={{ opacity: 0, x: -10 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: index * 0.05 }}
-                className="group flex items-start gap-4 p-2 rounded-lg hover:bg-muted transition-colors"
-              >
+            const content = (
+              <>
                 <div className={`p-2 rounded-full ${config.bgColor}`}>
                   <Icon className={`h-4 w-4 ${config.color}`} />
                 </div>
@@ -94,6 +105,28 @@ export function OwnerRecentActivity({ activities }: OwnerRecentActivityProps) {
                   </p>
                 </div>
                 <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors mt-1" />
+              </>
+            );
+
+            return (
+              <motion.div
+                key={index}
+                initial={{ opacity: 0, x: -10 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: index * 0.05 }}
+              >
+                {href ? (
+                  <Link
+                    href={href}
+                    className="group flex items-start gap-4 p-2 rounded-lg hover:bg-muted transition-colors"
+                  >
+                    {content}
+                  </Link>
+                ) : (
+                  <div className="group flex items-start gap-4 p-2 rounded-lg hover:bg-muted transition-colors">
+                    {content}
+                  </div>
+                )}
               </motion.div>
             );
           })}

--- a/lib/services/export-policy.service.ts
+++ b/lib/services/export-policy.service.ts
@@ -36,22 +36,21 @@ export class ExportPolicy {
         const invoiceId = filters?.invoiceId;
         if (!invoiceId) return false;
 
-        // Vérifier si owner du bien lié à la facture
+        // Les colonnes owner_id / tenant_id sont présentes directement sur
+        // invoices (cf. migration 20240101000000_initial_schema.sql). On évite
+        // les jointures imbriquées qui peuvent renvoyer null sous RLS.
         const { data: invoice } = await supabase
           .from("invoices")
-          .select(`
-            lease:leases(property:properties(owner_id))
-          `)
+          .select("owner_id, tenant_id")
           .eq("id", invoiceId)
           .single();
 
         if (!invoice) return false;
-        
-        const isOwner = (invoice.lease as any)?.property?.owner_id === profile.id;
-        if (isOwner) return true;
 
-        // Vérifier si locataire du bail lié
-        // TODO: Ajouter check locataire via roommates ou lease_signers
+        const invAny = invoice as any;
+        if (invAny.owner_id === profile.id) return true;
+        if (invAny.tenant_id === profile.id) return true;
+
         return false;
 
       case 'portability':

--- a/supabase/migrations/20260411100000_fix_work_orders_policy_recursion.sql
+++ b/supabase/migrations/20260411100000_fix_work_orders_policy_recursion.sql
@@ -1,0 +1,84 @@
+-- =====================================================
+-- Migration: Fix work_orders RLS recursion via tickets/properties/leases
+-- Date: 2026-04-11
+--
+-- CONTEXT:
+-- The original "Owners can view work orders of own properties" SELECT
+-- policy on `work_orders` (20240101000001_rls_policies.sql:427-436) runs
+-- this EXISTS subquery in its USING clause:
+--
+--   EXISTS (
+--     SELECT 1 FROM tickets t
+--     JOIN properties p ON p.id = t.property_id
+--     WHERE t.id = work_orders.ticket_id
+--       AND p.owner_id = public.user_profile_id()
+--   )
+--
+-- Reading `tickets` triggers the tickets SELECT RLS, which in turn
+-- joins through `properties` — and `properties` now has the
+-- "Tenants can view linked properties" policy that reads `leases`, and
+-- `leases` policies read back into `properties`. Postgres sees the
+-- whole graph at plan time and raises:
+--
+--   ERROR: 42P17 infinite recursion detected in policy for relation …
+--
+-- handleApiError (lib/helpers/api-error.ts) maps 42P17 to HTTP 500,
+-- which is what the owner Tickets page observed as "Erreur lors du
+-- chargement des interventions". Standalone work_orders (ticket_id
+-- NULL) are also never visible to owners under this policy.
+--
+-- FIX:
+-- Mirror the pattern used by 20260410213940_fix_properties_tenant_policy_recursion.sql:
+-- replace the inline EXISTS subquery with a SECURITY DEFINER helper
+-- that bypasses RLS on tickets/properties. The helper also covers
+-- the standalone case (work_orders.owner_id matches the profile
+-- directly, added by 20260408120000_providers_module_sota.sql).
+--
+-- Safe to re-run (CREATE OR REPLACE FUNCTION + DROP POLICY IF EXISTS).
+-- =====================================================
+
+-- =====================================================
+-- 1. SECURITY DEFINER helper: work_order ids the current authenticated
+--    user can read as an owner (via ticket.property.owner_id OR direct
+--    work_orders.owner_id for standalone orders).
+-- =====================================================
+CREATE OR REPLACE FUNCTION public.owner_accessible_work_order_ids()
+RETURNS SETOF UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT wo.id
+  FROM public.work_orders wo
+  LEFT JOIN public.tickets t ON t.id = wo.ticket_id
+  LEFT JOIN public.properties p ON p.id = COALESCE(wo.property_id, t.property_id)
+  WHERE
+    -- Standalone work_orders created through the providers module
+    wo.owner_id = public.user_profile_id()
+    -- Ticket-linked work_orders where the owner owns the property
+    OR p.owner_id = public.user_profile_id();
+$$;
+
+COMMENT ON FUNCTION public.owner_accessible_work_order_ids IS
+  'Returns work_order ids visible to the currently authenticated owner, '
+  'either through a ticket on one of their properties or a standalone '
+  'work_orders.owner_id match. SECURITY DEFINER to bypass RLS on tickets, '
+  'properties and leases and avoid the infinite recursion triggered by '
+  'nesting the tickets→properties→leases policies inside work_orders.';
+
+-- =====================================================
+-- 2. Rewrite the "Owners can view work orders of own properties"
+--    policy to use the helper — no more inline subquery on tickets.
+-- =====================================================
+DROP POLICY IF EXISTS "Owners can view work orders of own properties" ON work_orders;
+
+CREATE POLICY "Owners can view work orders of own properties"
+  ON work_orders FOR SELECT
+  USING (id IN (SELECT public.owner_accessible_work_order_ids()));
+
+COMMENT ON POLICY "Owners can view work orders of own properties" ON work_orders IS
+  'Owners can read work_orders attached to their properties (via the '
+  'linked ticket) and the standalone ones they created themselves. Uses '
+  'the owner_accessible_work_order_ids() SECURITY DEFINER helper to '
+  'avoid recursion through the tickets/properties/leases policies.';


### PR DESCRIPTION
## Summary

Fixes 7 bugs found during a visual prod audit on talok.fr with the Marie-Line (owner) / Thomas (tenant) test accounts. Each bug is an atomic commit.

| # | Bug | Commit | Root cause → fix |
|---|---|---|---|
| 3 | `POST /api/exports` 403 on owner invoice download | `393e1a8` | `ExportPolicy.canExport` joined `leases→properties→owner_id` without `!inner`, RLS could null the nested relation → `undefined === profile.id`. Uses direct `invoices.owner_id` / `tenant_id` columns instead. |
| 4 | `POST /api/invoices/[id]/generate-receipt` 404 | `1a52680` | The "Générer la quittance" button on `/owner/finances/invoices/[id]` pointed at a route that doesn't exist. Repointed to `POST /api/leases/[id]/generate-receipt` with `{ invoice_id }` in the body, guarded on `lease_id`. |
| 2 | `GET /api/deposits` 500 for owners | `7d67d65` | RBAC scoped `.in("lease_id", supabase.from(...).in("property_id", supabase.from(...)))` — PostgREST has no subquery form for `.in()`, the inner builder crashed. Resolves property → lease ids in two small fetches. |
| 5 | `GET /api/work-orders` 500 → "Erreur chargement interventions" | `84649d6` | Original `work_orders` SELECT policy inlined `tickets → properties` which now transitively reads `leases → properties` → Postgres 42P17. New migration `20260411100000_fix_work_orders_policy_recursion.sql` adds a `SECURITY DEFINER` helper `owner_accessible_work_order_ids()` and rewrites the owner policy (also covers standalone work orders). |
| 1 | Tenant "Aperçu du contrat" blank white iframe | `004adf7` | `createSignedUrl` happily signed a URL for a `signed_pdf_path` whose file was missing in storage. Before committing to the sealed branch, `list()` the parent folder and verify the filename is present with non-zero size; otherwise fall through to HTML regeneration. |
| 6 | "Activité récente" items on owner dashboard weren't clickable | `1ae7c85` | Component had a `ChevronRight` hint but no `Link` / `onClick`, and neither `fetchDashboard` nor `/api/owner/dashboard` carried the entity id. Threads `entityId` through both data sources and wraps each item in a `next/link` routed by type (`invoice → /owner/invoices/:id`, `ticket → /owner/tickets/:id`, `signature`/`lease → /owner/leases/:id`). |
| 7 | Literal "0" rendered under Total on the owner invoice detail | `4379d7d` | `{invoice.montant_paye && invoice.montant_paye > 0 && (...)}` — when `montant_paye` is `0`, short-circuit leaves the number `0` which React renders as text. Guard with `(invoice.montant_paye ?? 0) > 0`. |

## Out of scope (per audit instructions)

Not touched: `lib/subscriptions/plans.ts`, bail templates, `lib/documents/constants.ts`, the quittance flow fixed on branch P2. Bug 4 only repoints the broken frontend URL; it does not change the quittance generation logic.

## Test plan

- [ ] Run `supabase db push` so the new migration `20260411100000_fix_work_orders_policy_recursion.sql` applies
- [ ] Marie-Line (owner): open an invoice → "Télécharger" succeeds (Bug 3)
- [ ] Marie-Line: open a paid invoice on `/owner/finances/invoices/[id]` → "Générer la quittance" returns 200 (Bug 4)
- [ ] Marie-Line: open `/owner/money` and confirm `GET /api/deposits` returns 200 (Bug 2)
- [ ] Marie-Line: open `/owner/tickets` and `/owner/work-orders` → list loads without "Erreur chargement interventions" (Bug 5)
- [ ] Thomas (tenant): open `/tenant/lease` → "Aperçu du contrat interactif" renders actual content, not a blank rectangle (Bug 1)
- [ ] Marie-Line: click a facture in the dashboard "Activité récente" card → navigates to `/owner/invoices/:id` (Bug 6)
- [ ] Marie-Line: open an unpaid invoice → no stray "0" under the Total line (Bug 7)

https://claude.ai/code/session_01R4tLx1yDEj3ihtddd865EX