### PR TITLE
feat(syndic): Complete copropriété module (Phases 2-8/8)

### DIFF
--- a/app/api/copro/assemblies/[assemblyId]/close/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/close/route.ts
@@ -1,0 +1,91 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/copro/assemblies/[assemblyId]/close
+ *
+ * Clôture la session de l'assemblée :
+ * - Valide que le statut est 'in_progress'
+ * - Enregistre la date effective de tenue (held_at)
+ * - Transition : in_progress → held
+ *
+ * Note : les résolutions conservent leur statut de vote.
+ * Le PV peut ensuite être créé via POST /api/copro/assemblies/[id]/minutes
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { CloseAssemblySchema } from "@/lib/validations/syndic";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  if (assembly.status !== "in_progress") {
+    return NextResponse.json(
+      {
+        error: `Impossible de clôturer : l'assemblée doit être en statut 'in_progress' (actuellement: '${assembly.status}')`,
+      },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parseResult = CloseAssemblySchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+    const heldAt = input.held_at || new Date().toISOString();
+
+    const { data: updated, error: updateError } = await auth.serviceClient
+      .from("copro_assemblies")
+      .update({
+        status: "held",
+        held_at: heldAt,
+        notes: input.final_notes || undefined,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", assembly.id)
+      .select()
+      .single();
+
+    if (updateError) throw updateError;
+
+    // Compter les résolutions et leur statut pour le résumé
+    const { data: resolutions } = await auth.serviceClient
+      .from("copro_resolutions")
+      .select("status")
+      .eq("assembly_id", assembly.id);
+
+    const summary = (resolutions || []).reduce<Record<string, number>>((acc, r: any) => {
+      acc[r.status] = (acc[r.status] || 0) + 1;
+      return acc;
+    }, {});
+
+    return NextResponse.json({
+      success: true,
+      assembly: updated,
+      resolutions_summary: summary,
+      message: "Session clôturée. Vous pouvez maintenant générer le procès-verbal.",
+    });
+  } catch (error) {
+    console.error("[assembly:close]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/[assemblyId]/convocation-pdf/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/convocation-pdf/route.ts
@@ -1,0 +1,184 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/copro/assemblies/[assemblyId]/convocation-pdf?unit_id=X
+ *
+ * Retourne le HTML de la convocation pour un lot donné.
+ * Le client convertit ensuite en PDF via html2pdf.js (côté client)
+ * ou un job serveur via puppeteer (future enhancement).
+ *
+ * Si aucun unit_id fourni, retourne une convocation "modèle" sans destinataire.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { generateConvocationHtml, type ConvocationPdfData } from "@/lib/pdf/syndic-templates";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+  const { searchParams } = new URL(request.url);
+  const unitId = searchParams.get("unit_id");
+  const format = searchParams.get("format") || "html"; // 'html' | 'json'
+
+  try {
+    // 1. Charger l'assemblée complète
+    const { data: assemblyData, error: assemblyError } = await auth.serviceClient
+      .from("copro_assemblies")
+      .select("*")
+      .eq("id", assembly.id)
+      .single();
+
+    if (assemblyError || !assemblyData) {
+      return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+    }
+
+    // 2. Charger le site
+    const { data: site, error: siteError } = await auth.serviceClient
+      .from("sites")
+      .select(
+        "name, address_line1, address_line2, postal_code, city, syndic_profile_id, syndic_company_name, syndic_address, syndic_email, syndic_phone"
+      )
+      .eq("id", (assemblyData as any).site_id)
+      .single();
+
+    if (siteError || !site) {
+      return NextResponse.json({ error: "Site introuvable" }, { status: 404 });
+    }
+
+    // 3. Charger le profil syndic + syndic_profile (loi Hoguet)
+    const siteAny = site as any;
+    let syndicName = "Syndic";
+    let syndicNumeroCartePro: string | undefined;
+
+    if (siteAny.syndic_profile_id) {
+      const { data: syndicProfile } = await auth.serviceClient
+        .from("profiles")
+        .select("prenom, nom")
+        .eq("id", siteAny.syndic_profile_id)
+        .maybeSingle();
+
+      if (syndicProfile) {
+        syndicName = `${(syndicProfile as any).prenom || ""} ${(syndicProfile as any).nom || ""}`.trim();
+      }
+
+      const { data: syndicPro } = await auth.serviceClient
+        .from("syndic_profiles")
+        .select("numero_carte_pro, raison_sociale")
+        .eq("profile_id", siteAny.syndic_profile_id)
+        .maybeSingle();
+
+      if (syndicPro) {
+        syndicNumeroCartePro = (syndicPro as any).numero_carte_pro || undefined;
+      }
+    }
+
+    // 4. Charger les résolutions
+    const { data: resolutions } = await auth.serviceClient
+      .from("copro_resolutions")
+      .select("*")
+      .eq("assembly_id", assembly.id)
+      .order("resolution_number", { ascending: true });
+
+    // 5. Charger le destinataire (unit + owner) si unit_id fourni
+    let recipientName = "Tous les copropriétaires";
+    let recipientAddress: string | undefined;
+    let unitNumber: string | undefined;
+    let unitTantiemes: number | undefined;
+
+    if (unitId) {
+      const { data: unit } = await auth.serviceClient
+        .from("copro_units")
+        .select("lot_number, tantieme_general, owner_profile_id")
+        .eq("id", unitId)
+        .eq("site_id", (assemblyData as any).site_id)
+        .maybeSingle();
+
+      if (unit) {
+        const u = unit as any;
+        unitNumber = u.lot_number;
+        unitTantiemes = u.tantieme_general;
+
+        if (u.owner_profile_id) {
+          const { data: owner } = await auth.serviceClient
+            .from("profiles")
+            .select("prenom, nom")
+            .eq("id", u.owner_profile_id)
+            .maybeSingle();
+
+          if (owner) {
+            recipientName = `${(owner as any).prenom || ""} ${(owner as any).nom || ""}`.trim() || `Lot ${u.lot_number}`;
+          }
+        } else {
+          recipientName = `Lot ${u.lot_number} (non assigné)`;
+        }
+      }
+    }
+
+    // 6. Construire les données du template
+    const pdfData: ConvocationPdfData = {
+      site_name: siteAny.name,
+      site_address: siteAny.address_line1 + (siteAny.address_line2 ? `, ${siteAny.address_line2}` : ""),
+      site_city: siteAny.city,
+      site_postal_code: siteAny.postal_code,
+      syndic_name: syndicName,
+      syndic_company: siteAny.syndic_company_name || undefined,
+      syndic_address: siteAny.syndic_address || undefined,
+      syndic_email: siteAny.syndic_email || undefined,
+      syndic_phone: siteAny.syndic_phone || undefined,
+      syndic_numero_carte_pro: syndicNumeroCartePro,
+      assembly_reference: (assemblyData as any).reference_number || "",
+      assembly_type: (assemblyData as any).assembly_type,
+      assembly_title: (assemblyData as any).title,
+      scheduled_at: (assemblyData as any).scheduled_at,
+      location: (assemblyData as any).location || "",
+      location_address: (assemblyData as any).location_address || undefined,
+      online_meeting_url: (assemblyData as any).online_meeting_url || undefined,
+      is_hybrid: (assemblyData as any).is_hybrid || false,
+      fiscal_year: (assemblyData as any).fiscal_year || undefined,
+      second_convocation_at: (assemblyData as any).second_convocation_at || undefined,
+      recipient_name: recipientName,
+      recipient_address: recipientAddress,
+      unit_number: unitNumber,
+      unit_tantiemes: unitTantiemes,
+      resolutions: ((resolutions || []) as any[]).map((r) => ({
+        resolution_number: r.resolution_number,
+        title: r.title,
+        description: r.description,
+        category: r.category,
+        majority_rule: r.majority_rule,
+        estimated_amount_cents: r.estimated_amount_cents,
+        contract_partner: r.contract_partner,
+      })),
+      generated_at: new Date().toISOString(),
+    };
+
+    // 7. Retourner selon le format demandé
+    if (format === "json") {
+      return NextResponse.json(pdfData);
+    }
+
+    const html = generateConvocationHtml(pdfData);
+
+    return new NextResponse(html, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Disposition": `inline; filename="convocation-${(assemblyData as any).reference_number || assembly.id}.html"`,
+      },
+    });
+  } catch (error) {
+    console.error("[convocation-pdf:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/[assemblyId]/convocations/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/convocations/route.ts
@@ -1,0 +1,171 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/assemblies/[assemblyId]/convocations
+ * GET  — Liste des convocations envoyées pour une AG
+ * POST — Crée un batch de convocations pour une AG (une par unit_id)
+ *
+ * Note : l'envoi réel (email/postal) est géré par un job séparé.
+ * Cette route crée uniquement les enregistrements en DB avec status='pending'.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { CreateConvocationsBatchSchema } from "@/lib/validations/syndic";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  try {
+    const { data, error } = await auth.serviceClient
+      .from("copro_convocations")
+      .select("*")
+      .eq("assembly_id", assembly.id)
+      .order("created_at", { ascending: true });
+
+    if (error) throw error;
+
+    return NextResponse.json(data || []);
+  } catch (error) {
+    console.error("[convocations:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  // Ne convoquer que les AG en status 'draft' ou 'convened'
+  if (!["draft", "convened"].includes(assembly.status)) {
+    return NextResponse.json(
+      { error: `Impossible de convoquer une assemblée en statut '${assembly.status}'` },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parseResult = CreateConvocationsBatchSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    // Récupérer les unités cibles : soit spécifiques, soit toutes les unités actives du site
+    let unitsQuery = auth.serviceClient
+      .from("copro_units")
+      .select("id, lot_number, owner_profile_id, type")
+      .eq("site_id", assembly.site_id)
+      .eq("is_active", true);
+
+    if (input.unit_ids && input.unit_ids.length > 0) {
+      unitsQuery = unitsQuery.in("id", input.unit_ids);
+    }
+
+    const { data: units, error: unitsError } = await unitsQuery;
+    if (unitsError) throw unitsError;
+
+    if (!units || units.length === 0) {
+      return NextResponse.json(
+        { error: "Aucune unité trouvée pour cette convocation" },
+        { status: 404 }
+      );
+    }
+
+    // Récupérer les profils des propriétaires pour remplir les destinataires
+    const ownerIds = units
+      .map((u: any) => u.owner_profile_id)
+      .filter((id: string | null): id is string => !!id);
+
+    const ownersMap = new Map<string, { prenom: string; nom: string; email: string }>();
+    if (ownerIds.length > 0) {
+      const { data: owners } = await auth.serviceClient
+        .from("profiles")
+        .select("id, prenom, nom, email")
+        .in("id", ownerIds);
+
+      for (const owner of (owners || []) as any[]) {
+        ownersMap.set(owner.id, {
+          prenom: owner.prenom || "",
+          nom: owner.nom || "",
+          email: owner.email || "",
+        });
+      }
+    }
+
+    // Préparer les insertions
+    const now = new Date().toISOString();
+    const convocationsToInsert = (units as any[]).map((unit) => {
+      const owner = unit.owner_profile_id ? ownersMap.get(unit.owner_profile_id) : null;
+      const recipientName = owner
+        ? `${owner.prenom} ${owner.nom}`.trim() || `Lot ${unit.lot_number}`
+        : `Lot ${unit.lot_number} (non assigné)`;
+
+      return {
+        assembly_id: assembly.id,
+        site_id: assembly.site_id,
+        unit_id: unit.id,
+        recipient_profile_id: unit.owner_profile_id || null,
+        recipient_name: recipientName,
+        recipient_email: owner?.email || null,
+        delivery_method: input.delivery_method,
+        status: "pending" as const,
+        convocation_document_url: input.convocation_document_url || null,
+        ordre_du_jour_document_url: input.ordre_du_jour_document_url || null,
+      };
+    });
+
+    const { data: inserted, error: insertError } = await auth.serviceClient
+      .from("copro_convocations")
+      .insert(convocationsToInsert)
+      .select();
+
+    if (insertError) throw insertError;
+
+    // Passer l'AG en status 'convened' si elle était en 'draft'
+    if (assembly.status === "draft") {
+      await auth.serviceClient
+        .from("copro_assemblies")
+        .update({
+          status: "convened",
+          first_convocation_sent_at: now,
+          updated_at: now,
+        })
+        .eq("id", assembly.id);
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        count: inserted?.length || 0,
+        convocations: inserted,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[convocations:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/[assemblyId]/minutes/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/minutes/route.ts
@@ -1,0 +1,112 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/assemblies/[assemblyId]/minutes
+ * GET  — Liste les PV (versions) d'une AG
+ * POST — Crée un nouveau PV (version incrémentée)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { CreateMinuteSchema } from "@/lib/validations/syndic";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  try {
+    const { data, error } = await auth.serviceClient
+      .from("copro_minutes")
+      .select("*")
+      .eq("assembly_id", assembly.id)
+      .order("version", { ascending: false });
+
+    if (error) throw error;
+
+    return NextResponse.json(data || []);
+  } catch (error) {
+    console.error("[minutes:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  // Ne créer un PV que pour une AG tenue
+  if (!["held", "in_progress"].includes(assembly.status)) {
+    return NextResponse.json(
+      { error: "Le PV ne peut être créé que pour une assemblée tenue ou en cours" },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parseResult = CreateMinuteSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    // Déterminer la prochaine version
+    const { data: existingMinutes } = await auth.serviceClient
+      .from("copro_minutes")
+      .select("version")
+      .eq("assembly_id", assembly.id)
+      .order("version", { ascending: false })
+      .limit(1);
+
+    const nextVersion = existingMinutes && existingMinutes.length > 0
+      ? ((existingMinutes[0] as any).version as number) + 1
+      : 1;
+
+    // Calcul du délai de contestation (2 mois à partir de la notification)
+    const contestationDeadline = new Date();
+    contestationDeadline.setMonth(contestationDeadline.getMonth() + 2);
+
+    const { data: minute, error } = await auth.serviceClient
+      .from("copro_minutes")
+      .insert({
+        assembly_id: assembly.id,
+        site_id: assembly.site_id,
+        version: nextVersion,
+        content: input.content || {},
+        content_html: input.content_html || null,
+        document_url: input.document_url || null,
+        status: "draft",
+        contestation_deadline: contestationDeadline.toISOString(),
+        created_by: auth.user.id,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return NextResponse.json(minute, { status: 201 });
+  } catch (error) {
+    console.error("[minutes:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/[assemblyId]/my-vote/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/my-vote/route.ts
@@ -1,0 +1,308 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Routes dédiées au copropriétaire (portail /copro).
+ *
+ * GET /api/copro/assemblies/[id]/my-vote
+ *   Retourne l'assemblée, les résolutions, les lots du copropriétaire connecté
+ *   et ses votes déjà enregistrés.
+ *
+ * POST /api/copro/assemblies/[id]/my-vote
+ *   Enregistre un vote en ligne par le copropriétaire connecté.
+ *   Seuls les votes pour ses propres lots sont acceptés.
+ *
+ * Contraintes:
+ *   - L'assemblée doit être en statut 'convened' ou 'in_progress'
+ *   - L'utilisateur doit avoir un rôle dans user_site_roles pour le site
+ *   - Un lot ne peut voter qu'une fois par résolution (unique DB constraint)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { supabaseAdmin } from "@/app/api/_lib/supabase";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+const CastOnlineVoteSchema = z.object({
+  resolution_id: z.string().uuid(),
+  unit_id: z.string().uuid(),
+  vote: z.enum(["for", "against", "abstain"]),
+});
+
+// ============================================
+// GET — my assembly view
+// ============================================
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = supabaseAdmin();
+
+    // Profile
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+
+    // Assembly
+    const { data: assembly, error: assemblyError } = await serviceClient
+      .from("copro_assemblies")
+      .select("*")
+      .eq("id", params.assemblyId)
+      .maybeSingle();
+
+    if (assemblyError || !assembly) {
+      return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+    }
+
+    const assemblyAny = assembly as any;
+
+    // Vérifier que l'utilisateur est bien copropriétaire sur ce site
+    const { data: siteRoles } = await serviceClient
+      .from("user_site_roles")
+      .select("role_code, unit_ids")
+      .eq("user_id", user.id)
+      .eq("site_id", assemblyAny.site_id);
+
+    const isCopro = (siteRoles || []).length > 0;
+    const isAdmin = (profile as any).role === "admin" || (profile as any).role === "platform_admin";
+
+    if (!isCopro && !isAdmin) {
+      return NextResponse.json(
+        { error: "Vous n'êtes pas copropriétaire de ce site" },
+        { status: 403 }
+      );
+    }
+
+    // Récupérer les lots du copropriétaire (via owner_profile_id)
+    const { data: myUnits } = await serviceClient
+      .from("copro_units")
+      .select("id, lot_number, type, tantieme_general, tantiemes_speciaux")
+      .eq("site_id", assemblyAny.site_id)
+      .eq("owner_profile_id", (profile as any).id)
+      .eq("is_active", true);
+
+    // Résolutions
+    const { data: resolutions } = await serviceClient
+      .from("copro_resolutions")
+      .select("*")
+      .eq("assembly_id", assemblyAny.id)
+      .order("resolution_number", { ascending: true });
+
+    // Votes déjà enregistrés pour les lots du copropriétaire
+    const myUnitIds = ((myUnits || []) as any[]).map((u) => u.id);
+    let myVotes: any[] = [];
+    if (myUnitIds.length > 0) {
+      const { data: votes } = await serviceClient
+        .from("copro_votes")
+        .select("id, resolution_id, unit_id, vote, voted_at, vote_method")
+        .eq("assembly_id", assemblyAny.id)
+        .in("unit_id", myUnitIds);
+      myVotes = votes || [];
+    }
+
+    // PV publiés (visibles)
+    const { data: minutes } = await serviceClient
+      .from("copro_minutes")
+      .select("id, version, status, distributed_at, signed_by_president_at")
+      .eq("assembly_id", assemblyAny.id)
+      .in("status", ["signed", "distributed", "archived"])
+      .order("version", { ascending: false });
+
+    return NextResponse.json({
+      assembly: {
+        id: assemblyAny.id,
+        site_id: assemblyAny.site_id,
+        title: assemblyAny.title,
+        reference_number: assemblyAny.reference_number,
+        assembly_type: assemblyAny.assembly_type,
+        scheduled_at: assemblyAny.scheduled_at,
+        location: assemblyAny.location,
+        location_address: assemblyAny.location_address,
+        online_meeting_url: assemblyAny.online_meeting_url,
+        is_hybrid: assemblyAny.is_hybrid,
+        status: assemblyAny.status,
+        quorum_required: assemblyAny.quorum_required,
+        description: assemblyAny.description,
+      },
+      resolutions: resolutions || [],
+      my_units: myUnits || [],
+      my_votes: myVotes,
+      minutes: minutes || [],
+      can_vote_online: ["convened", "in_progress"].includes(assemblyAny.status),
+    });
+  } catch (error) {
+    console.error("[my-vote:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+// ============================================
+// POST — cast online vote
+// ============================================
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const parseResult = CastOnlineVoteSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+    const serviceClient = supabaseAdmin();
+
+    // Profile
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, prenom, nom")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+
+    // Assembly (vérifier statut)
+    const { data: assembly } = await serviceClient
+      .from("copro_assemblies")
+      .select("id, site_id, status")
+      .eq("id", params.assemblyId)
+      .maybeSingle();
+
+    if (!assembly) {
+      return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+    }
+
+    if (!["convened", "in_progress"].includes((assembly as any).status)) {
+      return NextResponse.json(
+        {
+          error: `Vote impossible : l'assemblée doit être en statut 'convened' ou 'in_progress' (actuellement: '${(assembly as any).status}')`,
+        },
+        { status: 409 }
+      );
+    }
+
+    // Résolution (vérifier qu'elle appartient à l'assemblée et est proposée)
+    const { data: resolution } = await serviceClient
+      .from("copro_resolutions")
+      .select("id, assembly_id, site_id, status")
+      .eq("id", input.resolution_id)
+      .maybeSingle();
+
+    if (!resolution || (resolution as any).assembly_id !== (assembly as any).id) {
+      return NextResponse.json({ error: "Résolution introuvable" }, { status: 404 });
+    }
+
+    if ((resolution as any).status !== "proposed") {
+      return NextResponse.json(
+        { error: "Cette résolution n'accepte plus de votes" },
+        { status: 409 }
+      );
+    }
+
+    // Lot : vérifier que le user en est bien propriétaire
+    const { data: unit } = await serviceClient
+      .from("copro_units")
+      .select("id, site_id, owner_profile_id, tantieme_general, lot_number")
+      .eq("id", input.unit_id)
+      .maybeSingle();
+
+    if (!unit) {
+      return NextResponse.json({ error: "Lot introuvable" }, { status: 404 });
+    }
+
+    const unitAny = unit as any;
+    if (unitAny.site_id !== (assembly as any).site_id) {
+      return NextResponse.json(
+        { error: "Ce lot n'appartient pas à la copropriété concernée" },
+        { status: 403 }
+      );
+    }
+
+    if (unitAny.owner_profile_id !== (profile as any).id) {
+      return NextResponse.json(
+        { error: "Vous n'êtes pas propriétaire de ce lot" },
+        { status: 403 }
+      );
+    }
+
+    const voterName = `${(profile as any).prenom || ""} ${(profile as any).nom || ""}`.trim() || "Copropriétaire";
+
+    // Enregistrer le vote
+    const { data: vote, error: voteError } = await serviceClient
+      .from("copro_votes")
+      .insert({
+        resolution_id: (resolution as any).id,
+        assembly_id: (resolution as any).assembly_id,
+        site_id: (resolution as any).site_id,
+        unit_id: unitAny.id,
+        voter_profile_id: (profile as any).id,
+        voter_name: voterName,
+        voter_tantiemes: unitAny.tantieme_general || 0,
+        vote: input.vote,
+        vote_method: "online_vote",
+        is_proxy: false,
+      })
+      .select()
+      .single();
+
+    if (voteError) {
+      if ((voteError as any).code === "23505") {
+        return NextResponse.json(
+          { error: "Vous avez déjà voté pour ce lot sur cette résolution" },
+          { status: 409 }
+        );
+      }
+      throw voteError;
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        vote,
+        message: "Vote enregistré avec succès",
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[my-vote:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/[assemblyId]/resolutions/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/resolutions/route.ts
@@ -1,0 +1,109 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/assemblies/[assemblyId]/resolutions
+ * GET  — Liste des résolutions d'une AG (ordre du jour)
+ * POST — Ajoute une résolution à l'AG
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { CreateResolutionSchema } from "@/lib/validations/syndic";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  try {
+    const { data, error } = await auth.serviceClient
+      .from("copro_resolutions")
+      .select("*")
+      .eq("assembly_id", assembly.id)
+      .order("resolution_number", { ascending: true });
+
+    if (error) throw error;
+
+    return NextResponse.json(data || []);
+  } catch (error) {
+    console.error("[resolutions:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  // Ne pas ajouter de résolution à une AG déjà tenue ou annulée
+  if (!["draft", "convened", "in_progress"].includes(assembly.status)) {
+    return NextResponse.json(
+      {
+        error: `Impossible d'ajouter une résolution à une assemblée en statut '${assembly.status}'`,
+      },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parseResult = CreateResolutionSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    const { data: resolution, error } = await auth.serviceClient
+      .from("copro_resolutions")
+      .insert({
+        assembly_id: assembly.id,
+        site_id: assembly.site_id,
+        resolution_number: input.resolution_number,
+        title: input.title,
+        description: input.description,
+        category: input.category,
+        majority_rule: input.majority_rule,
+        estimated_amount_cents: input.estimated_amount_cents || null,
+        contract_partner: input.contract_partner || null,
+        attached_documents: input.attached_documents || [],
+        status: "proposed",
+      })
+      .select()
+      .single();
+
+    if (error) {
+      // Contrainte unique sur (assembly_id, resolution_number)
+      if ((error as any).code === "23505") {
+        return NextResponse.json(
+          { error: `Une résolution avec le numéro ${input.resolution_number} existe déjà` },
+          { status: 409 }
+        );
+      }
+      throw error;
+    }
+
+    return NextResponse.json(resolution, { status: 201 });
+  } catch (error) {
+    console.error("[resolutions:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/[assemblyId]/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/route.ts
@@ -1,281 +1,153 @@
-export const runtime = 'nodejs';
-export const dynamic = 'force-dynamic';
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-// =====================================================
-// API Route: Assemblée Générale COPRO individuelle
-// GET /api/copro/assemblies/[assemblyId] - Détails d'une AG
-// PUT /api/copro/assemblies/[assemblyId] - Modifier une AG
-// POST /api/copro/assemblies/[assemblyId]/actions - Actions sur l'AG
-// =====================================================
+/**
+ * /api/copro/assemblies/[assemblyId]
+ * GET    — Récupère une assemblée avec ses résolutions
+ * PATCH  — Met à jour une assemblée (uniquement en status 'draft' ou 'convened')
+ * DELETE — Annule une assemblée (soft delete via status='cancelled')
+ *
+ * SOTA 2026 — utilise copro_assemblies
+ */
 
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
-import { z } from 'zod';
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { UpdateAssemblySchema } from "@/lib/validations/syndic";
 
 interface RouteParams {
   params: { assemblyId: string };
 }
 
-// Schéma de mise à jour
-const UpdateAssemblySchema = z.object({
-  label: z.string().min(5).optional(),
-  scheduled_at: z.string().datetime().optional(),
-  location_type: z.enum(['physical', 'video', 'hybrid']).optional(),
-  location_address: z.string().nullable().optional(),
-  location_room: z.string().nullable().optional(),
-  video_link: z.string().url().nullable().optional(),
-  video_password: z.string().nullable().optional(),
-  quorum_required: z.number().min(0).max(100).optional(),
-  president_name: z.string().nullable().optional(),
-  president_unit_id: z.string().uuid().nullable().optional(),
-  secretary_name: z.string().nullable().optional(),
-  secretary_unit_id: z.string().uuid().nullable().optional(),
-  scrutineer_name: z.string().nullable().optional(),
-  scrutineer_unit_id: z.string().uuid().nullable().optional(),
-  agenda: z.string().nullable().optional(),
-  notes: z.string().nullable().optional(),
-});
-
-// GET: Détails d'une AG
 export async function GET(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
   try {
-    const supabase = await createClient();
-    const { assemblyId } = params;
-    const { searchParams } = new URL(request.url);
-    const include = searchParams.get('include')?.split(',') || [];
-    
-    // Vérifier l'authentification
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
-    }
-    
-    // Récupérer l'AG
-    const { data: assembly, error } = await supabase
-      .from('assemblies')
-      .select(`
-        *,
-        site:sites(name, total_tantiemes_general)
-      `)
-      .eq('id', assemblyId)
+    // Récupérer l'assemblée complète avec ses résolutions
+    const { data: assemblyDetail, error: assemblyError } = await auth.serviceClient
+      .from("copro_assemblies")
+      .select("*")
+      .eq("id", assembly.id)
       .single();
-    
-    if (error) {
-      if (error.code === 'PGRST116') {
-        return NextResponse.json({ error: 'AG non trouvée' }, { status: 404 });
-      }
-      throw error;
-    }
-    
-    const result: any = { ...assembly };
-    
-    // Inclure les motions
-    if (include.includes('motions') || include.includes('all')) {
-      const { data: motions } = await supabase
-        .from('motions')
-        .select('*')
-        .eq('assembly_id', assemblyId)
-        .order('motion_number');
-      result.motions = motions || [];
-    }
-    
-    // Inclure les présences
-    if (include.includes('attendance') || include.includes('all')) {
-      const { data: attendance } = await supabase
-        .from('assembly_attendance')
-        .select(`
-          *,
-          unit:copro_units(lot_number)
-        `)
-        .eq('assembly_id', assemblyId)
-        .order('owner_name');
-      result.attendance = attendance || [];
-    }
-    
-    // Inclure les pouvoirs
-    if (include.includes('proxies') || include.includes('all')) {
-      const { data: proxies } = await supabase
-        .from('proxies')
-        .select(`
-          *,
-          grantor_unit:copro_units!proxies_grantor_unit_id_fkey(lot_number)
-        `)
-        .eq('assembly_id', assemblyId)
-        .order('grantor_name');
-      result.proxies = proxies || [];
-    }
-    
-    // Inclure les documents
-    if (include.includes('documents') || include.includes('all')) {
-      const { data: documents } = await supabase
-        .from('assembly_documents')
-        .select('*')
-        .eq('assembly_id', assemblyId)
-        .order('display_order');
-      result.documents = documents || [];
-    }
-    
-    // Calculer le quorum actuel
-    const { data: quorumData } = await supabase
-      .rpc('calculate_assembly_quorum', { p_assembly_id: assemblyId });
-    if (quorumData && (quorumData as any[]).length > 0) {
-      result.quorum = (quorumData as any[])[0];
-    }
-    
-    return NextResponse.json(result);
-  } catch (error: unknown) {
-    console.error('Erreur GET /api/copro/assemblies/[assemblyId]:', error);
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Une erreur est survenue" }, { status: 500 });
+
+    if (assemblyError) throw assemblyError;
+
+    const { data: resolutions } = await auth.serviceClient
+      .from("copro_resolutions")
+      .select("*")
+      .eq("assembly_id", assembly.id)
+      .order("resolution_number", { ascending: true });
+
+    const { data: convocations } = await auth.serviceClient
+      .from("copro_convocations")
+      .select("id, status, delivery_method, sent_at, delivered_at, recipient_name")
+      .eq("assembly_id", assembly.id);
+
+    const { data: minutes } = await auth.serviceClient
+      .from("copro_minutes")
+      .select("id, version, status, signed_by_president_at, distributed_at")
+      .eq("assembly_id", assembly.id)
+      .order("version", { ascending: false });
+
+    return NextResponse.json({
+      assembly: assemblyDetail,
+      resolutions: resolutions || [],
+      convocations: convocations || [],
+      minutes: minutes || [],
+    });
+  } catch (error) {
+    console.error("[assembly:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
   }
 }
 
-// PUT: Modifier une AG
-export async function PUT(request: NextRequest, { params }: RouteParams) {
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  // Ne pas autoriser la modification d'une AG déjà tenue ou annulée
+  if (!["draft", "convened"].includes(assembly.status)) {
+    return NextResponse.json(
+      {
+        error: `Impossible de modifier une assemblée en statut '${assembly.status}'. Seules les assemblées 'draft' ou 'convened' sont modifiables.`,
+      },
+      { status: 409 }
+    );
+  }
+
   try {
-    const supabase = await createClient();
-    const { assemblyId } = params;
-    
-    // Vérifier l'authentification
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
-    }
-    
     const body = await request.json();
-    const validationResult = UpdateAssemblySchema.safeParse(body);
-    
-    if (!validationResult.success) {
+    const parseResult = UpdateAssemblySchema.safeParse(body);
+
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: 'Données invalides', details: validationResult.error.errors },
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
         { status: 400 }
       );
     }
-    
-    const { data: assembly, error } = await supabase
-      .from('assemblies')
-      .update(validationResult.data)
-      .eq('id', assemblyId)
+
+    const updates = parseResult.data;
+
+    const { data: updated, error } = await auth.serviceClient
+      .from("copro_assemblies")
+      .update({
+        ...updates,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", assembly.id)
       .select()
       .single();
-    
+
     if (error) throw error;
-    
-    return NextResponse.json(assembly);
-  } catch (error: unknown) {
-    console.error('Erreur PUT /api/copro/assemblies/[assemblyId]:', error);
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Une erreur est survenue" }, { status: 500 });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("[assembly:PATCH]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
   }
 }
 
-// POST: Actions sur l'AG (démarrer, suspendre, clôturer, etc.)
-export async function POST(request: NextRequest, { params }: RouteParams) {
-  try {
-    const supabase = await createClient();
-    const { assemblyId } = params;
-    
-    // Vérifier l'authentification
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
-    }
-    
-    const body = await request.json();
-    const { action } = body;
-    
-    let updateData: any = {};
-    
-    switch (action) {
-      case 'convoke':
-        updateData = {
-          status: 'convoked',
-          convocation_sent_at: new Date().toISOString(),
-        };
-        break;
-        
-      case 'start':
-        updateData = {
-          status: 'in_progress',
-          started_at: new Date().toISOString(),
-        };
-        break;
-        
-      case 'suspend':
-        updateData = { status: 'suspended' };
-        break;
-        
-      case 'resume':
-        updateData = { status: 'in_progress' };
-        break;
-        
-      case 'close':
-        updateData = {
-          status: 'closed',
-          ended_at: new Date().toISOString(),
-        };
-        break;
-        
-      case 'cancel':
-        updateData = { status: 'cancelled' };
-        break;
-        
-      default:
-        return NextResponse.json({ error: 'Action invalide' }, { status: 400 });
-    }
-    
-    const { data: assembly, error } = await supabase
-      .from('assemblies')
-      .update(updateData)
-      .eq('id', assemblyId)
-      .select()
-      .single();
-    
-    if (error) throw error;
-    
-    return NextResponse.json({ success: true, assembly });
-  } catch (error: unknown) {
-    console.error('Erreur POST /api/copro/assemblies/[assemblyId]:', error);
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Une erreur est survenue" }, { status: 500 });
-  }
-}
-
-// DELETE: Supprimer une AG (uniquement brouillon)
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  // Ne pas supprimer une AG déjà tenue
+  if (assembly.status === "held") {
+    return NextResponse.json(
+      { error: "Impossible d'annuler une assemblée déjà tenue" },
+      { status: 409 }
+    );
+  }
+
   try {
-    const supabase = await createClient();
-    const { assemblyId } = params;
-    
-    // Vérifier l'authentification
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
-    }
-    
-    // Vérifier que l'AG est en brouillon
-    const { data: assembly } = await supabase
-      .from('assemblies')
-      .select('status')
-      .eq('id', assemblyId)
-      .single();
-    
-    if (assembly?.status !== 'draft') {
-      return NextResponse.json(
-        { error: 'Seules les AG en brouillon peuvent être supprimées' },
-        { status: 400 }
-      );
-    }
-    
-    // Supprimer (cascade supprimera les motions, votes, etc.)
-    const { error } = await supabase
-      .from('assemblies')
-      .delete()
-      .eq('id', assemblyId);
-    
+    const { error } = await auth.serviceClient
+      .from("copro_assemblies")
+      .update({
+        status: "cancelled",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", assembly.id);
+
     if (error) throw error;
-    
-    return NextResponse.json({ success: true });
-  } catch (error: unknown) {
-    console.error('Erreur DELETE /api/copro/assemblies/[assemblyId]:', error);
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Une erreur est survenue" }, { status: 500 });
+
+    return NextResponse.json({ success: true, message: "Assemblée annulée" });
+  } catch (error) {
+    console.error("[assembly:DELETE]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
   }
 }
-

--- a/app/api/copro/assemblies/[assemblyId]/start/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/start/route.ts
@@ -1,0 +1,103 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/copro/assemblies/[assemblyId]/start
+ *
+ * Démarre la session de l'assemblée :
+ * - Valide que le statut est 'convened' (convocations envoyées)
+ * - Enregistre le bureau (président, secrétaire, scrutateurs)
+ * - Enregistre les tantièmes présents/représentés
+ * - Calcule automatiquement si le quorum est atteint
+ * - Transition : convened → in_progress
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { StartAssemblySchema } from "@/lib/validations/syndic";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  if (assembly.status !== "convened") {
+    return NextResponse.json(
+      {
+        error: `Impossible de démarrer : l'assemblée doit être en statut 'convened' (actuellement: '${assembly.status}'). Envoyez d'abord les convocations.`,
+      },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const parseResult = StartAssemblySchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    // Récupérer l'assemblée complète pour comparer au quorum requis
+    const { data: assemblyFull, error: assemblyError } = await auth.serviceClient
+      .from("copro_assemblies")
+      .select("id, site_id, quorum_required")
+      .eq("id", assembly.id)
+      .single();
+
+    if (assemblyError || !assemblyFull) {
+      return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+    }
+
+    // Calculer si le quorum est atteint
+    const quorumRequired = (assemblyFull as any).quorum_required;
+    const quorumReached =
+      quorumRequired === null || quorumRequired === undefined
+        ? true // Pas de quorum requis = toujours atteint
+        : input.present_tantiemes >= quorumRequired;
+
+    const now = new Date().toISOString();
+
+    const { data: updated, error: updateError } = await auth.serviceClient
+      .from("copro_assemblies")
+      .update({
+        status: "in_progress",
+        presided_by: input.presided_by || null,
+        secretary_profile_id: input.secretary_profile_id || null,
+        scrutineers: input.scrutineers || [],
+        present_tantiemes: input.present_tantiemes,
+        quorum_reached: quorumReached,
+        updated_at: now,
+      })
+      .eq("id", assembly.id)
+      .select()
+      .single();
+
+    if (updateError) throw updateError;
+
+    return NextResponse.json({
+      success: true,
+      assembly: updated,
+      quorum_reached: quorumReached,
+      message: quorumReached
+        ? "Session démarrée, quorum atteint"
+        : "Session démarrée MAIS quorum NON atteint — seuls les votes à la majorité simple seront valides",
+    });
+  } catch (error) {
+    console.error("[assembly:start]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/[assemblyId]/units/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/units/route.ts
@@ -1,0 +1,100 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/copro/assemblies/[assemblyId]/units
+ *
+ * Retourne la liste des lots du site de l'assemblée, avec :
+ * - lot_number, type, surface
+ * - owner_profile_id + owner_name
+ * - tantieme_general
+ * - total de tantièmes du site
+ *
+ * Utilisé par la page live pour la saisie des votes (autocomplete).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  try {
+    // Charger les lots actifs du site
+    const { data: units, error: unitsError } = await auth.serviceClient
+      .from("copro_units")
+      .select("id, lot_number, type, surface, tantieme_general, tantiemes_speciaux, owner_profile_id")
+      .eq("site_id", assembly.site_id)
+      .eq("is_active", true)
+      .order("lot_number", { ascending: true });
+
+    if (unitsError) throw unitsError;
+
+    // Charger les propriétaires
+    const ownerIds = ((units || []) as any[])
+      .map((u) => u.owner_profile_id)
+      .filter((id): id is string => !!id);
+
+    const ownersMap = new Map<string, { prenom: string; nom: string }>();
+    if (ownerIds.length > 0) {
+      const { data: owners } = await auth.serviceClient
+        .from("profiles")
+        .select("id, prenom, nom")
+        .in("id", ownerIds);
+
+      for (const owner of (owners || []) as any[]) {
+        ownersMap.set(owner.id, {
+          prenom: owner.prenom || "",
+          nom: owner.nom || "",
+        });
+      }
+    }
+
+    // Charger les totaux tantièmes du site
+    const { data: site } = await auth.serviceClient
+      .from("sites")
+      .select("total_tantiemes_general, name")
+      .eq("id", assembly.site_id)
+      .single();
+
+    // Enrichir les lots avec owner_name
+    const enrichedUnits = ((units || []) as any[]).map((u) => {
+      const owner = u.owner_profile_id ? ownersMap.get(u.owner_profile_id) : null;
+      const ownerName = owner
+        ? `${owner.prenom} ${owner.nom}`.trim() || "Sans nom"
+        : "Non assigné";
+      return {
+        id: u.id,
+        lot_number: u.lot_number,
+        type: u.type,
+        surface: u.surface,
+        tantieme_general: u.tantieme_general,
+        tantiemes_speciaux: u.tantiemes_speciaux || {},
+        owner_profile_id: u.owner_profile_id,
+        owner_name: ownerName,
+      };
+    });
+
+    return NextResponse.json({
+      units: enrichedUnits,
+      site: {
+        name: (site as any)?.name || "Copropriété",
+        total_tantiemes_general: (site as any)?.total_tantiemes_general || 10000,
+      },
+      total_units: enrichedUnits.length,
+    });
+  } catch (error) {
+    console.error("[assembly:units:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/assemblies/route.ts
+++ b/app/api/copro/assemblies/route.ts
@@ -1,136 +1,142 @@
-export const runtime = 'nodejs';
-export const dynamic = 'force-dynamic';
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-// =====================================================
-// API Route: Assemblées Générales COPRO
-// GET /api/copro/assemblies?siteId= - Liste des AG
-// POST /api/copro/assemblies - Créer une AG
-// =====================================================
+/**
+ * /api/copro/assemblies
+ * GET  — Liste les assemblées d'un site (ou de tous les sites gérés)
+ * POST — Crée une nouvelle assemblée (statut 'draft')
+ *
+ * SOTA 2026 — utilise la table copro_assemblies créée en migration
+ * 20260411140000. Réécrit pour remplacer la version cassée qui pointait
+ * vers une table `assemblies` inexistante.
+ */
 
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
-import { z } from 'zod';
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { CreateAssemblySchema } from "@/lib/validations/syndic";
 
-// Schéma de validation
-const CreateAssemblySchema = z.object({
-  site_id: z.string().uuid(),
-  label: z.string().min(5, 'Label requis'),
-  assembly_type: z.enum(['AGO', 'AGE', 'AGM']),
-  scheduled_at: z.string().datetime(),
-  location_type: z.enum(['physical', 'video', 'hybrid']).default('physical'),
-  location_address: z.string().optional(),
-  location_room: z.string().optional(),
-  video_link: z.string().url().optional(),
-  video_password: z.string().optional(),
-  quorum_required: z.number().min(0).max(100).default(25),
-  agenda: z.string().optional(),
-  notes: z.string().optional(),
-});
-
-// GET: Liste des AG
 export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const siteId = searchParams.get("siteId");
+  const status = searchParams.get("status");
+  const upcoming = searchParams.get("upcoming") === "true";
+
+  const auth = await requireSyndic(request, { siteId });
+  if (auth instanceof NextResponse) return auth;
+
   try {
-    const supabase = await createClient();
-    const { searchParams } = new URL(request.url);
-    const siteId = searchParams.get('siteId');
-    const status = searchParams.get('status');
-    const upcoming = searchParams.get('upcoming') === 'true';
-    
-    // Vérifier l'authentification
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
-    }
-    
-    let query = supabase
-      .from('v_assemblies_summary')
-      .select('*')
-      .order('scheduled_at', { ascending: upcoming });
-    
+    let query = auth.serviceClient
+      .from("copro_assemblies")
+      .select("*")
+      .order("scheduled_at", { ascending: upcoming });
+
     if (siteId) {
-      query = query.eq('site_id', siteId);
+      query = query.eq("site_id", siteId);
+    } else if (!auth.isAdmin) {
+      // Restreindre aux sites gérés par ce syndic
+      const { data: mySites } = await auth.serviceClient
+        .from("sites")
+        .select("id")
+        .eq("syndic_profile_id", auth.profile.id);
+      const siteIds = (mySites || []).map((s: any) => s.id);
+      if (siteIds.length === 0) {
+        return NextResponse.json([]);
+      }
+      query = query.in("site_id", siteIds);
     }
-    
+
     if (status) {
-      query = query.eq('status', status);
+      query = query.eq("status", status);
     }
-    
+
     if (upcoming) {
       query = query
-        .in('status', ['draft', 'convoked'])
-        .gte('scheduled_at', new Date().toISOString());
+        .in("status", ["draft", "convened", "in_progress"])
+        .gte("scheduled_at", new Date().toISOString());
     }
-    
+
     const { data, error } = await query;
     if (error) throw error;
-    
+
     return NextResponse.json(data || []);
-  } catch (error: unknown) {
-    console.error('Erreur GET /api/copro/assemblies:', error);
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Une erreur est survenue" }, { status: 500 });
+  } catch (error) {
+    console.error("[assemblies:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
   }
 }
 
-// POST: Créer une AG
 export async function POST(request: NextRequest) {
   try {
-    const supabase = await createClient();
-    
-    // Vérifier l'authentification
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
-    }
-    
     const body = await request.json();
-    const validationResult = CreateAssemblySchema.safeParse(body);
-    
-    if (!validationResult.success) {
+    const parseResult = CreateAssemblySchema.safeParse(body);
+
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: 'Données invalides', details: validationResult.error.errors },
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
         { status: 400 }
       );
     }
-    
-    const input = validationResult.data;
-    
-    // Générer le numéro d'AG
-    const year = new Date(input.scheduled_at).getFullYear();
-    const { count } = await supabase
-      .from('assemblies')
-      .select('id', { count: 'exact', head: true })
-      .eq('site_id', input.site_id)
-      .gte('scheduled_at', `${year}-01-01`)
-      .lte('scheduled_at', `${year}-12-31`);
-    
-    const sequence = (count || 0) + 1;
-    const assemblyNumber = `${input.assembly_type}-${year}-${sequence.toString().padStart(2, '0')}`;
-    
-    // Récupérer le total des tantièmes du site
-    const { data: site } = await supabase
-      .from('sites')
-      .select('total_tantiemes_general')
-      .eq('id', input.site_id)
-      .single();
-    
-    // Créer l'AG
-    const { data: assembly, error } = await supabase
-      .from('assemblies')
+
+    const input = parseResult.data;
+
+    const auth = await requireSyndic(request, { siteId: input.site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // Générer un numéro de référence si absent
+    let referenceNumber = input.reference_number;
+    if (!referenceNumber) {
+      const year = new Date(input.scheduled_at).getFullYear();
+      const typePrefix = {
+        ordinaire: "AGO",
+        extraordinaire: "AGE",
+        concertation: "CONC",
+        consultation_ecrite: "CE",
+      }[input.assembly_type];
+
+      const { count } = await auth.serviceClient
+        .from("copro_assemblies")
+        .select("id", { count: "exact", head: true })
+        .eq("site_id", input.site_id)
+        .eq("assembly_type", input.assembly_type)
+        .gte("scheduled_at", `${year}-01-01`)
+        .lte("scheduled_at", `${year}-12-31`);
+
+      referenceNumber = `${typePrefix}-${year}-${String((count || 0) + 1).padStart(3, "0")}`;
+    }
+
+    const { data: assembly, error } = await auth.serviceClient
+      .from("copro_assemblies")
       .insert({
-        ...input,
-        assembly_number: assemblyNumber,
-        total_tantiemes: site?.total_tantiemes_general || 0,
-        created_by: user.id,
+        site_id: input.site_id,
+        assembly_type: input.assembly_type,
+        title: input.title,
+        reference_number: referenceNumber,
+        fiscal_year: input.fiscal_year ?? new Date(input.scheduled_at).getFullYear(),
+        scheduled_at: input.scheduled_at,
+        location: input.location || null,
+        location_address: input.location_address || null,
+        online_meeting_url: input.online_meeting_url || null,
+        is_hybrid: input.is_hybrid,
+        quorum_required: input.quorum_required ?? null,
+        description: input.description || null,
+        notes: input.notes || null,
+        status: "draft",
+        created_by: auth.user.id,
       })
       .select()
       .single();
-    
+
     if (error) throw error;
-    
+
     return NextResponse.json(assembly, { status: 201 });
-  } catch (error: unknown) {
-    console.error('Erreur POST /api/copro/assemblies:', error);
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Une erreur est survenue" }, { status: 500 });
+  } catch (error) {
+    console.error("[assemblies:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
   }
 }
-

--- a/app/api/copro/councils/route.ts
+++ b/app/api/copro/councils/route.ts
@@ -1,0 +1,126 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/councils
+ * GET  — Liste les conseils syndicaux (d'un site ou de tous)
+ * POST — Crée un nouveau conseil syndical
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { CreateCouncilSchema } from "@/lib/validations/syndic";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const siteId = searchParams.get("siteId");
+  const status = searchParams.get("status");
+
+  const auth = await requireSyndic(request, { siteId });
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    let query = auth.serviceClient
+      .from("copro_councils")
+      .select("*")
+      .order("mandate_start", { ascending: false });
+
+    if (siteId) {
+      query = query.eq("site_id", siteId);
+    } else if (!auth.isAdmin) {
+      // Restreindre aux sites gérés par ce syndic
+      const { data: mySites } = await auth.serviceClient
+        .from("sites")
+        .select("id")
+        .eq("syndic_profile_id", auth.profile.id);
+      const siteIds = (mySites || []).map((s: any) => s.id);
+      if (siteIds.length === 0) return NextResponse.json([]);
+      query = query.in("site_id", siteIds);
+    }
+
+    if (status) {
+      query = query.eq("status", status);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return NextResponse.json(data || []);
+  } catch (error) {
+    console.error("[councils:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parseResult = CreateCouncilSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    const auth = await requireSyndic(request, { siteId: input.site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // Validation dates
+    const mandateStart = new Date(input.mandate_start);
+    const mandateEnd = new Date(input.mandate_end);
+    if (mandateEnd <= mandateStart) {
+      return NextResponse.json(
+        { error: "La date de fin de mandat doit être postérieure à la date de début" },
+        { status: 400 }
+      );
+    }
+
+    const { data: council, error } = await auth.serviceClient
+      .from("copro_councils")
+      .insert({
+        site_id: input.site_id,
+        mandate_start: input.mandate_start,
+        mandate_end: input.mandate_end,
+        president_profile_id: input.president_profile_id || null,
+        president_unit_id: input.president_unit_id || null,
+        vice_president_profile_id: input.vice_president_profile_id || null,
+        vice_president_unit_id: input.vice_president_unit_id || null,
+        members: input.members,
+        elected_in_assembly_id: input.elected_in_assembly_id || null,
+        elected_resolution_id: input.elected_resolution_id || null,
+        internal_rules_document_url: input.internal_rules_document_url || null,
+        notes: input.notes || null,
+        status: "active",
+      })
+      .select()
+      .single();
+
+    if (error) {
+      // Index unique sur (site_id) WHERE status='active'
+      if ((error as any).code === "23505") {
+        return NextResponse.json(
+          {
+            error: "Un conseil syndical actif existe déjà pour ce site. Dissolvez-le d'abord.",
+          },
+          { status: 409 }
+        );
+      }
+      throw error;
+    }
+
+    return NextResponse.json(council, { status: 201 });
+  } catch (error) {
+    console.error("[councils:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/fonds-travaux/route.ts
+++ b/app/api/copro/fonds-travaux/route.ts
@@ -1,0 +1,135 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/fonds-travaux
+ * GET  — Liste les fonds travaux (loi ALUR) d'un site par exercice
+ * POST — Crée un nouveau fonds travaux pour un exercice
+ *
+ * Loi ALUR 2014 article 58 : cotisation minimale 5% du budget prévisionnel.
+ * Obligatoire pour les copropriétés > 5 ans depuis le 1er janvier 2017.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { CreateFondsTravauxSchema } from "@/lib/validations/syndic";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const siteId = searchParams.get("siteId");
+  const fiscalYear = searchParams.get("fiscalYear");
+
+  const auth = await requireSyndic(request, { siteId });
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    let query = auth.serviceClient
+      .from("copro_fonds_travaux")
+      .select("*")
+      .order("fiscal_year", { ascending: false });
+
+    if (siteId) {
+      query = query.eq("site_id", siteId);
+    } else if (!auth.isAdmin) {
+      const { data: mySites } = await auth.serviceClient
+        .from("sites")
+        .select("id")
+        .eq("syndic_profile_id", auth.profile.id);
+      const siteIds = (mySites || []).map((s: any) => s.id);
+      if (siteIds.length === 0) return NextResponse.json([]);
+      query = query.in("site_id", siteIds);
+    }
+
+    if (fiscalYear) {
+      query = query.eq("fiscal_year", parseInt(fiscalYear, 10));
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return NextResponse.json(data || []);
+  } catch (error) {
+    console.error("[fonds-travaux:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parseResult = CreateFondsTravauxSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    const auth = await requireSyndic(request, { siteId: input.site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // Validation : si non exempt, le taux doit être >= 5% (loi ALUR)
+    if (!input.loi_alur_exempt && input.cotisation_taux_percent < 5) {
+      return NextResponse.json(
+        {
+          error:
+            "Loi ALUR : le taux de cotisation doit être d'au moins 5% du budget prévisionnel (sauf exemption votée)",
+        },
+        { status: 400 }
+      );
+    }
+
+    // Si exempt, une raison doit être fournie
+    if (input.loi_alur_exempt && !input.exempt_reason) {
+      return NextResponse.json(
+        { error: "Une raison d'exemption doit être fournie si loi_alur_exempt est true" },
+        { status: 400 }
+      );
+    }
+
+    const { data: fund, error } = await auth.serviceClient
+      .from("copro_fonds_travaux")
+      .insert({
+        site_id: input.site_id,
+        exercise_id: input.exercise_id || null,
+        fiscal_year: input.fiscal_year,
+        cotisation_taux_percent: input.cotisation_taux_percent,
+        cotisation_montant_annual_cents: input.cotisation_montant_annual_cents,
+        budget_reference_cents: input.budget_reference_cents || null,
+        solde_initial_cents: input.solde_initial_cents,
+        solde_actuel_cents: input.solde_initial_cents,
+        dedicated_bank_account: input.dedicated_bank_account || null,
+        bank_name: input.bank_name || null,
+        loi_alur_exempt: input.loi_alur_exempt,
+        exempt_reason: input.exempt_reason || null,
+        exempt_voted_resolution_id: input.exempt_voted_resolution_id || null,
+        status: "active",
+      })
+      .select()
+      .single();
+
+    if (error) {
+      if ((error as any).code === "23505") {
+        return NextResponse.json(
+          { error: `Un fonds travaux existe déjà pour l'année ${input.fiscal_year}` },
+          { status: 409 }
+        );
+      }
+      throw error;
+    }
+
+    return NextResponse.json(fund, { status: 201 });
+  } catch (error) {
+    console.error("[fonds-travaux:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/mandates/route.ts
+++ b/app/api/copro/mandates/route.ts
@@ -1,0 +1,123 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/mandates
+ * GET  — Liste les mandats du syndic (ou d'un site spécifique)
+ * POST — Crée un nouveau mandat de syndic
+ *
+ * Note: cette route gère les mandats de SYNDIC (syndic_mandates),
+ * distincts des mandats agence (table mandates) et des mandats SEPA.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { CreateSyndicMandateSchema } from "@/lib/validations/syndic";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const siteId = searchParams.get("siteId");
+  const status = searchParams.get("status");
+
+  const auth = await requireSyndic(request, { siteId });
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    let query = auth.serviceClient
+      .from("syndic_mandates")
+      .select("*")
+      .order("start_date", { ascending: false });
+
+    if (siteId) {
+      query = query.eq("site_id", siteId);
+    } else if (!auth.isAdmin) {
+      query = query.eq("syndic_profile_id", auth.profile.id);
+    }
+
+    if (status) {
+      query = query.eq("status", status);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return NextResponse.json(data || []);
+  } catch (error) {
+    console.error("[mandates:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parseResult = CreateSyndicMandateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    const auth = await requireSyndic(request, { siteId: input.site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // Seul un admin peut créer un mandat pour un autre syndic_profile_id
+    if (!auth.isAdmin && input.syndic_profile_id !== auth.profile.id) {
+      return NextResponse.json(
+        { error: "Vous ne pouvez créer un mandat que pour votre propre profil syndic" },
+        { status: 403 }
+      );
+    }
+
+    // Validation durée : la loi impose 1-36 mois
+    const startDate = new Date(input.start_date);
+    const endDate = new Date(input.end_date);
+    if (endDate <= startDate) {
+      return NextResponse.json(
+        { error: "La date de fin doit être postérieure à la date de début" },
+        { status: 400 }
+      );
+    }
+
+    const { data: mandate, error } = await auth.serviceClient
+      .from("syndic_mandates")
+      .insert({
+        site_id: input.site_id,
+        syndic_profile_id: input.syndic_profile_id,
+        mandate_number: input.mandate_number || null,
+        title: input.title,
+        start_date: input.start_date,
+        end_date: input.end_date,
+        duration_months: input.duration_months,
+        tacit_renewal: input.tacit_renewal,
+        notice_period_months: input.notice_period_months,
+        honoraires_annuels_cents: input.honoraires_annuels_cents,
+        honoraires_particuliers: input.honoraires_particuliers || {},
+        currency: input.currency,
+        voted_in_assembly_id: input.voted_in_assembly_id || null,
+        voted_resolution_id: input.voted_resolution_id || null,
+        mandate_document_url: input.mandate_document_url || null,
+        notes: input.notes || null,
+        status: "draft",
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return NextResponse.json(mandate, { status: 201 });
+  } catch (error) {
+    console.error("[mandates:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/minutes/[minuteId]/pdf/route.ts
+++ b/app/api/copro/minutes/[minuteId]/pdf/route.ts
@@ -1,0 +1,185 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/copro/minutes/[minuteId]/pdf
+ *
+ * Retourne le HTML du procès-verbal.
+ * Le client convertit ensuite en PDF via html2pdf.js côté client.
+ *
+ * Query params:
+ *   - format=json — retourne les données brutes au lieu du HTML (debugging)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { generateMinuteHtml, type MinutePdfData } from "@/lib/pdf/syndic-templates";
+
+interface RouteParams {
+  params: { minuteId: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const format = searchParams.get("format") || "html";
+
+    // 1. Charger le PV
+    const supabaseAdminClient = (await import("@/app/api/_lib/supabase")).supabaseAdmin();
+    const { data: minute, error: minuteError } = await supabaseAdminClient
+      .from("copro_minutes")
+      .select("*")
+      .eq("id", params.minuteId)
+      .maybeSingle();
+
+    if (minuteError || !minute) {
+      return NextResponse.json({ error: "PV introuvable" }, { status: 404 });
+    }
+
+    // 2. Auth + vérif accès au site
+    const auth = await requireSyndic(request, { siteId: (minute as any).site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // 3. Charger l'assemblée
+    const { data: assembly, error: assemblyError } = await auth.serviceClient
+      .from("copro_assemblies")
+      .select("*")
+      .eq("id", (minute as any).assembly_id)
+      .single();
+
+    if (assemblyError || !assembly) {
+      return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+    }
+
+    // 4. Charger le site
+    const { data: site } = await auth.serviceClient
+      .from("sites")
+      .select(
+        "name, address_line1, address_line2, postal_code, city, total_tantiemes_general, syndic_company_name, syndic_profile_id"
+      )
+      .eq("id", (minute as any).site_id)
+      .single();
+
+    const siteAny = site as any;
+
+    // 5. Syndic profile
+    let syndicName = "Syndic";
+    if (siteAny?.syndic_profile_id) {
+      const { data: syndicProfile } = await auth.serviceClient
+        .from("profiles")
+        .select("prenom, nom")
+        .eq("id", siteAny.syndic_profile_id)
+        .maybeSingle();
+      if (syndicProfile) {
+        syndicName = `${(syndicProfile as any).prenom || ""} ${(syndicProfile as any).nom || ""}`.trim();
+      }
+    }
+
+    // 6. Charger les résolutions avec votes
+    const { data: resolutions } = await auth.serviceClient
+      .from("copro_resolutions")
+      .select("*")
+      .eq("assembly_id", (assembly as any).id)
+      .order("resolution_number", { ascending: true });
+
+    // 7. Charger les noms président/secrétaire/scrutateurs depuis assembly
+    let presidentName = "Non désigné";
+    let secretaryName = "Non désigné";
+    const scrutineersNames: string[] = [];
+
+    const assemblyAny = assembly as any;
+    if (assemblyAny.presided_by) {
+      const { data: p } = await auth.serviceClient
+        .from("profiles")
+        .select("prenom, nom")
+        .eq("id", assemblyAny.presided_by)
+        .maybeSingle();
+      if (p) presidentName = `${(p as any).prenom || ""} ${(p as any).nom || ""}`.trim() || presidentName;
+    }
+    if (assemblyAny.secretary_profile_id) {
+      const { data: s } = await auth.serviceClient
+        .from("profiles")
+        .select("prenom, nom")
+        .eq("id", assemblyAny.secretary_profile_id)
+        .maybeSingle();
+      if (s) secretaryName = `${(s as any).prenom || ""} ${(s as any).nom || ""}`.trim() || secretaryName;
+    }
+    if (assemblyAny.scrutineers && Array.isArray(assemblyAny.scrutineers)) {
+      const scrutineerIds = assemblyAny.scrutineers
+        .map((s: any) => s?.profile_id)
+        .filter((id: any): id is string => !!id);
+      if (scrutineerIds.length > 0) {
+        const { data: scrProfiles } = await auth.serviceClient
+          .from("profiles")
+          .select("id, prenom, nom")
+          .in("id", scrutineerIds);
+        for (const sp of (scrProfiles || []) as any[]) {
+          scrutineersNames.push(`${sp.prenom || ""} ${sp.nom || ""}`.trim());
+        }
+      }
+    }
+
+    // 8. Construire les données
+    const totalTantiemes = siteAny?.total_tantiemes_general || 10000;
+    const presentTantiemes = assemblyAny.present_tantiemes || 0;
+
+    const pdfData: MinutePdfData = {
+      site_name: siteAny?.name || "Copropriété",
+      site_address: siteAny
+        ? `${siteAny.address_line1}${siteAny.address_line2 ? `, ${siteAny.address_line2}` : ""}, ${siteAny.postal_code} ${siteAny.city}`
+        : "",
+      syndic_name: syndicName,
+      syndic_company: siteAny?.syndic_company_name || undefined,
+      assembly_reference: assemblyAny.reference_number || "",
+      assembly_type: assemblyAny.assembly_type,
+      assembly_title: assemblyAny.title,
+      scheduled_at: assemblyAny.scheduled_at,
+      held_at: assemblyAny.held_at || assemblyAny.scheduled_at,
+      location: assemblyAny.location || "",
+      president_name: presidentName,
+      secretary_name: secretaryName,
+      scrutineers_names: scrutineersNames,
+      total_tantiemes: totalTantiemes,
+      present_tantiemes: presentTantiemes,
+      quorum_required: assemblyAny.quorum_required || 0,
+      quorum_reached: assemblyAny.quorum_reached || false,
+      resolutions: ((resolutions || []) as any[]).map((r) => ({
+        resolution_number: r.resolution_number,
+        title: r.title,
+        description: r.description,
+        category: r.category,
+        majority_rule: r.majority_rule,
+        status: r.status,
+        votes_for_count: r.votes_for_count || 0,
+        votes_against_count: r.votes_against_count || 0,
+        votes_abstain_count: r.votes_abstain_count || 0,
+        tantiemes_for: r.tantiemes_for || 0,
+        tantiemes_against: r.tantiemes_against || 0,
+        tantiemes_abstain: r.tantiemes_abstain || 0,
+      })),
+      version: (minute as any).version || 1,
+      generated_at: new Date().toISOString(),
+      contestation_deadline: (minute as any).contestation_deadline || undefined,
+    };
+
+    if (format === "json") {
+      return NextResponse.json(pdfData);
+    }
+
+    const html = generateMinuteHtml(pdfData);
+
+    return new NextResponse(html, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Disposition": `inline; filename="pv-${assemblyAny.reference_number || (minute as any).id}-v${(minute as any).version}.html"`,
+      },
+    });
+  } catch (error) {
+    console.error("[minute-pdf:GET]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/minutes/[minuteId]/sign/route.ts
+++ b/app/api/copro/minutes/[minuteId]/sign/route.ts
@@ -1,0 +1,103 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/minutes/[minuteId]/sign
+ * POST — Signe un PV (par président, secrétaire ou scrutateur)
+ *
+ * Quand les 2 signatures principales (président + secrétaire) sont posées,
+ * le statut du PV passe automatiquement à 'signed'.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { SignMinuteSchema } from "@/lib/validations/syndic";
+
+interface RouteParams {
+  params: { minuteId: string };
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const body = await request.json();
+    const parseResult = SignMinuteSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    const supabaseAdminClient = (await import("@/app/api/_lib/supabase")).supabaseAdmin();
+    const { data: minute, error: minuteError } = await supabaseAdminClient
+      .from("copro_minutes")
+      .select("*")
+      .eq("id", params.minuteId)
+      .maybeSingle();
+
+    if (minuteError || !minute) {
+      return NextResponse.json({ error: "PV introuvable" }, { status: 404 });
+    }
+
+    const auth = await requireSyndic(request, { siteId: (minute as any).site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // Ne pas re-signer un PV déjà signé/distribué/archivé
+    if (["signed", "distributed", "archived"].includes((minute as any).status)) {
+      return NextResponse.json(
+        { error: `Ce PV est déjà en statut '${(minute as any).status}'` },
+        { status: 409 }
+      );
+    }
+
+    const now = new Date().toISOString();
+    const profileId = input.profile_id || auth.profile.id;
+
+    const updates: Record<string, any> = { updated_at: now };
+
+    if (input.role === "president") {
+      updates.signed_by_president_at = now;
+      updates.signed_by_president_profile_id = profileId;
+    } else if (input.role === "secretary") {
+      updates.signed_by_secretary_at = now;
+      updates.signed_by_secretary_profile_id = profileId;
+    } else if (input.role === "scrutineer") {
+      const existing = ((minute as any).scrutineers_signatures as any[]) || [];
+      existing.push({
+        profile_id: profileId,
+        signed_at: now,
+        signature_url: input.signature_url || null,
+      });
+      updates.scrutineers_signatures = existing;
+    }
+
+    // Check si le PV passe en 'signed' (président + secrétaire signés)
+    const presidentSigned = updates.signed_by_president_at || (minute as any).signed_by_president_at;
+    const secretarySigned = updates.signed_by_secretary_at || (minute as any).signed_by_secretary_at;
+    if (presidentSigned && secretarySigned && (minute as any).status === "draft") {
+      updates.status = "signed";
+    } else if (presidentSigned && secretarySigned && (minute as any).status === "reviewed") {
+      updates.status = "signed";
+    }
+
+    const { data: updated, error: updateError } = await auth.serviceClient
+      .from("copro_minutes")
+      .update(updates)
+      .eq("id", (minute as any).id)
+      .select()
+      .single();
+
+    if (updateError) throw updateError;
+
+    return NextResponse.json({ success: true, minute: updated });
+  } catch (error) {
+    console.error("[minute:sign]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/resolutions/[resolutionId]/vote/route.ts
+++ b/app/api/copro/resolutions/[resolutionId]/vote/route.ts
@@ -1,0 +1,235 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/resolutions/[resolutionId]/vote
+ * POST — Enregistre un vote sur une résolution + met à jour les compteurs
+ *
+ * Logique :
+ * 1. Vérifier que la résolution existe et que l'AG est en cours ou convoquée
+ * 2. Créer le vote (unique par (resolution_id, unit_id))
+ * 3. Recalculer les compteurs sur copro_resolutions (votes_for, tantiemes_for, etc.)
+ * 4. Appliquer les règles de majorité pour déterminer le statut final
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { CastVoteSchema } from "@/lib/validations/syndic";
+
+interface RouteParams {
+  params: { resolutionId: string };
+}
+
+// Détermine le statut d'une résolution selon la règle de majorité
+function computeResolutionStatus(
+  majorityRule: string,
+  tantiemesFor: number,
+  tantiemesAgainst: number,
+  tantiemesAbstain: number,
+  totalTantiemesPresent: number,
+  totalTantiemesSite: number,
+  votesForCount: number,
+  votesAgainstCount: number,
+  totalVotersCount: number
+): "voted_for" | "voted_against" | "abstained" {
+  // Article 24 : majorité simple des présents/représentés
+  if (majorityRule === "article_24") {
+    if (tantiemesFor > tantiemesAgainst) return "voted_for";
+    return "voted_against";
+  }
+
+  // Article 25 : majorité absolue de TOUS les copropriétaires (pas juste présents)
+  if (majorityRule === "article_25" || majorityRule === "article_25_1") {
+    if (tantiemesFor > totalTantiemesSite / 2) return "voted_for";
+    return "voted_against";
+  }
+
+  // Article 26 : double majorité (2/3 copropriétaires + 2/3 tantièmes)
+  if (majorityRule === "article_26" || majorityRule === "article_26_1") {
+    const twoThirdsTantiemes = (totalTantiemesSite * 2) / 3;
+    const twoThirdsCount = (totalVotersCount * 2) / 3;
+    if (tantiemesFor >= twoThirdsTantiemes && votesForCount >= twoThirdsCount) {
+      return "voted_for";
+    }
+    return "voted_against";
+  }
+
+  // Unanimité
+  if (majorityRule === "unanimite") {
+    if (tantiemesAgainst === 0 && tantiemesAbstain === 0 && tantiemesFor === totalTantiemesSite) {
+      return "voted_for";
+    }
+    return "voted_against";
+  }
+
+  return "abstained";
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const body = await request.json();
+    const parseResult = CastVoteSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parseResult.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    // Récupérer la résolution + l'assemblée
+    const supabaseAdminClient = (await import("@/app/api/_lib/supabase")).supabaseAdmin();
+
+    const { data: resolution, error: resolutionError } = await supabaseAdminClient
+      .from("copro_resolutions")
+      .select("id, assembly_id, site_id, majority_rule, status, resolution_number")
+      .eq("id", params.resolutionId)
+      .maybeSingle();
+
+    if (resolutionError || !resolution) {
+      return NextResponse.json({ error: "Résolution introuvable" }, { status: 404 });
+    }
+
+    const { data: assembly } = await supabaseAdminClient
+      .from("copro_assemblies")
+      .select("id, site_id, status")
+      .eq("id", (resolution as any).assembly_id)
+      .single();
+
+    if (!assembly) {
+      return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+    }
+
+    // Vérifier l'accès au site
+    const auth = await requireSyndic(request, { siteId: (assembly as any).site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // AG doit être en cours ou convoquée
+    if (!["convened", "in_progress"].includes((assembly as any).status)) {
+      return NextResponse.json(
+        {
+          error: `Impossible de voter sur une résolution dont l'assemblée est en statut '${(assembly as any).status}'`,
+        },
+        { status: 409 }
+      );
+    }
+
+    // Enregistrer le vote
+    const { data: vote, error: voteError } = await auth.serviceClient
+      .from("copro_votes")
+      .insert({
+        resolution_id: (resolution as any).id,
+        assembly_id: (resolution as any).assembly_id,
+        site_id: (resolution as any).site_id,
+        unit_id: input.unit_id,
+        voter_profile_id: input.voter_profile_id || null,
+        voter_name: input.voter_name,
+        voter_tantiemes: input.voter_tantiemes,
+        vote: input.vote,
+        is_proxy: input.is_proxy,
+        proxy_holder_profile_id: input.proxy_holder_profile_id || null,
+        proxy_holder_name: input.proxy_holder_name || null,
+        proxy_document_url: input.proxy_document_url || null,
+        proxy_scope: input.proxy_scope || null,
+        vote_method: input.vote_method,
+      })
+      .select()
+      .single();
+
+    if (voteError) {
+      if ((voteError as any).code === "23505") {
+        return NextResponse.json(
+          { error: "Ce lot a déjà voté sur cette résolution" },
+          { status: 409 }
+        );
+      }
+      throw voteError;
+    }
+
+    // Recalculer les compteurs
+    const { data: allVotes } = await auth.serviceClient
+      .from("copro_votes")
+      .select("vote, voter_tantiemes")
+      .eq("resolution_id", (resolution as any).id);
+
+    const counters = {
+      votes_for_count: 0,
+      votes_against_count: 0,
+      votes_abstain_count: 0,
+      tantiemes_for: 0,
+      tantiemes_against: 0,
+      tantiemes_abstain: 0,
+    };
+
+    for (const v of (allVotes || []) as any[]) {
+      if (v.vote === "for") {
+        counters.votes_for_count++;
+        counters.tantiemes_for += v.voter_tantiemes || 0;
+      } else if (v.vote === "against") {
+        counters.votes_against_count++;
+        counters.tantiemes_against += v.voter_tantiemes || 0;
+      } else if (v.vote === "abstain") {
+        counters.votes_abstain_count++;
+        counters.tantiemes_abstain += v.voter_tantiemes || 0;
+      }
+    }
+
+    // Récupérer total tantièmes du site pour calculer le statut final
+    const { data: site } = await auth.serviceClient
+      .from("sites")
+      .select("total_tantiemes_general")
+      .eq("id", (resolution as any).site_id)
+      .single();
+
+    const totalTantiemesSite = ((site as any)?.total_tantiemes_general as number) || 10000;
+    const totalPresent = counters.tantiemes_for + counters.tantiemes_against + counters.tantiemes_abstain;
+    const totalVoters = counters.votes_for_count + counters.votes_against_count + counters.votes_abstain_count;
+
+    const newStatus = computeResolutionStatus(
+      (resolution as any).majority_rule,
+      counters.tantiemes_for,
+      counters.tantiemes_against,
+      counters.tantiemes_abstain,
+      totalPresent,
+      totalTantiemesSite,
+      counters.votes_for_count,
+      counters.votes_against_count,
+      totalVoters
+    );
+
+    // Mettre à jour la résolution
+    const { error: updateError } = await auth.serviceClient
+      .from("copro_resolutions")
+      .update({
+        ...counters,
+        status: newStatus,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", (resolution as any).id);
+
+    if (updateError) {
+      console.error("[vote:POST] Update counters error:", updateError);
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        vote,
+        resolution: {
+          id: (resolution as any).id,
+          status: newStatus,
+          counters,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[vote:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/copro/assemblies/[id]/page.tsx
+++ b/app/copro/assemblies/[id]/page.tsx
@@ -1,356 +1,588 @@
 "use client";
-// @ts-nocheck
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   ArrowLeft,
   Calendar,
-  Clock,
   MapPin,
-  Users,
+  Video,
+  Vote,
   FileText,
+  Download,
   CheckCircle2,
   XCircle,
   AlertCircle,
-  Download,
+  Clock,
+  ThumbsUp,
+  ThumbsDown,
+  Minus,
   Loader2,
 } from "lucide-react";
-import { format } from "date-fns";
-import { fr } from "date-fns/locale";
-import { cn } from "@/lib/utils";
+import { useToast } from "@/components/ui/use-toast";
 
 interface Assembly {
   id: string;
-  site_name: string;
-  type: "ordinary" | "extraordinary";
+  site_id: string;
   title: string;
-  date: string;
-  time: string;
-  location: string;
-  description?: string;
-  status: "upcoming" | "in_progress" | "completed" | "cancelled";
-  total_owners: number;
-  present_owners: number;
-  proxy_owners: number;
-  resolutions: Resolution[];
+  reference_number: string | null;
+  assembly_type: string;
+  scheduled_at: string;
+  location: string | null;
+  location_address: string | null;
+  online_meeting_url: string | null;
+  is_hybrid: boolean;
+  status: string;
+  quorum_required: number | null;
+  description: string | null;
 }
 
 interface Resolution {
   id: string;
+  resolution_number: number;
   title: string;
   description: string;
-  majority: string;
-  votes_for: number;
-  votes_against: number;
-  votes_abstain: number;
-  status: "pending" | "approved" | "rejected";
+  category: string;
+  majority_rule: string;
+  status: string;
+  estimated_amount_cents: number | null;
 }
 
-const statusConfig = {
-  upcoming: { label: "À venir", color: "bg-blue-100 text-blue-700" },
-  in_progress: { label: "En cours", color: "bg-amber-100 text-amber-700" },
-  completed: { label: "Terminée", color: "bg-green-100 text-green-700" },
-  cancelled: { label: "Annulée", color: "bg-red-100 text-red-700" },
+interface Unit {
+  id: string;
+  lot_number: string;
+  type: string;
+  tantieme_general: number;
+}
+
+interface MyVote {
+  id: string;
+  resolution_id: string;
+  unit_id: string;
+  vote: "for" | "against" | "abstain";
+  voted_at: string;
+  vote_method: string;
+}
+
+interface Minute {
+  id: string;
+  version: number;
+  status: string;
+  distributed_at: string | null;
+  signed_by_president_at: string | null;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  ordinaire: "Assemblée Générale Ordinaire",
+  extraordinaire: "Assemblée Générale Extraordinaire",
+  concertation: "Concertation",
+  consultation_ecrite: "Consultation écrite",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  gestion: "Gestion",
+  budget: "Budget",
+  travaux: "Travaux",
+  reglement: "Règlement",
+  honoraires: "Honoraires",
+  conseil_syndical: "Conseil syndical",
+  assurance: "Assurance",
+  conflits: "Conflits",
+  autre: "Autre",
+};
+
+const MAJORITY_LABELS: Record<string, string> = {
+  article_24: "Article 24",
+  article_25: "Article 25",
+  article_25_1: "Article 25-1",
+  article_26: "Article 26",
+  article_26_1: "Article 26-1",
+  unanimite: "Unanimité",
 };
 
 export default function CoproAssemblyDetailPage() {
-  const params = useParams();
   const router = useRouter();
-  const assemblyId = params.id as string;
+  const params = useParams();
+  const { toast } = useToast();
+  const assemblyId = params?.id as string;
 
-  const [assembly, setAssembly] = useState<Assembly | null>(null);
   const [loading, setLoading] = useState(true);
+  const [assembly, setAssembly] = useState<Assembly | null>(null);
+  const [resolutions, setResolutions] = useState<Resolution[]>([]);
+  const [myUnits, setMyUnits] = useState<Unit[]>([]);
+  const [myVotes, setMyVotes] = useState<MyVote[]>([]);
+  const [minutes, setMinutes] = useState<Minute[]>([]);
+  const [canVoteOnline, setCanVoteOnline] = useState(false);
+  const [submittingVote, setSubmittingVote] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}/my-vote`);
+      if (!res.ok) {
+        if (res.status === 404) {
+          toast({ title: "Assemblée introuvable", variant: "destructive" });
+          router.push("/copro/assemblies");
+          return;
+        }
+        if (res.status === 403) {
+          toast({
+            title: "Accès refusé",
+            description: "Vous n'êtes pas copropriétaire de ce site",
+            variant: "destructive",
+          });
+          router.push("/copro/assemblies");
+          return;
+        }
+        throw new Error("Erreur de chargement");
+      }
+      const data = await res.json();
+      setAssembly(data.assembly);
+      setResolutions(data.resolutions || []);
+      setMyUnits(data.my_units || []);
+      setMyVotes(data.my_votes || []);
+      setMinutes(data.minutes || []);
+      setCanVoteOnline(data.can_vote_online || false);
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Chargement impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [assemblyId, router, toast]);
 
   useEffect(() => {
-    async function fetchAssembly() {
-      try {
-        // Simulation - en production, appeler l'API
-        const mockAssembly: Assembly = {
-          id: assemblyId,
-          site_name: "Résidence Les Jardins",
-          type: "ordinary",
-          title: "Assemblée Générale Ordinaire 2024",
-          date: "2024-12-15",
-          time: "18:00",
-          location: "Salle des fêtes - 15 rue de la Mairie, 75001 Paris",
-          description: "Ordre du jour : approbation des comptes, budget prévisionnel, travaux.",
-          status: "upcoming",
-          total_owners: 45,
-          present_owners: 0,
-          proxy_owners: 0,
-          resolutions: [
-            {
-              id: "1",
-              title: "Approbation des comptes 2023",
-              description: "Validation des comptes de l'exercice 2023",
-              majority: "simple",
-              votes_for: 0,
-              votes_against: 0,
-              votes_abstain: 0,
-              status: "pending",
-            },
-            {
-              id: "2",
-              title: "Budget prévisionnel 2025",
-              description: "Adoption du budget pour l'année 2025",
-              majority: "simple",
-              votes_for: 0,
-              votes_against: 0,
-              votes_abstain: 0,
-              status: "pending",
-            },
-            {
-              id: "3",
-              title: "Ravalement de façade",
-              description: "Vote des travaux de ravalement",
-              majority: "absolute",
-              votes_for: 0,
-              votes_against: 0,
-              votes_abstain: 0,
-              status: "pending",
-            },
-          ],
-        };
-        setAssembly(mockAssembly);
-      } catch (error) {
-        console.error("Erreur chargement assemblée:", error);
-      } finally {
-        setLoading(false);
+    if (assemblyId) fetchData();
+  }, [assemblyId, fetchData]);
+
+  const handleVote = async (
+    resolutionId: string,
+    unitId: string,
+    vote: "for" | "against" | "abstain"
+  ) => {
+    const voteKey = `${resolutionId}-${unitId}`;
+    setSubmittingVote(voteKey);
+
+    try {
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}/my-vote`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resolution_id: resolutionId, unit_id: unitId, vote }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors du vote");
       }
+
+      toast({
+        title: "Vote enregistré",
+        description: "Votre vote a bien été pris en compte",
+      });
+
+      await fetchData();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Vote impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmittingVote(null);
     }
-    if (assemblyId) fetchAssembly();
-  }, [assemblyId]);
+  };
+
+  const getMyVoteFor = (resolutionId: string, unitId: string): MyVote | undefined => {
+    return myVotes.find((v) => v.resolution_id === resolutionId && v.unit_id === unitId);
+  };
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-indigo-500" />
+      <div className="p-6 max-w-4xl mx-auto space-y-4">
+        <Skeleton className="h-10 w-96" />
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-96 w-full" />
       </div>
     );
   }
 
   if (!assembly) {
     return (
-      <div className="p-6">
-        <Card className="bg-white/80 backdrop-blur-sm">
-          <CardContent className="py-16 text-center">
-            <Calendar className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">Assemblée introuvable</h3>
-            <Button asChild>
-              <Link href="/copro/dashboard">Retour au tableau de bord</Link>
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="p-6 max-w-4xl mx-auto">
+        <p className="text-center py-12 text-muted-foreground">Assemblée introuvable</p>
       </div>
     );
   }
 
-  const status = statusConfig[assembly.status];
-  const quorum = assembly.total_owners > 0
-    ? Math.round(((assembly.present_owners + assembly.proxy_owners) / assembly.total_owners) * 100)
-    : 0;
+  const typeLabel = TYPE_LABELS[assembly.assembly_type] || assembly.assembly_type;
+  const hasMinutes = minutes.length > 0;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      className="p-6"
-    >
-      <div className="max-w-4xl mx-auto">
+    <div className="p-6">
+      <div className="max-w-4xl mx-auto space-y-6">
         {/* Header */}
-        <div className="mb-6">
+        <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }}>
           <Link
-            href="/copro/dashboard"
+            href="/copro/assemblies"
             className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 mb-4 transition-colors"
           >
             <ArrowLeft className="h-4 w-4" />
-            Retour au tableau de bord
+            Retour aux assemblées
           </Link>
-
-          <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
-            <div>
-              <div className="flex items-center gap-3 mb-2">
-                <Badge className={status.color}>{status.label}</Badge>
-                <Badge variant="outline">
-                  {assembly.type === "ordinary" ? "AG Ordinaire" : "AG Extraordinaire"}
-                </Badge>
-              </div>
-              <h1 className="text-2xl font-bold">{assembly.title}</h1>
-              <p className="text-muted-foreground">{assembly.site_name}</p>
-            </div>
-
-            {assembly.status === "completed" && (
-              <Button variant="outline">
-                <Download className="mr-2 h-4 w-4" />
-                Télécharger le PV
-              </Button>
-            )}
+          <div className="flex items-center gap-3 mb-2 flex-wrap">
+            <h1 className="text-2xl font-bold">{assembly.title}</h1>
+            <StatusBadge status={assembly.status} />
           </div>
-        </div>
+          <p className="text-muted-foreground">
+            {typeLabel}
+            {assembly.reference_number && ` · ${assembly.reference_number}`}
+          </p>
+        </motion.div>
 
-        <div className="grid gap-6 md:grid-cols-3">
-          {/* Informations */}
-          <Card className="bg-white/80 backdrop-blur-sm md:col-span-2">
-            <CardHeader>
-              <CardTitle>Informations</CardTitle>
+        {/* Info card */}
+        <Card>
+          <CardContent className="p-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <InfoItem
+              icon={Calendar}
+              label="Date prévue"
+              value={new Date(assembly.scheduled_at).toLocaleString("fr-FR", {
+                day: "numeric",
+                month: "long",
+                year: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            />
+            {assembly.location && <InfoItem icon={MapPin} label="Lieu" value={assembly.location} />}
+            {assembly.location_address && (
+              <InfoItem icon={MapPin} label="Adresse" value={assembly.location_address} />
+            )}
+            {assembly.online_meeting_url && (
+              <InfoItem icon={Video} label="Visio" value={assembly.online_meeting_url} />
+            )}
+            {assembly.quorum_required && (
+              <InfoItem
+                icon={Vote}
+                label="Quorum requis"
+                value={`${assembly.quorum_required.toLocaleString("fr-FR")} tantièmes`}
+              />
+            )}
+          </CardContent>
+          {assembly.description && (
+            <div className="px-6 pb-6">
+              <p className="text-sm text-muted-foreground">{assembly.description}</p>
+            </div>
+          )}
+        </Card>
+
+        {/* My units */}
+        {myUnits.length > 0 && (
+          <Card className="border-violet-200 dark:border-violet-800 bg-violet-50/50 dark:bg-violet-950/20">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Vos lots dans cette copropriété</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="flex items-center gap-3">
-                  <div className="h-10 w-10 rounded-lg bg-indigo-100 flex items-center justify-center">
-                    <Calendar className="h-5 w-5 text-indigo-600" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Date</p>
-                    <p className="font-medium">
-                      {format(new Date(assembly.date), "EEEE d MMMM yyyy", { locale: fr })}
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                {myUnits.map((unit) => (
+                  <Badge key={unit.id} variant="outline" className="border-violet-300 bg-white dark:bg-slate-900">
+                    Lot {unit.lot_number} — {unit.tantieme_general} tant.
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Resolutions */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Vote className="h-5 w-5 text-violet-600" />
+              Ordre du jour ({resolutions.length})
+            </CardTitle>
+            <CardDescription>
+              {canVoteOnline && myUnits.length > 0
+                ? "Vous pouvez voter en ligne avant la séance"
+                : canVoteOnline
+                ? "Vous n'avez pas de lot dans cette copropriété — consultation uniquement"
+                : "Consultation des résolutions"}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {resolutions.length === 0 ? (
+              <p className="text-muted-foreground text-center py-8">Aucune résolution</p>
+            ) : (
+              resolutions.map((resolution) => (
+                <ResolutionCard
+                  key={resolution.id}
+                  resolution={resolution}
+                  myUnits={myUnits}
+                  getMyVote={(unitId) => getMyVoteFor(resolution.id, unitId)}
+                  canVote={canVoteOnline && myUnits.length > 0}
+                  onVote={(unitId, vote) => handleVote(resolution.id, unitId, vote)}
+                  submittingVote={submittingVote}
+                />
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Download convocation */}
+        {assembly.status !== "draft" && myUnits.length > 0 && (
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3 min-w-0">
+                  <FileText className="h-8 w-8 text-blue-600 flex-shrink-0" />
+                  <div className="min-w-0">
+                    <p className="font-medium">Votre convocation</p>
+                    <p className="text-sm text-muted-foreground">
+                      Téléchargez la convocation officielle
                     </p>
                   </div>
                 </div>
-
-                <div className="flex items-center gap-3">
-                  <div className="h-10 w-10 rounded-lg bg-indigo-100 flex items-center justify-center">
-                    <Clock className="h-5 w-5 text-indigo-600" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Heure</p>
-                    <p className="font-medium">{assembly.time}</p>
-                  </div>
-                </div>
+                <a
+                  href={`/api/copro/assemblies/${assemblyId}/convocation-pdf?unit_id=${myUnits[0].id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Button variant="outline" className="flex-shrink-0">
+                    <Download className="h-4 w-4 mr-2" />
+                    Télécharger
+                  </Button>
+                </a>
               </div>
-
-              <div className="flex items-start gap-3">
-                <div className="h-10 w-10 rounded-lg bg-indigo-100 flex items-center justify-center shrink-0">
-                  <MapPin className="h-5 w-5 text-indigo-600" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Lieu</p>
-                  <p className="font-medium">{assembly.location}</p>
-                </div>
-              </div>
-
-              {assembly.description && (
-                <div className="pt-4 border-t">
-                  <p className="text-sm text-muted-foreground mb-1">Description</p>
-                  <p>{assembly.description}</p>
-                </div>
-              )}
             </CardContent>
           </Card>
+        )}
 
-          {/* Participation */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+        {/* Minutes (published only) */}
+        {hasMinutes && (
+          <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <Users className="h-5 w-5 text-indigo-500" />
-                Participation
+                <FileText className="h-5 w-5 text-emerald-600" />
+                Procès-verbaux
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="text-center">
-                <p className="text-4xl font-bold text-indigo-600">{quorum}%</p>
-                <p className="text-sm text-muted-foreground">Quorum</p>
-              </div>
-              <Progress value={quorum} className="h-2" />
-
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Présents</span>
-                  <span className="font-medium">{assembly.present_owners}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Représentés</span>
-                  <span className="font-medium">{assembly.proxy_owners}</span>
-                </div>
-                <div className="flex justify-between border-t pt-2">
-                  <span className="text-muted-foreground">Total copropriétaires</span>
-                  <span className="font-medium">{assembly.total_owners}</span>
-                </div>
+            <CardContent>
+              <div className="space-y-2">
+                {minutes.map((minute) => (
+                  <div
+                    key={minute.id}
+                    className="flex items-center justify-between rounded-lg border p-3"
+                  >
+                    <div>
+                      <p className="font-medium">Version {minute.version}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {minute.distributed_at
+                          ? `Distribué le ${new Date(minute.distributed_at).toLocaleDateString("fr-FR")}`
+                          : minute.signed_by_president_at
+                          ? `Signé le ${new Date(minute.signed_by_president_at).toLocaleDateString("fr-FR")}`
+                          : ""}
+                      </p>
+                    </div>
+                    <a
+                      href={`/api/copro/minutes/${minute.id}/pdf`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <Button variant="outline" size="sm">
+                        <Download className="h-4 w-4 mr-2" />
+                        PDF
+                      </Button>
+                    </a>
+                  </div>
+                ))}
               </div>
             </CardContent>
           </Card>
-        </div>
-
-        {/* Résolutions */}
-        <Card className="bg-white/80 backdrop-blur-sm mt-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <FileText className="h-5 w-5 text-indigo-500" />
-              Ordre du jour ({assembly.resolutions.length} résolutions)
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {assembly.resolutions.map((resolution, index) => {
-                const totalVotes =
-                  resolution.votes_for + resolution.votes_against + resolution.votes_abstain;
-                const forPercent =
-                  totalVotes > 0 ? Math.round((resolution.votes_for / totalVotes) * 100) : 0;
-
-                return (
-                  <div
-                    key={resolution.id}
-                    className="p-4 rounded-lg border border-slate-200 space-y-3"
-                  >
-                    <div className="flex items-start justify-between">
-                      <div>
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="text-sm font-medium text-muted-foreground">
-                            Résolution {index + 1}
-                          </span>
-                          {resolution.status === "approved" && (
-                            <Badge className="bg-green-100 text-green-700">
-                              <CheckCircle2 className="h-3 w-3 mr-1" />
-                              Adoptée
-                            </Badge>
-                          )}
-                          {resolution.status === "rejected" && (
-                            <Badge className="bg-red-100 text-red-700">
-                              <XCircle className="h-3 w-3 mr-1" />
-                              Rejetée
-                            </Badge>
-                          )}
-                          {resolution.status === "pending" && (
-                            <Badge className="bg-slate-100 text-slate-700">
-                              <AlertCircle className="h-3 w-3 mr-1" />
-                              En attente
-                            </Badge>
-                          )}
-                        </div>
-                        <h4 className="font-medium">{resolution.title}</h4>
-                        {resolution.description && (
-                          <p className="text-sm text-muted-foreground mt-1">
-                            {resolution.description}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-
-                    {totalVotes > 0 && (
-                      <div className="space-y-2">
-                        <Progress value={forPercent} className="h-2" />
-                        <div className="flex justify-between text-xs text-muted-foreground">
-                          <span>Pour: {resolution.votes_for}</span>
-                          <span>Contre: {resolution.votes_against}</span>
-                          <span>Abstention: {resolution.votes_abstain}</span>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
+        )}
       </div>
-    </motion.div>
+    </div>
   );
 }
 
+function InfoItem({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <Icon className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+      <div className="min-w-0">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+        <p className="text-sm truncate">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const config: Record<
+    string,
+    { label: string; icon: React.ComponentType<{ className?: string }>; className: string }
+  > = {
+    draft: { label: "Brouillon", icon: Clock, className: "bg-slate-100 text-slate-700" },
+    convened: { label: "Convoquée", icon: Calendar, className: "bg-blue-100 text-blue-700" },
+    in_progress: { label: "En cours", icon: AlertCircle, className: "bg-amber-100 text-amber-700" },
+    held: { label: "Tenue", icon: CheckCircle2, className: "bg-emerald-100 text-emerald-700" },
+    cancelled: { label: "Annulée", icon: XCircle, className: "bg-red-100 text-red-700" },
+  };
+  const c = config[status] || config.draft;
+  const Icon = c.icon;
+  return (
+    <Badge className={c.className}>
+      <Icon className="h-3 w-3 mr-1" />
+      {c.label}
+    </Badge>
+  );
+}
+
+function ResolutionCard({
+  resolution,
+  myUnits,
+  getMyVote,
+  canVote,
+  onVote,
+  submittingVote,
+}: {
+  resolution: Resolution;
+  myUnits: Unit[];
+  getMyVote: (unitId: string) => MyVote | undefined;
+  canVote: boolean;
+  onVote: (unitId: string, vote: "for" | "against" | "abstain") => void;
+  submittingVote: string | null;
+}) {
+  return (
+    <div className="rounded-xl border p-4 space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <span className="font-mono text-xs text-muted-foreground">#{resolution.resolution_number}</span>
+            <Badge variant="outline" className="text-xs">
+              {CATEGORY_LABELS[resolution.category] || resolution.category}
+            </Badge>
+            <Badge variant="outline" className="text-xs border-violet-300">
+              {MAJORITY_LABELS[resolution.majority_rule] || resolution.majority_rule}
+            </Badge>
+          </div>
+          <h4 className="font-medium">{resolution.title}</h4>
+          <p className="text-sm text-muted-foreground mt-1">{resolution.description}</p>
+          {resolution.estimated_amount_cents && (
+            <p className="text-xs text-amber-600 mt-1">
+              Montant estimé : {(resolution.estimated_amount_cents / 100).toLocaleString("fr-FR")} €
+            </p>
+          )}
+        </div>
+      </div>
+
+      {canVote && resolution.status === "proposed" && (
+        <div className="space-y-2 pt-2 border-t">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Votre vote</p>
+          {myUnits.map((unit) => {
+            const existingVote = getMyVote(unit.id);
+            const voteKey = `${resolution.id}-${unit.id}`;
+            const isSubmitting = submittingVote === voteKey;
+
+            if (existingVote) {
+              const voteLabel = { for: "Pour", against: "Contre", abstain: "Abstention" }[
+                existingVote.vote
+              ];
+              const voteColor = {
+                for: "text-emerald-600",
+                against: "text-red-600",
+                abstain: "text-amber-600",
+              }[existingVote.vote];
+              return (
+                <div
+                  key={unit.id}
+                  className="flex items-center justify-between rounded-lg bg-muted/50 p-2 text-sm"
+                >
+                  <span>Lot {unit.lot_number}</span>
+                  <span className={`font-semibold ${voteColor}`}>
+                    <CheckCircle2 className="h-3 w-3 inline mr-1" />
+                    {voteLabel} (enregistré)
+                  </span>
+                </div>
+              );
+            }
+
+            return (
+              <div
+                key={unit.id}
+                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-lg border p-2"
+              >
+                <span className="text-sm">Lot {unit.lot_number}</span>
+                <div className="flex gap-1">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onVote(unit.id, "for")}
+                    disabled={isSubmitting}
+                    className="border-emerald-200 hover:bg-emerald-50 text-emerald-700 dark:text-emerald-400"
+                  >
+                    {isSubmitting ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <>
+                        <ThumbsUp className="h-3 w-3 mr-1" />
+                        Pour
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onVote(unit.id, "against")}
+                    disabled={isSubmitting}
+                    className="border-red-200 hover:bg-red-50 text-red-700 dark:text-red-400"
+                  >
+                    <ThumbsDown className="h-3 w-3 mr-1" />
+                    Contre
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onVote(unit.id, "abstain")}
+                    disabled={isSubmitting}
+                    className="border-amber-200 hover:bg-amber-50 text-amber-700 dark:text-amber-400"
+                  >
+                    <Minus className="h-3 w-3 mr-1" />
+                    Abs.
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!canVote && resolution.status !== "proposed" && (
+        <p className="text-xs text-muted-foreground pt-2 border-t">
+          Vote terminé — statut :{" "}
+          <span className="font-semibold">
+            {resolution.status === "voted_for"
+              ? "ADOPTÉE"
+              : resolution.status === "voted_against"
+              ? "REJETÉE"
+              : resolution.status}
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/copro/assemblies/page.tsx
+++ b/app/copro/assemblies/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { motion } from "framer-motion";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -14,50 +14,86 @@ import {
   Clock,
   AlertCircle,
   XCircle,
+  Vote,
+  Radio,
 } from "lucide-react";
-import Link from "next/link";
+import { useToast } from "@/components/ui/use-toast";
 
-interface AssemblySummary {
+interface Assembly {
   id: string;
-  label: string;
-  site_name: string;
+  site_id: string;
+  title: string;
+  reference_number: string | null;
+  assembly_type: "ordinaire" | "extraordinaire" | "concertation" | "consultation_ecrite";
   scheduled_at: string;
-  type: "ordinary" | "extraordinary";
-  status: "upcoming" | "in_progress" | "completed" | "cancelled";
-  motions_count: number;
+  location: string | null;
+  status: "draft" | "convened" | "in_progress" | "held" | "adjourned" | "cancelled";
 }
 
-const statusConfig: Record<string, { label: string; icon: typeof Clock; className: string }> = {
-  upcoming: { label: "À venir", icon: Clock, className: "bg-blue-100 text-blue-700" },
-  in_progress: { label: "En cours", icon: AlertCircle, className: "bg-amber-100 text-amber-700" },
-  completed: { label: "Terminée", icon: CheckCircle2, className: "bg-green-100 text-green-700" },
-  cancelled: { label: "Annulée", icon: XCircle, className: "bg-red-100 text-red-700" },
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; icon: React.ComponentType<{ className?: string }>; className: string }
+> = {
+  draft: { label: "Brouillon", icon: Clock, className: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300" },
+  convened: { label: "Convoquée", icon: Calendar, className: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" },
+  in_progress: {
+    label: "En cours",
+    icon: Radio,
+    className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+  },
+  held: {
+    label: "Terminée",
+    icon: CheckCircle2,
+    className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+  },
+  adjourned: { label: "Ajournée", icon: AlertCircle, className: "bg-amber-100 text-amber-700" },
+  cancelled: { label: "Annulée", icon: XCircle, className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" },
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  ordinaire: "AG Ordinaire",
+  extraordinaire: "AG Extraordinaire",
+  concertation: "Concertation",
+  consultation_ecrite: "Consultation écrite",
 };
 
 export default function CoproAssembliesPage() {
-  const [assemblies, setAssemblies] = useState<AssemblySummary[]>([]);
+  const { toast } = useToast();
+  const [assemblies, setAssemblies] = useState<Assembly[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function fetchAssemblies() {
       try {
         const res = await fetch("/api/copro/assemblies");
-        if (res.ok) {
-          setAssemblies(await res.json());
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || "Erreur de chargement");
         }
+        const data = await res.json();
+        setAssemblies(Array.isArray(data) ? data : []);
       } catch (error) {
-        console.error("Erreur chargement assemblées:", error);
+        toast({
+          title: "Erreur",
+          description: error instanceof Error ? error.message : "Impossible de charger",
+          variant: "destructive",
+        });
       } finally {
         setLoading(false);
       }
     }
 
     fetchAssemblies();
-  }, []);
+  }, [toast]);
+
+  const upcoming = assemblies.filter(
+    (a) => ["convened", "in_progress"].includes(a.status) && new Date(a.scheduled_at) >= new Date()
+  );
+  const past = assemblies.filter((a) => ["held", "adjourned", "cancelled"].includes(a.status));
 
   if (loading) {
     return (
-      <div className="p-6 space-y-4">
+      <div className="p-6 max-w-4xl mx-auto space-y-4">
         <Skeleton className="h-10 w-64" />
         {[1, 2, 3].map((i) => (
           <Skeleton key={i} className="h-24 w-full" />
@@ -69,7 +105,6 @@ export default function CoproAssembliesPage() {
   return (
     <div className="p-6">
       <div className="max-w-4xl mx-auto space-y-6">
-        {/* Header */}
         <div>
           <Link
             href="/copro/dashboard"
@@ -78,73 +113,102 @@ export default function CoproAssembliesPage() {
             <ArrowLeft className="h-4 w-4" />
             Retour au tableau de bord
           </Link>
-          <h1 className="text-2xl font-bold">Assemblées Générales</h1>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Vote className="h-6 w-6 text-violet-600" />
+            Assemblées Générales
+          </h1>
           <p className="text-muted-foreground">
-            Consultez les assemblées générales de votre copropriété
+            Consultez les assemblées de votre copropriété et votez en ligne avant la séance
           </p>
         </div>
 
-        {/* List */}
         {assemblies.length === 0 ? (
           <Card>
             <CardContent className="py-16 text-center">
               <Calendar className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
               <h3 className="text-lg font-semibold mb-2">Aucune assemblée générale</h3>
               <p className="text-muted-foreground">
-                Aucune assemblée générale n&apos;est programmée pour le moment.
+                Aucune assemblée n'est programmée pour le moment.
               </p>
             </CardContent>
           </Card>
         ) : (
-          <div className="space-y-3">
-            {assemblies.map((assembly, index) => {
-              const status = statusConfig[assembly.status] || statusConfig.upcoming;
-              const StatusIcon = status.icon;
-              return (
-                <motion.div
-                  key={assembly.id}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                >
-                  <Link href={`/copro/assemblies/${assembly.id}`}>
-                    <Card className="hover:shadow-md transition-shadow cursor-pointer">
-                      <CardContent className="p-4 flex items-center justify-between">
-                        <div className="flex items-center gap-4">
-                          <div className="p-3 rounded-lg bg-indigo-100">
-                            <Calendar className="h-5 w-5 text-indigo-600" />
-                          </div>
-                          <div>
-                            <h3 className="font-semibold">{assembly.label}</h3>
-                            <p className="text-sm text-muted-foreground">
-                              {assembly.site_name} &middot;{" "}
-                              {new Date(assembly.scheduled_at).toLocaleDateString("fr-FR", {
-                                day: "numeric",
-                                month: "long",
-                                year: "numeric",
-                              })}
-                            </p>
-                            <div className="flex items-center gap-2 mt-1">
-                              <Badge className={status.className}>
-                                <StatusIcon className="h-3 w-3 mr-1" />
-                                {status.label}
-                              </Badge>
-                              <span className="text-xs text-muted-foreground">
-                                {assembly.motions_count} résolution(s)
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                        <ChevronRight className="h-5 w-5 text-muted-foreground" />
-                      </CardContent>
-                    </Card>
-                  </Link>
-                </motion.div>
-              );
-            })}
-          </div>
+          <>
+            {upcoming.length > 0 && (
+              <section className="space-y-3">
+                <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <Calendar className="h-5 w-5 text-blue-600" />
+                  À venir ({upcoming.length})
+                </h2>
+                <div className="space-y-3">
+                  {upcoming.map((a, i) => (
+                    <AssemblyCard key={a.id} assembly={a} delay={i * 0.05} />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {past.length > 0 && (
+              <section className="space-y-3">
+                <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <CheckCircle2 className="h-5 w-5 text-emerald-600" />
+                  Passées ({past.length})
+                </h2>
+                <div className="space-y-3">
+                  {past.map((a, i) => (
+                    <AssemblyCard key={a.id} assembly={a} delay={i * 0.05} />
+                  ))}
+                </div>
+              </section>
+            )}
+          </>
         )}
       </div>
     </div>
+  );
+}
+
+function AssemblyCard({ assembly, delay }: { assembly: Assembly; delay: number }) {
+  const status = STATUS_CONFIG[assembly.status] || STATUS_CONFIG.draft;
+  const StatusIcon = status.icon;
+  const typeLabel = TYPE_LABELS[assembly.assembly_type] || assembly.assembly_type;
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay }}>
+      <Link href={`/copro/assemblies/${assembly.id}`}>
+        <Card className="hover:shadow-md transition-shadow cursor-pointer">
+          <CardContent className="p-4 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-4 min-w-0">
+              <div className="p-3 rounded-lg bg-violet-100 dark:bg-violet-900/30 flex-shrink-0">
+                <Calendar className="h-5 w-5 text-violet-600 dark:text-violet-400" />
+              </div>
+              <div className="min-w-0">
+                <h3 className="font-semibold truncate">{assembly.title}</h3>
+                <p className="text-sm text-muted-foreground">
+                  {typeLabel}
+                  {assembly.reference_number && ` · ${assembly.reference_number}`}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {new Date(assembly.scheduled_at).toLocaleDateString("fr-FR", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </p>
+                <div className="mt-1">
+                  <Badge className={status.className}>
+                    <StatusIcon className="h-3 w-3 mr-1" />
+                    {status.label}
+                  </Badge>
+                </div>
+              </div>
+            </div>
+            <ChevronRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+          </CardContent>
+        </Card>
+      </Link>
+    </motion.div>
   );
 }

--- a/app/syndic/assemblies/[id]/_components/AddResolutionDialog.tsx
+++ b/app/syndic/assemblies/[id]/_components/AddResolutionDialog.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useState, useRef } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { Loader2, Plus } from "lucide-react";
+
+interface AddResolutionDialogProps {
+  assemblyId: string;
+  nextResolutionNumber: number;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+const CATEGORIES = [
+  { value: "gestion", label: "Gestion courante" },
+  { value: "budget", label: "Budget prévisionnel" },
+  { value: "travaux", label: "Travaux" },
+  { value: "reglement", label: "Modification du règlement" },
+  { value: "honoraires", label: "Honoraires syndic" },
+  { value: "conseil_syndical", label: "Conseil syndical" },
+  { value: "assurance", label: "Assurance" },
+  { value: "conflits", label: "Actions en justice" },
+  { value: "autre", label: "Autre" },
+];
+
+const MAJORITY_RULES = [
+  {
+    value: "article_24",
+    label: "Article 24 — Majorité simple",
+    description: "Majorité des voix des copropriétaires présents ou représentés",
+  },
+  {
+    value: "article_25",
+    label: "Article 25 — Majorité absolue",
+    description: "Majorité absolue des voix de tous les copropriétaires",
+  },
+  {
+    value: "article_25_1",
+    label: "Article 25-1 — Article 25 avec passerelle",
+    description: "Article 25 avec second vote article 24 possible",
+  },
+  {
+    value: "article_26",
+    label: "Article 26 — Double majorité",
+    description: "2/3 des copropriétaires représentant 2/3 des tantièmes",
+  },
+  {
+    value: "article_26_1",
+    label: "Article 26-1 — Article 26 avec passerelle",
+    description: "Article 26 avec passerelle article 25",
+  },
+  {
+    value: "unanimite",
+    label: "Unanimité",
+    description: "Accord de tous les copropriétaires",
+  },
+];
+
+export function AddResolutionDialog({
+  assemblyId,
+  nextResolutionNumber,
+  onClose,
+  onCreated,
+}: AddResolutionDialogProps) {
+  const { toast } = useToast();
+  const isSubmittingRef = useRef(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [form, setForm] = useState({
+    resolution_number: nextResolutionNumber,
+    title: "",
+    description: "",
+    category: "gestion",
+    majority_rule: "article_24",
+    estimated_amount: "",
+    contract_partner: "",
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmittingRef.current) return;
+
+    if (!form.title || form.title.length < 3) {
+      toast({ title: "Titre trop court", description: "Min 3 caractères", variant: "destructive" });
+      return;
+    }
+    if (!form.description || form.description.length < 3) {
+      toast({ title: "Description requise", variant: "destructive" });
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    setSubmitting(true);
+
+    try {
+      const payload: Record<string, any> = {
+        resolution_number: form.resolution_number,
+        title: form.title.trim(),
+        description: form.description.trim(),
+        category: form.category,
+        majority_rule: form.majority_rule,
+      };
+
+      if (form.estimated_amount) {
+        const amount = parseFloat(form.estimated_amount);
+        if (!isNaN(amount) && amount >= 0) {
+          payload.estimated_amount_cents = Math.round(amount * 100);
+        }
+      }
+      if (form.contract_partner.trim()) {
+        payload.contract_partner = form.contract_partner.trim();
+      }
+
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}/resolutions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la création");
+      }
+
+      toast({
+        title: "Résolution ajoutée",
+        description: `Résolution #${form.resolution_number} créée`,
+      });
+
+      onCreated();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de créer la résolution",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+      isSubmittingRef.current = false;
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-2xl bg-slate-900 border-white/10 text-white">
+        <DialogHeader>
+          <DialogTitle className="text-xl flex items-center gap-2">
+            <Plus className="h-5 w-5 text-violet-400" />
+            Ajouter une résolution
+          </DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Créez une résolution à soumettre au vote de l'assemblée
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-[100px_1fr] gap-4">
+            <div className="space-y-2">
+              <Label className="text-slate-300">N° ordre</Label>
+              <Input
+                type="number"
+                min="1"
+                value={form.resolution_number}
+                onChange={(e) => setForm({ ...form, resolution_number: parseInt(e.target.value, 10) || 1 })}
+                required
+                disabled={submitting}
+                className="bg-white/5 border-white/10 text-white"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-slate-300">Titre *</Label>
+              <Input
+                placeholder="Ex: Approbation des comptes 2025"
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                required
+                disabled={submitting}
+                className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-slate-300">Description *</Label>
+            <Textarea
+              placeholder="Description détaillée de la résolution, contexte, enjeux..."
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={4}
+              required
+              disabled={submitting}
+              className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label className="text-slate-300">Catégorie</Label>
+              <Select
+                value={form.category}
+                onValueChange={(value) => setForm({ ...form, category: value })}
+                disabled={submitting}
+              >
+                <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CATEGORIES.map((cat) => (
+                    <SelectItem key={cat.value} value={cat.value}>
+                      {cat.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-slate-300">Règle de majorité *</Label>
+              <Select
+                value={form.majority_rule}
+                onValueChange={(value) => setForm({ ...form, majority_rule: value })}
+                disabled={submitting}
+              >
+                <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MAJORITY_RULES.map((rule) => (
+                    <SelectItem key={rule.value} value={rule.value}>
+                      <div>
+                        <div className="font-medium">{rule.label}</div>
+                        <div className="text-xs text-slate-500">{rule.description}</div>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label className="text-slate-300">Montant estimé (€)</Label>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="Optionnel (pour travaux, devis)"
+                value={form.estimated_amount}
+                onChange={(e) => setForm({ ...form, estimated_amount: e.target.value })}
+                disabled={submitting}
+                className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-slate-300">Entreprise / Prestataire</Label>
+              <Input
+                placeholder="Optionnel (nom de l'entreprise)"
+                value={form.contract_partner}
+                onChange={(e) => setForm({ ...form, contract_partner: e.target.value })}
+                disabled={submitting}
+                className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+              className="border-white/20 text-white hover:bg-white/10"
+            >
+              Annuler
+            </Button>
+            <Button
+              type="submit"
+              disabled={submitting}
+              className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Création...
+                </>
+              ) : (
+                <>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Ajouter la résolution
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/syndic/assemblies/[id]/_components/DownloadPdfButton.tsx
+++ b/app/syndic/assemblies/[id]/_components/DownloadPdfButton.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { Download, FileText, Loader2 } from "lucide-react";
+
+interface DownloadPdfButtonProps {
+  variant: "convocation" | "minute";
+  assemblyId?: string;
+  minuteId?: string;
+  unitId?: string;
+  label?: string;
+  filename?: string;
+  className?: string;
+}
+
+/**
+ * Bouton de téléchargement PDF pour convocations et PV.
+ *
+ * Workflow:
+ * 1. Fetch du HTML depuis l'API
+ * 2. Conversion HTML → PDF via html2pdf.js (dynamique)
+ * 3. Download du fichier PDF
+ *
+ * Graceful degradation : si html2pdf échoue, ouvre le HTML dans un nouvel onglet
+ * (l'utilisateur peut alors imprimer en PDF via le navigateur).
+ */
+export function DownloadPdfButton({
+  variant,
+  assemblyId,
+  minuteId,
+  unitId,
+  label,
+  filename,
+  className,
+}: DownloadPdfButtonProps) {
+  const { toast } = useToast();
+  const [downloading, setDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    if (downloading) return;
+    setDownloading(true);
+
+    try {
+      // 1. Construire l'URL
+      let url: string;
+      if (variant === "convocation") {
+        if (!assemblyId) throw new Error("assemblyId manquant");
+        url = `/api/copro/assemblies/${assemblyId}/convocation-pdf`;
+        if (unitId) url += `?unit_id=${unitId}`;
+      } else {
+        if (!minuteId) throw new Error("minuteId manquant");
+        url = `/api/copro/minutes/${minuteId}/pdf`;
+      }
+
+      // 2. Fetch le HTML
+      const res = await fetch(url);
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur de génération");
+      }
+      const html = await res.text();
+
+      // 3. Charger html2pdf dynamiquement (bundle client only)
+      const html2pdfModule = await import("html2pdf.js");
+      const html2pdf = (html2pdfModule as any).default || html2pdfModule;
+
+      // 4. Créer un élément temporaire
+      const element = document.createElement("div");
+      element.innerHTML = html;
+      element.style.width = "210mm"; // A4
+
+      // 5. Générer le PDF
+      const defaultFilename =
+        variant === "convocation" ? "convocation.pdf" : "proces-verbal.pdf";
+      const outputFilename = filename || defaultFilename;
+
+      await html2pdf()
+        .set({
+          margin: [10, 10, 10, 10],
+          filename: outputFilename,
+          image: { type: "jpeg", quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true },
+          jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+        })
+        .from(element)
+        .save();
+
+      toast({
+        title: "Téléchargement démarré",
+        description: outputFilename,
+      });
+    } catch (error) {
+      console.error("[DownloadPdfButton]", error);
+      // Fallback : ouvrir le HTML dans un nouvel onglet
+      try {
+        let fallbackUrl: string;
+        if (variant === "convocation" && assemblyId) {
+          fallbackUrl = `/api/copro/assemblies/${assemblyId}/convocation-pdf${unitId ? `?unit_id=${unitId}` : ""}`;
+        } else if (variant === "minute" && minuteId) {
+          fallbackUrl = `/api/copro/minutes/${minuteId}/pdf`;
+        } else {
+          throw new Error("Paramètres invalides");
+        }
+        window.open(fallbackUrl, "_blank");
+        toast({
+          title: "Aperçu HTML ouvert",
+          description: "Utilisez Ctrl+P pour imprimer en PDF",
+        });
+      } catch {
+        toast({
+          title: "Erreur",
+          description: error instanceof Error ? error.message : "Impossible de télécharger",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const Icon = variant === "convocation" ? FileText : Download;
+  const defaultLabel = variant === "convocation" ? "Convocation PDF" : "Télécharger PDF";
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={handleDownload}
+      disabled={downloading}
+      className={className || "border-white/20 text-white hover:bg-white/10"}
+    >
+      {downloading ? (
+        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+      ) : (
+        <Icon className="h-4 w-4 mr-2" />
+      )}
+      {label || defaultLabel}
+    </Button>
+  );
+}

--- a/app/syndic/assemblies/[id]/_components/SendConvocationsDialog.tsx
+++ b/app/syndic/assemblies/[id]/_components/SendConvocationsDialog.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState, useRef } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { Loader2, Send, AlertCircle } from "lucide-react";
+
+interface SendConvocationsDialogProps {
+  assemblyId: string;
+  onClose: () => void;
+  onSent: () => void;
+}
+
+const DELIVERY_METHODS = [
+  {
+    value: "email",
+    label: "Email",
+    description: "Envoi électronique simple (rapide, gratuit, pas de preuve légale forte)",
+  },
+  {
+    value: "lre_numerique",
+    label: "LRE numérique",
+    description: "Lettre recommandée électronique (recommandée, valeur légale)",
+  },
+  {
+    value: "postal_recommande",
+    label: "LRAR postal",
+    description: "Lettre recommandée avec accusé de réception (traditionnelle)",
+  },
+  {
+    value: "postal_simple",
+    label: "Courrier simple",
+    description: "Courrier postal ordinaire",
+  },
+  {
+    value: "hand_delivered",
+    label: "Remise en main propre",
+    description: "Remise en main propre contre émargement",
+  },
+];
+
+export function SendConvocationsDialog({
+  assemblyId,
+  onClose,
+  onSent,
+}: SendConvocationsDialogProps) {
+  const { toast } = useToast();
+  const isSubmittingRef = useRef(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [form, setForm] = useState({
+    delivery_method: "lre_numerique",
+    convocation_document_url: "",
+    ordre_du_jour_document_url: "",
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmittingRef.current) return;
+
+    if (
+      !confirm(
+        "Confirmez l'envoi des convocations ? Une fois envoyées, l'assemblée passera en statut 'Convoquée'."
+      )
+    ) {
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    setSubmitting(true);
+
+    try {
+      const payload: Record<string, any> = {
+        delivery_method: form.delivery_method,
+      };
+
+      if (form.convocation_document_url.trim()) {
+        payload.convocation_document_url = form.convocation_document_url.trim();
+      }
+      if (form.ordre_du_jour_document_url.trim()) {
+        payload.ordre_du_jour_document_url = form.ordre_du_jour_document_url.trim();
+      }
+
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}/convocations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de l'envoi");
+      }
+
+      const data = await res.json();
+
+      toast({
+        title: "Convocations créées",
+        description: `${data.count} convocation(s) en attente d'envoi. L'assemblée est convoquée.`,
+      });
+
+      onSent();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible d'envoyer les convocations",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+      isSubmittingRef.current = false;
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-xl bg-slate-900 border-white/10 text-white">
+        <DialogHeader>
+          <DialogTitle className="text-xl flex items-center gap-2">
+            <Send className="h-5 w-5 text-blue-400" />
+            Envoyer les convocations
+          </DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Les convocations seront créées pour tous les lots actifs du site et prêtes à être envoyées.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="rounded-xl border border-amber-400/30 bg-amber-500/10 p-3 text-sm text-amber-100 flex items-start gap-3">
+            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+            <p>
+              Loi du 10 juillet 1965 : les convocations doivent être envoyées au moins{" "}
+              <strong>21 jours</strong> avant la date de l'assemblée (sauf urgence justifiée).
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-slate-300">Mode d'envoi *</Label>
+            <Select
+              value={form.delivery_method}
+              onValueChange={(value) => setForm({ ...form, delivery_method: value })}
+              disabled={submitting}
+            >
+              <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DELIVERY_METHODS.map((method) => (
+                  <SelectItem key={method.value} value={method.value}>
+                    <div>
+                      <div className="font-medium">{method.label}</div>
+                      <div className="text-xs text-slate-500">{method.description}</div>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-slate-300">URL du document convocation (optionnel)</Label>
+            <input
+              type="url"
+              placeholder="https://..."
+              value={form.convocation_document_url}
+              onChange={(e) => setForm({ ...form, convocation_document_url: e.target.value })}
+              disabled={submitting}
+              className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-400/50"
+            />
+            <p className="text-xs text-slate-500">PDF de la convocation (sera attaché aux envois)</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-slate-300">URL de l'ordre du jour (optionnel)</Label>
+            <input
+              type="url"
+              placeholder="https://..."
+              value={form.ordre_du_jour_document_url}
+              onChange={(e) => setForm({ ...form, ordre_du_jour_document_url: e.target.value })}
+              disabled={submitting}
+              className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-400/50"
+            />
+            <p className="text-xs text-slate-500">PDF de l'ordre du jour avec les résolutions</p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+              className="border-white/20 text-white hover:bg-white/10"
+            >
+              Annuler
+            </Button>
+            <Button
+              type="submit"
+              disabled={submitting}
+              className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Envoi...
+                </>
+              ) : (
+                <>
+                  <Send className="h-4 w-4 mr-2" />
+                  Envoyer les convocations
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/syndic/assemblies/[id]/edit/page.tsx
+++ b/app/syndic/assemblies/[id]/edit/page.tsx
@@ -1,7 +1,6 @@
 "use client";
-// @ts-nocheck
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
@@ -10,23 +9,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import {
-  ArrowLeft,
-  CalendarIcon,
-  Clock,
-  MapPin,
-  Save,
-  Loader2,
-  FileText,
-  Plus,
-  Trash2,
-} from "lucide-react";
-import { useToast } from "@/components/ui/use-toast";
-import { format } from "date-fns";
-import { fr } from "date-fns/locale";
-import { cn } from "@/lib/utils";
 import {
   Select,
   SelectContent,
@@ -34,360 +16,406 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  ArrowLeft,
+  CalendarIcon,
+  Loader2,
+  MapPin,
+  Save,
+  Video,
+} from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+import { Skeleton } from "@/components/ui/skeleton";
 
-interface Resolution {
-  id: string;
-  title: string;
-  description: string;
-  majority: string;
-}
+type AssemblyType = "ordinaire" | "extraordinaire" | "concertation" | "consultation_ecrite";
 
-interface Assembly {
-  id: string;
-  title: string;
-  type: string;
-  date: string;
-  time: string;
-  location: string;
-  description?: string;
-  resolutions: Resolution[];
-}
-
-const majorityOptions = [
-  { value: "simple", label: "Majorité simple (Art. 24)" },
-  { value: "absolute", label: "Majorité absolue (Art. 25)" },
-  { value: "double", label: "Double majorité (Art. 26)" },
-  { value: "unanimity", label: "Unanimité" },
+const ASSEMBLY_TYPES: { value: AssemblyType; label: string }[] = [
+  { value: "ordinaire", label: "AG Ordinaire" },
+  { value: "extraordinaire", label: "AG Extraordinaire" },
+  { value: "concertation", label: "Concertation" },
+  { value: "consultation_ecrite", label: "Consultation écrite" },
 ];
 
 export default function EditAssemblyPage() {
-  const params = useParams();
   const router = useRouter();
+  const params = useParams();
   const { toast } = useToast();
-  const assemblyId = params.id as string;
+  const isSubmittingRef = useRef(false);
 
-  const [assembly, setAssembly] = useState<Assembly | null>(null);
+  const assemblyId = params?.id as string;
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [status, setStatus] = useState<string>("draft");
+
+  const [form, setForm] = useState({
+    assembly_type: "ordinaire" as AssemblyType,
+    title: "",
+    scheduled_date: "",
+    scheduled_time: "18:00",
+    location: "",
+    location_address: "",
+    online_meeting_url: "",
+    is_hybrid: false,
+    quorum_required: "",
+    fiscal_year: "",
+    description: "",
+    notes: "",
+  });
 
   useEffect(() => {
-    async function fetchAssembly() {
+    if (!assemblyId) return;
+
+    const loadAssembly = async () => {
       try {
-        const response = await fetch(`/api/copro/assemblies/${assemblyId}`);
-        if (response.ok) {
-          const data = await response.json();
-          setAssembly(data.assembly || data);
+        const res = await fetch(`/api/copro/assemblies/${assemblyId}`);
+        if (!res.ok) {
+          if (res.status === 404) {
+            toast({ title: "Assemblée introuvable", variant: "destructive" });
+            router.push("/syndic/assemblies");
+            return;
+          }
+          throw new Error("Erreur de chargement");
         }
+
+        const data = await res.json();
+        const assembly = data.assembly;
+
+        if (!["draft", "convened"].includes(assembly.status)) {
+          toast({
+            title: "Modification impossible",
+            description: `Les assemblées en statut '${assembly.status}' ne peuvent plus être modifiées`,
+            variant: "destructive",
+          });
+          router.push(`/syndic/assemblies/${assemblyId}`);
+          return;
+        }
+
+        setStatus(assembly.status);
+        const scheduledDate = new Date(assembly.scheduled_at);
+        setForm({
+          assembly_type: assembly.assembly_type,
+          title: assembly.title,
+          scheduled_date: scheduledDate.toISOString().split("T")[0],
+          scheduled_time: scheduledDate.toTimeString().slice(0, 5),
+          location: assembly.location || "",
+          location_address: assembly.location_address || "",
+          online_meeting_url: assembly.online_meeting_url || "",
+          is_hybrid: assembly.is_hybrid || false,
+          quorum_required: assembly.quorum_required?.toString() || "",
+          fiscal_year: assembly.fiscal_year?.toString() || "",
+          description: assembly.description || "",
+          notes: assembly.notes || "",
+        });
       } catch (error) {
-        console.error("Erreur chargement assemblée:", error);
+        toast({
+          title: "Erreur",
+          description: error instanceof Error ? error.message : "Impossible de charger",
+          variant: "destructive",
+        });
       } finally {
         setLoading(false);
       }
+    };
+
+    loadAssembly();
+  }, [assemblyId, router, toast]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmittingRef.current) return;
+
+    if (!form.title || form.title.length < 3) {
+      toast({ title: "Titre trop court", variant: "destructive" });
+      return;
     }
-    if (assemblyId) fetchAssembly();
-  }, [assemblyId]);
-
-  const addResolution = () => {
-    if (!assembly) return;
-    setAssembly({
-      ...assembly,
-      resolutions: [
-        ...assembly.resolutions,
-        { id: Date.now().toString(), title: "", description: "", majority: "simple" },
-      ],
-    });
-  };
-
-  const removeResolution = (id: string) => {
-    if (!assembly || assembly.resolutions.length <= 1) return;
-    setAssembly({
-      ...assembly,
-      resolutions: assembly.resolutions.filter((r) => r.id !== id),
-    });
-  };
-
-  const updateResolution = (id: string, field: keyof Resolution, value: string) => {
-    if (!assembly) return;
-    setAssembly({
-      ...assembly,
-      resolutions: assembly.resolutions.map((r) =>
-        r.id === id ? { ...r, [field]: value } : r
-      ),
-    });
-  };
-
-  const handleSave = async () => {
-    if (!assembly) return;
-
-    if (!assembly.title || !assembly.location) {
-      toast({
-        title: "Champs requis",
-        description: "Veuillez remplir tous les champs obligatoires.",
-        variant: "destructive",
-      });
+    if (!form.scheduled_date) {
+      toast({ title: "Date requise", variant: "destructive" });
       return;
     }
 
-    setSaving(true);
+    isSubmittingRef.current = true;
+    setSubmitting(true);
+
     try {
-      const response = await fetch(`/api/copro/assemblies/${assemblyId}`, {
-        method: "PUT",
+      const scheduledAt = new Date(`${form.scheduled_date}T${form.scheduled_time}:00`).toISOString();
+
+      const payload = {
+        assembly_type: form.assembly_type,
+        title: form.title.trim(),
+        scheduled_at: scheduledAt,
+        fiscal_year: form.fiscal_year ? parseInt(form.fiscal_year, 10) : undefined,
+        location: form.location.trim() || undefined,
+        location_address: form.location_address.trim() || undefined,
+        online_meeting_url: form.online_meeting_url.trim() || undefined,
+        is_hybrid: form.is_hybrid,
+        quorum_required: form.quorum_required ? parseInt(form.quorum_required, 10) : undefined,
+        description: form.description.trim() || undefined,
+        notes: form.notes.trim() || undefined,
+      };
+
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}`, {
+        method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(assembly),
+        body: JSON.stringify(payload),
       });
 
-      if (!response.ok) throw new Error("Erreur sauvegarde");
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la sauvegarde");
+      }
 
-      toast({
-        title: "Assemblée mise à jour",
-        description: "Les modifications ont été enregistrées.",
-      });
-
+      toast({ title: "Assemblée mise à jour" });
       router.push(`/syndic/assemblies/${assemblyId}`);
     } catch (error) {
       toast({
         title: "Erreur",
-        description: "Impossible de sauvegarder les modifications.",
+        description: error instanceof Error ? error.message : "Impossible de sauvegarder",
         variant: "destructive",
       });
     } finally {
-      setSaving(false);
+      setSubmitting(false);
+      isSubmittingRef.current = false;
     }
   };
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-indigo-500" />
-      </div>
-    );
-  }
-
-  if (!assembly) {
-    return (
-      <div className="p-6">
-        <Card className="bg-white/80 backdrop-blur-sm">
-          <CardContent className="py-16 text-center">
-            <CalendarIcon className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">Assemblée introuvable</h3>
-            <Button asChild>
-              <Link href="/syndic/assemblies">Retour aux assemblées</Link>
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+        <div className="max-w-3xl mx-auto space-y-4">
+          <Skeleton className="h-12 w-96 bg-white/10" />
+          <Skeleton className="h-64 bg-white/10" />
+        </div>
       </div>
     );
   }
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      className="p-6"
-    >
-      <div className="max-w-3xl mx-auto">
-        {/* Header */}
-        <div className="mb-6">
-          <Link
-            href={`/syndic/assemblies/${assemblyId}`}
-            className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 mb-4 transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Retour à l'assemblée
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center gap-4"
+        >
+          <Link href={`/syndic/assemblies/${assemblyId}`}>
+            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour
+            </Button>
           </Link>
-          <h1 className="text-2xl font-bold">Modifier l'assemblée</h1>
-        </div>
+          <div>
+            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+              <CalendarIcon className="h-6 w-6 text-violet-400" />
+              Modifier l'assemblée
+            </h1>
+            <p className="text-slate-400">Statut actuel : {status === "draft" ? "Brouillon" : "Convoquée"}</p>
+          </div>
+        </motion.div>
 
-        <div className="space-y-6">
-          {/* Informations générales */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <CalendarIcon className="h-5 w-5 text-indigo-500" />
-                Informations générales
+              <CardTitle className="text-white">Informations</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-slate-300">Type *</Label>
+                <Select
+                  value={form.assembly_type}
+                  onValueChange={(value: AssemblyType) => setForm({ ...form, assembly_type: value })}
+                  disabled={submitting}
+                >
+                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ASSEMBLY_TYPES.map((t) => (
+                      <SelectItem key={t.value} value={t.value}>
+                        {t.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="title" className="text-slate-300">
+                  Titre *
+                </Label>
+                <Input
+                  id="title"
+                  value={form.title}
+                  onChange={(e) => setForm({ ...form, title: e.target.value })}
+                  required
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Date *</Label>
+                  <Input
+                    type="date"
+                    value={form.scheduled_date}
+                    onChange={(e) => setForm({ ...form, scheduled_date: e.target.value })}
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Heure *</Label>
+                  <Input
+                    type="time"
+                    value={form.scheduled_time}
+                    onChange={(e) => setForm({ ...form, scheduled_time: e.target.value })}
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Exercice</Label>
+                  <Input
+                    type="number"
+                    min="2020"
+                    max="2100"
+                    value={form.fiscal_year}
+                    onChange={(e) => setForm({ ...form, fiscal_year: e.target.value })}
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Quorum (tantièmes)</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    value={form.quorum_required}
+                    onChange={(e) => setForm({ ...form, quorum_required: e.target.value })}
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <MapPin className="h-5 w-5 text-violet-400" />
+                Lieu
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="title">Titre *</Label>
+                <Label className="text-slate-300">Lieu</Label>
                 <Input
-                  id="title"
-                  value={assembly.title}
-                  onChange={(e) => setAssembly({ ...assembly, title: e.target.value })}
-                  className="bg-white"
-                  required
+                  value={form.location}
+                  onChange={(e) => setForm({ ...form, location: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
                 />
               </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label>Date *</Label>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-full justify-start text-left font-normal bg-white",
-                          !assembly.date && "text-muted-foreground"
-                        )}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {assembly.date
-                          ? format(new Date(assembly.date), "PPP", { locale: fr })
-                          : "Sélectionner"}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={new Date(assembly.date)}
-                        onSelect={(date) =>
-                          date && setAssembly({ ...assembly, date: date.toISOString() })
-                        }
-                        locale={fr}
-                        initialFocus
-                      />
-                    </PopoverContent>
-                  </Popover>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="time" className="flex items-center gap-2">
-                    <Clock className="h-4 w-4 text-muted-foreground" />
-                    Heure *
-                  </Label>
-                  <Input
-                    id="time"
-                    type="time"
-                    value={assembly.time}
-                    onChange={(e) => setAssembly({ ...assembly, time: e.target.value })}
-                    className="bg-white"
-                    required
-                  />
-                </div>
-              </div>
-
               <div className="space-y-2">
-                <Label htmlFor="location" className="flex items-center gap-2">
-                  <MapPin className="h-4 w-4 text-muted-foreground" />
-                  Lieu *
+                <Label className="text-slate-300">Adresse</Label>
+                <Input
+                  value={form.location_address}
+                  onChange={(e) => setForm({ ...form, location_address: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-slate-300 flex items-center gap-2">
+                  <Video className="h-4 w-4" />
+                  Lien visio
                 </Label>
                 <Input
-                  id="location"
-                  value={assembly.location}
-                  onChange={(e) => setAssembly({ ...assembly, location: e.target.value })}
-                  className="bg-white"
-                  required
+                  type="url"
+                  value={form.online_meeting_url}
+                  onChange={(e) => setForm({ ...form, online_meeting_url: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
                 />
               </div>
+              <div className="flex items-center gap-2">
+                <input
+                  id="is_hybrid"
+                  type="checkbox"
+                  checked={form.is_hybrid}
+                  onChange={(e) => setForm({ ...form, is_hybrid: e.target.checked })}
+                  disabled={submitting}
+                  className="h-4 w-4 rounded border-white/30 bg-transparent"
+                />
+                <Label htmlFor="is_hybrid" className="text-slate-300 cursor-pointer">
+                  Assemblée hybride
+                </Label>
+              </div>
+            </CardContent>
+          </Card>
 
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardContent className="p-6 space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="description">Description</Label>
+                <Label className="text-slate-300">Description</Label>
                 <Textarea
-                  id="description"
-                  value={assembly.description || ""}
-                  onChange={(e) => setAssembly({ ...assembly, description: e.target.value })}
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
                   rows={3}
-                  className="bg-white resize-none"
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-slate-300">Notes internes</Label>
+                <Textarea
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  rows={2}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
                 />
               </div>
             </CardContent>
           </Card>
 
-          {/* Résolutions */}
-          <Card className="bg-white/80 backdrop-blur-sm">
-            <CardHeader className="flex flex-row items-center justify-between">
-              <div>
-                <CardTitle className="flex items-center gap-2">
-                  <FileText className="h-5 w-5 text-indigo-500" />
-                  Ordre du jour
-                </CardTitle>
-                <CardDescription>Résolutions à voter</CardDescription>
-              </div>
-              <Button type="button" variant="outline" size="sm" onClick={addResolution}>
-                <Plus className="mr-2 h-4 w-4" />
-                Ajouter
-              </Button>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {assembly.resolutions.map((resolution, index) => (
-                <div
-                  key={resolution.id}
-                  className="p-4 rounded-lg border border-slate-200 space-y-3"
-                >
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-muted-foreground">
-                      Résolution {index + 1}
-                    </span>
-                    {assembly.resolutions.length > 1 && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => removeResolution(resolution.id)}
-                        className="text-red-500 hover:text-red-700 hover:bg-red-50"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
-
-                  <Input
-                    value={resolution.title}
-                    onChange={(e) => updateResolution(resolution.id, "title", e.target.value)}
-                    placeholder="Titre de la résolution"
-                    className="bg-white"
-                  />
-
-                  <Textarea
-                    value={resolution.description}
-                    onChange={(e) => updateResolution(resolution.id, "description", e.target.value)}
-                    placeholder="Description..."
-                    rows={2}
-                    className="bg-white resize-none"
-                  />
-
-                  <Select
-                    value={resolution.majority}
-                    onValueChange={(value) => updateResolution(resolution.id, "majority", value)}
-                  >
-                    <SelectTrigger className="bg-white">
-                      <SelectValue placeholder="Type de majorité" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {majorityOptions.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-
-          {/* Actions */}
           <div className="flex gap-3 justify-end">
-            <Button variant="outline" asChild>
-              <Link href={`/syndic/assemblies/${assemblyId}`}>Annuler</Link>
-            </Button>
+            <Link href={`/syndic/assemblies/${assemblyId}`}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={submitting}
+                className="border-white/20 text-white hover:bg-white/10"
+              >
+                Annuler
+              </Button>
+            </Link>
             <Button
-              onClick={handleSave}
-              disabled={saving}
-              className="bg-gradient-to-r from-indigo-600 to-purple-600"
+              type="submit"
+              disabled={submitting}
+              className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
             >
-              {saving ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Sauvegarde...
+                </>
               ) : (
-                <Save className="mr-2 h-4 w-4" />
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  Enregistrer
+                </>
               )}
-              Sauvegarder
             </Button>
           </div>
-        </div>
+        </form>
       </div>
-    </motion.div>
+    </div>
   );
 }
-

--- a/app/syndic/assemblies/[id]/live/_components/BureauSetupCard.tsx
+++ b/app/syndic/assemblies/[id]/live/_components/BureauSetupCard.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState, useRef, useMemo } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Play, Users, Loader2, AlertCircle, UserCheck } from "lucide-react";
+
+interface Unit {
+  id: string;
+  lot_number: string;
+  owner_profile_id: string | null;
+  owner_name: string;
+  tantieme_general: number;
+}
+
+interface BureauSetupCardProps {
+  units: Unit[];
+  totalTantiemes: number;
+  onStart: (bureau: {
+    presided_by: string;
+    secretary_profile_id: string;
+    scrutineers: Array<{ profile_id: string }>;
+    present_tantiemes: number;
+  }) => void | Promise<void>;
+  starting: boolean;
+}
+
+export function BureauSetupCard({ units, totalTantiemes, onStart, starting }: BureauSetupCardProps) {
+  const isSubmittingRef = useRef(false);
+  const [presidentId, setPresidentId] = useState("");
+  const [secretaryId, setSecretaryId] = useState("");
+  const [scrutineerIds, setScrutineerIds] = useState<string[]>([]);
+  const [presentTantiemes, setPresentTantiemes] = useState("");
+
+  // Déduire la liste des propriétaires uniques
+  const ownersOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: { profile_id: string; name: string }[] = [];
+    for (const unit of units) {
+      if (unit.owner_profile_id && !seen.has(unit.owner_profile_id)) {
+        seen.add(unit.owner_profile_id);
+        options.push({ profile_id: unit.owner_profile_id, name: unit.owner_name });
+      }
+    }
+    return options.sort((a, b) => a.name.localeCompare(b.name));
+  }, [units]);
+
+  const handleSubmit = async () => {
+    if (isSubmittingRef.current) return;
+
+    const present = parseInt(presentTantiemes, 10) || 0;
+    if (present <= 0) {
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    try {
+      await onStart({
+        presided_by: presidentId,
+        secretary_profile_id: secretaryId,
+        scrutineers: scrutineerIds.map((id) => ({ profile_id: id })),
+        present_tantiemes: present,
+      });
+    } finally {
+      isSubmittingRef.current = false;
+    }
+  };
+
+  const toggleScrutineer = (profileId: string) => {
+    setScrutineerIds((prev) =>
+      prev.includes(profileId) ? prev.filter((id) => id !== profileId) : [...prev, profileId]
+    );
+  };
+
+  const percentPresent = totalTantiemes > 0
+    ? ((parseInt(presentTantiemes, 10) || 0) / totalTantiemes * 100).toFixed(1)
+    : "0";
+
+  return (
+    <Card className="bg-white/5 border-white/10 backdrop-blur">
+      <CardHeader>
+        <CardTitle className="text-white flex items-center gap-2">
+          <Users className="h-5 w-5 text-violet-400" />
+          Constitution du bureau
+        </CardTitle>
+        <CardDescription className="text-slate-400">
+          Désignez le président, le secrétaire et les scrutateurs avant de démarrer la session
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {ownersOptions.length === 0 && (
+          <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-100 flex items-start gap-2">
+            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+            Aucun propriétaire assigné aux lots. Vous ne pourrez pas constituer le bureau tant que les lots
+            n'auront pas de propriétaire.
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label className="text-slate-300">Président de séance</Label>
+          <Select
+            value={presidentId}
+            onValueChange={setPresidentId}
+            disabled={starting || ownersOptions.length === 0}
+          >
+            <SelectTrigger className="bg-white/5 border-white/10 text-white">
+              <SelectValue placeholder="Sélectionner un copropriétaire" />
+            </SelectTrigger>
+            <SelectContent>
+              {ownersOptions.map((owner) => (
+                <SelectItem key={owner.profile_id} value={owner.profile_id}>
+                  {owner.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-slate-300">Secrétaire de séance</Label>
+          <Select
+            value={secretaryId}
+            onValueChange={setSecretaryId}
+            disabled={starting || ownersOptions.length === 0}
+          >
+            <SelectTrigger className="bg-white/5 border-white/10 text-white">
+              <SelectValue placeholder="Sélectionner un copropriétaire" />
+            </SelectTrigger>
+            <SelectContent>
+              {ownersOptions.map((owner) => (
+                <SelectItem key={owner.profile_id} value={owner.profile_id}>
+                  {owner.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-slate-300">Scrutateurs (optionnel)</Label>
+          <div className="rounded-xl border border-white/10 bg-white/5 p-3 max-h-48 overflow-y-auto">
+            {ownersOptions.length === 0 ? (
+              <p className="text-sm text-slate-500">Aucun copropriétaire disponible</p>
+            ) : (
+              <div className="space-y-2">
+                {ownersOptions.map((owner) => (
+                  <label
+                    key={owner.profile_id}
+                    className="flex items-center gap-2 cursor-pointer hover:bg-white/5 p-1 rounded"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={scrutineerIds.includes(owner.profile_id)}
+                      onChange={() => toggleScrutineer(owner.profile_id)}
+                      disabled={starting}
+                      className="h-4 w-4 rounded border-white/30 bg-transparent"
+                    />
+                    <span className="text-sm text-white">{owner.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-slate-300">Tantièmes présents ou représentés *</Label>
+          <Input
+            type="number"
+            min="0"
+            max={totalTantiemes}
+            placeholder={`Max ${totalTantiemes.toLocaleString("fr-FR")}`}
+            value={presentTantiemes}
+            onChange={(e) => setPresentTantiemes(e.target.value)}
+            disabled={starting}
+            className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+          />
+          {presentTantiemes && (
+            <p className="text-xs text-slate-400">
+              = {percentPresent}% du total des tantièmes
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-4">
+          <Button
+            onClick={handleSubmit}
+            disabled={
+              starting ||
+              !presidentId ||
+              !secretaryId ||
+              !presentTantiemes ||
+              parseInt(presentTantiemes, 10) <= 0
+            }
+            className="bg-gradient-to-r from-emerald-500 to-green-600 hover:from-emerald-600 hover:to-green-700"
+          >
+            {starting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Démarrage...
+              </>
+            ) : (
+              <>
+                <Play className="h-4 w-4 mr-2" />
+                Démarrer la session
+              </>
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/syndic/assemblies/[id]/live/_components/QuorumGauge.tsx
+++ b/app/syndic/assemblies/[id]/live/_components/QuorumGauge.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Users, CheckCircle2, XCircle, Building2 } from "lucide-react";
+
+interface QuorumGaugeProps {
+  totalTantiemes: number;
+  presentTantiemes: number;
+  quorumRequired: number;
+  quorumReached: boolean;
+  siteName: string;
+}
+
+export function QuorumGauge({
+  totalTantiemes,
+  presentTantiemes,
+  quorumRequired,
+  quorumReached,
+  siteName,
+}: QuorumGaugeProps) {
+  const percent = totalTantiemes > 0 ? (presentTantiemes / totalTantiemes) * 100 : 0;
+  const quorumPercent = totalTantiemes > 0 ? (quorumRequired / totalTantiemes) * 100 : 0;
+
+  const gaugeColor = quorumReached ? "bg-emerald-500" : "bg-amber-500";
+  const textColor = quorumReached ? "text-emerald-300" : "text-amber-300";
+
+  return (
+    <Card className="bg-white/5 border-white/10 backdrop-blur">
+      <CardContent className="p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <Building2 className="h-5 w-5 text-violet-400" />
+            <h3 className="text-white font-semibold">{siteName}</h3>
+          </div>
+          <div className={`flex items-center gap-1 text-sm font-semibold ${textColor}`}>
+            {quorumReached ? (
+              <>
+                <CheckCircle2 className="h-4 w-4" />
+                Quorum atteint
+              </>
+            ) : (
+              <>
+                <XCircle className="h-4 w-4" />
+                Quorum non atteint
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Gauge bar */}
+        <div className="relative">
+          <div className="h-8 bg-white/5 rounded-full overflow-hidden border border-white/10">
+            <div
+              className={`h-full ${gaugeColor} transition-all duration-500`}
+              style={{ width: `${Math.min(percent, 100)}%` }}
+            />
+          </div>
+          {/* Quorum threshold marker */}
+          {quorumRequired > 0 && (
+            <div
+              className="absolute top-0 h-8 w-0.5 bg-amber-400"
+              style={{ left: `${Math.min(quorumPercent, 100)}%` }}
+              title={`Quorum requis : ${quorumRequired.toLocaleString("fr-FR")} tant. (${quorumPercent.toFixed(1)}%)`}
+            >
+              <div className="absolute top-8 -translate-x-1/2 text-[9px] text-amber-300 whitespace-nowrap">
+                Quorum ({quorumRequired.toLocaleString("fr-FR")})
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-3 gap-4 mt-6">
+          <div>
+            <p className="text-xs text-slate-400 uppercase">Tantièmes totaux</p>
+            <p className="text-2xl font-bold text-white">{totalTantiemes.toLocaleString("fr-FR")}</p>
+          </div>
+          <div>
+            <p className="text-xs text-slate-400 uppercase">Présents / représentés</p>
+            <p className={`text-2xl font-bold ${textColor}`}>
+              {presentTantiemes.toLocaleString("fr-FR")}
+            </p>
+            <p className="text-xs text-slate-500">{percent.toFixed(1)}%</p>
+          </div>
+          <div>
+            <p className="text-xs text-slate-400 uppercase">Quorum requis</p>
+            <p className="text-2xl font-bold text-amber-300">
+              {quorumRequired > 0 ? quorumRequired.toLocaleString("fr-FR") : "Aucun"}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/syndic/assemblies/[id]/live/_components/VoteRecorderCard.tsx
+++ b/app/syndic/assemblies/[id]/live/_components/VoteRecorderCard.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ThumbsUp,
+  ThumbsDown,
+  Minus,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Clock,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+
+interface Resolution {
+  id: string;
+  resolution_number: number;
+  title: string;
+  description: string;
+  category: string;
+  majority_rule: string;
+  status: string;
+  votes_for_count: number;
+  votes_against_count: number;
+  votes_abstain_count: number;
+  tantiemes_for: number;
+  tantiemes_against: number;
+  tantiemes_abstain: number;
+}
+
+interface Unit {
+  id: string;
+  lot_number: string;
+  owner_profile_id: string | null;
+  owner_name: string;
+  tantieme_general: number;
+}
+
+interface VoteRecorderCardProps {
+  resolution: Resolution;
+  units: Unit[];
+  onVoted: () => void | Promise<void>;
+}
+
+const MAJORITY_LABELS: Record<string, string> = {
+  article_24: "Art. 24",
+  article_25: "Art. 25",
+  article_25_1: "Art. 25-1",
+  article_26: "Art. 26",
+  article_26_1: "Art. 26-1",
+  unanimite: "Unanimité",
+};
+
+const STATUS_CONFIG: Record<string, { label: string; color: string; icon: React.ComponentType<{ className?: string }> }> = {
+  proposed: { label: "Non votée", color: "bg-slate-500/20 text-slate-200", icon: Clock },
+  voted_for: { label: "ADOPTÉE", color: "bg-emerald-500/20 text-emerald-200", icon: CheckCircle2 },
+  voted_against: { label: "REJETÉE", color: "bg-red-500/20 text-red-200", icon: XCircle },
+  abstained: { label: "Abstention", color: "bg-amber-500/20 text-amber-200", icon: AlertCircle },
+  adjourned: { label: "Ajournée", color: "bg-orange-500/20 text-orange-200", icon: Clock },
+  withdrawn: { label: "Retirée", color: "bg-slate-500/20 text-slate-300", icon: XCircle },
+};
+
+export function VoteRecorderCard({ resolution, units, onVoted }: VoteRecorderCardProps) {
+  const { toast } = useToast();
+  const isSubmittingRef = useRef(false);
+  const [expanded, setExpanded] = useState(true);
+  const [selectedUnitId, setSelectedUnitId] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const statusConfig = STATUS_CONFIG[resolution.status] || STATUS_CONFIG.proposed;
+  const StatusIcon = statusConfig.icon;
+  const isVoted = ["voted_for", "voted_against", "abstained", "adjourned", "withdrawn"].includes(
+    resolution.status
+  );
+
+  const totalVotes =
+    resolution.votes_for_count + resolution.votes_against_count + resolution.votes_abstain_count;
+
+  const castVote = async (voteType: "for" | "against" | "abstain") => {
+    if (isSubmittingRef.current) return;
+    if (!selectedUnitId) {
+      toast({ title: "Sélectionnez un lot", variant: "destructive" });
+      return;
+    }
+
+    const unit = units.find((u) => u.id === selectedUnitId);
+    if (!unit) {
+      toast({ title: "Lot introuvable", variant: "destructive" });
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    setSubmitting(true);
+
+    try {
+      const payload = {
+        unit_id: unit.id,
+        voter_profile_id: unit.owner_profile_id || undefined,
+        voter_name: unit.owner_name,
+        voter_tantiemes: unit.tantieme_general,
+        vote: voteType,
+        vote_method: "hand_vote" as const,
+      };
+
+      const res = await fetch(`/api/copro/resolutions/${resolution.id}/vote`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors du vote");
+      }
+
+      toast({
+        title: "Vote enregistré",
+        description: `${unit.owner_name} (${unit.tantieme_general} tant.) — ${voteType === "for" ? "Pour" : voteType === "against" ? "Contre" : "Abstention"}`,
+      });
+
+      setSelectedUnitId("");
+      await onVoted();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible d'enregistrer le vote",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+      isSubmittingRef.current = false;
+    }
+  };
+
+  return (
+    <Card className="bg-white/5 border-white/10 backdrop-blur">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1 flex-wrap">
+              <span className="font-mono text-xs text-slate-500">#{resolution.resolution_number}</span>
+              <Badge variant="outline" className="border-violet-400/30 text-violet-200 text-xs">
+                {MAJORITY_LABELS[resolution.majority_rule] || resolution.majority_rule}
+              </Badge>
+              <Badge className={statusConfig.color}>
+                <StatusIcon className="h-3 w-3 mr-1" />
+                {statusConfig.label}
+              </Badge>
+            </div>
+            <h4 className="text-white font-medium">{resolution.title}</h4>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setExpanded(!expanded)}
+            className="text-slate-400 hover:text-white hover:bg-white/10 flex-shrink-0"
+          >
+            {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </Button>
+        </div>
+      </CardHeader>
+
+      {expanded && (
+        <CardContent className="space-y-4">
+          <p className="text-sm text-slate-400">{resolution.description}</p>
+
+          {/* Vote counts */}
+          {totalVotes > 0 && (
+            <div className="grid grid-cols-3 gap-3 py-3 border-t border-white/10">
+              <div className="text-center">
+                <p className="text-xs text-slate-400 uppercase">Pour</p>
+                <p className="text-xl font-bold text-emerald-300">{resolution.votes_for_count}</p>
+                <p className="text-xs text-slate-500">{resolution.tantiemes_for.toLocaleString("fr-FR")} tant.</p>
+              </div>
+              <div className="text-center">
+                <p className="text-xs text-slate-400 uppercase">Contre</p>
+                <p className="text-xl font-bold text-red-300">{resolution.votes_against_count}</p>
+                <p className="text-xs text-slate-500">{resolution.tantiemes_against.toLocaleString("fr-FR")} tant.</p>
+              </div>
+              <div className="text-center">
+                <p className="text-xs text-slate-400 uppercase">Abstention</p>
+                <p className="text-xl font-bold text-amber-300">{resolution.votes_abstain_count}</p>
+                <p className="text-xs text-slate-500">{resolution.tantiemes_abstain.toLocaleString("fr-FR")} tant.</p>
+              </div>
+            </div>
+          )}
+
+          {/* Vote input */}
+          {!isVoted && (
+            <div className="space-y-3 pt-3 border-t border-white/10">
+              <p className="text-xs text-slate-400 uppercase tracking-wide">Enregistrer un vote</p>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Select value={selectedUnitId} onValueChange={setSelectedUnitId} disabled={submitting}>
+                  <SelectTrigger className="flex-1 bg-white/5 border-white/10 text-white">
+                    <SelectValue placeholder="Sélectionner un lot" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {units.map((unit) => (
+                      <SelectItem key={unit.id} value={unit.id}>
+                        Lot {unit.lot_number} — {unit.owner_name} ({unit.tantieme_general} tant.)
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <div className="flex gap-1">
+                  <Button
+                    onClick={() => castVote("for")}
+                    disabled={!selectedUnitId || submitting}
+                    size="sm"
+                    className="bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30 border border-emerald-400/40"
+                  >
+                    {submitting ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <>
+                        <ThumbsUp className="h-4 w-4 mr-1" />
+                        Pour
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    onClick={() => castVote("against")}
+                    disabled={!selectedUnitId || submitting}
+                    size="sm"
+                    className="bg-red-500/20 text-red-200 hover:bg-red-500/30 border border-red-400/40"
+                  >
+                    <ThumbsDown className="h-4 w-4 mr-1" />
+                    Contre
+                  </Button>
+                  <Button
+                    onClick={() => castVote("abstain")}
+                    disabled={!selectedUnitId || submitting}
+                    size="sm"
+                    className="bg-amber-500/20 text-amber-200 hover:bg-amber-500/30 border border-amber-400/40"
+                  >
+                    <Minus className="h-4 w-4 mr-1" />
+                    Abstention
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/app/syndic/assemblies/[id]/live/page.tsx
+++ b/app/syndic/assemblies/[id]/live/page.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ArrowLeft,
+  Play,
+  Square,
+  Users,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Loader2,
+  Vote,
+  Radio,
+} from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+import { BureauSetupCard } from "./_components/BureauSetupCard";
+import { VoteRecorderCard } from "./_components/VoteRecorderCard";
+import { QuorumGauge } from "./_components/QuorumGauge";
+
+interface Assembly {
+  id: string;
+  site_id: string;
+  title: string;
+  reference_number: string | null;
+  assembly_type: string;
+  status: string;
+  quorum_required: number | null;
+  present_tantiemes: number | null;
+  quorum_reached: boolean | null;
+  presided_by: string | null;
+  secretary_profile_id: string | null;
+  scrutineers: Array<{ profile_id: string; unit_id?: string }> | null;
+  held_at: string | null;
+}
+
+interface Resolution {
+  id: string;
+  resolution_number: number;
+  title: string;
+  description: string;
+  category: string;
+  majority_rule: string;
+  status: string;
+  votes_for_count: number;
+  votes_against_count: number;
+  votes_abstain_count: number;
+  tantiemes_for: number;
+  tantiemes_against: number;
+  tantiemes_abstain: number;
+}
+
+interface Unit {
+  id: string;
+  lot_number: string;
+  owner_profile_id: string | null;
+  owner_name: string;
+  tantieme_general: number;
+}
+
+interface SiteInfo {
+  name: string;
+  total_tantiemes_general: number;
+}
+
+export default function LiveAssemblyPage() {
+  const router = useRouter();
+  const params = useParams();
+  const { toast } = useToast();
+  const assemblyId = params?.id as string;
+
+  const [loading, setLoading] = useState(true);
+  const [assembly, setAssembly] = useState<Assembly | null>(null);
+  const [resolutions, setResolutions] = useState<Resolution[]>([]);
+  const [units, setUnits] = useState<Unit[]>([]);
+  const [site, setSite] = useState<SiteInfo | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [closing, setClosing] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [assemblyRes, unitsRes] = await Promise.all([
+        fetch(`/api/copro/assemblies/${assemblyId}`),
+        fetch(`/api/copro/assemblies/${assemblyId}/units`),
+      ]);
+
+      if (!assemblyRes.ok) {
+        if (assemblyRes.status === 404) {
+          toast({ title: "Assemblée introuvable", variant: "destructive" });
+          router.push("/syndic/assemblies");
+          return;
+        }
+        throw new Error("Erreur de chargement");
+      }
+
+      const assemblyData = await assemblyRes.json();
+      setAssembly(assemblyData.assembly);
+      setResolutions(assemblyData.resolutions || []);
+
+      if (unitsRes.ok) {
+        const unitsData = await unitsRes.json();
+        setUnits(unitsData.units || []);
+        setSite(unitsData.site || null);
+      }
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Chargement impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [assemblyId, router, toast]);
+
+  useEffect(() => {
+    if (assemblyId) {
+      fetchData();
+    }
+  }, [assemblyId, fetchData]);
+
+  const handleStart = async (bureau: {
+    presided_by: string;
+    secretary_profile_id: string;
+    scrutineers: Array<{ profile_id: string }>;
+    present_tantiemes: number;
+  }) => {
+    setStarting(true);
+    try {
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(bureau),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur");
+      }
+
+      const data = await res.json();
+      toast({
+        title: "Session démarrée",
+        description: data.message,
+        variant: data.quorum_reached ? "default" : "destructive",
+      });
+
+      await fetchData();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de démarrer",
+        variant: "destructive",
+      });
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const handleClose = async () => {
+    if (!confirm("Clôturer définitivement cette assemblée ? Les résolutions ne pourront plus être votées.")) {
+      return;
+    }
+
+    setClosing(true);
+    try {
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}/close`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur");
+      }
+
+      const data = await res.json();
+      toast({
+        title: "Session clôturée",
+        description: data.message,
+      });
+
+      router.push(`/syndic/assemblies/${assemblyId}`);
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de clôturer",
+        variant: "destructive",
+      });
+    } finally {
+      setClosing(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+        <div className="max-w-6xl mx-auto space-y-6">
+          <Skeleton className="h-12 w-96 bg-white/10" />
+          <Skeleton className="h-48 bg-white/10" />
+          <Skeleton className="h-96 bg-white/10" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!assembly) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+        <p className="text-white text-center py-12">Assemblée introuvable</p>
+      </div>
+    );
+  }
+
+  const canStart = assembly.status === "convened";
+  const isInProgress = assembly.status === "in_progress";
+  const isHeld = assembly.status === "held";
+  const totalTantiemes = site?.total_tantiemes_general || 10000;
+  const presentTantiemes = assembly.present_tantiemes || 0;
+
+  // Si l'AG n'est pas encore convoquée, rediriger vers la page détail
+  if (assembly.status === "draft") {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+        <div className="max-w-3xl mx-auto">
+          <Card className="bg-white/5 border-amber-400/40 backdrop-blur">
+            <CardContent className="p-8 text-center">
+              <AlertCircle className="h-12 w-12 text-amber-400 mx-auto mb-4" />
+              <h2 className="text-xl font-bold text-white mb-2">Assemblée en brouillon</h2>
+              <p className="text-slate-300 mb-6">
+                Vous devez d'abord envoyer les convocations avant de démarrer la session.
+              </p>
+              <Link href={`/syndic/assemblies/${assemblyId}`}>
+                <Button className="bg-violet-500 hover:bg-violet-600">
+                  <ArrowLeft className="h-4 w-4 mr-2" />
+                  Retour à l'assemblée
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Header */}
+        <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
+          <Link href={`/syndic/assemblies/${assemblyId}`}>
+            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10 mb-4">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour à l'assemblée
+            </Button>
+          </Link>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="flex items-center gap-3 mb-2">
+                <Radio className={`h-6 w-6 ${isInProgress ? "text-red-400 animate-pulse" : "text-slate-400"}`} />
+                <h1 className="text-2xl font-bold text-white">Session en direct</h1>
+                {isInProgress && (
+                  <Badge className="bg-red-500/20 text-red-200 border-red-400/40 border">
+                    ● EN COURS
+                  </Badge>
+                )}
+                {isHeld && (
+                  <Badge className="bg-emerald-500/20 text-emerald-200 border-emerald-400/40 border">
+                    Clôturée
+                  </Badge>
+                )}
+              </div>
+              <p className="text-slate-400">{assembly.title}</p>
+              <p className="text-slate-500 font-mono text-xs">{assembly.reference_number}</p>
+            </div>
+
+            {isInProgress && (
+              <Button
+                onClick={handleClose}
+                disabled={closing}
+                className="bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700"
+              >
+                {closing ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Clôture...
+                  </>
+                ) : (
+                  <>
+                    <Square className="h-4 w-4 mr-2" />
+                    Clôturer la session
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </motion.div>
+
+        {/* Quorum gauge */}
+        <QuorumGauge
+          totalTantiemes={totalTantiemes}
+          presentTantiemes={presentTantiemes}
+          quorumRequired={assembly.quorum_required || 0}
+          quorumReached={assembly.quorum_reached || false}
+          siteName={site?.name || "Copropriété"}
+        />
+
+        {/* Bureau setup (if convened, not yet started) */}
+        {canStart && (
+          <BureauSetupCard
+            units={units}
+            totalTantiemes={totalTantiemes}
+            onStart={handleStart}
+            starting={starting}
+          />
+        )}
+
+        {/* Vote recording (if in progress) */}
+        {isInProgress && resolutions.length > 0 && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2 text-white">
+              <Vote className="h-5 w-5 text-violet-400" />
+              <h2 className="text-lg font-semibold">Résolutions à voter</h2>
+            </div>
+            {resolutions.map((resolution) => (
+              <VoteRecorderCard
+                key={resolution.id}
+                resolution={resolution}
+                units={units}
+                onVoted={fetchData}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Held state summary */}
+        {isHeld && (
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <CheckCircle2 className="h-5 w-5 text-emerald-400" />
+                Session clôturée
+              </CardTitle>
+              <CardDescription className="text-slate-400">
+                Tenue le {new Date(assembly.held_at || "").toLocaleString("fr-FR")}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-slate-300 mb-4">
+                La session est terminée. Vous pouvez maintenant générer le procès-verbal.
+              </p>
+              <Link href={`/syndic/assemblies/${assemblyId}`}>
+                <Button className="bg-violet-500 hover:bg-violet-600">
+                  Retour à l'assemblée
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/syndic/assemblies/[id]/page.tsx
+++ b/app/syndic/assemblies/[id]/page.tsx
@@ -29,6 +29,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { formatDateShort } from "@/lib/helpers/format";
 import { AddResolutionDialog } from "./_components/AddResolutionDialog";
 import { SendConvocationsDialog } from "./_components/SendConvocationsDialog";
+import { DownloadPdfButton } from "./_components/DownloadPdfButton";
 
 interface Assembly {
   id: string;
@@ -310,6 +311,14 @@ export default function AssemblyDetailPage() {
               Envoyer les convocations
             </Button>
           )}
+          {resolutions.length > 0 && (
+            <DownloadPdfButton
+              variant="convocation"
+              assemblyId={assemblyId}
+              label="Télécharger convocation (PDF)"
+              filename={`convocation-${assembly.reference_number || assembly.id}.pdf`}
+            />
+          )}
         </div>
 
         {/* Resolutions */}
@@ -459,7 +468,15 @@ export default function AssemblyDetailPage() {
                         </p>
                       </div>
                     </div>
-                    <Badge className="bg-slate-500/20 text-slate-200 capitalize">{minute.status}</Badge>
+                    <div className="flex items-center gap-2">
+                      <Badge className="bg-slate-500/20 text-slate-200 capitalize">{minute.status}</Badge>
+                      <DownloadPdfButton
+                        variant="minute"
+                        minuteId={minute.id}
+                        label="PDF"
+                        filename={`pv-${assembly.reference_number || assembly.id}-v${minute.version}.pdf`}
+                      />
+                    </div>
                   </div>
                 ))}
               </div>

--- a/app/syndic/assemblies/[id]/page.tsx
+++ b/app/syndic/assemblies/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   Edit,
   Trash2,
   Vote,
+  Radio,
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { formatDateShort } from "@/lib/helpers/format";
@@ -220,6 +221,8 @@ export default function AssemblyDetailPage() {
   const canEdit = ["draft", "convened"].includes(assembly.status);
   const canConvene = ["draft", "convened"].includes(assembly.status);
   const canAddResolution = ["draft", "convened", "in_progress"].includes(assembly.status);
+  const canStartLive = assembly.status === "convened" && resolutions.length > 0;
+  const isLive = assembly.status === "in_progress";
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
@@ -310,6 +313,22 @@ export default function AssemblyDetailPage() {
               <Send className="h-4 w-4 mr-2" />
               Envoyer les convocations
             </Button>
+          )}
+          {canStartLive && (
+            <Link href={`/syndic/assemblies/${assemblyId}/live`}>
+              <Button className="bg-gradient-to-r from-emerald-500 to-green-600 hover:from-emerald-600 hover:to-green-700">
+                <Radio className="h-4 w-4 mr-2" />
+                Démarrer la session
+              </Button>
+            </Link>
+          )}
+          {isLive && (
+            <Link href={`/syndic/assemblies/${assemblyId}/live`}>
+              <Button className="bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 animate-pulse">
+                <Radio className="h-4 w-4 mr-2" />
+                Session en cours — accéder
+              </Button>
+            </Link>
           )}
           {resolutions.length > 0 && (
             <DownloadPdfButton

--- a/app/syndic/assemblies/[id]/page.tsx
+++ b/app/syndic/assemblies/[id]/page.tsx
@@ -1,327 +1,412 @@
 "use client";
-// @ts-nocheck
 
-import { useState, useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useState, useEffect, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   ArrowLeft,
   Calendar,
-  Clock,
   MapPin,
+  Video,
   Users,
   FileText,
+  Plus,
+  Send,
   CheckCircle2,
   XCircle,
   AlertCircle,
-  Download,
-  Send,
-  Loader2,
+  Clock,
   Edit,
+  Trash2,
+  Vote,
 } from "lucide-react";
-import { format } from "date-fns";
-import { fr } from "date-fns/locale";
-import { cn } from "@/lib/utils";
+import { useToast } from "@/components/ui/use-toast";
+import { formatDateShort } from "@/lib/helpers/format";
+import { AddResolutionDialog } from "./_components/AddResolutionDialog";
+import { SendConvocationsDialog } from "./_components/SendConvocationsDialog";
 
 interface Assembly {
   id: string;
   site_id: string;
-  site_name: string;
-  type: "ordinary" | "extraordinary";
   title: string;
-  date: string;
-  time: string;
-  location: string;
-  description?: string;
-  status: "draft" | "convocations_sent" | "in_progress" | "completed" | "cancelled";
-  total_owners: number;
-  present_owners: number;
-  proxy_owners: number;
-  resolutions: Resolution[];
+  reference_number: string | null;
+  assembly_type: string;
+  scheduled_at: string;
+  location: string | null;
+  location_address: string | null;
+  online_meeting_url: string | null;
+  is_hybrid: boolean;
+  status: string;
+  quorum_required: number | null;
+  fiscal_year: number | null;
+  description: string | null;
+  notes: string | null;
+  first_convocation_sent_at: string | null;
+  held_at: string | null;
 }
 
 interface Resolution {
   id: string;
+  resolution_number: number;
   title: string;
   description: string;
-  majority: "simple" | "absolute" | "double" | "unanimity";
-  votes_for: number;
-  votes_against: number;
-  votes_abstain: number;
-  status: "pending" | "approved" | "rejected";
+  category: string;
+  majority_rule: string;
+  status: string;
+  estimated_amount_cents: number | null;
+  votes_for_count: number;
+  votes_against_count: number;
+  votes_abstain_count: number;
+  tantiemes_for: number;
+  tantiemes_against: number;
+  tantiemes_abstain: number;
 }
 
-const statusConfig = {
-  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700" },
-  convocations_sent: { label: "Convocations envoyées", color: "bg-blue-100 text-blue-700" },
-  in_progress: { label: "En cours", color: "bg-amber-100 text-amber-700" },
-  completed: { label: "Terminée", color: "bg-green-100 text-green-700" },
-  cancelled: { label: "Annulée", color: "bg-red-100 text-red-700" },
+interface ConvocationSummary {
+  id: string;
+  status: string;
+  delivery_method: string;
+  sent_at: string | null;
+  delivered_at: string | null;
+  recipient_name: string;
+}
+
+interface MinuteSummary {
+  id: string;
+  version: number;
+  status: string;
+  signed_by_president_at: string | null;
+  distributed_at: string | null;
+}
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  draft: { label: "Brouillon", color: "bg-slate-500/20 text-slate-200 border-slate-400/40" },
+  convened: { label: "Convoquée", color: "bg-blue-500/20 text-blue-200 border-blue-400/40" },
+  in_progress: { label: "En cours", color: "bg-amber-500/20 text-amber-200 border-amber-400/40" },
+  held: { label: "Tenue", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40" },
+  cancelled: { label: "Annulée", color: "bg-red-500/20 text-red-200 border-red-400/40" },
+};
+
+const RESOLUTION_STATUS_LABELS: Record<
+  string,
+  { label: string; color: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  proposed: { label: "Proposée", color: "bg-slate-500/20 text-slate-200", icon: Clock },
+  voted_for: { label: "Adoptée", color: "bg-emerald-500/20 text-emerald-200", icon: CheckCircle2 },
+  voted_against: { label: "Rejetée", color: "bg-red-500/20 text-red-200", icon: XCircle },
+  abstained: { label: "Abstention", color: "bg-amber-500/20 text-amber-200", icon: AlertCircle },
+  adjourned: { label: "Ajournée", color: "bg-orange-500/20 text-orange-200", icon: Clock },
+  withdrawn: { label: "Retirée", color: "bg-slate-500/20 text-slate-300", icon: XCircle },
+};
+
+const MAJORITY_LABELS: Record<string, string> = {
+  article_24: "Art. 24 (majorité simple)",
+  article_25: "Art. 25 (majorité absolue)",
+  article_25_1: "Art. 25-1 (absolue + passerelle)",
+  article_26: "Art. 26 (double majorité)",
+  article_26_1: "Art. 26-1 (double + passerelle)",
+  unanimite: "Unanimité",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  gestion: "Gestion",
+  budget: "Budget",
+  travaux: "Travaux",
+  reglement: "Règlement",
+  honoraires: "Honoraires",
+  conseil_syndical: "Conseil syndical",
+  assurance: "Assurance",
+  conflits: "Conflits",
+  autre: "Autre",
 };
 
 export default function AssemblyDetailPage() {
-  const params = useParams();
   const router = useRouter();
-  const assemblyId = params.id as string;
+  const params = useParams();
+  const { toast } = useToast();
+  const assemblyId = params?.id as string;
 
-  const [assembly, setAssembly] = useState<Assembly | null>(null);
   const [loading, setLoading] = useState(true);
+  const [assembly, setAssembly] = useState<Assembly | null>(null);
+  const [resolutions, setResolutions] = useState<Resolution[]>([]);
+  const [convocations, setConvocations] = useState<ConvocationSummary[]>([]);
+  const [minutes, setMinutes] = useState<MinuteSummary[]>([]);
+  const [showAddResolution, setShowAddResolution] = useState(false);
+  const [showSendConvocations, setShowSendConvocations] = useState(false);
+
+  const fetchAssembly = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}`);
+      if (!res.ok) {
+        if (res.status === 404) {
+          toast({ title: "Assemblée introuvable", variant: "destructive" });
+          router.push("/syndic/assemblies");
+          return;
+        }
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur de chargement");
+      }
+      const data = await res.json();
+      setAssembly(data.assembly);
+      setResolutions(data.resolutions || []);
+      setConvocations(data.convocations || []);
+      setMinutes(data.minutes || []);
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de charger l'assemblée",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [assemblyId, router, toast]);
 
   useEffect(() => {
-    async function fetchAssembly() {
-      try {
-        const response = await fetch(`/api/copro/assemblies/${assemblyId}`);
-        if (response.ok) {
-          const data = await response.json();
-          setAssembly(data.assembly || data);
-        }
-      } catch (error) {
-        console.error("Erreur chargement assemblée:", error);
-      } finally {
-        setLoading(false);
-      }
+    if (assemblyId) {
+      fetchAssembly();
     }
-    if (assemblyId) fetchAssembly();
-  }, [assemblyId]);
+  }, [assemblyId, fetchAssembly]);
+
+  const handleDelete = async () => {
+    if (!confirm("Annuler cette assemblée ? Cette action peut être réversible en la recréant.")) return;
+
+    try {
+      const res = await fetch(`/api/copro/assemblies/${assemblyId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur");
+      }
+      toast({ title: "Assemblée annulée" });
+      router.push("/syndic/assemblies");
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible d'annuler",
+        variant: "destructive",
+      });
+    }
+  };
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-indigo-500" />
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+        <div className="max-w-5xl mx-auto space-y-6">
+          <Skeleton className="h-12 w-96 bg-white/10" />
+          <Skeleton className="h-48 bg-white/10" />
+          <Skeleton className="h-96 bg-white/10" />
+        </div>
       </div>
     );
   }
 
   if (!assembly) {
     return (
-      <div className="p-6">
-        <Card className="bg-white/80 backdrop-blur-sm">
-          <CardContent className="py-16 text-center">
-            <Calendar className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">Assemblée introuvable</h3>
-            <p className="text-muted-foreground mb-6">
-              Cette assemblée n'existe pas ou vous n'y avez pas accès.
-            </p>
-            <Button asChild>
-              <Link href="/syndic/assemblies">Retour aux assemblées</Link>
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+        <div className="max-w-5xl mx-auto">
+          <p className="text-white text-center py-12">Assemblée introuvable</p>
+        </div>
       </div>
     );
   }
 
-  const status = statusConfig[assembly.status] || statusConfig.draft;
-  const quorum = assembly.total_owners > 0
-    ? Math.round(((assembly.present_owners + assembly.proxy_owners) / assembly.total_owners) * 100)
-    : 0;
+  const statusConfig = STATUS_LABELS[assembly.status] || STATUS_LABELS.draft;
+  const canEdit = ["draft", "convened"].includes(assembly.status);
+  const canConvene = ["draft", "convened"].includes(assembly.status);
+  const canAddResolution = ["draft", "convened", "in_progress"].includes(assembly.status);
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      className="p-6"
-    >
-      <div className="max-w-4xl mx-auto">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-5xl mx-auto space-y-6">
         {/* Header */}
-        <div className="mb-6">
-          <Link
-            href="/syndic/assemblies"
-            className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 mb-4 transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Retour aux assemblées
+        <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
+          <Link href="/syndic/assemblies">
+            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10 mb-4">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour aux assemblées
+            </Button>
           </Link>
 
           <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
             <div>
               <div className="flex items-center gap-3 mb-2">
-                <h1 className="text-2xl font-bold">{assembly.title}</h1>
-                <Badge className={status.color}>{status.label}</Badge>
+                <h1 className="text-2xl font-bold text-white">{assembly.title}</h1>
+                <Badge className={`${statusConfig.color} border`}>{statusConfig.label}</Badge>
               </div>
-              <p className="text-muted-foreground">{assembly.site_name}</p>
+              <p className="text-slate-400 font-mono text-sm">
+                {assembly.reference_number || "Pas de référence"}
+              </p>
             </div>
-
             <div className="flex gap-2">
-              {assembly.status === "draft" && (
-                <>
-                  <Button variant="outline" asChild>
-                    <Link href={`/syndic/assemblies/${assemblyId}/edit`}>
-                      <Edit className="mr-2 h-4 w-4" />
-                      Modifier
-                    </Link>
+              {canEdit && (
+                <Link href={`/syndic/assemblies/${assembly.id}/edit`}>
+                  <Button variant="outline" size="sm" className="border-white/20 text-white hover:bg-white/10">
+                    <Edit className="h-4 w-4 mr-2" />
+                    Modifier
                   </Button>
-                  <Button className="bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700">
-                    <Send className="mr-2 h-4 w-4" />
-                    Envoyer convocations
-                  </Button>
-                </>
+                </Link>
               )}
-              {assembly.status === "completed" && (
-                <Button variant="outline">
-                  <Download className="mr-2 h-4 w-4" />
-                  Télécharger le PV
+              {assembly.status !== "cancelled" && assembly.status !== "held" && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleDelete}
+                  className="border-red-400/40 text-red-200 hover:bg-red-500/10"
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Annuler
                 </Button>
               )}
             </div>
           </div>
+        </motion.div>
+
+        {/* Info card */}
+        <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <CardContent className="p-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <InfoItem
+              icon={Calendar}
+              label="Date prévue"
+              value={`${formatDateShort(assembly.scheduled_at)} à ${new Date(assembly.scheduled_at).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`}
+            />
+            {assembly.fiscal_year && (
+              <InfoItem icon={FileText} label="Exercice" value={assembly.fiscal_year.toString()} />
+            )}
+            {assembly.location && <InfoItem icon={MapPin} label="Lieu" value={assembly.location} />}
+            {assembly.online_meeting_url && (
+              <InfoItem icon={Video} label="Visio" value="Lien de connexion disponible" />
+            )}
+            {assembly.quorum_required !== null && (
+              <InfoItem icon={Users} label="Quorum requis" value={`${assembly.quorum_required} tantièmes`} />
+            )}
+            {assembly.first_convocation_sent_at && (
+              <InfoItem
+                icon={Send}
+                label="Convoquée le"
+                value={formatDateShort(assembly.first_convocation_sent_at)}
+              />
+            )}
+          </CardContent>
+          {assembly.description && (
+            <div className="px-6 pb-6">
+              <p className="text-sm text-slate-300">{assembly.description}</p>
+            </div>
+          )}
+        </Card>
+
+        {/* Actions */}
+        <div className="flex flex-wrap gap-3">
+          {canConvene && resolutions.length > 0 && (
+            <Button
+              onClick={() => setShowSendConvocations(true)}
+              className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700"
+            >
+              <Send className="h-4 w-4 mr-2" />
+              Envoyer les convocations
+            </Button>
+          )}
         </div>
 
-        <div className="grid gap-6 md:grid-cols-3">
-          {/* Informations */}
-          <Card className="bg-white/80 backdrop-blur-sm md:col-span-2">
-            <CardHeader>
-              <CardTitle>Informations</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex items-center gap-3">
-                  <div className="h-10 w-10 rounded-lg bg-indigo-100 flex items-center justify-center">
-                    <Calendar className="h-5 w-5 text-indigo-600" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Date</p>
-                    <p className="font-medium">
-                      {format(new Date(assembly.date), "EEEE d MMMM yyyy", { locale: fr })}
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-3">
-                  <div className="h-10 w-10 rounded-lg bg-indigo-100 flex items-center justify-center">
-                    <Clock className="h-5 w-5 text-indigo-600" />
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground">Heure</p>
-                    <p className="font-medium">{assembly.time}</p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-3">
-                <div className="h-10 w-10 rounded-lg bg-indigo-100 flex items-center justify-center shrink-0">
-                  <MapPin className="h-5 w-5 text-indigo-600" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">Lieu</p>
-                  <p className="font-medium">{assembly.location}</p>
-                </div>
-              </div>
-
-              {assembly.description && (
-                <div className="pt-4 border-t">
-                  <p className="text-sm text-muted-foreground mb-1">Description</p>
-                  <p>{assembly.description}</p>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Participation */}
-          <Card className="bg-white/80 backdrop-blur-sm">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Users className="h-5 w-5 text-indigo-500" />
-                Participation
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="text-center">
-                <p className="text-4xl font-bold text-indigo-600">{quorum}%</p>
-                <p className="text-sm text-muted-foreground">Quorum atteint</p>
-              </div>
-              <Progress value={quorum} className="h-2" />
-              
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Présents</span>
-                  <span className="font-medium">{assembly.present_owners}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Représentés</span>
-                  <span className="font-medium">{assembly.proxy_owners}</span>
-                </div>
-                <div className="flex justify-between border-t pt-2">
-                  <span className="text-muted-foreground">Total copropriétaires</span>
-                  <span className="font-medium">{assembly.total_owners}</span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Résolutions */}
-        <Card className="bg-white/80 backdrop-blur-sm mt-6">
+        {/* Resolutions */}
+        <Card className="bg-white/5 border-white/10 backdrop-blur">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <FileText className="h-5 w-5 text-indigo-500" />
-              Résolutions ({assembly.resolutions?.length || 0})
-            </CardTitle>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle className="text-white flex items-center gap-2">
+                  <Vote className="h-5 w-5 text-violet-400" />
+                  Ordre du jour ({resolutions.length})
+                </CardTitle>
+                <CardDescription className="text-slate-400">
+                  Résolutions soumises au vote de l'assemblée
+                </CardDescription>
+              </div>
+              {canAddResolution && (
+                <Button
+                  size="sm"
+                  onClick={() => setShowAddResolution(true)}
+                  className="bg-violet-500 hover:bg-violet-600"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Ajouter
+                </Button>
+              )}
+            </div>
           </CardHeader>
           <CardContent>
-            {!assembly.resolutions || assembly.resolutions.length === 0 ? (
-              <div className="py-8 text-center text-muted-foreground">
-                <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                <p>Aucune résolution enregistrée</p>
+            {resolutions.length === 0 ? (
+              <div className="text-center py-8 text-slate-400">
+                <Vote className="h-10 w-10 mx-auto mb-3 text-slate-500" />
+                <p>Aucune résolution pour le moment</p>
+                {canAddResolution && (
+                  <p className="text-xs mt-2">Ajoutez une résolution pour commencer l'ordre du jour</p>
+                )}
               </div>
             ) : (
-              <div className="space-y-4">
-                {assembly.resolutions.map((resolution, index) => {
-                  const totalVotes = resolution.votes_for + resolution.votes_against + resolution.votes_abstain;
-                  const forPercent = totalVotes > 0 ? Math.round((resolution.votes_for / totalVotes) * 100) : 0;
+              <div className="space-y-3">
+                {resolutions.map((resolution) => {
+                  const resStatus =
+                    RESOLUTION_STATUS_LABELS[resolution.status] || RESOLUTION_STATUS_LABELS.proposed;
+                  const StatusIcon = resStatus.icon;
+                  const hasVotes =
+                    resolution.votes_for_count + resolution.votes_against_count + resolution.votes_abstain_count > 0;
 
                   return (
                     <div
                       key={resolution.id}
-                      className="p-4 rounded-lg border border-slate-200 space-y-3"
+                      className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-3"
                     >
-                      <div className="flex items-start justify-between">
-                        <div>
-                          <div className="flex items-center gap-2 mb-1">
-                            <span className="text-sm font-medium text-muted-foreground">
-                              Résolution {index + 1}
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1 flex-wrap">
+                            <span className="font-mono text-xs text-slate-500">
+                              #{resolution.resolution_number}
                             </span>
-                            {resolution.status === "approved" && (
-                              <Badge className="bg-green-100 text-green-700">
-                                <CheckCircle2 className="h-3 w-3 mr-1" />
-                                Adoptée
-                              </Badge>
-                            )}
-                            {resolution.status === "rejected" && (
-                              <Badge className="bg-red-100 text-red-700">
-                                <XCircle className="h-3 w-3 mr-1" />
-                                Rejetée
-                              </Badge>
-                            )}
-                            {resolution.status === "pending" && (
-                              <Badge className="bg-slate-100 text-slate-700">
-                                <AlertCircle className="h-3 w-3 mr-1" />
-                                En attente
-                              </Badge>
-                            )}
+                            <Badge variant="outline" className="border-white/20 text-slate-300 text-xs">
+                              {CATEGORY_LABELS[resolution.category] || resolution.category}
+                            </Badge>
+                            <Badge variant="outline" className="border-violet-400/30 text-violet-200 text-xs">
+                              {MAJORITY_LABELS[resolution.majority_rule] || resolution.majority_rule}
+                            </Badge>
                           </div>
-                          <h4 className="font-medium">{resolution.title}</h4>
-                          {resolution.description && (
-                            <p className="text-sm text-muted-foreground mt-1">
-                              {resolution.description}
+                          <h4 className="text-white font-medium">{resolution.title}</h4>
+                          <p className="text-sm text-slate-400 mt-1">{resolution.description}</p>
+                          {resolution.estimated_amount_cents && (
+                            <p className="text-xs text-amber-200 mt-2">
+                              Montant estimé : {(resolution.estimated_amount_cents / 100).toLocaleString("fr-FR")} €
                             </p>
                           )}
                         </div>
+                        <Badge className={resStatus.color}>
+                          <StatusIcon className="h-3 w-3 mr-1" />
+                          {resStatus.label}
+                        </Badge>
                       </div>
 
-                      {totalVotes > 0 && (
-                        <div className="space-y-2">
-                          <Progress value={forPercent} className="h-2" />
-                          <div className="flex justify-between text-xs text-muted-foreground">
-                            <span>Pour: {resolution.votes_for}</span>
-                            <span>Contre: {resolution.votes_against}</span>
-                            <span>Abstention: {resolution.votes_abstain}</span>
-                          </div>
+                      {hasVotes && (
+                        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-white/10">
+                          <VoteStat
+                            label="Pour"
+                            count={resolution.votes_for_count}
+                            tantiemes={resolution.tantiemes_for}
+                            color="text-emerald-300"
+                          />
+                          <VoteStat
+                            label="Contre"
+                            count={resolution.votes_against_count}
+                            tantiemes={resolution.tantiemes_against}
+                            color="text-red-300"
+                          />
+                          <VoteStat
+                            label="Abstention"
+                            count={resolution.votes_abstain_count}
+                            tantiemes={resolution.tantiemes_abstain}
+                            color="text-amber-300"
+                          />
                         </div>
                       )}
                     </div>
@@ -331,8 +416,138 @@ export default function AssemblyDetailPage() {
             )}
           </CardContent>
         </Card>
+
+        {/* Convocations summary */}
+        {convocations.length > 0 && (
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <Send className="h-5 w-5 text-blue-400" />
+                Convocations ({convocations.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ConvocationStats convocations={convocations} />
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Minutes */}
+        {minutes.length > 0 && (
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <FileText className="h-5 w-5 text-emerald-400" />
+                Procès-verbaux ({minutes.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {minutes.map((minute) => (
+                  <div
+                    key={minute.id}
+                    className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 p-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      <FileText className="h-4 w-4 text-slate-400" />
+                      <div>
+                        <p className="text-white text-sm">Version {minute.version}</p>
+                        <p className="text-xs text-slate-400">
+                          {minute.signed_by_president_at
+                            ? `Signé le ${formatDateShort(minute.signed_by_president_at)}`
+                            : "Non signé"}
+                        </p>
+                      </div>
+                    </div>
+                    <Badge className="bg-slate-500/20 text-slate-200 capitalize">{minute.status}</Badge>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
       </div>
-    </motion.div>
+
+      {showAddResolution && (
+        <AddResolutionDialog
+          assemblyId={assemblyId}
+          nextResolutionNumber={resolutions.length + 1}
+          onClose={() => setShowAddResolution(false)}
+          onCreated={() => {
+            setShowAddResolution(false);
+            fetchAssembly();
+          }}
+        />
+      )}
+
+      {showSendConvocations && (
+        <SendConvocationsDialog
+          assemblyId={assemblyId}
+          onClose={() => setShowSendConvocations(false)}
+          onSent={() => {
+            setShowSendConvocations(false);
+            fetchAssembly();
+          }}
+        />
+      )}
+    </div>
   );
 }
 
+function InfoItem({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <Icon className="h-4 w-4 text-slate-400 mt-0.5" />
+      <div>
+        <p className="text-xs text-slate-500 uppercase tracking-wide">{label}</p>
+        <p className="text-sm text-white mt-0.5">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function VoteStat({
+  label,
+  count,
+  tantiemes,
+  color,
+}: {
+  label: string;
+  count: number;
+  tantiemes: number;
+  color: string;
+}) {
+  return (
+    <div className="text-center">
+      <p className="text-xs text-slate-400">{label}</p>
+      <p className={`text-lg font-bold ${color}`}>{count}</p>
+      <p className="text-xs text-slate-500">{tantiemes.toLocaleString("fr-FR")} tant.</p>
+    </div>
+  );
+}
+
+function ConvocationStats({ convocations }: { convocations: ConvocationSummary[] }) {
+  const byStatus = convocations.reduce<Record<string, number>>((acc, c) => {
+    acc[c.status] = (acc[c.status] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {Object.entries(byStatus).map(([status, count]) => (
+        <div key={status} className="rounded-lg border border-white/10 bg-white/5 p-3 text-center">
+          <p className="text-xs text-slate-400 capitalize">{status}</p>
+          <p className="text-xl font-bold text-white mt-1">{count}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/syndic/assemblies/new/page.tsx
+++ b/app/syndic/assemblies/new/page.tsx
@@ -1,8 +1,7 @@
 "use client";
-// @ts-nocheck
 
-import { useState, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -17,439 +16,473 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   ArrowLeft,
   Building2,
   CalendarIcon,
-  Clock,
-  MapPin,
-  Users,
-  FileText,
-  Plus,
-  Trash2,
   Loader2,
-  Send,
+  MapPin,
+  Save,
+  Video,
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
-import { format, addDays, setHours, setMinutes } from "date-fns";
-import { fr } from "date-fns/locale";
-import { cn } from "@/lib/utils";
-
-const assemblyTypes = [
-  { value: "ordinary", label: "AG Ordinaire", description: "Assemblée annuelle obligatoire" },
-  { value: "extraordinary", label: "AG Extraordinaire", description: "Assemblée exceptionnelle" },
-];
 
 interface Site {
   id: string;
   name: string;
-  address: string;
-  total_owners: number;
+  address_line1?: string;
+  postal_code?: string;
+  city?: string;
+  total_tantiemes_general?: number;
 }
 
-interface Resolution {
-  id: string;
-  title: string;
-  description: string;
-  majority: "simple" | "absolute" | "double" | "unanimity";
-}
-
-const majorityOptions = [
-  { value: "simple", label: "Majorité simple (Art. 24)", description: "Majorité des voix exprimées" },
-  { value: "absolute", label: "Majorité absolue (Art. 25)", description: "Majorité de tous les copropriétaires" },
-  { value: "double", label: "Double majorité (Art. 26)", description: "2/3 des voix de tous les copropriétaires" },
-  { value: "unanimity", label: "Unanimité", description: "Accord de tous les copropriétaires" },
+const ASSEMBLY_TYPES = [
+  { value: "ordinaire", label: "AG Ordinaire", description: "Assemblée annuelle obligatoire" },
+  { value: "extraordinaire", label: "AG Extraordinaire", description: "Assemblée exceptionnelle" },
+  {
+    value: "concertation",
+    label: "Concertation",
+    description: "Réunion sans vote (information, consultation)",
+  },
+  {
+    value: "consultation_ecrite",
+    label: "Consultation écrite",
+    description: "Vote par correspondance sans réunion",
+  },
 ];
 
 export default function NewAssemblyPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { toast } = useToast();
+  const isSubmittingRef = useRef(false);
 
-  const preselectedSiteId = searchParams.get("siteId");
-
-  const [loading, setLoading] = useState(false);
-  const [sites, setSites] = useState<Site[]>([]);
   const [loadingSites, setLoadingSites] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [sites, setSites] = useState<Site[]>([]);
 
   const [form, setForm] = useState({
-    site_id: preselectedSiteId || "",
-    type: "ordinary",
+    site_id: "",
+    assembly_type: "ordinaire" as "ordinaire" | "extraordinaire" | "concertation" | "consultation_ecrite",
     title: "",
-    date: addDays(new Date(), 30),
-    time: "18:00",
+    scheduled_date: "",
+    scheduled_time: "18:00",
     location: "",
+    location_address: "",
+    online_meeting_url: "",
+    is_hybrid: false,
+    quorum_required: "",
+    fiscal_year: new Date().getFullYear().toString(),
     description: "",
+    notes: "",
   });
 
-  const [resolutions, setResolutions] = useState<Resolution[]>([
-    { id: "1", title: "", description: "", majority: "simple" },
-  ]);
-
   useEffect(() => {
-    async function fetchSites() {
+    const loadSites = async () => {
       try {
-        const response = await fetch("/api/copro/sites");
-        if (response.ok) {
-          const data = await response.json();
-          setSites(data.sites || data || []);
-        }
+        const res = await fetch("/api/copro/sites");
+        if (!res.ok) throw new Error("Impossible de charger les sites");
+        const data = await res.json();
+        setSites(Array.isArray(data) ? data : []);
       } catch (error) {
-        console.error("Erreur chargement sites:", error);
+        toast({
+          title: "Erreur",
+          description: error instanceof Error ? error.message : "Erreur de chargement",
+          variant: "destructive",
+        });
       } finally {
         setLoadingSites(false);
       }
-    }
-    fetchSites();
-  }, []);
-
-  const addResolution = () => {
-    setResolutions([
-      ...resolutions,
-      { id: Date.now().toString(), title: "", description: "", majority: "simple" },
-    ]);
-  };
-
-  const removeResolution = (id: string) => {
-    if (resolutions.length > 1) {
-      setResolutions(resolutions.filter((r) => r.id !== id));
-    }
-  };
-
-  const updateResolution = (id: string, field: keyof Resolution, value: string) => {
-    setResolutions(
-      resolutions.map((r) => (r.id === id ? { ...r, [field]: value } : r))
-    );
-  };
+    };
+    loadSites();
+  }, [toast]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmittingRef.current) return;
 
-    if (!form.site_id || !form.title || !form.location) {
-      toast({
-        title: "Champs requis",
-        description: "Veuillez remplir tous les champs obligatoires.",
-        variant: "destructive",
-      });
+    // Validations
+    if (!form.site_id) {
+      toast({ title: "Site requis", description: "Sélectionnez une copropriété", variant: "destructive" });
+      return;
+    }
+    if (!form.title || form.title.length < 3) {
+      toast({ title: "Titre requis", description: "Au moins 3 caractères", variant: "destructive" });
+      return;
+    }
+    if (!form.scheduled_date) {
+      toast({ title: "Date requise", description: "Choisissez une date", variant: "destructive" });
       return;
     }
 
-    const validResolutions = resolutions.filter((r) => r.title.trim());
-    if (validResolutions.length === 0) {
-      toast({
-        title: "Résolutions requises",
-        description: "Ajoutez au moins une résolution à l'ordre du jour.",
-        variant: "destructive",
-      });
-      return;
-    }
+    isSubmittingRef.current = true;
+    setSubmitting(true);
 
-    setLoading(true);
     try {
-      const response = await fetch("/api/copro/assemblies", {
+      const scheduledAt = new Date(`${form.scheduled_date}T${form.scheduled_time}:00`).toISOString();
+
+      const payload = {
+        site_id: form.site_id,
+        assembly_type: form.assembly_type,
+        title: form.title.trim(),
+        scheduled_at: scheduledAt,
+        fiscal_year: form.fiscal_year ? parseInt(form.fiscal_year, 10) : undefined,
+        location: form.location.trim() || undefined,
+        location_address: form.location_address.trim() || undefined,
+        online_meeting_url: form.online_meeting_url.trim() || undefined,
+        is_hybrid: form.is_hybrid,
+        quorum_required: form.quorum_required ? parseInt(form.quorum_required, 10) : undefined,
+        description: form.description.trim() || undefined,
+        notes: form.notes.trim() || undefined,
+      };
+
+      const res = await fetch("/api/copro/assemblies", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...form,
-          resolutions: validResolutions,
-        }),
+        body: JSON.stringify(payload),
       });
 
-      if (!response.ok) throw new Error("Erreur création");
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la création");
+      }
+
+      const assembly = await res.json();
 
       toast({
-        title: "Assemblée planifiée",
-        description: "Les convocations seront envoyées aux copropriétaires.",
+        title: "Assemblée créée",
+        description: `${assembly.reference_number || assembly.title} a été créée en brouillon`,
       });
 
-      router.push(`/syndic/assemblies`);
+      router.push(`/syndic/assemblies/${assembly.id}`);
     } catch (error) {
       toast({
         title: "Erreur",
-        description: "Impossible de créer l'assemblée.",
+        description: error instanceof Error ? error.message : "Impossible de créer l'assemblée",
         variant: "destructive",
       });
     } finally {
-      setLoading(false);
+      setSubmitting(false);
+      isSubmittingRef.current = false;
     }
   };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      className="p-6"
-    >
-      <div className="max-w-3xl mx-auto">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-3xl mx-auto space-y-6">
         {/* Header */}
-        <div className="mb-8">
-          <Link
-            href="/syndic/assemblies"
-            className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 mb-4 transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Retour aux assemblées
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center gap-4"
+        >
+          <Link href="/syndic/assemblies">
+            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour
+            </Button>
           </Link>
-          <h1 className="text-3xl font-bold bg-gradient-to-r from-slate-900 via-indigo-900 to-slate-900 bg-clip-text text-transparent">
-            Planifier une assemblée
-          </h1>
-          <p className="text-muted-foreground mt-1">
-            Organisez une assemblée générale de copropriété
-          </p>
-        </div>
+          <div>
+            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+              <CalendarIcon className="h-6 w-6 text-violet-400" />
+              Nouvelle assemblée générale
+            </h1>
+            <p className="text-slate-400">Créez une AG en brouillon — vous pourrez ensuite ajouter les résolutions</p>
+          </div>
+        </motion.div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
-          {/* Informations générales */}
-          <Card className="bg-white/80 backdrop-blur-sm">
+          {/* Site selection */}
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <CalendarIcon className="h-5 w-5 text-indigo-500" />
-                Informations générales
+              <CardTitle className="text-white flex items-center gap-2">
+                <Building2 className="h-5 w-5 text-violet-400" />
+                Copropriété
               </CardTitle>
+              <CardDescription className="text-slate-400">
+                Choisissez la copropriété concernée
+              </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-4">
-              {/* Site */}
-              <div className="space-y-2">
-                <Label htmlFor="site_id" className="flex items-center gap-2">
-                  <Building2 className="h-4 w-4 text-muted-foreground" />
-                  Site concerné *
-                </Label>
+            <CardContent className="space-y-3">
+              <Label htmlFor="site_id" className="text-slate-300">
+                Site *
+              </Label>
+              {loadingSites ? (
+                <div className="text-slate-400 text-sm">Chargement des sites...</div>
+              ) : sites.length === 0 ? (
+                <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+                  Aucune copropriété disponible.{" "}
+                  <Link href="/syndic/sites" className="underline">
+                    Créez votre premier site
+                  </Link>
+                </div>
+              ) : (
                 <Select
                   value={form.site_id}
                   onValueChange={(value) => setForm({ ...form, site_id: value })}
-                  disabled={loadingSites}
+                  disabled={submitting}
                 >
-                  <SelectTrigger className="bg-white">
-                    <SelectValue placeholder={loadingSites ? "Chargement..." : "Sélectionner un site"} />
+                  <SelectTrigger id="site_id" className="bg-white/5 border-white/10 text-white">
+                    <SelectValue placeholder="Sélectionner une copropriété" />
                   </SelectTrigger>
                   <SelectContent>
                     {sites.map((site) => (
                       <SelectItem key={site.id} value={site.id}>
                         {site.name}
+                        {site.city && ` — ${site.city}`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Type & title */}
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white">Nature de l'assemblée</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-slate-300">Type *</Label>
+                <Select
+                  value={form.assembly_type}
+                  onValueChange={(value: typeof form.assembly_type) => setForm({ ...form, assembly_type: value })}
+                  disabled={submitting}
+                >
+                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ASSEMBLY_TYPES.map((type) => (
+                      <SelectItem key={type.value} value={type.value}>
+                        <div>
+                          <div className="font-medium">{type.label}</div>
+                          <div className="text-xs text-slate-500">{type.description}</div>
+                        </div>
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               </div>
 
-              {/* Type */}
               <div className="space-y-2">
-                <Label>Type d'assemblée *</Label>
-                <div className="grid grid-cols-2 gap-3">
-                  {assemblyTypes.map((type) => (
-                    <div
-                      key={type.value}
-                      onClick={() => setForm({ ...form, type: type.value })}
-                      className={cn(
-                        "p-3 rounded-lg border-2 cursor-pointer transition-all",
-                        form.type === type.value
-                          ? "border-indigo-500 bg-indigo-50"
-                          : "border-slate-200 hover:border-slate-300 bg-white"
-                      )}
-                    >
-                      <p className="font-medium text-sm">{type.label}</p>
-                      <p className="text-xs text-muted-foreground">{type.description}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Titre */}
-              <div className="space-y-2">
-                <Label htmlFor="title">Titre *</Label>
+                <Label htmlFor="title" className="text-slate-300">
+                  Titre *
+                </Label>
                 <Input
                   id="title"
+                  placeholder="Ex: AG Annuelle 2026"
                   value={form.title}
                   onChange={(e) => setForm({ ...form, title: e.target.value })}
-                  placeholder="Ex: Assemblée Générale Ordinaire 2025"
-                  className="bg-white"
                   required
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
                 />
               </div>
 
-              {/* Date et Heure */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Date *</Label>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-full justify-start text-left font-normal bg-white",
-                          !form.date && "text-muted-foreground"
-                        )}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {form.date ? format(form.date, "PPP", { locale: fr }) : "Sélectionner"}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={form.date}
-                        onSelect={(date) => date && setForm({ ...form, date })}
-                        locale={fr}
-                        initialFocus
-                        disabled={(date) => date < new Date()}
-                      />
-                    </PopoverContent>
-                  </Popover>
+                  <Label htmlFor="scheduled_date" className="text-slate-300">
+                    Date *
+                  </Label>
+                  <Input
+                    id="scheduled_date"
+                    type="date"
+                    value={form.scheduled_date}
+                    onChange={(e) => setForm({ ...form, scheduled_date: e.target.value })}
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                    min={new Date().toISOString().split("T")[0]}
+                  />
                 </div>
-
                 <div className="space-y-2">
-                  <Label htmlFor="time" className="flex items-center gap-2">
-                    <Clock className="h-4 w-4 text-muted-foreground" />
+                  <Label htmlFor="scheduled_time" className="text-slate-300">
                     Heure *
                   </Label>
                   <Input
-                    id="time"
+                    id="scheduled_time"
                     type="time"
-                    value={form.time}
-                    onChange={(e) => setForm({ ...form, time: e.target.value })}
-                    className="bg-white"
+                    value={form.scheduled_time}
+                    onChange={(e) => setForm({ ...form, scheduled_time: e.target.value })}
                     required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
                   />
                 </div>
               </div>
 
-              {/* Lieu */}
-              <div className="space-y-2">
-                <Label htmlFor="location" className="flex items-center gap-2">
-                  <MapPin className="h-4 w-4 text-muted-foreground" />
-                  Lieu *
-                </Label>
-                <Input
-                  id="location"
-                  value={form.location}
-                  onChange={(e) => setForm({ ...form, location: e.target.value })}
-                  placeholder="Adresse complète du lieu de réunion"
-                  className="bg-white"
-                  required
-                />
-              </div>
-
-              {/* Description */}
-              <div className="space-y-2">
-                <Label htmlFor="description">Description</Label>
-                <Textarea
-                  id="description"
-                  value={form.description}
-                  onChange={(e) => setForm({ ...form, description: e.target.value })}
-                  placeholder="Informations complémentaires..."
-                  rows={3}
-                  className="bg-white resize-none"
-                />
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="fiscal_year" className="text-slate-300">
+                    Exercice concerné
+                  </Label>
+                  <Input
+                    id="fiscal_year"
+                    type="number"
+                    min="2020"
+                    max="2100"
+                    value={form.fiscal_year}
+                    onChange={(e) => setForm({ ...form, fiscal_year: e.target.value })}
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="quorum_required" className="text-slate-300">
+                    Quorum requis (tantièmes)
+                  </Label>
+                  <Input
+                    id="quorum_required"
+                    type="number"
+                    min="0"
+                    placeholder="Optionnel"
+                    value={form.quorum_required}
+                    onChange={(e) => setForm({ ...form, quorum_required: e.target.value })}
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
               </div>
             </CardContent>
           </Card>
 
-          {/* Ordre du jour */}
-          <Card className="bg-white/80 backdrop-blur-sm">
-            <CardHeader className="flex flex-row items-center justify-between">
-              <div>
-                <CardTitle className="flex items-center gap-2">
-                  <FileText className="h-5 w-5 text-indigo-500" />
-                  Ordre du jour
-                </CardTitle>
-                <CardDescription>Résolutions à voter lors de l'assemblée</CardDescription>
-              </div>
-              <Button type="button" variant="outline" size="sm" onClick={addResolution}>
-                <Plus className="mr-2 h-4 w-4" />
-                Ajouter
-              </Button>
+          {/* Location */}
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <MapPin className="h-5 w-5 text-violet-400" />
+                Lieu et modalités
+              </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              {resolutions.map((resolution, index) => (
-                <div
-                  key={resolution.id}
-                  className="p-4 rounded-lg border border-slate-200 space-y-3"
-                >
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-muted-foreground">
-                      Résolution {index + 1}
-                    </span>
-                    {resolutions.length > 1 && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => removeResolution(resolution.id)}
-                        className="text-red-500 hover:text-red-700 hover:bg-red-50"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
+              <div className="space-y-2">
+                <Label htmlFor="location" className="text-slate-300">
+                  Lieu (description courte)
+                </Label>
+                <Input
+                  id="location"
+                  placeholder="Ex: Salle polyvalente"
+                  value={form.location}
+                  onChange={(e) => setForm({ ...form, location: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="location_address" className="text-slate-300">
+                  Adresse complète
+                </Label>
+                <Input
+                  id="location_address"
+                  placeholder="12 rue des Lilas, 75001 Paris"
+                  value={form.location_address}
+                  onChange={(e) => setForm({ ...form, location_address: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="online_meeting_url" className="text-slate-300 flex items-center gap-2">
+                  <Video className="h-4 w-4" />
+                  Lien visio (optionnel)
+                </Label>
+                <Input
+                  id="online_meeting_url"
+                  type="url"
+                  placeholder="https://meet.google.com/..."
+                  value={form.online_meeting_url}
+                  onChange={(e) => setForm({ ...form, online_meeting_url: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  id="is_hybrid"
+                  type="checkbox"
+                  checked={form.is_hybrid}
+                  onChange={(e) => setForm({ ...form, is_hybrid: e.target.checked })}
+                  disabled={submitting}
+                  className="h-4 w-4 rounded border-white/30 bg-transparent"
+                />
+                <Label htmlFor="is_hybrid" className="text-slate-300 cursor-pointer">
+                  Assemblée hybride (présentiel + visio)
+                </Label>
+              </div>
+            </CardContent>
+          </Card>
 
-                  <Input
-                    value={resolution.title}
-                    onChange={(e) => updateResolution(resolution.id, "title", e.target.value)}
-                    placeholder="Titre de la résolution"
-                    className="bg-white"
-                  />
-
-                  <Textarea
-                    value={resolution.description}
-                    onChange={(e) => updateResolution(resolution.id, "description", e.target.value)}
-                    placeholder="Description..."
-                    rows={2}
-                    className="bg-white resize-none"
-                  />
-
-                  <Select
-                    value={resolution.majority}
-                    onValueChange={(value) => updateResolution(resolution.id, "majority", value)}
-                  >
-                    <SelectTrigger className="bg-white">
-                      <SelectValue placeholder="Type de majorité" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {majorityOptions.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          <div>
-                            <span className="font-medium">{option.label}</span>
-                            <span className="text-muted-foreground text-xs ml-2">
-                              {option.description}
-                            </span>
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ))}
+          {/* Description */}
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white">Description et notes</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="description" className="text-slate-300">
+                  Description (publique)
+                </Label>
+                <Textarea
+                  id="description"
+                  placeholder="Contexte de l'assemblée, sujets principaux..."
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  rows={3}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="notes" className="text-slate-300">
+                  Notes internes (privées)
+                </Label>
+                <Textarea
+                  id="notes"
+                  placeholder="Notes privées non visibles des copropriétaires"
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  rows={2}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
             </CardContent>
           </Card>
 
           {/* Actions */}
-          <div className="flex gap-3">
-            <Button type="button" variant="outline" onClick={() => router.back()} className="flex-1">
-              Annuler
-            </Button>
+          <div className="flex gap-3 justify-end">
+            <Link href="/syndic/assemblies">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={submitting}
+                className="border-white/20 text-white hover:bg-white/10"
+              >
+                Annuler
+              </Button>
+            </Link>
             <Button
               type="submit"
-              disabled={loading}
-              className="flex-1 bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700"
+              disabled={submitting || loadingSites || sites.length === 0}
+              className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
             >
-              {loading ? (
+              {submitting ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                   Création...
                 </>
               ) : (
                 <>
-                  <Send className="mr-2 h-4 w-4" />
-                  Planifier l'assemblée
+                  <Save className="h-4 w-4 mr-2" />
+                  Créer l'assemblée
                 </>
               )}
             </Button>
           </div>
         </form>
       </div>
-    </motion.div>
+    </div>
   );
 }
-

--- a/app/syndic/assemblies/page.tsx
+++ b/app/syndic/assemblies/page.tsx
@@ -1,23 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import Link from "next/link";
 import { motion } from "framer-motion";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  DialogFooter,
-} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
@@ -37,243 +27,101 @@ import {
   Calendar,
   Plus,
   Search,
-  Users,
-  MapPin,
-  Clock,
-  FileText,
-  Video,
-  CheckCircle2,
-  XCircle,
-  Edit,
   Eye,
-  Send,
-  Building2
+  Video,
+  MapPin,
+  Building2,
+  AlertCircle,
+  CheckCircle2,
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { formatDateShort } from "@/lib/helpers/format";
-import Link from "next/link";
 
 interface Assembly {
   id: string;
   site_id: string;
-  site_name: string;
-  type: "ordinaire" | "extraordinaire";
   title: string;
-  date: string;
-  time: string;
-  location: string;
-  video_link?: string;
-  status: "draft" | "convened" | "ongoing" | "completed" | "cancelled";
-  quorum_required: number;
-  attendees_count: number;
-  agenda: AgendaItem[];
-  created_at: string;
-}
-
-interface AgendaItem {
-  id: string;
-  order: number;
-  title: string;
-  description?: string;
-  type: "information" | "vote_simple" | "vote_qualifie" | "vote_unanime";
-  result?: "approved" | "rejected" | "deferred";
-}
-
-interface Site {
-  id: string;
-  name: string;
-  units_count: number;
+  reference_number: string | null;
+  assembly_type: "ordinaire" | "extraordinaire" | "concertation" | "consultation_ecrite";
+  scheduled_at: string;
+  location: string | null;
+  online_meeting_url: string | null;
+  is_hybrid: boolean;
+  status: "draft" | "convened" | "in_progress" | "held" | "adjourned" | "cancelled";
+  quorum_required: number | null;
+  present_tantiemes: number | null;
+  fiscal_year: number | null;
 }
 
 const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
-  draft: { label: "Brouillon", color: "bg-gray-100 text-gray-800" },
-  convened: { label: "Convoquée", color: "bg-blue-100 text-blue-800" },
-  ongoing: { label: "En cours", color: "bg-amber-100 text-amber-800" },
-  completed: { label: "Terminée", color: "bg-green-100 text-green-800" },
-  cancelled: { label: "Annulée", color: "bg-red-100 text-red-800" },
+  draft: { label: "Brouillon", color: "bg-slate-500/20 text-slate-200 border-slate-400/40" },
+  convened: { label: "Convoquée", color: "bg-blue-500/20 text-blue-200 border-blue-400/40" },
+  in_progress: { label: "En cours", color: "bg-amber-500/20 text-amber-200 border-amber-400/40" },
+  held: { label: "Tenue", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40" },
+  adjourned: { label: "Ajournée", color: "bg-orange-500/20 text-orange-200 border-orange-400/40" },
+  cancelled: { label: "Annulée", color: "bg-red-500/20 text-red-200 border-red-400/40" },
 };
 
-const TYPE_CONFIG: Record<string, { label: string; color: string }> = {
-  ordinaire: { label: "AG Ordinaire", color: "bg-cyan-100 text-cyan-800" },
-  extraordinaire: { label: "AG Extraordinaire", color: "bg-violet-100 text-violet-800" },
+const TYPE_CONFIG: Record<string, { label: string; short: string }> = {
+  ordinaire: { label: "AG Ordinaire", short: "AGO" },
+  extraordinaire: { label: "AG Extraordinaire", short: "AGE" },
+  concertation: { label: "Concertation", short: "CONC" },
+  consultation_ecrite: { label: "Consultation écrite", short: "CE" },
 };
 
 export default function SyndicAssembliesPage() {
   const { toast } = useToast();
   const [loading, setLoading] = useState(true);
   const [assemblies, setAssemblies] = useState<Assembly[]>([]);
-  const [sites, setSites] = useState<Site[]>([]);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
-  const [dialogOpen, setDialogOpen] = useState(false);
-
-  // Form state
-  const [newAssembly, setNewAssembly] = useState({
-    site_id: "",
-    type: "ordinaire" as Assembly["type"],
-    title: "",
-    date: "",
-    time: "18:00",
-    location: "",
-    video_link: "",
-    agenda: [] as { title: string; type: string }[],
-  });
+  const [typeFilter, setTypeFilter] = useState<string>("all");
 
   useEffect(() => {
-    fetchData();
-  }, []);
+    const fetchAssemblies = async () => {
+      try {
+        const res = await fetch("/api/copro/assemblies");
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || "Impossible de charger les assemblées");
+        }
+        const data = await res.json();
+        setAssemblies(Array.isArray(data) ? data : []);
+      } catch (error) {
+        toast({
+          title: "Erreur",
+          description: error instanceof Error ? error.message : "Impossible de charger les assemblées",
+          variant: "destructive",
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAssemblies();
+  }, [toast]);
 
-  const fetchData = async () => {
-    try {
-      // Simuler les données
-      const mockAssemblies: Assembly[] = [
-        {
-          id: "1",
-          site_id: "1",
-          site_name: "Résidence Les Lilas",
-          type: "ordinaire",
-          title: "AG Annuelle 2025",
-          date: "2025-03-15",
-          time: "18:00",
-          location: "Salle polyvalente, 12 rue des Lilas",
-          status: "convened",
-          quorum_required: 25,
-          attendees_count: 0,
-          agenda: [
-            { id: "1", order: 1, title: "Approbation des comptes 2024", type: "vote_simple" },
-            { id: "2", order: 2, title: "Budget prévisionnel 2025", type: "vote_simple" },
-            { id: "3", order: 3, title: "Travaux de ravalement", type: "vote_qualifie" },
-          ],
-          created_at: "2025-01-15",
-        },
-        {
-          id: "2",
-          site_id: "2",
-          site_name: "Le Clos des Vignes",
-          type: "extraordinaire",
-          title: "AG Travaux urgents",
-          date: "2025-02-01",
-          time: "14:00",
-          location: "En visioconférence",
-          video_link: "https://meet.example.com/abc123",
-          status: "completed",
-          quorum_required: 33,
-          attendees_count: 42,
-          agenda: [
-            { id: "1", order: 1, title: "Réparation toiture suite tempête", type: "vote_simple", result: "approved" },
-          ],
-          created_at: "2025-01-10",
-        },
-      ];
-
-      const mockSites: Site[] = [
-        { id: "1", name: "Résidence Les Lilas", units_count: 48 },
-        { id: "2", name: "Le Clos des Vignes", units_count: 32 },
-        { id: "3", name: "Villa Marina", units_count: 24 },
-      ];
-
-      setAssemblies(mockAssemblies);
-      setSites(mockSites);
-    } catch (error) {
-      console.error("Erreur:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleCreateAssembly = async () => {
-    if (!newAssembly.site_id || !newAssembly.title || !newAssembly.date) {
-      toast({
-        title: "Erreur",
-        description: "Veuillez remplir tous les champs obligatoires",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    try {
-      const site = sites.find(s => s.id === newAssembly.site_id);
-      const assembly: Assembly = {
-        id: Date.now().toString(),
-        site_id: newAssembly.site_id,
-        site_name: site?.name || "",
-        type: newAssembly.type,
-        title: newAssembly.title,
-        date: newAssembly.date,
-        time: newAssembly.time,
-        location: newAssembly.location,
-        video_link: newAssembly.video_link,
-        status: "draft",
-        quorum_required: newAssembly.type === "ordinaire" ? 25 : 33,
-        attendees_count: 0,
-        agenda: newAssembly.agenda.map((item, index) => ({
-          id: `${index}`,
-          order: index + 1,
-          title: item.title,
-          type: item.type as AgendaItem["type"],
-        })),
-        created_at: new Date().toISOString(),
-      };
-
-      setAssemblies([assembly, ...assemblies]);
-      toast({
-        title: "AG créée",
-        description: "L'assemblée générale a été créée avec succès",
-      });
-
-      setDialogOpen(false);
-      setNewAssembly({
-        site_id: "",
-        type: "ordinaire",
-        title: "",
-        date: "",
-        time: "18:00",
-        location: "",
-        video_link: "",
-        agenda: [],
-      });
-    } catch (error) {
-      toast({
-        title: "Erreur",
-        description: "Impossible de créer l'assemblée",
-        variant: "destructive",
-      });
-    }
-  };
-
-  const handleConvoke = async (assemblyId: string) => {
-    setAssemblies(assemblies.map(a => 
-      a.id === assemblyId ? { ...a, status: "convened" as const } : a
-    ));
-    toast({
-      title: "Convocations envoyées",
-      description: "Tous les copropriétaires ont été notifiés",
+  const filteredAssemblies = useMemo(() => {
+    return assemblies.filter((assembly) => {
+      const matchesSearch =
+        search === "" ||
+        assembly.title.toLowerCase().includes(search.toLowerCase()) ||
+        (assembly.reference_number || "").toLowerCase().includes(search.toLowerCase());
+      const matchesStatus = statusFilter === "all" || assembly.status === statusFilter;
+      const matchesType = typeFilter === "all" || assembly.assembly_type === typeFilter;
+      return matchesSearch && matchesStatus && matchesType;
     });
-  };
+  }, [assemblies, search, statusFilter, typeFilter]);
 
-  const addAgendaItem = () => {
-    setNewAssembly({
-      ...newAssembly,
-      agenda: [...newAssembly.agenda, { title: "", type: "vote_simple" }],
-    });
-  };
-
-  const filteredAssemblies = assemblies.filter(assembly => {
-    const matchesSearch = 
-      assembly.title.toLowerCase().includes(search.toLowerCase()) ||
-      assembly.site_name.toLowerCase().includes(search.toLowerCase());
-    const matchesStatus = statusFilter === "all" || assembly.status === statusFilter;
-    return matchesSearch && matchesStatus;
-  });
-
-  if (loading) {
-    return (
-      <div className="p-6 space-y-6 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 min-h-screen">
-        <Skeleton className="h-10 w-48 bg-white/10" />
-        <Skeleton className="h-96 bg-white/10" />
-      </div>
-    );
-  }
+  const stats = useMemo(() => {
+    return {
+      total: assemblies.length,
+      upcoming: assemblies.filter(
+        (a) => ["draft", "convened"].includes(a.status) && new Date(a.scheduled_at) > new Date()
+      ).length,
+      held: assemblies.filter((a) => a.status === "held").length,
+      draft: assemblies.filter((a) => a.status === "draft").length,
+    };
+  }, [assemblies]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
@@ -289,311 +137,195 @@ export default function SyndicAssembliesPage() {
               <Calendar className="h-6 w-6 text-violet-400" />
               Assemblées Générales
             </h1>
-            <p className="text-slate-400">
-              Gérez les AG de vos copropriétés
-            </p>
+            <p className="text-slate-400">Gérez les AG de vos copropriétés selon la loi du 10 juillet 1965</p>
           </div>
-          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-            <DialogTrigger asChild>
-              <Button className="bg-gradient-to-r from-violet-500 to-purple-600">
-                <Plus className="h-4 w-4 mr-2" />
-                Nouvelle AG
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-              <DialogHeader>
-                <DialogTitle>Planifier une Assemblée Générale</DialogTitle>
-                <DialogDescription>
-                  Créez une nouvelle AG pour une de vos copropriétés
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4 py-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label>Copropriété *</Label>
-                    <Select
-                      value={newAssembly.site_id}
-                      onValueChange={(v) => setNewAssembly({ ...newAssembly, site_id: v })}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Sélectionner" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {sites.map(site => (
-                          <SelectItem key={site.id} value={site.id}>
-                            {site.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label>Type *</Label>
-                    <Select
-                      value={newAssembly.type}
-                      onValueChange={(v) => setNewAssembly({ ...newAssembly, type: v as Assembly["type"] })}
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="ordinaire">AG Ordinaire</SelectItem>
-                        <SelectItem value="extraordinaire">AG Extraordinaire</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Titre de l'AG *</Label>
-                  <Input
-                    value={newAssembly.title}
-                    onChange={(e) => setNewAssembly({ ...newAssembly, title: e.target.value })}
-                    placeholder="Ex: AG Annuelle 2025"
-                  />
-                </div>
-
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label>Date *</Label>
-                    <Input
-                      type="date"
-                      value={newAssembly.date}
-                      onChange={(e) => setNewAssembly({ ...newAssembly, date: e.target.value })}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>Heure</Label>
-                    <Input
-                      type="time"
-                      value={newAssembly.time}
-                      onChange={(e) => setNewAssembly({ ...newAssembly, time: e.target.value })}
-                    />
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Lieu</Label>
-                  <Input
-                    value={newAssembly.location}
-                    onChange={(e) => setNewAssembly({ ...newAssembly, location: e.target.value })}
-                    placeholder="Adresse ou 'En visioconférence'"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Lien visioconférence (optionnel)</Label>
-                  <Input
-                    value={newAssembly.video_link}
-                    onChange={(e) => setNewAssembly({ ...newAssembly, video_link: e.target.value })}
-                    placeholder="https://..."
-                  />
-                </div>
-
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <Label>Ordre du jour</Label>
-                    <Button type="button" variant="outline" size="sm" onClick={addAgendaItem}>
-                      <Plus className="h-3 w-3 mr-1" />
-                      Ajouter
-                    </Button>
-                  </div>
-                  {newAssembly.agenda.map((item, index) => (
-                    <div key={index} className="grid grid-cols-3 gap-2">
-                      <div className="col-span-2">
-                        <Input
-                          placeholder={`Résolution ${index + 1}`}
-                          value={item.title}
-                          onChange={(e) => {
-                            const agenda = [...newAssembly.agenda];
-                            agenda[index].title = e.target.value;
-                            setNewAssembly({ ...newAssembly, agenda });
-                          }}
-                        />
-                      </div>
-                      <Select
-                        value={item.type}
-                        onValueChange={(v) => {
-                          const agenda = [...newAssembly.agenda];
-                          agenda[index].type = v;
-                          setNewAssembly({ ...newAssembly, agenda });
-                        }}
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="information">Information</SelectItem>
-                          <SelectItem value="vote_simple">Vote simple</SelectItem>
-                          <SelectItem value="vote_qualifie">Vote qualifié</SelectItem>
-                          <SelectItem value="vote_unanime">Vote unanime</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setDialogOpen(false)}>
-                  Annuler
-                </Button>
-                <Button onClick={handleCreateAssembly}>
-                  Créer l'AG
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+          <Link href="/syndic/assemblies/new">
+            <Button className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700">
+              <Plus className="h-4 w-4 mr-2" />
+              Nouvelle AG
+            </Button>
+          </Link>
         </motion.div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <StatCard label="Total" value={stats.total} icon={Calendar} color="text-violet-400" />
+          <StatCard label="À venir" value={stats.upcoming} icon={AlertCircle} color="text-amber-400" />
+          <StatCard label="Tenues" value={stats.held} icon={CheckCircle2} color="text-emerald-400" />
+          <StatCard label="Brouillons" value={stats.draft} icon={Building2} color="text-blue-400" />
+        </div>
 
         {/* Filters */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-          className="flex flex-col sm:flex-row gap-4"
-        >
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
-            <Input
-              placeholder="Rechercher..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-9 bg-white/5 border-white/10 text-white placeholder:text-slate-500"
-            />
-          </div>
-          <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-[180px] bg-white/5 border-white/10 text-white">
-              <SelectValue placeholder="Statut" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Tous les statuts</SelectItem>
-              {Object.entries(STATUS_CONFIG).map(([key, config]) => (
-                <SelectItem key={key} value={key}>
-                  {config.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </motion.div>
+        <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <CardContent className="p-4">
+            <div className="flex flex-col md:flex-row gap-3">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+                <Input
+                  placeholder="Rechercher par titre ou numéro..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-9 bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="w-full md:w-48 bg-white/5 border-white/10 text-white">
+                  <SelectValue placeholder="Statut" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Tous les statuts</SelectItem>
+                  <SelectItem value="draft">Brouillon</SelectItem>
+                  <SelectItem value="convened">Convoquée</SelectItem>
+                  <SelectItem value="in_progress">En cours</SelectItem>
+                  <SelectItem value="held">Tenue</SelectItem>
+                  <SelectItem value="cancelled">Annulée</SelectItem>
+                </SelectContent>
+              </Select>
+              <Select value={typeFilter} onValueChange={setTypeFilter}>
+                <SelectTrigger className="w-full md:w-48 bg-white/5 border-white/10 text-white">
+                  <SelectValue placeholder="Type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Tous les types</SelectItem>
+                  <SelectItem value="ordinaire">Ordinaire</SelectItem>
+                  <SelectItem value="extraordinaire">Extraordinaire</SelectItem>
+                  <SelectItem value="concertation">Concertation</SelectItem>
+                  <SelectItem value="consultation_ecrite">Consultation écrite</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
 
-        {/* Assemblies list */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2 }}
-        >
-          <Card className="border-white/10 bg-white/5">
-            <CardContent className="p-0">
-              {filteredAssemblies.length === 0 ? (
-                <div className="text-center py-12">
-                  <Calendar className="h-12 w-12 mx-auto text-slate-500 mb-4" />
-                  <p className="text-slate-400">Aucune assemblée générale</p>
-                </div>
-              ) : (
-                <>
-                  {/* Mobile card view */}
-                  <div className="md:hidden space-y-3">
-                    {filteredAssemblies.map((assembly) => (
-                      <div key={assembly.id} className="rounded-lg border border-white/10 bg-slate-800/30 p-4 space-y-3">
-                        <div className="flex items-start justify-between">
-                          <div>
-                            <p className="text-white font-medium">{assembly.title}</p>
-                            <p className="text-sm text-slate-400">{assembly.agenda.length} résolution(s)</p>
+        {/* Assemblies table */}
+        <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <CardContent className="p-0">
+            {loading ? (
+              <div className="p-6 space-y-3">
+                {[1, 2, 3].map((i) => (
+                  <Skeleton key={i} className="h-12 bg-white/10" />
+                ))}
+              </div>
+            ) : filteredAssemblies.length === 0 ? (
+              <div className="p-12 text-center text-slate-400">
+                <Calendar className="h-12 w-12 mx-auto mb-3 text-slate-500" />
+                <p className="mb-4">
+                  {assemblies.length === 0
+                    ? "Aucune assemblée générale pour le moment."
+                    : "Aucun résultat pour ces filtres."}
+                </p>
+                {assemblies.length === 0 && (
+                  <Link href="/syndic/assemblies/new">
+                    <Button variant="outline" className="border-white/20 text-white hover:bg-white/10">
+                      <Plus className="h-4 w-4 mr-2" />
+                      Créer votre première AG
+                    </Button>
+                  </Link>
+                )}
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-white/10 hover:bg-transparent">
+                    <TableHead className="text-slate-300">Référence</TableHead>
+                    <TableHead className="text-slate-300">Titre</TableHead>
+                    <TableHead className="text-slate-300">Type</TableHead>
+                    <TableHead className="text-slate-300">Date prévue</TableHead>
+                    <TableHead className="text-slate-300">Lieu</TableHead>
+                    <TableHead className="text-slate-300">Statut</TableHead>
+                    <TableHead className="text-slate-300 text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredAssemblies.map((assembly) => {
+                    const statusConfig = STATUS_CONFIG[assembly.status] || STATUS_CONFIG.draft;
+                    const typeConfig = TYPE_CONFIG[assembly.assembly_type] || TYPE_CONFIG.ordinaire;
+                    return (
+                      <TableRow key={assembly.id} className="border-white/10 hover:bg-white/5">
+                        <TableCell className="font-mono text-xs text-slate-400">
+                          {assembly.reference_number || "—"}
+                        </TableCell>
+                        <TableCell className="text-white font-medium">{assembly.title}</TableCell>
+                        <TableCell>
+                          <Badge variant="outline" className="border-violet-400/40 text-violet-200">
+                            {typeConfig.short}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-slate-300">
+                          {formatDateShort(assembly.scheduled_at)}
+                        </TableCell>
+                        <TableCell className="text-slate-400">
+                          <div className="flex items-center gap-1 text-sm">
+                            {assembly.is_hybrid ? (
+                              <>
+                                <Video className="h-3 w-3" />
+                                Hybride
+                              </>
+                            ) : assembly.online_meeting_url ? (
+                              <>
+                                <Video className="h-3 w-3" />
+                                Visio
+                              </>
+                            ) : assembly.location ? (
+                              <>
+                                <MapPin className="h-3 w-3" />
+                                {assembly.location.slice(0, 30)}
+                                {assembly.location.length > 30 && "..."}
+                              </>
+                            ) : (
+                              "—"
+                            )}
                           </div>
-                          <Badge className={STATUS_CONFIG[assembly.status].color}>{STATUS_CONFIG[assembly.status].label}</Badge>
-                        </div>
-                        <div className="grid grid-cols-2 gap-2 text-sm">
-                          <div className="flex items-center gap-2 text-slate-300"><Building2 className="h-4 w-4 text-slate-500" />{assembly.site_name}</div>
-                          <div className="flex items-center gap-2 text-slate-300"><Clock className="h-4 w-4 text-slate-500" />{formatDateShort(assembly.date)} à {assembly.time}</div>
-                        </div>
-                        <div className="flex items-center justify-between pt-1 border-t border-white/10">
-                          <Badge className={TYPE_CONFIG[assembly.type].color}>{TYPE_CONFIG[assembly.type].label}</Badge>
-                          <div className="flex items-center gap-1">
-                            {assembly.status === "draft" && <Button variant="ghost" size="sm" className="text-slate-400 hover:text-white" onClick={() => handleConvoke(assembly.id)}><Send className="h-4 w-4" /></Button>}
-                            <Button variant="ghost" size="sm" className="text-slate-400 hover:text-white"><Eye className="h-4 w-4" /></Button>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Desktop table view */}
-                  <div className="hidden md:block">
-                    <Table>
-                      <TableHeader>
-                        <TableRow className="border-white/10">
-                          <TableHead className="text-slate-400">AG</TableHead>
-                          <TableHead className="text-slate-400">Copropriété</TableHead>
-                          <TableHead className="text-slate-400">Date</TableHead>
-                          <TableHead className="text-slate-400">Type</TableHead>
-                          <TableHead className="text-slate-400">Statut</TableHead>
-                          <TableHead className="text-slate-400 text-right">Actions</TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {filteredAssemblies.map((assembly) => (
-                          <TableRow key={assembly.id} className="border-white/10">
-                            <TableCell>
-                              <div className="text-white font-medium">{assembly.title}</div>
-                              <div className="text-sm text-slate-400">
-                                {assembly.agenda.length} résolution(s)
-                              </div>
-                            </TableCell>
-                            <TableCell className="text-slate-300">
-                              <div className="flex items-center gap-2">
-                                <Building2 className="h-4 w-4 text-slate-500" />
-                                {assembly.site_name}
-                              </div>
-                            </TableCell>
-                            <TableCell className="text-slate-300">
-                              <div className="flex items-center gap-2">
-                                <Clock className="h-4 w-4 text-slate-500" />
-                                {formatDateShort(assembly.date)} à {assembly.time}
-                              </div>
-                            </TableCell>
-                            <TableCell>
-                              <Badge className={TYPE_CONFIG[assembly.type].color}>
-                                {TYPE_CONFIG[assembly.type].label}
-                              </Badge>
-                            </TableCell>
-                            <TableCell>
-                              <Badge className={STATUS_CONFIG[assembly.status].color}>
-                                {STATUS_CONFIG[assembly.status].label}
-                              </Badge>
-                            </TableCell>
-                            <TableCell className="text-right">
-                              <div className="flex items-center justify-end gap-1">
-                                {assembly.status === "draft" && (
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="text-slate-400 hover:text-white"
-                                    onClick={() => handleConvoke(assembly.id)}
-                                  >
-                                    <Send className="h-4 w-4" />
-                                  </Button>
-                                )}
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="text-slate-400 hover:text-white"
-                                >
-                                  <Eye className="h-4 w-4" />
-                                </Button>
-                              </div>
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </motion.div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge className={`${statusConfig.color} border`}>{statusConfig.label}</Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Link href={`/syndic/assemblies/${assembly.id}`}>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-slate-300 hover:text-white hover:bg-white/10"
+                            >
+                              <Eye className="h-4 w-4" />
+                            </Button>
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
       </div>
     </div>
   );
 }
 
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  color,
+}: {
+  label: string;
+  value: number;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+}) {
+  return (
+    <Card className="bg-white/5 border-white/10 backdrop-blur">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-slate-400">{label}</p>
+            <p className="text-2xl font-bold text-white mt-1">{value}</p>
+          </div>
+          <Icon className={`h-8 w-8 ${color}`} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/syndic/councils/new/page.tsx
+++ b/app/syndic/councils/new/page.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ArrowLeft, Building2, Users, Loader2, Save } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+
+interface Site {
+  id: string;
+  name: string;
+  city?: string;
+}
+
+export default function NewCouncilPage() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const isSubmittingRef = useRef(false);
+
+  const [loadingSites, setLoadingSites] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [sites, setSites] = useState<Site[]>([]);
+
+  const [form, setForm] = useState({
+    site_id: "",
+    mandate_start: "",
+    mandate_end: "",
+    duration_years: 1,
+    notes: "",
+  });
+
+  useEffect(() => {
+    const loadSites = async () => {
+      try {
+        const res = await fetch("/api/copro/sites");
+        if (res.ok) {
+          const data = await res.json();
+          setSites(Array.isArray(data) ? data : []);
+        }
+      } catch (error) {
+        toast({
+          title: "Erreur",
+          description: "Impossible de charger les sites",
+          variant: "destructive",
+        });
+      } finally {
+        setLoadingSites(false);
+      }
+    };
+    loadSites();
+  }, [toast]);
+
+  // Auto-calc end date from start + duration
+  useEffect(() => {
+    if (form.mandate_start && form.duration_years > 0) {
+      const start = new Date(form.mandate_start);
+      const end = new Date(start);
+      end.setFullYear(end.getFullYear() + form.duration_years);
+      end.setDate(end.getDate() - 1);
+      setForm((prev) => ({ ...prev, mandate_end: end.toISOString().split("T")[0] }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.mandate_start, form.duration_years]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmittingRef.current) return;
+
+    if (!form.site_id || !form.mandate_start || !form.mandate_end) {
+      toast({ title: "Champs requis", variant: "destructive" });
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    setSubmitting(true);
+
+    try {
+      const payload = {
+        site_id: form.site_id,
+        mandate_start: form.mandate_start,
+        mandate_end: form.mandate_end,
+        members: [], // Membres ajoutés en édition après création
+        notes: form.notes.trim() || undefined,
+      };
+
+      const res = await fetch("/api/copro/councils", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la création");
+      }
+
+      toast({
+        title: "Conseil créé",
+        description: "Ajoutez maintenant les membres depuis la page de détail",
+      });
+      router.push("/syndic/councils");
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de créer le conseil",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+      isSubmittingRef.current = false;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center gap-4"
+        >
+          <Link href="/syndic/councils">
+            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+              <Users className="h-6 w-6 text-violet-400" />
+              Nouveau conseil syndical
+            </h1>
+            <p className="text-slate-400">Élu en assemblée générale (loi du 10 juillet 1965, art. 21)</p>
+          </div>
+        </motion.div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <Building2 className="h-5 w-5 text-violet-400" />
+                Copropriété
+              </CardTitle>
+              <CardDescription className="text-slate-400">
+                Un seul conseil actif par copropriété à la fois
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loadingSites ? (
+                <p className="text-slate-400 text-sm">Chargement...</p>
+              ) : sites.length === 0 ? (
+                <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+                  Aucune copropriété disponible.
+                </div>
+              ) : (
+                <Select
+                  value={form.site_id}
+                  onValueChange={(value) => setForm({ ...form, site_id: value })}
+                  disabled={submitting}
+                >
+                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                    <SelectValue placeholder="Sélectionner une copropriété" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sites.map((site) => (
+                      <SelectItem key={site.id} value={site.id}>
+                        {site.name}
+                        {site.city && ` — ${site.city}`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white">Durée du mandat</CardTitle>
+              <CardDescription className="text-slate-400">
+                Typiquement 1 à 3 ans (renouvelable par AG)
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Début *</Label>
+                  <Input
+                    type="date"
+                    value={form.mandate_start}
+                    onChange={(e) => setForm({ ...form, mandate_start: e.target.value })}
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Durée (années)</Label>
+                  <Input
+                    type="number"
+                    min="1"
+                    max="3"
+                    value={form.duration_years}
+                    onChange={(e) =>
+                      setForm({ ...form, duration_years: parseInt(e.target.value, 10) || 1 })
+                    }
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Fin *</Label>
+                  <Input
+                    type="date"
+                    value={form.mandate_end}
+                    onChange={(e) => setForm({ ...form, mandate_end: e.target.value })}
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardContent className="p-6 space-y-4">
+              <div className="space-y-2">
+                <Label className="text-slate-300">Notes (optionnel)</Label>
+                <Textarea
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  rows={3}
+                  disabled={submitting}
+                  placeholder="Contexte, circonstances d'élection..."
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+              <div className="rounded-lg border border-blue-400/30 bg-blue-500/10 p-3 text-sm text-blue-100">
+                <p>
+                  💡 <strong>Étape suivante</strong> : après création, vous pourrez ajouter les membres
+                  du conseil, désigner le président et le vice-président.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex gap-3 justify-end">
+            <Link href="/syndic/councils">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={submitting}
+                className="border-white/20 text-white hover:bg-white/10"
+              >
+                Annuler
+              </Button>
+            </Link>
+            <Button
+              type="submit"
+              disabled={submitting || loadingSites || sites.length === 0}
+              className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Création...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  Créer le conseil
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/syndic/councils/page.tsx
+++ b/app/syndic/councils/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Users,
+  Plus,
+  Calendar,
+  CheckCircle2,
+  AlertCircle,
+  XCircle,
+} from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+import { formatDateShort } from "@/lib/helpers/format";
+
+interface CouncilMember {
+  profile_id: string;
+  unit_id?: string;
+  role: "member" | "president" | "vice_president";
+  elected_at?: string;
+}
+
+interface CoproCouncil {
+  id: string;
+  site_id: string;
+  mandate_start: string;
+  mandate_end: string;
+  president_profile_id: string | null;
+  vice_president_profile_id: string | null;
+  members: CouncilMember[];
+  members_count: number;
+  status: "active" | "suspended" | "dissolved" | "expired";
+}
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; color: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  active: { label: "Actif", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40", icon: CheckCircle2 },
+  suspended: { label: "Suspendu", color: "bg-amber-500/20 text-amber-200 border-amber-400/40", icon: AlertCircle },
+  dissolved: { label: "Dissous", color: "bg-red-500/20 text-red-200 border-red-400/40", icon: XCircle },
+  expired: { label: "Expiré", color: "bg-slate-500/20 text-slate-300 border-slate-500/40", icon: AlertCircle },
+};
+
+export default function SyndicCouncilsPage() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [councils, setCouncils] = useState<CoproCouncil[]>([]);
+
+  useEffect(() => {
+    const fetchCouncils = async () => {
+      try {
+        const res = await fetch("/api/copro/councils");
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || "Erreur de chargement");
+        }
+        const data = await res.json();
+        setCouncils(Array.isArray(data) ? data : []);
+      } catch (error) {
+        toast({
+          title: "Erreur",
+          description: error instanceof Error ? error.message : "Impossible de charger les conseils",
+          variant: "destructive",
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCouncils();
+  }, [toast]);
+
+  const activeCount = councils.filter((c) => c.status === "active").length;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+        >
+          <div>
+            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+              <Users className="h-6 w-6 text-violet-400" />
+              Conseils syndicaux
+            </h1>
+            <p className="text-slate-400">
+              Assistent et contrôlent le syndic (loi du 10 juillet 1965, art. 21)
+            </p>
+          </div>
+          <Link href="/syndic/councils/new">
+            <Button className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700">
+              <Plus className="h-4 w-4 mr-2" />
+              Nouveau conseil
+            </Button>
+          </Link>
+        </motion.div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-slate-400">Total</p>
+                  <p className="text-2xl font-bold text-white mt-1">{councils.length}</p>
+                </div>
+                <Users className="h-8 w-8 text-violet-400" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-slate-400">Actifs</p>
+                  <p className="text-2xl font-bold text-white mt-1">{activeCount}</p>
+                </div>
+                <CheckCircle2 className="h-8 w-8 text-emerald-400" />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <CardContent className="p-0">
+            {loading ? (
+              <div className="p-6 space-y-3">
+                {[1, 2, 3].map((i) => (
+                  <Skeleton key={i} className="h-12 bg-white/10" />
+                ))}
+              </div>
+            ) : councils.length === 0 ? (
+              <div className="p-12 text-center text-slate-400">
+                <Users className="h-12 w-12 mx-auto mb-3 text-slate-500" />
+                <p className="mb-4">Aucun conseil syndical pour le moment</p>
+                <Link href="/syndic/councils/new">
+                  <Button variant="outline" className="border-white/20 text-white hover:bg-white/10">
+                    <Plus className="h-4 w-4 mr-2" />
+                    Créer un conseil
+                  </Button>
+                </Link>
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-white/10 hover:bg-transparent">
+                    <TableHead className="text-slate-300">Période de mandat</TableHead>
+                    <TableHead className="text-slate-300">Membres</TableHead>
+                    <TableHead className="text-slate-300">Président</TableHead>
+                    <TableHead className="text-slate-300">Statut</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {councils.map((council) => {
+                    const config = STATUS_CONFIG[council.status] || STATUS_CONFIG.active;
+                    const Icon = config.icon;
+                    return (
+                      <TableRow key={council.id} className="border-white/10 hover:bg-white/5">
+                        <TableCell className="text-slate-300 text-sm">
+                          <div className="flex items-center gap-1">
+                            <Calendar className="h-3 w-3" />
+                            {formatDateShort(council.mandate_start)} → {formatDateShort(council.mandate_end)}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-white">
+                          {council.members_count} membre{council.members_count > 1 ? "s" : ""}
+                        </TableCell>
+                        <TableCell className="text-slate-300 font-mono text-xs">
+                          {council.president_profile_id
+                            ? `${council.president_profile_id.slice(0, 8)}...`
+                            : "—"}
+                        </TableCell>
+                        <TableCell>
+                          <Badge className={`${config.color} border`}>
+                            <Icon className="h-3 w-3 mr-1" />
+                            {config.label}
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/syndic/fonds-travaux/new/page.tsx
+++ b/app/syndic/fonds-travaux/new/page.tsx
@@ -1,0 +1,469 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ArrowLeft,
+  Building2,
+  Hammer,
+  Loader2,
+  Save,
+  ShieldCheck,
+  AlertCircle,
+} from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+
+interface Site {
+  id: string;
+  name: string;
+  city?: string;
+}
+
+const EXEMPT_REASONS = [
+  {
+    value: "copropriete_neuve_moins_5_ans",
+    label: "Copropriété neuve < 5 ans",
+    description: "Exemption automatique pour les copropriétés neuves",
+  },
+  {
+    value: "unanimite_dispense",
+    label: "Dispense votée à l'unanimité",
+    description: "Votée en AG à l'unanimité des copropriétaires",
+  },
+  {
+    value: "dtg_pas_de_travaux_prevus",
+    label: "DTG — aucun travaux prévu",
+    description: "Diagnostic technique global concluant à l'absence de travaux",
+  },
+];
+
+export default function NewFondsTravauxPage() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const isSubmittingRef = useRef(false);
+
+  const [loadingSites, setLoadingSites] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [sites, setSites] = useState<Site[]>([]);
+
+  const currentYear = new Date().getFullYear();
+
+  const [form, setForm] = useState({
+    site_id: "",
+    fiscal_year: currentYear.toString(),
+    budget_reference: "",
+    cotisation_taux_percent: "5.00",
+    solde_initial: "0",
+    dedicated_bank_account: "",
+    bank_name: "",
+    loi_alur_exempt: false,
+    exempt_reason: "" as "" | "copropriete_neuve_moins_5_ans" | "unanimite_dispense" | "dtg_pas_de_travaux_prevus",
+  });
+
+  useEffect(() => {
+    const loadSites = async () => {
+      try {
+        const res = await fetch("/api/copro/sites");
+        if (res.ok) {
+          const data = await res.json();
+          setSites(Array.isArray(data) ? data : []);
+        }
+      } catch (error) {
+        toast({
+          title: "Erreur",
+          description: "Impossible de charger les sites",
+          variant: "destructive",
+        });
+      } finally {
+        setLoadingSites(false);
+      }
+    };
+    loadSites();
+  }, [toast]);
+
+  // Auto-calcule le montant annuel à partir du budget de référence et du taux
+  const cotisationAmountCents = (() => {
+    const budget = parseFloat(form.budget_reference) || 0;
+    const rate = parseFloat(form.cotisation_taux_percent) || 0;
+    return Math.round((budget * rate) / 100 * 100); // En centimes
+  })();
+
+  const cotisationAmountEuros = (cotisationAmountCents / 100).toLocaleString("fr-FR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmittingRef.current) return;
+
+    if (!form.site_id || !form.fiscal_year) {
+      toast({ title: "Champs requis", variant: "destructive" });
+      return;
+    }
+
+    const rate = parseFloat(form.cotisation_taux_percent);
+    if (!form.loi_alur_exempt && (isNaN(rate) || rate < 5)) {
+      toast({
+        title: "Taux insuffisant",
+        description: "Loi ALUR : minimum 5% du budget prévisionnel (sauf exemption)",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (form.loi_alur_exempt && !form.exempt_reason) {
+      toast({
+        title: "Raison d'exemption requise",
+        description: "Sélectionnez une raison d'exemption loi ALUR",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (cotisationAmountCents <= 0 && !form.loi_alur_exempt) {
+      toast({
+        title: "Montant invalide",
+        description: "Renseignez un budget de référence pour calculer la cotisation",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    setSubmitting(true);
+
+    try {
+      const budgetRefCents = form.budget_reference
+        ? Math.round(parseFloat(form.budget_reference) * 100)
+        : undefined;
+      const soldeInitialCents = form.solde_initial
+        ? Math.round(parseFloat(form.solde_initial) * 100)
+        : 0;
+
+      const payload: Record<string, any> = {
+        site_id: form.site_id,
+        fiscal_year: parseInt(form.fiscal_year, 10),
+        cotisation_taux_percent: rate,
+        cotisation_montant_annual_cents: cotisationAmountCents,
+        solde_initial_cents: soldeInitialCents,
+        loi_alur_exempt: form.loi_alur_exempt,
+      };
+
+      if (budgetRefCents !== undefined) payload.budget_reference_cents = budgetRefCents;
+      if (form.dedicated_bank_account) payload.dedicated_bank_account = form.dedicated_bank_account.trim();
+      if (form.bank_name) payload.bank_name = form.bank_name.trim();
+      if (form.loi_alur_exempt && form.exempt_reason) payload.exempt_reason = form.exempt_reason;
+
+      const res = await fetch("/api/copro/fonds-travaux", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la création");
+      }
+
+      toast({ title: "Fonds travaux créé", description: `Exercice ${form.fiscal_year}` });
+      router.push("/syndic/fonds-travaux");
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de créer le fonds",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+      isSubmittingRef.current = false;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-cyan-50/30 to-slate-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center gap-4"
+        >
+          <Link href="/syndic/fonds-travaux">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              <Hammer className="h-6 w-6 text-cyan-600" />
+              Nouveau fonds travaux
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Loi ALUR 2014 (art. 58) — obligatoire pour copropriétés &gt; 5 ans
+            </p>
+          </div>
+        </motion.div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Building2 className="h-5 w-5 text-cyan-600" />
+                Copropriété et exercice
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {loadingSites ? (
+                <p className="text-sm text-muted-foreground">Chargement...</p>
+              ) : sites.length === 0 ? (
+                <div className="rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-100">
+                  Aucune copropriété disponible.
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <Label>Copropriété *</Label>
+                  <Select
+                    value={form.site_id}
+                    onValueChange={(value) => setForm({ ...form, site_id: value })}
+                    disabled={submitting}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Sélectionner" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {sites.map((site) => (
+                        <SelectItem key={site.id} value={site.id}>
+                          {site.name}
+                          {site.city && ` — ${site.city}`}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label>Exercice fiscal *</Label>
+                <Input
+                  type="number"
+                  min="2017"
+                  max="2100"
+                  value={form.fiscal_year}
+                  onChange={(e) => setForm({ ...form, fiscal_year: e.target.value })}
+                  required
+                  disabled={submitting}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldCheck className="h-5 w-5 text-cyan-600" />
+                Cotisation (loi ALUR)
+              </CardTitle>
+              <CardDescription>
+                Cotisation minimale légale : 5% du budget prévisionnel annuel
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label>Budget prévisionnel de référence (€ HT)</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="Ex: 25000.00"
+                  value={form.budget_reference}
+                  onChange={(e) => setForm({ ...form, budget_reference: e.target.value })}
+                  disabled={submitting || form.loi_alur_exempt}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Budget annuel de la copropriété sur lequel est calculée la cotisation
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Taux de cotisation (%) *</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="0.01"
+                  value={form.cotisation_taux_percent}
+                  onChange={(e) => setForm({ ...form, cotisation_taux_percent: e.target.value })}
+                  required
+                  disabled={submitting || form.loi_alur_exempt}
+                />
+                {!form.loi_alur_exempt && parseFloat(form.cotisation_taux_percent) < 5 && (
+                  <p className="text-xs text-amber-600 flex items-center gap-1">
+                    <AlertCircle className="h-3 w-3" />
+                    Taux inférieur au minimum légal de 5%
+                  </p>
+                )}
+              </div>
+
+              {cotisationAmountCents > 0 && !form.loi_alur_exempt && (
+                <div className="rounded-xl bg-cyan-50 dark:bg-cyan-500/10 p-4 border border-cyan-200 dark:border-cyan-400/30">
+                  <p className="text-sm text-cyan-900 dark:text-cyan-100">
+                    <strong>Cotisation annuelle calculée</strong> : {cotisationAmountEuros} €
+                  </p>
+                  <p className="text-xs text-cyan-700 dark:text-cyan-300 mt-1">
+                    = {form.budget_reference} € × {form.cotisation_taux_percent}%
+                  </p>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label>Solde initial (€)</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={form.solde_initial}
+                  onChange={(e) => setForm({ ...form, solde_initial: e.target.value })}
+                  disabled={submitting}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Solde reporté de l'exercice précédent (si applicable)
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Compte bancaire dédié</CardTitle>
+              <CardDescription>
+                Obligatoire loi ALUR : le fonds travaux doit être placé sur un compte séparé
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label>IBAN</Label>
+                <Input
+                  placeholder="FR76 XXXX XXXX XXXX"
+                  value={form.dedicated_bank_account}
+                  onChange={(e) => setForm({ ...form, dedicated_bank_account: e.target.value.toUpperCase() })}
+                  disabled={submitting}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Nom de la banque</Label>
+                <Input
+                  placeholder="Crédit Mutuel, BNP, etc."
+                  value={form.bank_name}
+                  onChange={(e) => setForm({ ...form, bank_name: e.target.value })}
+                  disabled={submitting}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Exemption (cas particuliers)</CardTitle>
+              <CardDescription>
+                Certaines copropriétés sont dispensées de la cotisation obligatoire
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-start gap-3">
+                <input
+                  id="loi_alur_exempt"
+                  type="checkbox"
+                  checked={form.loi_alur_exempt}
+                  onChange={(e) =>
+                    setForm({
+                      ...form,
+                      loi_alur_exempt: e.target.checked,
+                      exempt_reason: e.target.checked ? form.exempt_reason : "",
+                    })
+                  }
+                  disabled={submitting}
+                  className="mt-1 h-4 w-4 rounded border-slate-300"
+                />
+                <div>
+                  <Label htmlFor="loi_alur_exempt" className="cursor-pointer">
+                    Copropriété exemptée du fonds travaux
+                  </Label>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    À cocher si la copropriété bénéficie d'une exemption légale
+                  </p>
+                </div>
+              </div>
+
+              {form.loi_alur_exempt && (
+                <div className="space-y-2 pl-7">
+                  <Label>Raison de l'exemption *</Label>
+                  <Select
+                    value={form.exempt_reason}
+                    onValueChange={(value: typeof form.exempt_reason) =>
+                      setForm({ ...form, exempt_reason: value })
+                    }
+                    disabled={submitting}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Sélectionner une raison" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {EXEMPT_REASONS.map((reason) => (
+                        <SelectItem key={reason.value} value={reason.value}>
+                          <div>
+                            <div className="font-medium">{reason.label}</div>
+                            <div className="text-xs text-muted-foreground">{reason.description}</div>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <div className="flex gap-3 justify-end">
+            <Link href="/syndic/fonds-travaux">
+              <Button type="button" variant="outline" disabled={submitting}>
+                Annuler
+              </Button>
+            </Link>
+            <Button
+              type="submit"
+              disabled={submitting || loadingSites || sites.length === 0}
+              className="bg-gradient-to-r from-cyan-500 to-blue-600 hover:from-cyan-600 hover:to-blue-700"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Création...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  Créer le fonds travaux
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/syndic/layout.tsx
+++ b/app/syndic/layout.tsx
@@ -20,16 +20,19 @@ import {
   Building2, Users, Calendar, Euro,
   FileText, Settings, Bell, HelpCircle,
   LayoutDashboard, ClipboardList, UserPlus,
-  Calculator, AlertTriangle, Hammer,
+  Calculator, AlertTriangle, Hammer, Scale,
 } from "lucide-react";
 
 // Navigation syndic
 const navigation = [
   { name: "Dashboard", href: "/syndic/dashboard", icon: LayoutDashboard },
   { name: "Copropriétés", href: "/syndic/sites", icon: Building2 },
-  { name: "Comptabilité", href: "/syndic/accounting", icon: Calculator },
   { name: "Assemblées", href: "/syndic/assemblies", icon: Calendar },
+  { name: "Mandats", href: "/syndic/mandates", icon: FileText },
+  { name: "Conseils syndicaux", href: "/syndic/councils", icon: Users },
+  { name: "Comptabilité", href: "/syndic/accounting", icon: Calculator },
   { name: "Appels de fonds", href: "/syndic/calls", icon: Euro },
+  { name: "Fonds travaux", href: "/syndic/fonds-travaux", icon: Hammer },
   { name: "Dépenses", href: "/syndic/expenses", icon: FileText },
   { name: "Impayés", href: "/syndic/impayes", icon: AlertTriangle },
   { name: "Invitations", href: "/syndic/invites", icon: UserPlus },

--- a/app/syndic/mandates/new/page.tsx
+++ b/app/syndic/mandates/new/page.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ArrowLeft, Building2, FileText, Loader2, Save } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+
+interface Site {
+  id: string;
+  name: string;
+  city?: string;
+}
+
+export default function NewMandatePage() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const isSubmittingRef = useRef(false);
+
+  const [loadingSites, setLoadingSites] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [sites, setSites] = useState<Site[]>([]);
+  const [myProfileId, setMyProfileId] = useState<string | null>(null);
+
+  const [form, setForm] = useState({
+    site_id: "",
+    title: "Mandat de syndic",
+    mandate_number: "",
+    start_date: "",
+    end_date: "",
+    duration_months: 12,
+    tacit_renewal: false,
+    notice_period_months: 3,
+    honoraires_annuels: "",
+    voted_in_assembly_id: "",
+    notes: "",
+  });
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const [sitesRes, profileRes] = await Promise.all([
+          fetch("/api/copro/sites"),
+          fetch("/api/me/profile"),
+        ]);
+
+        if (sitesRes.ok) {
+          const sitesData = await sitesRes.json();
+          setSites(Array.isArray(sitesData) ? sitesData : []);
+        }
+
+        if (profileRes.ok) {
+          const profile = await profileRes.json();
+          setMyProfileId(profile.id || null);
+        }
+      } catch (error) {
+        toast({
+          title: "Erreur",
+          description: "Impossible de charger les données",
+          variant: "destructive",
+        });
+      } finally {
+        setLoadingSites(false);
+      }
+    };
+    loadData();
+  }, [toast]);
+
+  // Auto-calculate end_date when start_date or duration changes
+  useEffect(() => {
+    if (form.start_date && form.duration_months > 0) {
+      const start = new Date(form.start_date);
+      const end = new Date(start);
+      end.setMonth(end.getMonth() + form.duration_months);
+      end.setDate(end.getDate() - 1); // Dernière journée incluse
+      setForm((prev) => ({ ...prev, end_date: end.toISOString().split("T")[0] }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.start_date, form.duration_months]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isSubmittingRef.current) return;
+
+    if (!form.site_id || !form.start_date || !form.end_date || !form.honoraires_annuels) {
+      toast({
+        title: "Champs requis",
+        description: "Site, dates et honoraires sont obligatoires",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!myProfileId) {
+      toast({
+        title: "Profil introuvable",
+        description: "Impossible de créer un mandat sans profil syndic",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const honorairesValue = parseFloat(form.honoraires_annuels);
+    if (isNaN(honorairesValue) || honorairesValue < 0) {
+      toast({ title: "Montant invalide", variant: "destructive" });
+      return;
+    }
+
+    if (form.duration_months < 1 || form.duration_months > 36) {
+      toast({
+        title: "Durée invalide",
+        description: "Loi du 10 juillet 1965 : durée entre 1 et 36 mois",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    isSubmittingRef.current = true;
+    setSubmitting(true);
+
+    try {
+      const payload = {
+        site_id: form.site_id,
+        syndic_profile_id: myProfileId,
+        title: form.title.trim() || "Mandat de syndic",
+        mandate_number: form.mandate_number.trim() || undefined,
+        start_date: form.start_date,
+        end_date: form.end_date,
+        duration_months: form.duration_months,
+        tacit_renewal: form.tacit_renewal,
+        notice_period_months: form.notice_period_months,
+        honoraires_annuels_cents: Math.round(honorairesValue * 100),
+        currency: "EUR",
+        voted_in_assembly_id: form.voted_in_assembly_id || undefined,
+        notes: form.notes.trim() || undefined,
+      };
+
+      const res = await fetch("/api/copro/mandates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la création");
+      }
+
+      toast({ title: "Mandat créé", description: "Le mandat a été créé en brouillon" });
+      router.push("/syndic/mandates");
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de créer le mandat",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+      isSubmittingRef.current = false;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center gap-4"
+        >
+          <Link href="/syndic/mandates">
+            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Retour
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+              <FileText className="h-6 w-6 text-violet-400" />
+              Nouveau mandat de syndic
+            </h1>
+            <p className="text-slate-400">Loi du 10 juillet 1965 — durée 1 à 36 mois</p>
+          </div>
+        </motion.div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white flex items-center gap-2">
+                <Building2 className="h-5 w-5 text-violet-400" />
+                Copropriété
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {loadingSites ? (
+                <p className="text-slate-400 text-sm">Chargement...</p>
+              ) : sites.length === 0 ? (
+                <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+                  Aucune copropriété disponible.
+                </div>
+              ) : (
+                <Select
+                  value={form.site_id}
+                  onValueChange={(value) => setForm({ ...form, site_id: value })}
+                  disabled={submitting}
+                >
+                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                    <SelectValue placeholder="Sélectionner une copropriété" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {sites.map((site) => (
+                      <SelectItem key={site.id} value={site.id}>
+                        {site.name}
+                        {site.city && ` — ${site.city}`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white">Durée du mandat</CardTitle>
+              <CardDescription className="text-slate-400">
+                La loi impose une durée entre 1 et 36 mois
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-slate-300">Titre du mandat</Label>
+                <Input
+                  value={form.title}
+                  onChange={(e) => setForm({ ...form, title: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label className="text-slate-300">Numéro de référence (optionnel)</Label>
+                <Input
+                  placeholder="MDS-2026-001"
+                  value={form.mandate_number}
+                  onChange={(e) => setForm({ ...form, mandate_number: e.target.value })}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Date début *</Label>
+                  <Input
+                    type="date"
+                    value={form.start_date}
+                    onChange={(e) => setForm({ ...form, start_date: e.target.value })}
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Durée (mois) *</Label>
+                  <Input
+                    type="number"
+                    min="1"
+                    max="36"
+                    value={form.duration_months}
+                    onChange={(e) =>
+                      setForm({ ...form, duration_months: parseInt(e.target.value, 10) || 12 })
+                    }
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-slate-300">Date fin</Label>
+                  <Input
+                    type="date"
+                    value={form.end_date}
+                    onChange={(e) => setForm({ ...form, end_date: e.target.value })}
+                    required
+                    disabled={submitting}
+                    className="bg-white/5 border-white/10 text-white"
+                  />
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  id="tacit_renewal"
+                  type="checkbox"
+                  checked={form.tacit_renewal}
+                  onChange={(e) => setForm({ ...form, tacit_renewal: e.target.checked })}
+                  disabled={submitting}
+                  className="h-4 w-4 rounded border-white/30 bg-transparent"
+                />
+                <Label htmlFor="tacit_renewal" className="text-slate-300 cursor-pointer">
+                  Tacite reconduction
+                </Label>
+              </div>
+              <div className="space-y-2">
+                <Label className="text-slate-300">Préavis de résiliation (mois)</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  max="12"
+                  value={form.notice_period_months}
+                  onChange={(e) =>
+                    setForm({ ...form, notice_period_months: parseInt(e.target.value, 10) || 3 })
+                  }
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardHeader>
+              <CardTitle className="text-white">Honoraires</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-slate-300">Honoraires annuels HT (€) *</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="6000.00"
+                  value={form.honoraires_annuels}
+                  onChange={(e) => setForm({ ...form, honoraires_annuels: e.target.value })}
+                  required
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/5 border-white/10 backdrop-blur">
+            <CardContent className="p-6 space-y-4">
+              <div className="space-y-2">
+                <Label className="text-slate-300">Notes internes</Label>
+                <Textarea
+                  placeholder="Notes privées sur le mandat (facultatif)"
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  rows={3}
+                  disabled={submitting}
+                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex gap-3 justify-end">
+            <Link href="/syndic/mandates">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={submitting}
+                className="border-white/20 text-white hover:bg-white/10"
+              >
+                Annuler
+              </Button>
+            </Link>
+            <Button
+              type="submit"
+              disabled={submitting || loadingSites || sites.length === 0}
+              className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Création...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  Créer le mandat
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/syndic/mandates/page.tsx
+++ b/app/syndic/mandates/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  FileText,
+  Plus,
+  Calendar,
+  Euro,
+  CheckCircle2,
+  AlertCircle,
+  Clock,
+  XCircle,
+} from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+import { formatDateShort } from "@/lib/helpers/format";
+
+interface SyndicMandate {
+  id: string;
+  site_id: string;
+  syndic_profile_id: string;
+  mandate_number: string | null;
+  title: string;
+  start_date: string;
+  end_date: string;
+  duration_months: number;
+  tacit_renewal: boolean;
+  honoraires_annuels_cents: number;
+  status: "draft" | "pending_signature" | "active" | "suspended" | "terminated" | "expired";
+  signed_at: string | null;
+  terminated_at: string | null;
+}
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; color: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  draft: { label: "Brouillon", color: "bg-slate-500/20 text-slate-200 border-slate-400/40", icon: Clock },
+  pending_signature: {
+    label: "En attente signature",
+    color: "bg-amber-500/20 text-amber-200 border-amber-400/40",
+    icon: AlertCircle,
+  },
+  active: { label: "Actif", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40", icon: CheckCircle2 },
+  suspended: { label: "Suspendu", color: "bg-orange-500/20 text-orange-200 border-orange-400/40", icon: AlertCircle },
+  terminated: { label: "Résilié", color: "bg-red-500/20 text-red-200 border-red-400/40", icon: XCircle },
+  expired: { label: "Expiré", color: "bg-slate-500/20 text-slate-300 border-slate-500/40", icon: Clock },
+};
+
+export default function SyndicMandatesPage() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [mandates, setMandates] = useState<SyndicMandate[]>([]);
+
+  useEffect(() => {
+    const fetchMandates = async () => {
+      try {
+        const res = await fetch("/api/copro/mandates");
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || "Erreur de chargement");
+        }
+        const data = await res.json();
+        setMandates(Array.isArray(data) ? data : []);
+      } catch (error) {
+        toast({
+          title: "Erreur",
+          description: error instanceof Error ? error.message : "Impossible de charger les mandats",
+          variant: "destructive",
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMandates();
+  }, [toast]);
+
+  const activeCount = mandates.filter((m) => m.status === "active").length;
+  const draftCount = mandates.filter((m) => m.status === "draft").length;
+  const expiringCount = mandates.filter((m) => {
+    if (m.status !== "active") return false;
+    const end = new Date(m.end_date);
+    const threeMonthsFromNow = new Date();
+    threeMonthsFromNow.setMonth(threeMonthsFromNow.getMonth() + 3);
+    return end <= threeMonthsFromNow;
+  }).length;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+        >
+          <div>
+            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+              <FileText className="h-6 w-6 text-violet-400" />
+              Mandats de syndic
+            </h1>
+            <p className="text-slate-400">Gérez vos mandats selon la loi du 10 juillet 1965 (durée 1-36 mois)</p>
+          </div>
+          <Link href="/syndic/mandates/new">
+            <Button className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700">
+              <Plus className="h-4 w-4 mr-2" />
+              Nouveau mandat
+            </Button>
+          </Link>
+        </motion.div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <StatCard label="Total" value={mandates.length} icon={FileText} color="text-violet-400" />
+          <StatCard label="Actifs" value={activeCount} icon={CheckCircle2} color="text-emerald-400" />
+          <StatCard label="Brouillons" value={draftCount} icon={Clock} color="text-slate-400" />
+          <StatCard
+            label="Expirent < 3 mois"
+            value={expiringCount}
+            icon={AlertCircle}
+            color="text-amber-400"
+          />
+        </div>
+
+        <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <CardContent className="p-0">
+            {loading ? (
+              <div className="p-6 space-y-3">
+                {[1, 2, 3].map((i) => (
+                  <Skeleton key={i} className="h-12 bg-white/10" />
+                ))}
+              </div>
+            ) : mandates.length === 0 ? (
+              <div className="p-12 text-center text-slate-400">
+                <FileText className="h-12 w-12 mx-auto mb-3 text-slate-500" />
+                <p className="mb-4">Aucun mandat pour le moment</p>
+                <Link href="/syndic/mandates/new">
+                  <Button variant="outline" className="border-white/20 text-white hover:bg-white/10">
+                    <Plus className="h-4 w-4 mr-2" />
+                    Créer votre premier mandat
+                  </Button>
+                </Link>
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-white/10 hover:bg-transparent">
+                    <TableHead className="text-slate-300">Référence</TableHead>
+                    <TableHead className="text-slate-300">Titre</TableHead>
+                    <TableHead className="text-slate-300">Période</TableHead>
+                    <TableHead className="text-slate-300">Durée</TableHead>
+                    <TableHead className="text-slate-300 text-right">Honoraires/an</TableHead>
+                    <TableHead className="text-slate-300">Statut</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {mandates.map((mandate) => {
+                    const config = STATUS_CONFIG[mandate.status] || STATUS_CONFIG.draft;
+                    const Icon = config.icon;
+                    return (
+                      <TableRow key={mandate.id} className="border-white/10 hover:bg-white/5">
+                        <TableCell className="font-mono text-xs text-slate-400">
+                          {mandate.mandate_number || "—"}
+                        </TableCell>
+                        <TableCell className="text-white font-medium">{mandate.title}</TableCell>
+                        <TableCell className="text-slate-300 text-sm">
+                          <div className="flex items-center gap-1">
+                            <Calendar className="h-3 w-3" />
+                            {formatDateShort(mandate.start_date)} → {formatDateShort(mandate.end_date)}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-slate-300">
+                          {mandate.duration_months} mois
+                          {mandate.tacit_renewal && (
+                            <Badge variant="outline" className="ml-2 border-blue-400/30 text-blue-200 text-xs">
+                              Reconduction
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right text-white">
+                          <div className="flex items-center justify-end gap-1">
+                            <Euro className="h-3 w-3 text-slate-400" />
+                            {(mandate.honoraires_annuels_cents / 100).toLocaleString("fr-FR", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge className={`${config.color} border`}>
+                            <Icon className="h-3 w-3 mr-1" />
+                            {config.label}
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  color,
+}: {
+  label: string;
+  value: number;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+}) {
+  return (
+    <Card className="bg-white/5 border-white/10 backdrop-blur">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-slate-400">{label}</p>
+            <p className="text-2xl font-bold text-white mt-1">{value}</p>
+          </div>
+          <Icon className={`h-8 w-8 ${color}`} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/helpers/syndic-auth.ts
+++ b/lib/helpers/syndic-auth.ts
@@ -1,0 +1,129 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { supabaseAdmin } from "@/app/api/_lib/supabase";
+
+/**
+ * Helper SOTA 2026 — Authentification syndic
+ *
+ * Vérifie que l'utilisateur est :
+ *   1. Authentifié
+ *   2. Profil avec rôle syndic (ou admin/platform_admin pour bypass)
+ *   3. (optionnel) Propriétaire du site concerné (syndic_profile_id = profile.id)
+ *
+ * Usage:
+ *   const auth = await requireSyndic(request, { siteId });
+ *   if (auth instanceof NextResponse) return auth; // Error response
+ *   const { user, profile, isAdmin } = auth;
+ */
+
+export interface SyndicAuthResult {
+  user: { id: string; email?: string | null };
+  profile: {
+    id: string;
+    role: string;
+    prenom: string | null;
+    nom: string | null;
+  };
+  isAdmin: boolean;
+  serviceClient: ReturnType<typeof supabaseAdmin>;
+}
+
+export async function requireSyndic(
+  _request: Request,
+  options: { siteId?: string | null } = {}
+): Promise<SyndicAuthResult | NextResponse> {
+  const supabase = await createClient();
+
+  // 1. Authentification
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+  }
+
+  // 2. Profil + rôle (via service role pour bypass RLS récursion)
+  const serviceClient = supabaseAdmin();
+  const { data: profile, error: profileError } = await serviceClient
+    .from("profiles")
+    .select("id, role, prenom, nom")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (profileError || !profile) {
+    return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+  }
+
+  const allowedRoles = ["syndic", "admin", "platform_admin"];
+  if (!allowedRoles.includes((profile as any).role)) {
+    return NextResponse.json(
+      { error: "Accès réservé aux utilisateurs syndic" },
+      { status: 403 }
+    );
+  }
+
+  const isAdmin = ["admin", "platform_admin"].includes((profile as any).role);
+
+  // 3. Si siteId fourni, vérifier que le syndic est bien propriétaire du site
+  if (options.siteId && !isAdmin) {
+    const { data: site, error: siteError } = await serviceClient
+      .from("sites")
+      .select("id, syndic_profile_id")
+      .eq("id", options.siteId)
+      .maybeSingle();
+
+    if (siteError || !site) {
+      return NextResponse.json(
+        { error: "Site introuvable" },
+        { status: 404 }
+      );
+    }
+
+    if ((site as any).syndic_profile_id !== (profile as any).id) {
+      return NextResponse.json(
+        { error: "Vous n'êtes pas le syndic de ce site" },
+        { status: 403 }
+      );
+    }
+  }
+
+  return {
+    user: { id: user.id, email: user.email },
+    profile: profile as SyndicAuthResult["profile"],
+    isAdmin,
+    serviceClient,
+  };
+}
+
+/**
+ * Vérifie qu'une assemblée appartient bien à un site géré par le syndic.
+ * Retourne l'assemblée si OK, NextResponse d'erreur sinon.
+ */
+export async function requireAssemblyAccess(
+  request: Request,
+  assemblyId: string
+): Promise<
+  | { auth: SyndicAuthResult; assembly: { id: string; site_id: string; status: string } }
+  | NextResponse
+> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+
+  const serviceClient = supabaseAdmin();
+  const { data: assembly, error } = await serviceClient
+    .from("copro_assemblies")
+    .select("id, site_id, status")
+    .eq("id", assemblyId)
+    .maybeSingle();
+
+  if (error || !assembly) {
+    return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+  }
+
+  const auth = await requireSyndic(request, { siteId: (assembly as any).site_id });
+  if (auth instanceof NextResponse) return auth;
+
+  return {
+    auth,
+    assembly: assembly as { id: string; site_id: string; status: string },
+  };
+}

--- a/lib/pdf/syndic-templates.ts
+++ b/lib/pdf/syndic-templates.ts
@@ -1,0 +1,661 @@
+/**
+ * HTML templates for syndic copropriété PDFs (convocations + PV)
+ * Uses the new copro_* schema created in Phase 2/8.
+ *
+ * These HTML strings can be rendered client-side via html2pdf.js
+ * or server-side via puppeteer (future enhancement).
+ */
+
+// ============================================
+// Types
+// ============================================
+
+export interface ConvocationPdfData {
+  // Site (copropriété)
+  site_name: string;
+  site_address: string;
+  site_city: string;
+  site_postal_code: string;
+
+  // Syndic
+  syndic_name: string;
+  syndic_company?: string;
+  syndic_address?: string;
+  syndic_email?: string;
+  syndic_phone?: string;
+  syndic_siret?: string;
+  syndic_numero_carte_pro?: string;
+
+  // Assembly
+  assembly_reference: string;
+  assembly_type: "ordinaire" | "extraordinaire" | "concertation" | "consultation_ecrite";
+  assembly_title: string;
+  scheduled_at: string; // ISO
+  location: string;
+  location_address?: string;
+  online_meeting_url?: string;
+  is_hybrid: boolean;
+  fiscal_year?: number;
+  second_convocation_at?: string;
+
+  // Recipient
+  recipient_name: string;
+  recipient_address?: string;
+  unit_number?: string;
+  unit_tantiemes?: number;
+
+  // Agenda (résolutions)
+  resolutions: Array<{
+    resolution_number: number;
+    title: string;
+    description: string;
+    category: string;
+    majority_rule: string;
+    estimated_amount_cents?: number | null;
+    contract_partner?: string | null;
+  }>;
+
+  // Meta
+  generated_at: string;
+}
+
+export interface MinutePdfData {
+  // Site
+  site_name: string;
+  site_address: string;
+
+  // Syndic
+  syndic_name: string;
+  syndic_company?: string;
+
+  // Assembly
+  assembly_reference: string;
+  assembly_type: "ordinaire" | "extraordinaire" | "concertation" | "consultation_ecrite";
+  assembly_title: string;
+  scheduled_at: string;
+  held_at: string;
+  location: string;
+
+  // Présidence
+  president_name: string;
+  secretary_name: string;
+  scrutineers_names: string[];
+
+  // Quorum
+  total_tantiemes: number;
+  present_tantiemes: number;
+  quorum_required: number;
+  quorum_reached: boolean;
+
+  // Résolutions votées
+  resolutions: Array<{
+    resolution_number: number;
+    title: string;
+    description: string;
+    category: string;
+    majority_rule: string;
+    status: string; // voted_for / voted_against / abstained / adjourned
+    votes_for_count: number;
+    votes_against_count: number;
+    votes_abstain_count: number;
+    tantiemes_for: number;
+    tantiemes_against: number;
+    tantiemes_abstain: number;
+  }>;
+
+  // Version + meta
+  version: number;
+  generated_at: string;
+  contestation_deadline?: string;
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+function escapeHtml(str: string | null | undefined): string {
+  if (!str) return "";
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatDate(iso: string | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleDateString("fr-FR", {
+      day: "2-digit",
+      month: "long",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatDateTime(iso: string | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString("fr-FR", {
+      day: "2-digit",
+      month: "long",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatCents(cents: number | null | undefined): string {
+  if (cents === null || cents === undefined) return "—";
+  return (cents / 100).toLocaleString("fr-FR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }) + " €";
+}
+
+const ASSEMBLY_TYPE_LABELS: Record<string, string> = {
+  ordinaire: "Assemblée Générale Ordinaire",
+  extraordinaire: "Assemblée Générale Extraordinaire",
+  concertation: "Concertation",
+  consultation_ecrite: "Consultation écrite",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  gestion: "Gestion courante",
+  budget: "Budget",
+  travaux: "Travaux",
+  reglement: "Règlement de copropriété",
+  honoraires: "Honoraires syndic",
+  conseil_syndical: "Conseil syndical",
+  assurance: "Assurance",
+  conflits: "Actions en justice",
+  autre: "Autre",
+};
+
+const MAJORITY_LABELS: Record<string, string> = {
+  article_24: "Article 24 — Majorité simple",
+  article_25: "Article 25 — Majorité absolue",
+  article_25_1: "Article 25-1 — Majorité absolue avec passerelle",
+  article_26: "Article 26 — Double majorité",
+  article_26_1: "Article 26-1 — Double majorité avec passerelle",
+  unanimite: "Unanimité",
+};
+
+const RESOLUTION_STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  proposed: { label: "Non votée", color: "#666" },
+  voted_for: { label: "ADOPTÉE", color: "#059669" },
+  voted_against: { label: "REJETÉE", color: "#dc2626" },
+  abstained: { label: "Abstention majoritaire", color: "#d97706" },
+  adjourned: { label: "Ajournée", color: "#ea580c" },
+  withdrawn: { label: "Retirée", color: "#6b7280" },
+};
+
+// ============================================
+// Shared styles
+// ============================================
+
+const SHARED_STYLES = `
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      font-size: 11pt;
+      line-height: 1.5;
+      color: #1a1a1a;
+      padding: 40px;
+    }
+    .header {
+      text-align: center;
+      margin-bottom: 30px;
+      padding-bottom: 20px;
+      border-bottom: 3px solid #7c3aed;
+    }
+    .header h1 {
+      font-size: 20pt;
+      font-weight: bold;
+      color: #1e1b4b;
+      margin-bottom: 8px;
+    }
+    .header .subtitle {
+      font-size: 13pt;
+      color: #555;
+      margin-bottom: 4px;
+    }
+    .header .reference {
+      font-family: 'Courier New', monospace;
+      font-size: 10pt;
+      color: #888;
+      margin-top: 8px;
+    }
+    .info-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+      margin-bottom: 30px;
+      padding: 20px;
+      background: #f9fafb;
+      border-left: 4px solid #7c3aed;
+      border-radius: 4px;
+    }
+    .info-block h3 {
+      font-size: 9pt;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #6b7280;
+      margin-bottom: 6px;
+    }
+    .info-block p {
+      font-size: 11pt;
+      color: #1a1a1a;
+      line-height: 1.4;
+    }
+    .info-block p.strong { font-weight: 600; }
+    .section {
+      margin-top: 30px;
+      margin-bottom: 20px;
+    }
+    .section-title {
+      font-size: 14pt;
+      font-weight: bold;
+      color: #1e1b4b;
+      padding-bottom: 8px;
+      border-bottom: 2px solid #e5e7eb;
+      margin-bottom: 16px;
+    }
+    .resolution-block {
+      margin-bottom: 20px;
+      padding: 16px;
+      background: #fafafa;
+      border-left: 3px solid #7c3aed;
+      border-radius: 4px;
+      page-break-inside: avoid;
+    }
+    .resolution-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 10px;
+    }
+    .resolution-title {
+      font-weight: bold;
+      font-size: 12pt;
+      color: #1e1b4b;
+      flex: 1;
+    }
+    .resolution-number {
+      display: inline-block;
+      font-family: 'Courier New', monospace;
+      color: #7c3aed;
+      font-weight: bold;
+      margin-right: 8px;
+    }
+    .resolution-meta {
+      font-size: 9pt;
+      color: #6b7280;
+      margin-bottom: 8px;
+    }
+    .resolution-meta span {
+      display: inline-block;
+      padding: 2px 8px;
+      background: #ede9fe;
+      color: #5b21b6;
+      border-radius: 12px;
+      margin-right: 6px;
+    }
+    .resolution-description {
+      font-size: 10pt;
+      color: #374151;
+      line-height: 1.6;
+      margin: 8px 0;
+    }
+    .resolution-amount {
+      font-size: 10pt;
+      color: #d97706;
+      font-weight: 600;
+      margin-top: 6px;
+    }
+    .resolution-result {
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid #e5e7eb;
+    }
+    .vote-counts {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+      margin-top: 8px;
+    }
+    .vote-count {
+      text-align: center;
+      padding: 8px;
+      background: white;
+      border-radius: 4px;
+      border: 1px solid #e5e7eb;
+    }
+    .vote-count-label {
+      font-size: 8pt;
+      color: #6b7280;
+      text-transform: uppercase;
+    }
+    .vote-count-value {
+      font-size: 14pt;
+      font-weight: bold;
+      margin: 2px 0;
+    }
+    .vote-count-tantiemes {
+      font-size: 8pt;
+      color: #9ca3af;
+    }
+    .status-badge {
+      display: inline-block;
+      padding: 4px 12px;
+      font-size: 9pt;
+      font-weight: bold;
+      border-radius: 12px;
+      color: white;
+    }
+    .footer {
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid #e5e7eb;
+      font-size: 9pt;
+      color: #6b7280;
+      text-align: center;
+    }
+    .legal-notice {
+      margin-top: 20px;
+      padding: 12px;
+      background: #fef3c7;
+      border-left: 3px solid #d97706;
+      border-radius: 4px;
+      font-size: 9pt;
+      color: #92400e;
+    }
+    .signatures {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 40px;
+      margin-top: 50px;
+    }
+    .signature-block {
+      text-align: center;
+    }
+    .signature-line {
+      border-top: 1px solid #333;
+      padding-top: 8px;
+      margin-top: 60px;
+      font-size: 9pt;
+      color: #6b7280;
+    }
+  </style>
+`;
+
+// ============================================
+// CONVOCATION template
+// ============================================
+
+export function generateConvocationHtml(data: ConvocationPdfData): string {
+  const typeLabel = ASSEMBLY_TYPE_LABELS[data.assembly_type] || data.assembly_type;
+
+  const resolutionsHtml = data.resolutions
+    .map((res) => {
+      const amount = res.estimated_amount_cents
+        ? `<p class="resolution-amount">Montant estimé : ${formatCents(res.estimated_amount_cents)}</p>`
+        : "";
+      const partner = res.contract_partner
+        ? `<p class="resolution-meta">Prestataire : ${escapeHtml(res.contract_partner)}</p>`
+        : "";
+
+      return `
+      <div class="resolution-block">
+        <div class="resolution-header">
+          <div class="resolution-title">
+            <span class="resolution-number">Résolution n°${res.resolution_number}</span>
+            ${escapeHtml(res.title)}
+          </div>
+        </div>
+        <div class="resolution-meta">
+          <span>${escapeHtml(CATEGORY_LABELS[res.category] || res.category)}</span>
+          <span>${escapeHtml(MAJORITY_LABELS[res.majority_rule] || res.majority_rule)}</span>
+        </div>
+        <div class="resolution-description">${escapeHtml(res.description).replace(/\n/g, "<br>")}</div>
+        ${partner}
+        ${amount}
+      </div>
+    `;
+    })
+    .join("");
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convocation ${escapeHtml(data.assembly_reference)}</title>
+  ${SHARED_STYLES}
+</head>
+<body>
+  <div class="header">
+    <h1>CONVOCATION</h1>
+    <div class="subtitle">${escapeHtml(typeLabel)}</div>
+    <div class="reference">${escapeHtml(data.assembly_reference)}</div>
+  </div>
+
+  <div class="info-grid">
+    <div class="info-block">
+      <h3>Copropriété</h3>
+      <p class="strong">${escapeHtml(data.site_name)}</p>
+      <p>${escapeHtml(data.site_address)}</p>
+      <p>${escapeHtml(data.site_postal_code)} ${escapeHtml(data.site_city)}</p>
+    </div>
+    <div class="info-block">
+      <h3>Syndic</h3>
+      ${data.syndic_company ? `<p class="strong">${escapeHtml(data.syndic_company)}</p>` : ""}
+      <p>${escapeHtml(data.syndic_name)}</p>
+      ${data.syndic_address ? `<p>${escapeHtml(data.syndic_address)}</p>` : ""}
+      ${data.syndic_email ? `<p>Email : ${escapeHtml(data.syndic_email)}</p>` : ""}
+      ${data.syndic_phone ? `<p>Tél : ${escapeHtml(data.syndic_phone)}</p>` : ""}
+      ${data.syndic_numero_carte_pro ? `<p style="font-size:9pt;color:#888;">Carte pro : ${escapeHtml(data.syndic_numero_carte_pro)}</p>` : ""}
+    </div>
+  </div>
+
+  <div class="info-grid">
+    <div class="info-block">
+      <h3>Destinataire</h3>
+      <p class="strong">${escapeHtml(data.recipient_name)}</p>
+      ${data.unit_number ? `<p>Lot n°${escapeHtml(data.unit_number)}</p>` : ""}
+      ${data.unit_tantiemes ? `<p>${data.unit_tantiemes} tantièmes</p>` : ""}
+      ${data.recipient_address ? `<p>${escapeHtml(data.recipient_address)}</p>` : ""}
+    </div>
+    <div class="info-block">
+      <h3>Date et lieu</h3>
+      <p class="strong">${formatDateTime(data.scheduled_at)}</p>
+      <p>${escapeHtml(data.location || "À définir")}</p>
+      ${data.location_address ? `<p>${escapeHtml(data.location_address)}</p>` : ""}
+      ${data.is_hybrid ? `<p style="color:#2563eb;">✓ Assemblée hybride (présentiel + visio)</p>` : ""}
+      ${data.online_meeting_url ? `<p style="font-size:9pt;color:#2563eb;">Lien visio : ${escapeHtml(data.online_meeting_url)}</p>` : ""}
+    </div>
+  </div>
+
+  <div class="section">
+    <h2 class="section-title">Ordre du jour</h2>
+    ${resolutionsHtml || '<p style="color:#888;">Aucune résolution inscrite.</p>'}
+  </div>
+
+  <div class="legal-notice">
+    <strong>Mentions légales (loi du 10 juillet 1965) :</strong>
+    <ul style="margin-left: 16px; margin-top: 4px;">
+      <li>Vous pouvez vous faire représenter par un mandataire (pouvoir).</li>
+      <li>Vote par correspondance possible sous 3 jours avant l'assemblée.</li>
+      <li>Délai de contestation des décisions : 2 mois à compter de la notification du procès-verbal.</li>
+      <li>Les copropriétaires opposants ou défaillants bénéficient d'un délai spécifique pour contester.</li>
+    </ul>
+    ${data.second_convocation_at ? `<p style="margin-top:8px;"><strong>Seconde convocation :</strong> ${formatDateTime(data.second_convocation_at)} (en cas de défaut de quorum)</p>` : ""}
+  </div>
+
+  <div class="footer">
+    <p>Document généré le ${formatDateTime(data.generated_at)}</p>
+    ${data.fiscal_year ? `<p>Exercice ${data.fiscal_year}</p>` : ""}
+  </div>
+</body>
+</html>`;
+}
+
+// ============================================
+// MINUTE (PV) template
+// ============================================
+
+export function generateMinuteHtml(data: MinutePdfData): string {
+  const typeLabel = ASSEMBLY_TYPE_LABELS[data.assembly_type] || data.assembly_type;
+  const quorumPercent = data.total_tantiemes > 0 ? ((data.present_tantiemes / data.total_tantiemes) * 100).toFixed(1) : "0";
+
+  const resolutionsHtml = data.resolutions
+    .map((res) => {
+      const statusConfig = RESOLUTION_STATUS_LABELS[res.status] || RESOLUTION_STATUS_LABELS.proposed;
+      const totalTantiemes = res.tantiemes_for + res.tantiemes_against + res.tantiemes_abstain;
+
+      return `
+      <div class="resolution-block">
+        <div class="resolution-header">
+          <div class="resolution-title">
+            <span class="resolution-number">Résolution n°${res.resolution_number}</span>
+            ${escapeHtml(res.title)}
+          </div>
+          <span class="status-badge" style="background: ${statusConfig.color}">
+            ${statusConfig.label}
+          </span>
+        </div>
+        <div class="resolution-meta">
+          <span>${escapeHtml(CATEGORY_LABELS[res.category] || res.category)}</span>
+          <span>${escapeHtml(MAJORITY_LABELS[res.majority_rule] || res.majority_rule)}</span>
+        </div>
+        <div class="resolution-description">${escapeHtml(res.description).replace(/\n/g, "<br>")}</div>
+
+        <div class="resolution-result">
+          <div class="vote-counts">
+            <div class="vote-count">
+              <div class="vote-count-label">POUR</div>
+              <div class="vote-count-value" style="color:#059669;">${res.votes_for_count}</div>
+              <div class="vote-count-tantiemes">${res.tantiemes_for.toLocaleString("fr-FR")} tant.</div>
+            </div>
+            <div class="vote-count">
+              <div class="vote-count-label">CONTRE</div>
+              <div class="vote-count-value" style="color:#dc2626;">${res.votes_against_count}</div>
+              <div class="vote-count-tantiemes">${res.tantiemes_against.toLocaleString("fr-FR")} tant.</div>
+            </div>
+            <div class="vote-count">
+              <div class="vote-count-label">ABSTENTION</div>
+              <div class="vote-count-value" style="color:#d97706;">${res.votes_abstain_count}</div>
+              <div class="vote-count-tantiemes">${res.tantiemes_abstain.toLocaleString("fr-FR")} tant.</div>
+            </div>
+          </div>
+          ${
+            totalTantiemes > 0
+              ? `<p style="text-align:right;font-size:9pt;color:#6b7280;margin-top:6px;">
+                  Total exprimé : ${totalTantiemes.toLocaleString("fr-FR")} tantièmes
+                </p>`
+              : ""
+          }
+        </div>
+      </div>
+    `;
+    })
+    .join("");
+
+  const scrutineersList = data.scrutineers_names.length > 0
+    ? data.scrutineers_names.map((n) => escapeHtml(n)).join(", ")
+    : "—";
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Procès-verbal ${escapeHtml(data.assembly_reference)}</title>
+  ${SHARED_STYLES}
+</head>
+<body>
+  <div class="header">
+    <h1>PROCÈS-VERBAL</h1>
+    <div class="subtitle">${escapeHtml(typeLabel)}</div>
+    <div class="reference">${escapeHtml(data.assembly_reference)} — Version ${data.version}</div>
+  </div>
+
+  <div class="info-grid">
+    <div class="info-block">
+      <h3>Copropriété</h3>
+      <p class="strong">${escapeHtml(data.site_name)}</p>
+      <p>${escapeHtml(data.site_address)}</p>
+    </div>
+    <div class="info-block">
+      <h3>Syndic</h3>
+      ${data.syndic_company ? `<p class="strong">${escapeHtml(data.syndic_company)}</p>` : ""}
+      <p>${escapeHtml(data.syndic_name)}</p>
+    </div>
+  </div>
+
+  <div class="info-grid">
+    <div class="info-block">
+      <h3>Date de tenue</h3>
+      <p class="strong">${formatDateTime(data.held_at)}</p>
+      <p>Date convoquée : ${formatDateTime(data.scheduled_at)}</p>
+    </div>
+    <div class="info-block">
+      <h3>Lieu</h3>
+      <p>${escapeHtml(data.location || "Non précisé")}</p>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2 class="section-title">Présidence et quorum</h2>
+    <div class="info-grid">
+      <div class="info-block">
+        <h3>Bureau de l'assemblée</h3>
+        <p><strong>Président :</strong> ${escapeHtml(data.president_name)}</p>
+        <p><strong>Secrétaire :</strong> ${escapeHtml(data.secretary_name)}</p>
+        <p><strong>Scrutateur(s) :</strong> ${scrutineersList}</p>
+      </div>
+      <div class="info-block">
+        <h3>Quorum</h3>
+        <p>Tantièmes totaux : ${data.total_tantiemes.toLocaleString("fr-FR")}</p>
+        <p>Présents ou représentés : ${data.present_tantiemes.toLocaleString("fr-FR")} (${quorumPercent}%)</p>
+        <p>Quorum requis : ${data.quorum_required.toLocaleString("fr-FR")}</p>
+        <p style="margin-top:6px;color:${data.quorum_reached ? "#059669" : "#dc2626"};font-weight:bold;">
+          ${data.quorum_reached ? "✓ Quorum atteint" : "✗ Quorum non atteint"}
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2 class="section-title">Résolutions</h2>
+    ${resolutionsHtml || '<p style="color:#888;">Aucune résolution.</p>'}
+  </div>
+
+  <div class="signatures">
+    <div class="signature-block">
+      <div class="signature-line">Le Président<br><strong>${escapeHtml(data.president_name)}</strong></div>
+    </div>
+    <div class="signature-block">
+      <div class="signature-line">Le Secrétaire<br><strong>${escapeHtml(data.secretary_name)}</strong></div>
+    </div>
+  </div>
+
+  <div class="legal-notice">
+    <strong>Délai de contestation (art. 42 loi du 10 juillet 1965) :</strong>
+    <p>Les décisions de l'assemblée peuvent être contestées devant le tribunal judiciaire
+    dans un délai de <strong>deux mois</strong> à compter de la notification du présent procès-verbal
+    aux copropriétaires opposants ou défaillants.</p>
+    ${data.contestation_deadline ? `<p style="margin-top:6px;"><strong>Date limite de contestation :</strong> ${formatDate(data.contestation_deadline)}</p>` : ""}
+  </div>
+
+  <div class="footer">
+    <p>Procès-verbal généré le ${formatDateTime(data.generated_at)} — Version ${data.version}</p>
+  </div>
+</body>
+</html>`;
+}

--- a/lib/validations/syndic.ts
+++ b/lib/validations/syndic.ts
@@ -1,0 +1,244 @@
+import { z } from "zod";
+
+/**
+ * Zod schemas for the syndic/copro module API routes.
+ * Covers: assemblies, convocations, resolutions, votes, minutes,
+ *         mandates, councils, fonds_travaux.
+ */
+
+// ============================================
+// ASSEMBLIES
+// ============================================
+
+export const CreateAssemblySchema = z.object({
+  site_id: z.string().uuid(),
+  assembly_type: z.enum(["ordinaire", "extraordinaire", "concertation", "consultation_ecrite"]),
+  title: z.string().min(3, "Titre requis").max(255),
+  reference_number: z.string().max(50).optional(),
+  fiscal_year: z.number().int().min(2020).max(2100).optional(),
+  scheduled_at: z.string().datetime({ message: "Date ISO 8601 requise" }),
+  location: z.string().max(255).optional(),
+  location_address: z.string().max(500).optional(),
+  online_meeting_url: z.string().url().optional().or(z.literal("")),
+  is_hybrid: z.boolean().default(false),
+  quorum_required: z.number().int().nonnegative().optional(),
+  description: z.string().max(2000).optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+export const UpdateAssemblySchema = CreateAssemblySchema.partial().omit({ site_id: true });
+
+export const ConveneAssemblySchema = z.object({
+  convocation_date: z.string().datetime().optional(), // Défaut = now()
+  second_convocation_at: z.string().datetime().optional(),
+});
+
+// ============================================
+// CONVOCATIONS
+// ============================================
+
+export const CreateConvocationsBatchSchema = z.object({
+  // Envoyer à toutes les unités du site OU à une liste spécifique
+  unit_ids: z.array(z.string().uuid()).optional(),
+  delivery_method: z.enum([
+    "email",
+    "postal_simple",
+    "postal_recommande",
+    "hand_delivered",
+    "lrar",
+    "lre_numerique",
+  ]),
+  convocation_document_url: z.string().url().optional(),
+  ordre_du_jour_document_url: z.string().url().optional(),
+});
+
+export const UpdateConvocationSchema = z.object({
+  status: z.enum(["pending", "sent", "delivered", "read", "returned", "refused", "failed"]).optional(),
+  delivered_at: z.string().datetime().optional(),
+  read_at: z.string().datetime().optional(),
+  tracking_number: z.string().max(100).optional(),
+  accuse_reception_url: z.string().url().optional(),
+  accuse_reception_at: z.string().datetime().optional(),
+  error_message: z.string().max(500).optional(),
+});
+
+// ============================================
+// RESOLUTIONS
+// ============================================
+
+export const CreateResolutionSchema = z.object({
+  resolution_number: z.number().int().positive(),
+  title: z.string().min(3, "Titre requis").max(255),
+  description: z.string().min(3, "Description requise"),
+  category: z
+    .enum([
+      "gestion",
+      "budget",
+      "travaux",
+      "reglement",
+      "honoraires",
+      "conseil_syndical",
+      "assurance",
+      "conflits",
+      "autre",
+    ])
+    .default("gestion"),
+  majority_rule: z.enum([
+    "article_24",
+    "article_25",
+    "article_25_1",
+    "article_26",
+    "article_26_1",
+    "unanimite",
+  ]),
+  estimated_amount_cents: z.number().int().nonnegative().optional(),
+  contract_partner: z.string().max(255).optional(),
+  attached_documents: z.array(z.any()).optional(),
+});
+
+export const UpdateResolutionSchema = CreateResolutionSchema.partial().extend({
+  status: z
+    .enum(["proposed", "voted_for", "voted_against", "abstained", "adjourned", "withdrawn"])
+    .optional(),
+});
+
+// ============================================
+// VOTES
+// ============================================
+
+export const CastVoteSchema = z.object({
+  unit_id: z.string().uuid(),
+  voter_profile_id: z.string().uuid().optional(),
+  voter_name: z.string().min(1),
+  voter_tantiemes: z.number().int().nonnegative(),
+  vote: z.enum(["for", "against", "abstain"]),
+  is_proxy: z.boolean().default(false),
+  proxy_holder_profile_id: z.string().uuid().optional(),
+  proxy_holder_name: z.string().max(255).optional(),
+  proxy_document_url: z.string().url().optional(),
+  proxy_scope: z.enum(["general", "specific", "limited"]).optional(),
+  vote_method: z
+    .enum(["in_person", "proxy", "mail_vote", "online_vote", "hand_vote"])
+    .default("in_person"),
+});
+
+// ============================================
+// MINUTES (PV)
+// ============================================
+
+export const CreateMinuteSchema = z.object({
+  content: z.record(z.any()).default({}),
+  content_html: z.string().optional(),
+  document_url: z.string().url().optional(),
+});
+
+export const SignMinuteSchema = z.object({
+  role: z.enum(["president", "secretary", "scrutineer"]),
+  profile_id: z.string().uuid().optional(),
+  signature_url: z.string().url().optional(),
+});
+
+// ============================================
+// SYNDIC MANDATES
+// ============================================
+
+export const CreateSyndicMandateSchema = z.object({
+  site_id: z.string().uuid(),
+  syndic_profile_id: z.string().uuid(),
+  mandate_number: z.string().max(50).optional(),
+  title: z.string().max(255).default("Mandat de syndic"),
+  start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Format YYYY-MM-DD requis"),
+  end_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Format YYYY-MM-DD requis"),
+  duration_months: z.number().int().min(1).max(36),
+  tacit_renewal: z.boolean().default(false),
+  notice_period_months: z.number().int().min(0).max(12).default(3),
+  honoraires_annuels_cents: z.number().int().nonnegative(),
+  honoraires_particuliers: z.record(z.any()).optional(),
+  currency: z.string().length(3).default("EUR"),
+  voted_in_assembly_id: z.string().uuid().optional(),
+  voted_resolution_id: z.string().uuid().optional(),
+  mandate_document_url: z.string().url().optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+export const TerminateMandateSchema = z.object({
+  termination_reason: z.string().min(3, "Raison requise").max(1000),
+  termination_type: z.enum([
+    "end_of_term",
+    "early_termination",
+    "non_renewal",
+    "revoked_by_ag",
+    "resignation",
+  ]),
+});
+
+// ============================================
+// COPRO COUNCILS
+// ============================================
+
+export const CreateCouncilSchema = z.object({
+  site_id: z.string().uuid(),
+  mandate_start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  mandate_end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  president_profile_id: z.string().uuid().optional(),
+  president_unit_id: z.string().uuid().optional(),
+  vice_president_profile_id: z.string().uuid().optional(),
+  vice_president_unit_id: z.string().uuid().optional(),
+  members: z
+    .array(
+      z.object({
+        profile_id: z.string().uuid(),
+        unit_id: z.string().uuid().optional(),
+        role: z.enum(["member", "president", "vice_president"]).default("member"),
+        elected_at: z.string().datetime().optional(),
+      })
+    )
+    .default([]),
+  elected_in_assembly_id: z.string().uuid().optional(),
+  elected_resolution_id: z.string().uuid().optional(),
+  internal_rules_document_url: z.string().url().optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+// ============================================
+// COPRO FONDS TRAVAUX (Loi ALUR)
+// ============================================
+
+export const CreateFondsTravauxSchema = z.object({
+  site_id: z.string().uuid(),
+  exercise_id: z.string().uuid().optional(),
+  fiscal_year: z.number().int().min(2017).max(2100),
+  cotisation_taux_percent: z
+    .number()
+    .min(0, "Taux positif requis")
+    .max(100)
+    .default(5.0),
+  cotisation_montant_annual_cents: z.number().int().nonnegative(),
+  budget_reference_cents: z.number().int().nonnegative().optional(),
+  solde_initial_cents: z.number().int().nonnegative().default(0),
+  dedicated_bank_account: z
+    .string()
+    .regex(/^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$/, "IBAN invalide")
+    .optional(),
+  bank_name: z.string().max(100).optional(),
+  loi_alur_exempt: z.boolean().default(false),
+  exempt_reason: z
+    .enum(["copropriete_neuve_moins_5_ans", "unanimite_dispense", "dtg_pas_de_travaux_prevus"])
+    .optional(),
+  exempt_voted_resolution_id: z.string().uuid().optional(),
+});
+
+export const UpdateFondsTravauxSchema = CreateFondsTravauxSchema.partial().omit({ site_id: true });
+
+// ============================================
+// Type exports
+// ============================================
+
+export type CreateAssemblyInput = z.infer<typeof CreateAssemblySchema>;
+export type UpdateAssemblyInput = z.infer<typeof UpdateAssemblySchema>;
+export type CreateResolutionInput = z.infer<typeof CreateResolutionSchema>;
+export type CastVoteInput = z.infer<typeof CastVoteSchema>;
+export type CreateMinuteInput = z.infer<typeof CreateMinuteSchema>;
+export type CreateSyndicMandateInput = z.infer<typeof CreateSyndicMandateSchema>;
+export type CreateCouncilInput = z.infer<typeof CreateCouncilSchema>;
+export type CreateFondsTravauxInput = z.infer<typeof CreateFondsTravauxSchema>;

--- a/lib/validations/syndic.ts
+++ b/lib/validations/syndic.ts
@@ -33,6 +33,25 @@ export const ConveneAssemblySchema = z.object({
   second_convocation_at: z.string().datetime().optional(),
 });
 
+export const StartAssemblySchema = z.object({
+  presided_by: z.string().uuid().optional(),
+  secretary_profile_id: z.string().uuid().optional(),
+  scrutineers: z
+    .array(
+      z.object({
+        profile_id: z.string().uuid(),
+        unit_id: z.string().uuid().optional(),
+      })
+    )
+    .optional(),
+  present_tantiemes: z.number().int().nonnegative(),
+});
+
+export const CloseAssemblySchema = z.object({
+  held_at: z.string().datetime().optional(), // Défaut = now()
+  final_notes: z.string().max(2000).optional(),
+});
+
 // ============================================
 // CONVOCATIONS
 // ============================================

--- a/supabase/migrations/20260411140000_copro_assemblies_module.sql
+++ b/supabase/migrations/20260411140000_copro_assemblies_module.sql
@@ -1,0 +1,496 @@
+-- ============================================
+-- Migration: Module Assemblées Générales de Copropriété
+-- Date: 2026-04-11
+-- Phase: 2/8 du module syndic
+--
+-- Crée les 5 tables cœur du processus d'AG :
+--   1. copro_assemblies     — Les AG (date, type, statut)
+--   2. copro_convocations   — Envois de convocations par copropriétaire
+--   3. copro_resolutions    — Résolutions à voter dans une AG
+--   4. copro_votes          — Votes par résolution et copropriétaire
+--   5. copro_minutes        — PV d'assemblée générés
+--
+-- Architecture :
+--   - FK racine vers sites(id) — cohérent avec copro_units
+--   - RLS via user_site_roles (pattern existant)
+--   - Triggers updated_at
+--   - Indexes sur les foreign keys
+-- ============================================
+
+-- ============================================
+-- 1. COPRO_ASSEMBLIES — Les assemblées générales
+-- ============================================
+CREATE TABLE IF NOT EXISTS public.copro_assemblies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  -- Type d'assemblée
+  assembly_type TEXT NOT NULL CHECK (
+    assembly_type IN ('ordinaire', 'extraordinaire', 'concertation', 'consultation_ecrite')
+  ),
+
+  -- Identification
+  title TEXT NOT NULL,
+  reference_number TEXT, -- Numéro interne (ex: AG-2026-001)
+  fiscal_year INTEGER, -- Exercice concerné (pour AG ordinaire)
+
+  -- Planification
+  scheduled_at TIMESTAMPTZ NOT NULL,
+  location TEXT,
+  location_address TEXT,
+  online_meeting_url TEXT, -- Visio optionnelle
+  is_hybrid BOOLEAN NOT NULL DEFAULT false,
+
+  -- Règles de quorum et majorité
+  quorum_required INTEGER, -- Tantièmes minimum pour la tenue
+  second_convocation_at TIMESTAMPTZ, -- Si pas de quorum
+  first_convocation_sent_at TIMESTAMPTZ,
+  second_convocation_sent_at TIMESTAMPTZ,
+
+  -- Statut
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (
+    status IN ('draft', 'convened', 'in_progress', 'held', 'adjourned', 'cancelled')
+  ),
+
+  -- Tenue effective
+  held_at TIMESTAMPTZ,
+  presided_by UUID REFERENCES public.profiles(id), -- Président de séance
+  secretary_profile_id UUID REFERENCES public.profiles(id), -- Secrétaire
+  scrutineers JSONB DEFAULT '[]', -- Scrutateurs [{profile_id, unit_id}]
+  present_tantiemes INTEGER, -- Total tantièmes présents/représentés
+  quorum_reached BOOLEAN,
+
+  -- Métadonnées
+  description TEXT,
+  notes TEXT,
+  meta JSONB DEFAULT '{}',
+  created_by UUID REFERENCES auth.users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_assemblies_site ON public.copro_assemblies(site_id);
+CREATE INDEX IF NOT EXISTS idx_copro_assemblies_status ON public.copro_assemblies(site_id, status);
+CREATE INDEX IF NOT EXISTS idx_copro_assemblies_scheduled ON public.copro_assemblies(scheduled_at);
+
+COMMENT ON TABLE public.copro_assemblies IS
+'Assemblées générales de copropriété (ordinaires, extraordinaires, concertations, consultations écrites)';
+
+-- ============================================
+-- 2. COPRO_CONVOCATIONS — Envois de convocations
+-- ============================================
+CREATE TABLE IF NOT EXISTS public.copro_convocations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assembly_id UUID NOT NULL REFERENCES public.copro_assemblies(id) ON DELETE CASCADE,
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  -- Destinataire (unit + owner)
+  unit_id UUID REFERENCES public.copro_units(id) ON DELETE SET NULL,
+  recipient_profile_id UUID REFERENCES public.profiles(id),
+  recipient_name TEXT NOT NULL,
+  recipient_email TEXT,
+  recipient_address TEXT,
+
+  -- Mode d'envoi
+  delivery_method TEXT NOT NULL CHECK (
+    delivery_method IN ('email', 'postal_simple', 'postal_recommande', 'hand_delivered', 'lrar', 'lre_numerique')
+  ),
+
+  -- État d'envoi
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (
+    status IN ('pending', 'sent', 'delivered', 'read', 'returned', 'refused', 'failed')
+  ),
+  sent_at TIMESTAMPTZ,
+  delivered_at TIMESTAMPTZ,
+  read_at TIMESTAMPTZ,
+
+  -- Preuve postale / accusé de réception
+  tracking_number TEXT, -- Numéro de suivi LRAR
+  accuse_reception_url TEXT, -- Scan AR postal ou LRE
+  accuse_reception_at TIMESTAMPTZ,
+
+  -- Convocation PDF
+  convocation_document_url TEXT,
+  ordre_du_jour_document_url TEXT,
+
+  -- Coût (pour suivi des frais)
+  postal_cost_cents INTEGER DEFAULT 0,
+
+  -- Métadonnées
+  error_message TEXT, -- Si status = 'failed'
+  meta JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_convocations_assembly ON public.copro_convocations(assembly_id);
+CREATE INDEX IF NOT EXISTS idx_copro_convocations_site ON public.copro_convocations(site_id);
+CREATE INDEX IF NOT EXISTS idx_copro_convocations_unit ON public.copro_convocations(unit_id);
+CREATE INDEX IF NOT EXISTS idx_copro_convocations_status ON public.copro_convocations(assembly_id, status);
+
+COMMENT ON TABLE public.copro_convocations IS
+'Envois de convocations aux copropriétaires pour une assemblée générale. Traçabilité légale (LRAR, accusé de réception).';
+
+-- ============================================
+-- 3. COPRO_RESOLUTIONS — Résolutions à voter
+-- ============================================
+CREATE TABLE IF NOT EXISTS public.copro_resolutions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assembly_id UUID NOT NULL REFERENCES public.copro_assemblies(id) ON DELETE CASCADE,
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  -- Ordre et identification
+  resolution_number INTEGER NOT NULL, -- Numéro dans l'ordre du jour
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+
+  -- Catégorie
+  category TEXT NOT NULL DEFAULT 'gestion' CHECK (
+    category IN (
+      'gestion',           -- Gestion courante
+      'budget',            -- Vote du budget
+      'travaux',           -- Travaux
+      'reglement',         -- Modification règlement copropriété
+      'honoraires',        -- Honoraires syndic
+      'conseil_syndical',  -- Désignation conseil syndical
+      'assurance',         -- Contrats d'assurance
+      'conflits',          -- Actions en justice
+      'autre'
+    )
+  ),
+
+  -- Règle de majorité (loi du 10 juillet 1965)
+  majority_rule TEXT NOT NULL CHECK (
+    majority_rule IN (
+      'article_24',     -- Majorité simple des présents/représentés
+      'article_25',     -- Majorité absolue de tous les copropriétaires
+      'article_25_1',   -- Article 25 avec second vote article 24 possible
+      'article_26',     -- Double majorité (2/3 copropriétaires + 2/3 tantièmes)
+      'article_26_1',   -- Article 26 avec passerelle article 25
+      'unanimite'       -- Unanimité
+    )
+  ),
+
+  -- Montant estimé (pour travaux, budgets)
+  estimated_amount_cents INTEGER,
+  contract_partner TEXT, -- Entreprise concernée (pour travaux)
+
+  -- Résultat du vote
+  status TEXT NOT NULL DEFAULT 'proposed' CHECK (
+    status IN ('proposed', 'voted_for', 'voted_against', 'abstained', 'adjourned', 'withdrawn')
+  ),
+  votes_for_count INTEGER DEFAULT 0,
+  votes_against_count INTEGER DEFAULT 0,
+  votes_abstain_count INTEGER DEFAULT 0,
+  tantiemes_for INTEGER DEFAULT 0,
+  tantiemes_against INTEGER DEFAULT 0,
+  tantiemes_abstain INTEGER DEFAULT 0,
+  second_vote_applied BOOLEAN DEFAULT false, -- Si article 25-1 déclenché
+
+  -- Documents associés (devis, plans, etc.)
+  attached_documents JSONB DEFAULT '[]',
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT copro_resolutions_number_unique UNIQUE (assembly_id, resolution_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_resolutions_assembly ON public.copro_resolutions(assembly_id);
+CREATE INDEX IF NOT EXISTS idx_copro_resolutions_site ON public.copro_resolutions(site_id);
+CREATE INDEX IF NOT EXISTS idx_copro_resolutions_status ON public.copro_resolutions(assembly_id, status);
+
+COMMENT ON TABLE public.copro_resolutions IS
+'Résolutions votées en assemblée générale. Règles de majorité loi du 10 juillet 1965.';
+
+-- ============================================
+-- 4. COPRO_VOTES — Votes individuels par résolution
+-- ============================================
+CREATE TABLE IF NOT EXISTS public.copro_votes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  resolution_id UUID NOT NULL REFERENCES public.copro_resolutions(id) ON DELETE CASCADE,
+  assembly_id UUID NOT NULL REFERENCES public.copro_assemblies(id) ON DELETE CASCADE,
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  -- Votant (copropriétaire)
+  unit_id UUID REFERENCES public.copro_units(id) ON DELETE SET NULL,
+  voter_profile_id UUID REFERENCES public.profiles(id),
+  voter_name TEXT NOT NULL,
+
+  -- Tantièmes au moment du vote (snapshot pour audit)
+  voter_tantiemes INTEGER NOT NULL DEFAULT 0,
+
+  -- Vote
+  vote TEXT NOT NULL CHECK (vote IN ('for', 'against', 'abstain')),
+
+  -- Pouvoir / procuration
+  is_proxy BOOLEAN NOT NULL DEFAULT false,
+  proxy_holder_profile_id UUID REFERENCES public.profiles(id), -- Mandataire
+  proxy_holder_name TEXT,
+  proxy_document_url TEXT, -- Document de pouvoir signé
+  proxy_scope TEXT CHECK (proxy_scope IN ('general', 'specific', 'limited')),
+
+  -- Modalité de vote
+  vote_method TEXT NOT NULL DEFAULT 'in_person' CHECK (
+    vote_method IN ('in_person', 'proxy', 'mail_vote', 'online_vote', 'hand_vote')
+  ),
+  voted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Traçabilité
+  vote_ip_address INET,
+  vote_user_agent TEXT,
+
+  meta JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_votes_resolution ON public.copro_votes(resolution_id);
+CREATE INDEX IF NOT EXISTS idx_copro_votes_assembly ON public.copro_votes(assembly_id);
+CREATE INDEX IF NOT EXISTS idx_copro_votes_unit ON public.copro_votes(unit_id);
+CREATE INDEX IF NOT EXISTS idx_copro_votes_voter ON public.copro_votes(voter_profile_id);
+
+-- Un copropriétaire ne peut voter qu'une fois par résolution
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_copro_vote_per_unit_resolution
+  ON public.copro_votes(resolution_id, unit_id)
+  WHERE unit_id IS NOT NULL;
+
+COMMENT ON TABLE public.copro_votes IS
+'Votes individuels des copropriétaires sur chaque résolution. Supporte pouvoirs, vote par correspondance, vote en ligne.';
+
+-- ============================================
+-- 5. COPRO_MINUTES — Procès-verbaux
+-- ============================================
+CREATE TABLE IF NOT EXISTS public.copro_minutes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assembly_id UUID NOT NULL REFERENCES public.copro_assemblies(id) ON DELETE CASCADE,
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  -- Contenu
+  version INTEGER NOT NULL DEFAULT 1,
+  content JSONB NOT NULL DEFAULT '{}', -- Structure {preamble, attendees, resolutions[], decisions, closing}
+  content_html TEXT, -- Version rendue pour affichage
+  document_url TEXT, -- PDF du PV signé
+
+  -- État
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (
+    status IN ('draft', 'reviewed', 'signed', 'distributed', 'archived')
+  ),
+
+  -- Signatures
+  signed_by_president_at TIMESTAMPTZ,
+  signed_by_president_profile_id UUID REFERENCES public.profiles(id),
+  signed_by_secretary_at TIMESTAMPTZ,
+  signed_by_secretary_profile_id UUID REFERENCES public.profiles(id),
+  scrutineers_signatures JSONB DEFAULT '[]', -- [{profile_id, signed_at, signature_url}]
+
+  -- Distribution
+  distributed_at TIMESTAMPTZ,
+  distribution_method TEXT CHECK (distribution_method IN ('email', 'postal', 'hand_delivered', 'portal')),
+
+  -- Délai de contestation (2 mois légaux)
+  contestation_deadline TIMESTAMPTZ,
+
+  created_by UUID REFERENCES auth.users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT copro_minutes_version_unique UNIQUE (assembly_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_minutes_assembly ON public.copro_minutes(assembly_id);
+CREATE INDEX IF NOT EXISTS idx_copro_minutes_site ON public.copro_minutes(site_id);
+CREATE INDEX IF NOT EXISTS idx_copro_minutes_status ON public.copro_minutes(site_id, status);
+
+COMMENT ON TABLE public.copro_minutes IS
+'Procès-verbaux d''assemblées générales de copropriété. Versionning + signatures + délai de contestation légal (2 mois).';
+
+-- ============================================
+-- ROW LEVEL SECURITY — Pattern via user_site_roles
+-- ============================================
+
+ALTER TABLE public.copro_assemblies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.copro_convocations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.copro_resolutions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.copro_votes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.copro_minutes ENABLE ROW LEVEL SECURITY;
+
+-- Helper : le syndic d'un site a accès total
+-- Helper : les copropriétaires voient en lecture seule
+-- Helper : les admins voient tout
+
+-- ===== copro_assemblies =====
+DROP POLICY IF EXISTS "copro_assemblies_syndic_all" ON public.copro_assemblies;
+CREATE POLICY "copro_assemblies_syndic_all" ON public.copro_assemblies
+  FOR ALL TO authenticated
+  USING (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "copro_assemblies_coproprietaire_select" ON public.copro_assemblies;
+CREATE POLICY "copro_assemblies_coproprietaire_select" ON public.copro_assemblies
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT site_id FROM public.user_site_roles
+      WHERE user_id = auth.uid()
+    )
+  );
+
+-- ===== copro_convocations =====
+DROP POLICY IF EXISTS "copro_convocations_syndic_all" ON public.copro_convocations;
+CREATE POLICY "copro_convocations_syndic_all" ON public.copro_convocations
+  FOR ALL TO authenticated
+  USING (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "copro_convocations_recipient_select" ON public.copro_convocations;
+CREATE POLICY "copro_convocations_recipient_select" ON public.copro_convocations
+  FOR SELECT TO authenticated
+  USING (
+    recipient_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR site_id IN (
+      SELECT site_id FROM public.user_site_roles WHERE user_id = auth.uid()
+    )
+  );
+
+-- ===== copro_resolutions =====
+DROP POLICY IF EXISTS "copro_resolutions_syndic_all" ON public.copro_resolutions;
+CREATE POLICY "copro_resolutions_syndic_all" ON public.copro_resolutions
+  FOR ALL TO authenticated
+  USING (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "copro_resolutions_coproprietaire_select" ON public.copro_resolutions;
+CREATE POLICY "copro_resolutions_coproprietaire_select" ON public.copro_resolutions
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT site_id FROM public.user_site_roles WHERE user_id = auth.uid()
+    )
+  );
+
+-- ===== copro_votes =====
+DROP POLICY IF EXISTS "copro_votes_syndic_all" ON public.copro_votes;
+CREATE POLICY "copro_votes_syndic_all" ON public.copro_votes
+  FOR ALL TO authenticated
+  USING (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "copro_votes_voter_own" ON public.copro_votes;
+CREATE POLICY "copro_votes_voter_own" ON public.copro_votes
+  FOR SELECT TO authenticated
+  USING (
+    voter_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+-- ===== copro_minutes =====
+DROP POLICY IF EXISTS "copro_minutes_syndic_all" ON public.copro_minutes;
+CREATE POLICY "copro_minutes_syndic_all" ON public.copro_minutes
+  FOR ALL TO authenticated
+  USING (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "copro_minutes_coproprietaire_select" ON public.copro_minutes;
+CREATE POLICY "copro_minutes_coproprietaire_select" ON public.copro_minutes
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT site_id FROM public.user_site_roles WHERE user_id = auth.uid()
+    )
+    AND status IN ('signed', 'distributed', 'archived')
+  );
+
+-- ============================================
+-- TRIGGERS updated_at
+-- ============================================
+DROP TRIGGER IF EXISTS update_copro_assemblies_updated_at ON public.copro_assemblies;
+CREATE TRIGGER update_copro_assemblies_updated_at
+  BEFORE UPDATE ON public.copro_assemblies
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_copro_convocations_updated_at ON public.copro_convocations;
+CREATE TRIGGER update_copro_convocations_updated_at
+  BEFORE UPDATE ON public.copro_convocations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_copro_resolutions_updated_at ON public.copro_resolutions;
+CREATE TRIGGER update_copro_resolutions_updated_at
+  BEFORE UPDATE ON public.copro_resolutions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_copro_minutes_updated_at ON public.copro_minutes;
+CREATE TRIGGER update_copro_minutes_updated_at
+  BEFORE UPDATE ON public.copro_minutes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ============================================
+-- GRANTS
+-- ============================================
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_assemblies TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_convocations TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_resolutions TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_votes TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_minutes TO authenticated;

--- a/supabase/migrations/20260411140100_copro_governance_module.sql
+++ b/supabase/migrations/20260411140100_copro_governance_module.sql
@@ -1,0 +1,331 @@
+-- ============================================
+-- Migration: Module Gouvernance Copropriété & Fonds Travaux (Loi ALUR)
+-- Date: 2026-04-11
+-- Phase: 2/8 du module syndic
+--
+-- Crée 3 tables complémentaires :
+--   1. syndic_mandates     — Contrats syndic signés (mandat légal)
+--   2. copro_councils      — Conseils syndicaux (membres + mandat)
+--   3. copro_fonds_travaux — Fonds travaux obligatoire loi ALUR
+--
+-- Architecture :
+--   - FK vers sites(id) — cohérent avec copro_assemblies
+--   - RLS via sites.syndic_profile_id + user_site_roles
+-- ============================================
+
+-- ============================================
+-- 1. SYNDIC_MANDATES — Mandats de syndic
+-- ============================================
+-- Note: la table `mandates` existe déjà pour les agences immobilières (gestion locative)
+-- et `agency_mandates` pour les mandats white-label. Celle-ci est spécifique aux syndics
+-- de copropriété (loi du 10 juillet 1965).
+CREATE TABLE IF NOT EXISTS public.syndic_mandates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+  syndic_profile_id UUID NOT NULL REFERENCES public.profiles(id),
+
+  -- Identification du mandat
+  mandate_number TEXT, -- Numéro interne
+  title TEXT NOT NULL DEFAULT 'Mandat de syndic',
+
+  -- Durée (loi : 1 an minimum, 3 ans maximum)
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  duration_months INTEGER NOT NULL CHECK (duration_months BETWEEN 1 AND 36),
+
+  -- Renouvellement / reconduction
+  tacit_renewal BOOLEAN NOT NULL DEFAULT false,
+  notice_period_months INTEGER DEFAULT 3, -- Préavis de résiliation
+  previous_mandate_id UUID REFERENCES public.syndic_mandates(id), -- Chaînage des mandats
+
+  -- Honoraires
+  honoraires_annuels_cents INTEGER NOT NULL CHECK (honoraires_annuels_cents >= 0),
+  honoraires_particuliers JSONB DEFAULT '{}', -- {edl: 15000, ag_supplement: 50000, etc.}
+  currency TEXT NOT NULL DEFAULT 'EUR',
+
+  -- Désignation par assemblée générale
+  voted_in_assembly_id UUID REFERENCES public.copro_assemblies(id),
+  voted_resolution_id UUID REFERENCES public.copro_resolutions(id),
+  voted_at TIMESTAMPTZ,
+
+  -- Document du mandat signé
+  mandate_document_url TEXT,
+  signed_at TIMESTAMPTZ,
+
+  -- Statut
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (
+    status IN ('draft', 'pending_signature', 'active', 'suspended', 'terminated', 'expired')
+  ),
+
+  -- Résiliation
+  terminated_at TIMESTAMPTZ,
+  terminated_by UUID REFERENCES auth.users(id),
+  termination_reason TEXT,
+  termination_type TEXT CHECK (
+    termination_type IS NULL OR
+    termination_type IN ('end_of_term', 'early_termination', 'non_renewal', 'revoked_by_ag', 'resignation')
+  ),
+
+  notes TEXT,
+  meta JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT syndic_mandate_dates_valid CHECK (end_date > start_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_syndic_mandates_site ON public.syndic_mandates(site_id);
+CREATE INDEX IF NOT EXISTS idx_syndic_mandates_syndic ON public.syndic_mandates(syndic_profile_id);
+CREATE INDEX IF NOT EXISTS idx_syndic_mandates_status ON public.syndic_mandates(site_id, status);
+CREATE INDEX IF NOT EXISTS idx_syndic_mandates_end_date ON public.syndic_mandates(end_date);
+
+-- Un seul mandat actif par site à la fois
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_active_syndic_mandate_per_site
+  ON public.syndic_mandates(site_id)
+  WHERE status = 'active';
+
+COMMENT ON TABLE public.syndic_mandates IS
+'Mandats de syndic de copropriété. Distincts des mandats agence immobilière. Loi du 10 juillet 1965 (durée 1-3 ans, renouvellement par AG).';
+
+-- ============================================
+-- 2. COPRO_COUNCILS — Conseils syndicaux
+-- ============================================
+CREATE TABLE IF NOT EXISTS public.copro_councils (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  -- Durée du mandat
+  mandate_start DATE NOT NULL,
+  mandate_end DATE NOT NULL,
+
+  -- Président du conseil syndical
+  president_profile_id UUID REFERENCES public.profiles(id),
+  president_unit_id UUID REFERENCES public.copro_units(id),
+
+  -- Vice-président (optionnel)
+  vice_president_profile_id UUID REFERENCES public.profiles(id),
+  vice_president_unit_id UUID REFERENCES public.copro_units(id),
+
+  -- Membres du conseil (structurés en JSONB pour flexibilité)
+  -- Format: [{profile_id, unit_id, role: 'member' | 'president' | 'vice_president', elected_at}]
+  members JSONB NOT NULL DEFAULT '[]',
+  members_count INTEGER GENERATED ALWAYS AS (jsonb_array_length(COALESCE(members, '[]'::jsonb))) STORED,
+
+  -- Désignation par AG
+  elected_in_assembly_id UUID REFERENCES public.copro_assemblies(id),
+  elected_resolution_id UUID REFERENCES public.copro_resolutions(id),
+
+  -- Règlement du conseil
+  internal_rules_document_url TEXT,
+
+  -- Statut
+  status TEXT NOT NULL DEFAULT 'active' CHECK (
+    status IN ('active', 'suspended', 'dissolved', 'expired')
+  ),
+
+  -- Dissolution
+  dissolved_at TIMESTAMPTZ,
+  dissolution_reason TEXT,
+
+  notes TEXT,
+  meta JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT copro_council_dates_valid CHECK (mandate_end > mandate_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_councils_site ON public.copro_councils(site_id);
+CREATE INDEX IF NOT EXISTS idx_copro_councils_status ON public.copro_councils(site_id, status);
+CREATE INDEX IF NOT EXISTS idx_copro_councils_president ON public.copro_councils(president_profile_id);
+
+-- Un seul conseil actif par site
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_active_copro_council_per_site
+  ON public.copro_councils(site_id)
+  WHERE status = 'active';
+
+COMMENT ON TABLE public.copro_councils IS
+'Conseils syndicaux de copropriété. Élus en AG, assistent et contrôlent le syndic (loi du 10 juillet 1965).';
+
+-- ============================================
+-- 3. COPRO_FONDS_TRAVAUX — Fonds travaux obligatoire (Loi ALUR 2014)
+-- ============================================
+-- Obligatoire depuis 1er janvier 2017 pour les copropriétés de + de 5 ans
+-- Cotisation minimale : 5% du budget prévisionnel annuel
+CREATE TABLE IF NOT EXISTS public.copro_fonds_travaux (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  -- Exercice concerné
+  exercise_id UUID REFERENCES public.accounting_exercises(id) ON DELETE SET NULL,
+  fiscal_year INTEGER NOT NULL, -- Ex: 2026
+
+  -- Cotisation (loi ALUR : minimum 5% du budget prévisionnel)
+  cotisation_taux_percent DECIMAL(5, 2) NOT NULL DEFAULT 5.00 CHECK (cotisation_taux_percent >= 0),
+  cotisation_montant_annual_cents INTEGER NOT NULL CHECK (cotisation_montant_annual_cents >= 0),
+  budget_reference_cents INTEGER, -- Budget prévisionnel de référence
+
+  -- Solde
+  solde_initial_cents INTEGER NOT NULL DEFAULT 0,
+  solde_actuel_cents INTEGER NOT NULL DEFAULT 0,
+  total_collected_cents INTEGER NOT NULL DEFAULT 0,
+  total_spent_cents INTEGER NOT NULL DEFAULT 0,
+
+  -- Dates
+  derniere_cotisation_at TIMESTAMPTZ,
+  next_cotisation_due_at DATE,
+
+  -- Dérogation possible (copropriétés neuves ou à l'unanimité)
+  loi_alur_exempt BOOLEAN NOT NULL DEFAULT false,
+  exempt_reason TEXT CHECK (
+    exempt_reason IS NULL OR
+    exempt_reason IN ('copropriete_neuve_moins_5_ans', 'unanimite_dispense', 'dtg_pas_de_travaux_prevus')
+  ),
+  exempt_voted_resolution_id UUID REFERENCES public.copro_resolutions(id),
+
+  -- Statut
+  status TEXT NOT NULL DEFAULT 'active' CHECK (
+    status IN ('active', 'paused', 'closed')
+  ),
+
+  -- Compte bancaire dédié (obligatoire loi ALUR)
+  dedicated_bank_account TEXT, -- IBAN
+  bank_name TEXT,
+
+  meta JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT copro_fonds_travaux_unique_year UNIQUE (site_id, fiscal_year)
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_fonds_travaux_site ON public.copro_fonds_travaux(site_id);
+CREATE INDEX IF NOT EXISTS idx_copro_fonds_travaux_exercise ON public.copro_fonds_travaux(exercise_id);
+CREATE INDEX IF NOT EXISTS idx_copro_fonds_travaux_status ON public.copro_fonds_travaux(site_id, status);
+
+COMMENT ON TABLE public.copro_fonds_travaux IS
+'Fonds travaux obligatoire loi ALUR 2014 (article 58). Cotisation minimale 5% du budget. Obligatoire pour copropriétés >5 ans depuis 01/01/2017.';
+
+-- ============================================
+-- ROW LEVEL SECURITY
+-- ============================================
+
+ALTER TABLE public.syndic_mandates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.copro_councils ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.copro_fonds_travaux ENABLE ROW LEVEL SECURITY;
+
+-- ===== syndic_mandates =====
+DROP POLICY IF EXISTS "syndic_mandates_syndic_all" ON public.syndic_mandates;
+CREATE POLICY "syndic_mandates_syndic_all" ON public.syndic_mandates
+  FOR ALL TO authenticated
+  USING (
+    syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "syndic_mandates_coproprietaire_select" ON public.syndic_mandates;
+CREATE POLICY "syndic_mandates_coproprietaire_select" ON public.syndic_mandates
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT site_id FROM public.user_site_roles WHERE user_id = auth.uid()
+    )
+  );
+
+-- ===== copro_councils =====
+DROP POLICY IF EXISTS "copro_councils_syndic_all" ON public.copro_councils;
+CREATE POLICY "copro_councils_syndic_all" ON public.copro_councils
+  FOR ALL TO authenticated
+  USING (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "copro_councils_member_select" ON public.copro_councils;
+CREATE POLICY "copro_councils_member_select" ON public.copro_councils
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT site_id FROM public.user_site_roles WHERE user_id = auth.uid()
+    )
+    OR president_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR vice_president_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+-- ===== copro_fonds_travaux =====
+DROP POLICY IF EXISTS "copro_fonds_travaux_syndic_all" ON public.copro_fonds_travaux;
+CREATE POLICY "copro_fonds_travaux_syndic_all" ON public.copro_fonds_travaux
+  FOR ALL TO authenticated
+  USING (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  )
+  WITH CHECK (
+    site_id IN (
+      SELECT id FROM public.sites
+      WHERE syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+    OR EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role IN ('admin', 'platform_admin'))
+  );
+
+DROP POLICY IF EXISTS "copro_fonds_travaux_coproprietaire_select" ON public.copro_fonds_travaux;
+CREATE POLICY "copro_fonds_travaux_coproprietaire_select" ON public.copro_fonds_travaux
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT site_id FROM public.user_site_roles WHERE user_id = auth.uid()
+    )
+  );
+
+-- ============================================
+-- TRIGGERS updated_at
+-- ============================================
+DROP TRIGGER IF EXISTS update_syndic_mandates_updated_at ON public.syndic_mandates;
+CREATE TRIGGER update_syndic_mandates_updated_at
+  BEFORE UPDATE ON public.syndic_mandates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_copro_councils_updated_at ON public.copro_councils;
+CREATE TRIGGER update_copro_councils_updated_at
+  BEFORE UPDATE ON public.copro_councils
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_copro_fonds_travaux_updated_at ON public.copro_fonds_travaux;
+CREATE TRIGGER update_copro_fonds_travaux_updated_at
+  BEFORE UPDATE ON public.copro_fonds_travaux
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ============================================
+-- GRANTS
+-- ============================================
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.syndic_mandates TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_councils TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_fonds_travaux TO authenticated;


### PR DESCRIPTION
## Summary

Ships the complete syndic copropriété module — 7 commits, ~11 000 lignes, covering schema, REST APIs, UI syndic, PDF generation, live session, and copropriétaire portal with online voting.

Feature flag `NEXT_PUBLIC_SYNDIC_ENABLED` remains OFF in prod. Enable when ready for beta testing.

## Phases delivered

### Phase 2/8 — Schéma DB (`9dce5d2`)
8 new tables with RLS, triggers, and indexes:
- `copro_assemblies`, `copro_convocations`, `copro_resolutions`, `copro_votes`, `copro_minutes`
- `syndic_mandates`, `copro_councils`, `copro_fonds_travaux`
- 30 indexes, 16 RLS policies, 7 updated_at triggers
- Uses `sites(id)` as root FK (consistent with existing `copro_units`)

### Phase 3/8 — REST APIs (`260965a`)
12 route files + shared helper + Zod schemas:
- `GET/POST /api/copro/assemblies` + `[id]` (GET/PATCH/DELETE)
- `POST /api/copro/assemblies/[id]/convocations` (batch send)
- `GET/POST /api/copro/assemblies/[id]/resolutions`
- `POST /api/copro/resolutions/[id]/vote` (with loi 10/07/1965 majority rule computation)
- `GET/POST /api/copro/assemblies/[id]/minutes` + `/minutes/[id]/sign`
- `GET/POST /api/copro/mandates`, `/councils`, `/fonds-travaux`
- `lib/helpers/syndic-auth.ts` — `requireSyndic()` + `requireAssemblyAccess()`
- `lib/validations/syndic.ts` — 14 Zod schemas

### Phase 4/8 — UI assemblées syndic (`5105645`)
- `/syndic/assemblies` — liste + stats + filtres
- `/syndic/assemblies/new` — formulaire création
- `/syndic/assemblies/[id]` — détail + actions contextuelles
- Dialogs: `AddResolutionDialog`, `SendConvocationsDialog`

### Phase 5/8 — UI gouvernance (`ebd5eee`)
- `/syndic/mandates` + `/new` — mandats syndic (loi Hoguet, durée 1-36 mois)
- `/syndic/councils` + `/new` — conseils syndicaux
- `/syndic/fonds-travaux/new` — création fonds ALUR (5% min)
- `/syndic/assemblies/[id]/edit` — édition AG (réécriture @ts-nocheck)
- Layout nav : +3 entrées (Mandats, Conseils, Fonds travaux)

### Phase 6/8 — Génération PDF (`c4db771`)
- `lib/pdf/syndic-templates.ts` — templates HTML convocation + PV
- `GET /api/copro/assemblies/[id]/convocation-pdf?unit_id=X`
- `GET /api/copro/minutes/[id]/pdf`
- `DownloadPdfButton` component (html2pdf.js client-side + fallback HTML)
- Notices légales embarquées (loi 10/07/1965, délai contestation 2 mois)

### Phase 7/8 — Session live (`b3baefa`)
- `POST /api/copro/assemblies/[id]/start` (convened → in_progress + bureau)
- `POST /api/copro/assemblies/[id]/close` (in_progress → held)
- `GET /api/copro/assemblies/[id]/units`
- `/syndic/assemblies/[id]/live` — page dédiée session temps réel
- Components: `BureauSetupCard`, `VoteRecorderCard`, `QuorumGauge`

### Phase 8/8 — Portail copropriétaire (`10c0196`)
- `GET/POST /api/copro/assemblies/[id]/my-vote` — vue filtrée + vote en ligne
- `/copro/assemblies` — liste "à venir" / "passées"
- `/copro/assemblies/[id]` — détail + vote en ligne par lot + download PDFs
- Vérification ownership : un copropriétaire ne peut voter que pour ses lots

## Legal compliance enforced

| Loi / Article | Implémentation |
|---|---|
| Loi 10/07/1965 — art. 24/25/25-1/26/26-1 | 6 règles de majorité dans `computeResolutionStatus()` |
| Loi 10/07/1965 — art. 21 | Conseil syndical avec président, membres, mandat 1-3 ans |
| Loi 10/07/1965 — art. 42 | Délai contestation PV : 2 mois auto-calculé |
| Loi Hoguet | Durée mandat 1-36 mois + carte pro sur convocations |
| Loi ALUR 2014 art. 58 | Fonds travaux minimum 5% sauf exemption documentée |
| Quorum | Calcul automatique au démarrage de session |
| Traçabilité convocations | LRAR, LRE numérique, accusé de réception |

## Workflow complet

```
SYNDIC SIDE:                      COPRO SIDE:
1. Create AG (draft)              
2. Add résolutions                
3. Send convocations              3. Receive convocation
   (→ convened)                   4. Download PDF
                                  5. Vote online (pre-AG)
4. Start live session             
   (→ in_progress)                
5. Record in-person votes         6. Vote in-person (if present)
6. Close session                  
   (→ held)                       
7. Generate PV (draft)            
8. Sign PV (→ signed)             9. Download signed PV
```

## Migrations à appliquer

Les 2 migrations Phase 2 sont déjà appliquées en prod :
- `20260411140000_copro_assemblies_module.sql` ✅
- `20260411140100_copro_governance_module.sql` ✅

Vérifié via : `SELECT COUNT(*)` sur les 8 tables → 8/8 ✅

## Test plan

- [ ] Enable `NEXT_PUBLIC_SYNDIC_ENABLED=true` sur staging
- [ ] Créer compte syndic via `/signup/role`
- [ ] Complete `/syndic/onboarding/profile` avec carte pro + RCP
- [ ] Créer un site avec lots + copropriétaires
- [ ] Créer une AG via `/syndic/assemblies/new`
- [ ] Ajouter 3 résolutions (art. 24, 25, 26)
- [ ] Télécharger la convocation PDF
- [ ] Envoyer les convocations (draft → convened)
- [ ] Démarrer session `/live` avec bureau + quorum
- [ ] Voter chaque résolution (in_progress)
- [ ] Clôturer la session (held)
- [ ] Générer le PV, signer (draft → signed)
- [ ] Télécharger le PV PDF
- [ ] Créer un conseil syndical et un mandat
- [ ] Créer un fonds travaux (vérif warning 5% ALUR)
- [ ] Assigner un copro via `user_site_roles` et tester portail `/copro/assemblies`
- [ ] Vote en ligne depuis le portail copro
- [ ] Vérifier que le vote en ligne apparaît côté syndic

https://claude.ai/code/session_01SvBvuEtFNo2DZQ2pKD3ZJq
