### PR TITLE
Fix RLS recursion and improve RBAC enforcement across APIs

### DIFF
--- a/app/api/leases/[id]/html/route.ts
+++ b/app/api/leases/[id]/html/route.ts
@@ -30,13 +30,14 @@ export async function GET(
 
     const { data: leaseCheck } = await serviceClient
       .from("leases")
-      .select("sealed_at, signed_pdf_path, property:properties(owner_id, ville)")
+      .select("tenant_id, sealed_at, signed_pdf_path, property:properties(owner_id, ville)")
       .eq("id", leaseId)
       .single();
 
     if (!leaseCheck) return NextResponse.json({ error: "Bail non trouvé" }, { status: 404 });
 
     const isOwner = (leaseCheck.property as any)?.owner_id === profile.id;
+    const isDirectTenant = (leaseCheck as any).tenant_id === profile.id;
     const { data: signerCheck } = await serviceClient
       .from("lease_signers")
       .select("id")
@@ -45,7 +46,10 @@ export async function GET(
       .maybeSingle();
     const isAdmin = profile.role === "admin";
 
-    if (!isOwner && !signerCheck && !isAdmin) {
+    // Tenants whose bail was created without the e-signature flow are not
+    // in `lease_signers` but are still referenced by `leases.tenant_id` —
+    // allow them to read their own bail HTML via the direct FK.
+    if (!isOwner && !signerCheck && !isDirectTenant && !isAdmin) {
       return NextResponse.json({ error: "Accès non autorisé à ce bail" }, { status: 403 });
     }
 

--- a/components/documents/LeasePreview.tsx
+++ b/components/documents/LeasePreview.tsx
@@ -16,6 +16,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [isSealed, setIsSealed] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
   const [iframeKey, setIframeKey] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -25,8 +26,12 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
   const fetchLeaseHtml = useCallback(async () => {
     try {
       setLoading(true);
+      setFetchError(null);
       const response = await fetch(`/api/leases/${leaseId}/html`);
-      if (!response.ok) throw new Error("Erreur lors de la récupération du bail");
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body?.error || `HTTP ${response.status}`);
+      }
 
       const data = await response.json();
 
@@ -35,13 +40,18 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
         setIsSealed(true);
         setHtml("");
       } else {
-        setHtml(data.html || "");
+        setHtml(typeof data.html === "string" ? data.html : "");
         setPdfUrl(null);
         setIsSealed(false);
       }
       setIframeKey(prev => prev + 1);
     } catch (error) {
       console.error("LeasePreview Error:", error);
+      const message = error instanceof Error ? error.message : "Erreur inconnue";
+      setFetchError(message);
+      setHtml("");
+      setPdfUrl(null);
+      setIsSealed(false);
       toast({
         title: "Erreur",
         description: "Impossible de charger l'aperçu du bail",
@@ -160,9 +170,24 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
               </div>
             </div>
           ) : (
-            <div className="absolute inset-0 flex flex-col items-center justify-center px-4">
+            <div className="absolute inset-0 flex flex-col items-center justify-center px-4 text-center">
               <FileText className="h-8 w-8 text-white/40" />
-              <p className="text-xs text-white/60 mt-2">Aucun aperçu disponible</p>
+              <p className="text-xs text-white/70 mt-2 font-medium">
+                {fetchError ? "Aperçu indisponible" : "Aucun aperçu disponible"}
+              </p>
+              {fetchError && (
+                <p className="text-[10px] text-white/50 mt-1 max-w-xs font-mono">
+                  {fetchError}
+                </p>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={fetchLeaseHtml}
+                className="mt-3 text-white/80 hover:text-white hover:bg-white/10 text-xs h-7"
+              >
+                <RefreshCw className="h-3 w-3 mr-1" /> Réessayer
+              </Button>
             </div>
           )}
         </div>

--- a/lib/hooks/use-api.ts
+++ b/lib/hooks/use-api.ts
@@ -268,7 +268,7 @@ export function useInvoiceApi(ownerId: string) {
 
   const sendReminder = useApiMutation({
     mutator: async (invoiceId: string) => {
-      const res = await fetch(`/api/invoices/${invoiceId}/send-reminder`, {
+      const res = await fetch(`/api/invoices/${invoiceId}/remind`, {
         method: "POST",
       });
       if (!res.ok) throw new Error("Erreur");


### PR DESCRIPTION
## Summary
This PR addresses PostgreSQL RLS (Row-Level Security) recursion errors and improves role-based access control (RBAC) enforcement across multiple API endpoints by pre-resolving nested queries and using the service client strategically.

## Key Changes

### API Endpoints
- **`/api/deposits`**: Pre-resolve allowed lease IDs for owners before querying, avoiding nested `.in()` queries that caused 500 errors with "invalid input syntax for type uuid"
- **`/api/work-orders`**: Switch to service client to bypass RLS recursion (42P17 error), enforce RBAC at application level with proper role-based filtering and error handling
- **`/api/exports`**: Use service client for invoice queries and simplify RBAC by reading `owner_id`/`tenant_id` directly from invoices table instead of traversing leases→properties
- **`/api/leases/[id]/html`**: Add fallback to `leases.tenant_id` for tenants not in `lease_signers` (legacy lease support)

### Services & Utilities
- **`ExportPolicy`**: Switch to service client and improve invoice access checks by reading direct FK columns; add fallback to `lease_signers` for legacy leases
- **`LeasePreview`**: Add error state display with retry button and improved error message handling

### Dashboard & UI
- **`OwnerRecentActivity`**: Make activity items clickable with optional `href` prop; add `id` field for proper React keys
- **`fetchDashboard`**: Backfill `href` navigation targets for recent activity items (invoices and tickets)
- **`InvoiceDetailClient`**: Add `lease_id` field and fix receipt generation endpoint to use `/api/leases/{lease_id}/generate-receipt`

## Implementation Details
- Service client is used to bypass RLS constraints where application-level RBAC checks are sufficient
- Nested query builders are avoided in favor of pre-resolved arrays passed to `.in()` filters
- Error handling for RLS recursion (code 42P17) gracefully returns empty results instead of crashing
- Tenant access to leases now supports both `lease_signers` entries and direct `tenant_id` matches for backward compatibility

https://claude.ai/code/session_01U1bgYghejaRQ3bYxeXbqA7