### PR TITLE
fix(signup): surface real error + reset Turnstile token on expire

### DIFF
--- a/app/signup/account/page.tsx
+++ b/app/signup/account/page.tsx
@@ -314,9 +314,11 @@ function AccountCreationContent() {
         router.push(`/signup/verify-email?email=${encodeURIComponent(validated.email)}${role ? `&role=${role}` : ""}`);
       }
     } catch (error: unknown) {
-      const message = (error as Error).message?.toLowerCase() || "";
+      const rawMessage = (error as Error).message || "";
+      const message = rawMessage.toLowerCase();
+      const errorCode = (error as any).code as string | undefined;
 
-      if (message.includes("already registered") || message.includes("already exists") || (error as any).code === "PGRST301") {
+      if (message.includes("already registered") || message.includes("already exists") || errorCode === "EMAIL_EXISTS" || errorCode === "PGRST301") {
         toast({
           title: "Email déjà utilisé",
           description: "Connexion ou réinitialisation nécessaire.",
@@ -328,6 +330,15 @@ function AccountCreationContent() {
           description: "Veuillez patienter avant de réessayer.",
           variant: "destructive",
         });
+      } else if (errorCode === "CAPTCHA_FAILED" || message.includes("anti-spam") || message.includes("captcha") || message.includes("turnstile")) {
+        // Le token Turnstile a expiré ou n'a pas été soumis. On le purge
+        // pour forcer un renouvellement : le user doit re-cocher le widget.
+        setTurnstileToken(null);
+        toast({
+          title: "Vérification anti-spam expirée",
+          description: "Re-validez le CAPTCHA ci-dessous puis réessayez.",
+          variant: "destructive",
+        });
       } else if (message.includes("password") || message.includes("mot de passe")) {
         toast({
           title: "Mot de passe invalide",
@@ -337,7 +348,7 @@ function AccountCreationContent() {
       } else {
         toast({
           title: "Erreur",
-          description: "Impossible de créer le compte. Veuillez réessayer.",
+          description: rawMessage || "Impossible de créer le compte. Veuillez réessayer.",
           variant: "destructive",
         });
       }
@@ -693,7 +704,11 @@ function AccountCreationContent() {
             </div>
           )}
 
-          <TurnstileWidget onSuccess={setTurnstileToken} />
+          <TurnstileWidget
+            onSuccess={setTurnstileToken}
+            onExpire={() => setTurnstileToken(null)}
+            onError={() => setTurnstileToken(null)}
+          />
 
           <Button
             type="submit"


### PR DESCRIPTION
## Summary

Follow-up hotfix on top of #385 to diagnose and mitigate the `POST /api/v1/auth/register` 400 errors observed on https://talok.fr. The root cause was masked by the frontend error handler, making prod debugging impossible.

## Root cause

`app/signup/account/page.tsx` caught API errors and only matched 3 substrings (`already registered`, `rate limit`, `password`). Everything else (CAPTCHA failures, Zod validation errors, Supabase auth errors) fell through to a silent generic toast: *« Impossible de créer le compte. Veuillez réessayer »*. The real server message was never shown to the user — nor to us.

On top of that, `TurnstileWidget` was mounted without `onExpire` / `onError` handlers. Cloudflare Turnstile tokens expire after ~5 minutes. When a user stayed on the page too long (typing a password, reading consents), the local `turnstileToken` stayed stale and the submit sent an expired token → 400 `CAPTCHA_FAILED` → silent fallback toast.

## Changes

- **`app/signup/account/page.tsx` catch block** — the generic fallback now surfaces `error.message` (the actual server error) instead of a meaningless string. A developer or user will finally see the real reason.
- **New `CAPTCHA_FAILED` branch** — matches `error.code === "CAPTCHA_FAILED"` plus `anti-spam` / `captcha` / `turnstile` substrings. Purges the local token and displays a dedicated toast asking the user to re-validate the widget.
- **Turnstile auto-reset** — `onExpire` and `onError` now call `setTurnstileToken(null)`, so stale tokens can no longer reach `/api/v1/auth/register`.
- **`EMAIL_EXISTS` error code** is now matched alongside the message substring.

## Scope

Frontend only. The register route itself and its Turnstile / Zod / Supabase validation are untouched — this PR surfaces existing 400s rather than changing when they fire.

## Test plan

- [ ] Deploy preview loads on Netlify
- [ ] Submit the form with a valid owner signup → success toast + redirect to `/signup/verify-email`
- [ ] Leave the page open > 5 min, then submit → toast says *« Vérification anti-spam expirée »* instead of the silent generic error, and Turnstile widget re-challenges automatically
- [ ] Submit with an invalid email → toast now shows the real Zod message instead of the generic fallback
- [ ] Existing register → welcome email unit tests (`tests/unit/api/register-welcome-email.test.ts`) still pass

https://claude.ai/code/session_018RBUkJDrRJB8UAmHiFLRfp