### PR TITLE
Fix case-insensitive document type matching and date handling

### DIFF
--- a/app/tenant/documents/page.tsx
+++ b/app/tenant/documents/page.tsx
@@ -242,6 +242,23 @@ export default function TenantDocumentsPage() {
   });
 
   // ── Documents clés (4 slots fixes) ──
+  // Ensembles de types (lowercase) — alignés avec la vue SQL v_tenant_key_documents
+  // et le CHECK CONSTRAINT documents.type (qui stocke "EDL_entree" en capitales).
+  const BAIL_TYPES = useMemo(() => new Set([
+    "bail", "contrat_bail", "contrat", "lease",
+    "avenant", "bail_signe", "bail_signe_locataire", "bail_signe_proprietaire",
+  ]), []);
+  const QUITTANCE_TYPES = useMemo(() => new Set([
+    "quittance", "quittance_loyer", "receipt",
+  ]), []);
+  const EDL_TYPES = useMemo(() => new Set([
+    "edl_entree", "edl_sortie", "edl", "inventaire",
+    "etat_des_lieux", "etat_lieux",
+  ]), []);
+  const ASSURANCE_TYPES = useMemo(() => new Set([
+    "attestation_assurance", "assurance", "assurance_pno", "assurance_habitation",
+  ]), []);
+
   const keyDocuments = useMemo(() => {
     if (!documents.length) return { bail: null, quittance: null, edl: null, assurance: null };
 
@@ -253,16 +270,20 @@ export default function TenantDocumentsPage() {
     let assurance: any = null;
 
     for (const doc of sorted) {
-      const type = detectType(doc);
-      if (!bail && (type === "contrat_bail" || type === "bail" || type === "lease" || type === "contrat")) bail = doc;
-      if (!quittance && (type === "quittance" || type === "receipt")) quittance = doc;
-      if (!edlEntree && (type === "EDL_entree" || type === "edl_entree" || type === "edl")) edlEntree = doc;
-      if (!assurance && (type === "attestation_assurance" || type === "assurance")) assurance = doc;
+      // Comparaison case-insensitive : les DB historiques mélangent "EDL_entree" et "edl_entree".
+      const rawType = (doc.type ?? "").toString().toLowerCase();
+      const detected = (detectType(doc) ?? "").toLowerCase();
+      const matches = (set: Set<string>) => set.has(rawType) || set.has(detected);
+
+      if (!bail && matches(BAIL_TYPES)) bail = doc;
+      if (!quittance && matches(QUITTANCE_TYPES)) quittance = doc;
+      if (!edlEntree && matches(EDL_TYPES)) edlEntree = doc;
+      if (!assurance && matches(ASSURANCE_TYPES)) assurance = doc;
       if (bail && quittance && edlEntree && assurance) break;
     }
 
     return { bail, quittance, edl: edlEntree, assurance };
-  }, [documents]);
+  }, [documents, BAIL_TYPES, QUITTANCE_TYPES, EDL_TYPES, ASSURANCE_TYPES]);
 
   // ── Filtrage et tri des documents ──
   const filteredDocuments = useMemo(() => {

--- a/components/documents/DocumentCard.tsx
+++ b/components/documents/DocumentCard.tsx
@@ -15,6 +15,24 @@ import { GlassCard } from "@/components/ui/glass-card";
 import { cn } from "@/lib/utils";
 import { DOCUMENT_CONFIG } from "@/lib/documents/document-config";
 
+/**
+ * Formate une date en FR. Retourne "Date inconnue" si la date est nulle,
+ * vide, ou invalide — évite les "Invalid Date" visibles à l'utilisateur.
+ */
+function formatSafeDocDate(
+  primary: string | null | undefined,
+  fallback?: string | null,
+): string {
+  const candidates = [primary, fallback].filter((s): s is string => !!s && s.length > 0);
+  for (const c of candidates) {
+    const d = new Date(c);
+    if (!isNaN(d.getTime())) {
+      return d.toLocaleDateString("fr-FR", { day: "numeric", month: "short", year: "numeric" });
+    }
+  }
+  return "Date inconnue";
+}
+
 // Re-export pour rétrocompatibilité (les importeurs existants)
 export { DOCUMENT_CONFIG } from "@/lib/documents/document-config";
 
@@ -23,7 +41,9 @@ export interface DocumentCardDoc {
   type: string;
   title?: string | null;
   storage_path?: string;
-  created_at: string;
+  created_at: string | null;
+  uploaded_at?: string | null;
+  updated_at?: string | null;
   metadata?: Record<string, any> | null;
   lease_id?: string | null;
   property_id?: string | null;
@@ -84,7 +104,7 @@ export function DocumentCard({
           <p className="text-sm font-bold text-foreground line-clamp-2" title={displayTitle}>{displayTitle}</p>
           <p className="text-xs text-muted-foreground flex items-center gap-1.5 mt-0.5">
             <Calendar className="h-3 w-3" />
-            {new Date(doc.created_at).toLocaleDateString("fr-FR", { day: 'numeric', month: 'short', year: 'numeric' })}
+            {formatSafeDocDate(doc.created_at, doc.uploaded_at ?? doc.updated_at)}
           </p>
         </div>
         <div className="flex items-center gap-1 shrink-0">
@@ -169,7 +189,7 @@ export function DocumentCard({
         <div className="flex items-center gap-4 mt-3 text-sm text-muted-foreground">
           <div className="flex items-center gap-1.5">
             <Calendar className="h-3.5 w-3.5" />
-            {new Date(doc.created_at).toLocaleDateString("fr-FR", { day: 'numeric', month: 'short', year: 'numeric' })}
+            {formatSafeDocDate(doc.created_at, doc.uploaded_at ?? doc.updated_at)}
           </div>
           {doc.metadata?.file_size && (
             <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded uppercase font-medium">

--- a/lib/documents/format-name.ts
+++ b/lib/documents/format-name.ts
@@ -1,13 +1,33 @@
 import { TYPE_TO_LABEL } from "@/lib/documents/constants";
 
 /**
+ * Lookup case-insensitive dans TYPE_TO_LABEL.
+ *
+ * En base, les types sont censés être stockés exactement comme dans constants.ts
+ * (ex. "EDL_entree"), mais certains documents historiques utilisent la forme
+ * lowercase ("edl_entree"). On résout les deux pour garantir un label lisible.
+ */
+function labelForType(type: string | null | undefined): string | null {
+  if (!type) return null;
+  if (type in TYPE_TO_LABEL) {
+    return TYPE_TO_LABEL[type as keyof typeof TYPE_TO_LABEL];
+  }
+  const lower = type.toLowerCase();
+  for (const key of Object.keys(TYPE_TO_LABEL)) {
+    if (key.toLowerCase() === lower) {
+      return TYPE_TO_LABEL[key as keyof typeof TYPE_TO_LABEL];
+    }
+  }
+  return null;
+}
+
+/**
  * Génère un titre lisible pour un document.
  * Si le type a un label connu, l'utilise. Sinon, nettoie le nom de fichier.
  */
 export function getDisplayName(filename: string, type?: string | null): string {
-  if (type && type in TYPE_TO_LABEL) {
-    return TYPE_TO_LABEL[type as keyof typeof TYPE_TO_LABEL];
-  }
+  const label = labelForType(type);
+  if (label) return label;
   return cleanFilename(filename);
 }
 
@@ -39,9 +59,9 @@ export function getDocumentDisplayName(doc: {
     return cleanFilename(candidates[0]);
   }
 
-  // Fallback: type label + date
-  if (doc.type && doc.type in TYPE_TO_LABEL) {
-    const label = TYPE_TO_LABEL[doc.type as keyof typeof TYPE_TO_LABEL];
+  // Fallback: type label (case-insensitive) + date si disponible
+  const label = labelForType(doc.type);
+  if (label) {
     const date = formatSafeShortDate(doc.created_at);
     return date ? `${label} — ${date}` : label;
   }


### PR DESCRIPTION
## Summary
This PR improves document type matching and date formatting to handle inconsistencies in the database where document types are stored in mixed cases (e.g., "EDL_entree" vs "edl_entree") and dates may be null or invalid.

## Key Changes

- **Case-insensitive document type matching**: Introduced `BAIL_TYPES`, `QUITTANCE_TYPES`, `EDL_TYPES`, and `ASSURANCE_TYPES` Sets in the tenant documents page to match document types regardless of case, accommodating historical database records that use lowercase variants.

- **Improved type label lookup**: Added `labelForType()` helper function in `format-name.ts` that performs case-insensitive lookups in `TYPE_TO_LABEL`, ensuring consistent label resolution across the application.

- **Safe date formatting**: Implemented `formatSafeDocDate()` function in `DocumentCard.tsx` that gracefully handles null, empty, or invalid dates by returning "Date inconnue" instead of displaying "Invalid Date" to users. Falls back to `uploaded_at` or `updated_at` if `created_at` is unavailable.

- **Updated type definitions**: Modified `DocumentCardDoc` interface to allow `created_at` to be nullable and added optional `uploaded_at` and `updated_at` fields for fallback date sources.

## Implementation Details

- Type matching now uses both raw database values and detected types (both lowercased) for maximum compatibility
- The `labelForType()` function iterates through `TYPE_TO_LABEL` keys with case-insensitive comparison as a fallback
- Date formatting validates dates before formatting to prevent runtime errors
- All changes maintain backward compatibility with existing code

https://claude.ai/code/session_019JBxeeDTzWLAoecnNWhbn6