### PR TITLE
Add syndic and agency role support to onboarding flow

### DIFF
--- a/app/api/me/profile/route.ts
+++ b/app/api/me/profile/route.ts
@@ -112,23 +112,40 @@ export async function POST(request: Request) {
 
     const profileId = (newProfile as { id: string }).id;
 
-    // Filet de sécurité : créer le profil spécialisé (owner_profiles / tenant_profiles) si le trigger DB n'a pas tourné
-    if (role === "owner") {
-      await serviceClient
-        .from("owner_profiles")
-        .upsert({ profile_id: profileId, type: "particulier" }, { onConflict: "profile_id", ignoreDuplicates: true });
-    } else if (role === "tenant") {
-      await serviceClient
-        .from("tenant_profiles")
-        .upsert({ profile_id: profileId }, { onConflict: "profile_id", ignoreDuplicates: true });
-    } else if (role === "provider") {
-      await serviceClient
-        .from("provider_profiles")
-        .upsert({ profile_id: profileId, type_services: [] }, { onConflict: "profile_id", ignoreDuplicates: true });
-    } else if (role === "agency") {
-      await serviceClient
-        .from("agency_profiles")
-        .upsert({ profile_id: profileId }, { onConflict: "profile_id", ignoreDuplicates: true });
+    // Filet de sécurité : créer le profil spécialisé si le trigger DB n'a pas tourné
+    try {
+      if (role === "owner") {
+        await serviceClient
+          .from("owner_profiles")
+          .upsert({ profile_id: profileId, type: "particulier" }, { onConflict: "profile_id", ignoreDuplicates: true });
+      } else if (role === "tenant") {
+        await serviceClient
+          .from("tenant_profiles")
+          .upsert({ profile_id: profileId }, { onConflict: "profile_id", ignoreDuplicates: true });
+      } else if (role === "provider") {
+        await serviceClient
+          .from("provider_profiles")
+          .upsert({ profile_id: profileId, type_services: [] }, { onConflict: "profile_id", ignoreDuplicates: true });
+      } else if (role === "agency") {
+        await serviceClient
+          .from("agency_profiles")
+          .upsert({ profile_id: profileId }, { onConflict: "profile_id", ignoreDuplicates: true });
+      } else if (role === "guarantor") {
+        await serviceClient
+          .from("guarantor_profiles")
+          .upsert({ profile_id: profileId }, { onConflict: "profile_id", ignoreDuplicates: true });
+      } else if (role === "syndic") {
+        // syndic_profiles n'est pas encore dans database.types.ts : cast local
+        await (serviceClient as any)
+          .from("syndic_profiles")
+          .upsert({ profile_id: profileId, type_syndic: "professionnel" }, { onConflict: "profile_id", ignoreDuplicates: true });
+      }
+    } catch (specializedError) {
+      console.error("[POST /api/me/profile] Specialized profile upsert failed (non-blocking):", {
+        role,
+        profile_id: profileId,
+        error: specializedError,
+      });
     }
 
     // Filet de sécurité : lier lease_signers orphelins + backfill invoices (au cas où le trigger DB n'a pas tourné)

--- a/lib/emails/templates.ts
+++ b/lib/emails/templates.ts
@@ -1320,7 +1320,7 @@ export const emailTemplates = {
    */
   onboardingReminder24h: (data: {
     userName: string;
-    role: 'owner' | 'tenant' | 'provider' | 'guarantor';
+    role: 'owner' | 'tenant' | 'provider' | 'guarantor' | 'syndic' | 'agency';
     progressPercent: number;
     nextStepLabel: string;
     onboardingUrl: string;
@@ -1365,15 +1365,20 @@ export const emailTemplates = {
    */
   onboardingReminder72h: (data: {
     userName: string;
-    role: 'owner' | 'tenant' | 'provider' | 'guarantor';
+    role: 'owner' | 'tenant' | 'provider' | 'guarantor' | 'syndic' | 'agency';
     progressPercent: number;
     onboardingUrl: string;
   }) => {
-    const roleMessages = {
+    const roleMessages: Record<
+      'owner' | 'tenant' | 'provider' | 'guarantor' | 'syndic' | 'agency',
+      string
+    > = {
       owner: 'Vos futurs locataires vous attendent ! Finalisez votre espace pour commencer à gérer vos biens.',
       tenant: 'Votre propriétaire attend votre dossier complet. Finalisez votre inscription pour signer votre bail.',
       provider: 'Des propriétaires recherchent des prestataires comme vous. Complétez votre profil pour être visible.',
       guarantor: 'Le locataire que vous accompagnez a besoin de votre cautionnement. Finalisez votre inscription.',
+      syndic: 'Vos copropriétaires comptent sur vous. Finalisez la configuration de votre cabinet pour lancer votre première assemblée.',
+      agency: 'Vos propriétaires mandants vous attendent. Finalisez votre espace pour gérer vos mandats en toute sérénité.',
     };
 
     return {
@@ -1411,7 +1416,7 @@ export const emailTemplates = {
    */
   onboardingReminder7d: (data: {
     userName: string;
-    role: 'owner' | 'tenant' | 'provider' | 'guarantor';
+    role: 'owner' | 'tenant' | 'provider' | 'guarantor' | 'syndic' | 'agency';
     onboardingUrl: string;
   }) => ({
     subject: `💭 ${escapeHtml(data.userName)}, nous pensons à vous`,
@@ -1447,10 +1452,13 @@ export const emailTemplates = {
    */
   onboardingCompleted: (data: {
     userName: string;
-    role: 'owner' | 'tenant' | 'provider' | 'guarantor';
+    role: 'owner' | 'tenant' | 'provider' | 'guarantor' | 'syndic' | 'agency';
     dashboardUrl: string;
   }) => {
-    const roleConfig = {
+    const roleConfig: Record<
+      'owner' | 'tenant' | 'provider' | 'guarantor' | 'syndic' | 'agency',
+      { emoji: string; title: string; nextSteps: Array<{ label: string; url: string }> }
+    > = {
       owner: {
         emoji: '🏠',
         title: 'propriétaire',
@@ -1484,6 +1492,24 @@ export const emailTemplates = {
         nextSteps: [
           { label: 'Voir le bail', url: '/guarantor/lease' },
           { label: 'Mes documents', url: '/guarantor/documents' },
+        ],
+      },
+      syndic: {
+        emoji: '🏢',
+        title: 'syndic de copropriété',
+        nextSteps: [
+          { label: 'Ajouter une copropriété', url: '/syndic/sites' },
+          { label: 'Préparer une assemblée', url: '/syndic/assemblies' },
+          { label: 'Lancer un appel de fonds', url: '/syndic/calls' },
+        ],
+      },
+      agency: {
+        emoji: '🏢',
+        title: 'agence immobilière',
+        nextSteps: [
+          { label: 'Créer un mandat', url: '/agency/mandates' },
+          { label: 'Inviter votre équipe', url: '/agency/settings/team' },
+          { label: 'Voir vos biens gérés', url: '/agency/properties' },
         ],
       },
     };

--- a/supabase/migrations/20260411130300_onboarding_role_constraints_allow_syndic_agency.sql
+++ b/supabase/migrations/20260411130300_onboarding_role_constraints_allow_syndic_agency.sql
@@ -1,0 +1,32 @@
+-- ============================================
+-- Migration : Autoriser syndic + agency dans onboarding_analytics et onboarding_reminders
+-- Date : 2026-04-11
+-- Contexte :
+--   La migration 20260114000000 a créé les tables `onboarding_analytics`
+--   et `onboarding_reminders` avec une contrainte CHECK sur `role` limitée
+--   à ('owner', 'tenant', 'provider', 'guarantor').
+--
+--   Résultat : toute tentative de tracer l'onboarding d'un compte syndic
+--   ou agency (appelée depuis useOnboarding → onboardingAnalyticsService
+--   → startOnboarding) échoue avec une violation de contrainte CHECK.
+--
+--   De même, impossible de planifier un rappel d'onboarding (24h/72h/7d)
+--   ou une relance de complétion pour un syndic ou une agence.
+--
+--   Cette migration remplace la contrainte par la liste complète des rôles
+--   supportés par la plateforme Talok.
+-- ============================================
+
+ALTER TABLE public.onboarding_analytics
+  DROP CONSTRAINT IF EXISTS onboarding_analytics_role_check;
+
+ALTER TABLE public.onboarding_analytics
+  ADD CONSTRAINT onboarding_analytics_role_check
+  CHECK (role IN ('owner', 'tenant', 'provider', 'guarantor', 'syndic', 'agency'));
+
+ALTER TABLE public.onboarding_reminders
+  DROP CONSTRAINT IF EXISTS onboarding_reminders_role_check;
+
+ALTER TABLE public.onboarding_reminders
+  ADD CONSTRAINT onboarding_reminders_role_check
+  CHECK (role IN ('owner', 'tenant', 'provider', 'guarantor', 'syndic', 'agency'));


### PR DESCRIPTION
## Summary
This PR extends onboarding support to two new user roles: **syndic** (property management company) and **agency** (real estate agency). Previously, the onboarding system only supported owner, tenant, provider, and guarantor roles.

## Key Changes

- **Profile Creation**: Added specialized profile creation for `syndic_profiles` and `guarantor_profiles` in the POST `/api/me/profile` endpoint, with proper error handling via try-catch wrapper
- **Email Templates**: Updated all onboarding email templates (`onboardingReminder24h`, `onboardingReminder72h`, `onboardingReminder7d`, `onboardingCompleted`) to support the new roles with role-specific messaging and next steps
- **Database Constraints**: Created migration to update CHECK constraints on `onboarding_analytics` and `onboarding_reminders` tables to allow 'syndic' and 'agency' roles
- **Type Safety**: Added explicit TypeScript Record types for role-specific configurations in email templates

## Implementation Details

- The specialized profile upsert operations are now wrapped in a try-catch block to prevent blocking the main profile creation if the operation fails (non-blocking safety net)
- Syndic profiles include a `type_syndic: "professionnel"` default value
- Email templates include role-specific messaging:
  - **Syndic**: Focused on managing co-ownership buildings and assemblies
  - **Agency**: Focused on managing mandates and team collaboration
- The `syndic_profiles` table reference includes a type cast comment noting it's not yet in `database.types.ts`

https://claude.ai/code/session_011iheVZqqa8nbT1etpqwtMB