### PR TITLE
Centralize role labels and colors into single source of truth

### DIFF
--- a/app/admin/users/[id]/page.tsx
+++ b/app/admin/users/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDateShort } from "@/lib/helpers/format";
+import { getRoleColor, getRoleLabel } from "@/lib/helpers/role-labels";
 import { useToast } from "@/components/ui/use-toast";
 
 interface UserProfile {
@@ -51,15 +52,6 @@ interface UserSubscription {
   status: string;
   current_period_end: string | null;
 }
-
-const ROLE_LABELS: Record<string, string> = {
-  admin: "Admin",
-  platform_admin: "Super Admin",
-  owner: "Proprietaire",
-  tenant: "Locataire",
-  provider: "Prestataire",
-  guarantor: "Garant",
-};
 
 export default function AdminUserDetailPage() {
   const params = useParams();
@@ -227,12 +219,8 @@ export default function AdminUserDetailPage() {
                   )}
                 </div>
                 <div>
-                  <Badge className={cn(
-                    user.role === "admin" || user.role === "platform_admin"
-                      ? "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-400"
-                      : "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-400"
-                  )}>
-                    {ROLE_LABELS[user.role] || user.role}
+                  <Badge className={cn(getRoleColor(user.role))}>
+                    {getRoleLabel(user.role)}
                   </Badge>
                   {user.suspended && (
                     <Badge variant="destructive" className="ml-2">Suspendu</Badge>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -60,25 +60,12 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDateShort } from "@/lib/helpers/format";
+import {
+  getRoleColor,
+  getRoleLabel,
+  ROLE_OPTIONS,
+} from "@/lib/helpers/role-labels";
 import { useToast } from "@/components/ui/use-toast";
-
-const ROLE_LABELS: Record<string, string> = {
-  admin: "Admin",
-  platform_admin: "Super Admin",
-  owner: "Proprietaire",
-  tenant: "Locataire",
-  provider: "Prestataire",
-  guarantor: "Garant",
-};
-
-const ROLE_COLORS: Record<string, string> = {
-  admin: "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-400",
-  platform_admin: "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400",
-  owner: "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-400",
-  tenant: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400",
-  provider: "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400",
-  guarantor: "bg-slate-100 text-slate-700 dark:bg-slate-500/20 dark:text-slate-400",
-};
 
 export default function AdminUsersPage() {
   const { toast } = useToast();
@@ -185,8 +172,8 @@ export default function AdminUsersPage() {
         </Button>
       </motion.div>
 
-      {/* Stats rapides */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {/* Stats rapides — statut + total */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
         <div className="rounded-xl bg-blue-50 dark:bg-blue-500/10 p-4 text-center">
           <Users className="mx-auto mb-2 h-5 w-5 text-blue-600" />
           <p className="text-2xl font-bold text-blue-700 dark:text-blue-400">{total}</p>
@@ -206,13 +193,65 @@ export default function AdminUsersPage() {
           </p>
           <p className="text-xs text-muted-foreground">Suspendus (page)</p>
         </div>
-        <div className="rounded-xl bg-purple-50 dark:bg-purple-500/10 p-4 text-center">
-          <Shield className="mx-auto mb-2 h-5 w-5 text-purple-600" />
-          <p className="text-2xl font-bold text-purple-700 dark:text-purple-400">
-            {users.filter((u) => u.role === "admin" || u.role === "platform_admin").length}
-          </p>
-          <p className="text-xs text-muted-foreground">Admins (page)</p>
-        </div>
+      </div>
+
+      {/* Répartition par type de compte (sur la page courante) */}
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
+        {[
+          { key: "owner", label: "Propriétaires", icon: Users, color: "blue" },
+          { key: "tenant", label: "Locataires", icon: Users, color: "emerald" },
+          { key: "provider", label: "Prestataires", icon: Users, color: "amber" },
+          { key: "agency", label: "Agences", icon: Users, color: "indigo" },
+          { key: "syndic", label: "Syndics", icon: Users, color: "teal" },
+          { key: "__other", label: "Autres", icon: Shield, color: "slate" },
+        ].map((kpi) => {
+          const KNOWN = ["owner", "tenant", "provider", "agency", "syndic"];
+          const count =
+            kpi.key === "__other"
+              ? users.filter((u) => !KNOWN.includes(u.role)).length
+              : users.filter((u) => u.role === kpi.key).length;
+          const Icon = kpi.icon;
+          return (
+            <div
+              key={kpi.key}
+              className={cn(
+                "rounded-xl p-4 text-center",
+                kpi.color === "blue" && "bg-blue-50 dark:bg-blue-500/10",
+                kpi.color === "emerald" && "bg-emerald-50 dark:bg-emerald-500/10",
+                kpi.color === "amber" && "bg-amber-50 dark:bg-amber-500/10",
+                kpi.color === "indigo" && "bg-indigo-50 dark:bg-indigo-500/10",
+                kpi.color === "teal" && "bg-teal-50 dark:bg-teal-500/10",
+                kpi.color === "slate" && "bg-slate-50 dark:bg-slate-500/10",
+              )}
+            >
+              <Icon
+                className={cn(
+                  "mx-auto mb-2 h-5 w-5",
+                  kpi.color === "blue" && "text-blue-600",
+                  kpi.color === "emerald" && "text-emerald-600",
+                  kpi.color === "amber" && "text-amber-600",
+                  kpi.color === "indigo" && "text-indigo-600",
+                  kpi.color === "teal" && "text-teal-600",
+                  kpi.color === "slate" && "text-slate-600",
+                )}
+              />
+              <p
+                className={cn(
+                  "text-2xl font-bold",
+                  kpi.color === "blue" && "text-blue-700 dark:text-blue-400",
+                  kpi.color === "emerald" && "text-emerald-700 dark:text-emerald-400",
+                  kpi.color === "amber" && "text-amber-700 dark:text-amber-400",
+                  kpi.color === "indigo" && "text-indigo-700 dark:text-indigo-400",
+                  kpi.color === "teal" && "text-teal-700 dark:text-teal-400",
+                  kpi.color === "slate" && "text-slate-700 dark:text-slate-400",
+                )}
+              >
+                {count}
+              </p>
+              <p className="text-xs text-muted-foreground">{kpi.label}</p>
+            </div>
+          );
+        })}
       </div>
 
       {/* Filtres + Tableau */}
@@ -239,16 +278,16 @@ export default function AdminUsersPage() {
             </form>
 
             <Select value={roleFilter} onValueChange={(v) => { setRoleFilter(v); setPage(1); }}>
-              <SelectTrigger className="w-[160px]">
+              <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Role" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">Tous les roles</SelectItem>
-                <SelectItem value="owner">Proprietaires</SelectItem>
-                <SelectItem value="tenant">Locataires</SelectItem>
-                <SelectItem value="provider">Prestataires</SelectItem>
-                <SelectItem value="admin">Admins</SelectItem>
-                <SelectItem value="guarantor">Garants</SelectItem>
+                <SelectItem value="all">Tous les rôles</SelectItem>
+                {ROLE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
 
@@ -304,8 +343,8 @@ export default function AdminUsersPage() {
                         </div>
                       </TableCell>
                       <TableCell>
-                        <Badge className={cn(ROLE_COLORS[user.role] || "bg-slate-100 text-slate-700")}>
-                          {ROLE_LABELS[user.role] || user.role}
+                        <Badge className={cn(getRoleColor(user.role))}>
+                          {getRoleLabel(user.role)}
                         </Badge>
                       </TableCell>
                       <TableCell>

--- a/lib/helpers/role-labels.ts
+++ b/lib/helpers/role-labels.ts
@@ -1,21 +1,64 @@
 /**
- * Traduction des rôles utilisateur
+ * Traduction et style des rôles utilisateur — SSOT
  *
- * Centralise les labels affichés pour les rôles dans l'application.
+ * Centralise les labels, couleurs et options affichés pour les rôles
+ * dans l'application. Couvre les 8 valeurs de USER_ROLES
+ * (lib/constants/roles.ts) plus coproprietaire (rôle copro).
+ *
+ * IMPORTANT: Ne jamais dupliquer ROLE_LABELS / ROLE_COLORS dans d'autres
+ * fichiers. Tout passe par ce module.
  */
 
 const ROLE_LABELS: Record<string, string> = {
-  owner: "Propriétaire",
-  tenant: "Locataire",
   admin: "Administrateur",
   platform_admin: "Admin plateforme",
+  owner: "Propriétaire",
+  tenant: "Locataire",
   provider: "Prestataire",
   guarantor: "Garant",
+  agency: "Agence",
+  syndic: "Syndic",
+  coproprietaire: "Copropriétaire",
+  // Alias historiques
   agent: "Agent",
   manager: "Gestionnaire",
   colocataire: "Colocataire",
   garant: "Garant",
 };
+
+/**
+ * Classes Tailwind (light + dark) pour le badge de chaque rôle.
+ * Une couleur distincte par rôle principal pour une lecture visuelle immédiate.
+ */
+const ROLE_COLORS: Record<string, string> = {
+  admin: "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-400",
+  platform_admin: "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400",
+  owner: "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-400",
+  tenant: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400",
+  provider: "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400",
+  guarantor: "bg-slate-100 text-slate-700 dark:bg-slate-500/20 dark:text-slate-400",
+  agency: "bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-400",
+  syndic: "bg-teal-100 text-teal-700 dark:bg-teal-500/20 dark:text-teal-400",
+  coproprietaire: "bg-cyan-100 text-cyan-700 dark:bg-cyan-500/20 dark:text-cyan-400",
+};
+
+const DEFAULT_ROLE_COLOR =
+  "bg-slate-100 text-slate-700 dark:bg-slate-500/20 dark:text-slate-400";
+
+/**
+ * Options pour les <Select> de filtrage par rôle.
+ * Ordre = priorité d'affichage dans les dropdowns admin.
+ */
+export const ROLE_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "owner", label: "Propriétaires" },
+  { value: "tenant", label: "Locataires" },
+  { value: "provider", label: "Prestataires" },
+  { value: "agency", label: "Agences" },
+  { value: "syndic", label: "Syndics" },
+  { value: "guarantor", label: "Garants" },
+  { value: "admin", label: "Admins" },
+  { value: "platform_admin", label: "Super admins" },
+];
 
 /**
  * Retourne le label traduit pour un rôle donné.
@@ -25,4 +68,14 @@ const ROLE_LABELS: Record<string, string> = {
 export function getRoleLabel(role: string | null | undefined): string {
   if (!role) return "";
   return ROLE_LABELS[role] || role;
+}
+
+/**
+ * Retourne les classes Tailwind pour le badge de rôle.
+ * @param role - Le rôle brut depuis la BDD
+ * @returns Les classes Tailwind light + dark
+ */
+export function getRoleColor(role: string | null | undefined): string {
+  if (!role) return DEFAULT_ROLE_COLOR;
+  return ROLE_COLORS[role] || DEFAULT_ROLE_COLOR;
 }


### PR DESCRIPTION
## Summary
Refactored role management across the admin users section by consolidating duplicated role labels and colors into a centralized helper module. This eliminates code duplication and ensures consistent role styling and labeling throughout the application.

## Key Changes
- **Extracted role configuration to `lib/helpers/role-labels.ts`**: Moved `ROLE_LABELS` and `ROLE_COLORS` constants from individual page components into a dedicated module that serves as the single source of truth
- **Added new helper functions**: 
  - `getRoleLabel(role)` - Returns translated role label with fallback
  - `getRoleColor(role)` - Returns Tailwind classes for role badge styling with fallback
  - `ROLE_OPTIONS` - Exported array for role filter dropdowns
- **Extended role support**: Added support for new roles (`agency`, `syndic`, `coproprietaire`) and historical aliases (`agent`, `manager`, `colocataire`)
- **Updated admin users page** (`app/admin/users/page.tsx`):
  - Removed inline role constants and imported from centralized module
  - Refactored stats section from 4 columns to 3 columns (removed admin-only stat)
  - Added new "Account type distribution" grid showing breakdown by role (owner, tenant, provider, agency, syndic, other)
  - Updated role filter dropdown to use `ROLE_OPTIONS` for consistency
  - Updated role badge rendering to use `getRoleColor()` and `getRoleLabel()`
- **Updated user detail page** (`app/admin/users/[id]/page.tsx`):
  - Removed duplicate `ROLE_LABELS` constant
  - Updated role badge to use centralized helper functions
  - Simplified conditional logic for role styling

## Implementation Details
- All role styling now flows through a single module, preventing style inconsistencies
- Default fallback color (slate) applied for unknown roles
- Role options array maintains priority order for dropdown display
- Comments added to clarify that this module covers all 8 USER_ROLES plus additional roles

https://claude.ai/code/session_013ktwrbbpFFc4SByUxN7sjM