### PR TITLE
Centralize unpaid invoice calculations & fix tenant payment UI bugs

### DIFF
--- a/app/api/invoices/[id]/receipt/route.ts
+++ b/app/api/invoices/[id]/receipt/route.ts
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { generateReceiptPDF } from "@/lib/services/receipt-generator";
+import { ensureReceiptDocument } from "@/lib/services/final-documents.service";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 
@@ -175,7 +176,21 @@ export async function GET(
       dateEmission: new Date().toISOString().substring(0, 10),
     });
 
-    // 8. Retourner le PDF
+    // 8. Persistance fire-and-forget : si la quittance n'est pas encore stockée
+    //    en base (cas Bug 7 : facture marquée payée hors webhook Stripe), on
+    //    déclenche la création du document via `ensureReceiptDocument` pour que
+    //    la page /tenant/documents la voie. La réponse au client n'attend pas.
+    if (lastPayment?.id) {
+      void ensureReceiptDocument(serviceClient as any, lastPayment.id).catch(
+        (err) =>
+          console.error(
+            "[Receipt] ensureReceiptDocument fire-and-forget failed:",
+            err?.message ?? err
+          )
+      );
+    }
+
+    // 9. Retourner le PDF
     const filename = `quittance_${inv.periode || "loyer"}.pdf`;
     return new NextResponse(Buffer.from(pdfBytes), {
       status: 200,

--- a/app/api/invoices/[id]/route.ts
+++ b/app/api/invoices/[id]/route.ts
@@ -113,11 +113,27 @@ export async function GET(
 
     const settlement = await getInvoiceSettlement(serviceClient as any, id);
 
+    // Bug 10 : `date_emission` ne doit jamais être postérieure à `date_echeance`.
+    // Quand une facture est créée rétroactivement (cron lancé tardivement), la
+    // base stocke `created_at = now()` mais l'échéance dans le passé. On clamp
+    // `date_emission` à min(date_emission||created_at, date_echeance) pour
+    // afficher des dates cohérentes côté UI.
+    const rawIssued = invoiceAny.date_emission || invoiceAny.created_at || null;
+    const rawDue = invoiceAny.date_echeance || invoiceAny.due_date || null;
+    let normalizedIssued = rawIssued;
+    if (rawIssued && rawDue) {
+      const issuedTs = new Date(rawIssued).getTime();
+      const dueTs = new Date(rawDue).getTime();
+      if (Number.isFinite(issuedTs) && Number.isFinite(dueTs) && issuedTs > dueTs) {
+        normalizedIssued = rawDue;
+      }
+    }
+
     return NextResponse.json({
       invoice: {
         ...invoiceAny,
-        date_echeance: invoiceAny.date_echeance || invoiceAny.due_date || null,
-        date_emission: invoiceAny.date_emission || invoiceAny.created_at || null,
+        date_echeance: rawDue,
+        date_emission: normalizedIssued,
         property: invoiceAny.lease?.property || null,
         payments: payments || [],
         montant_paye: settlement?.totalPaid || 0,

--- a/app/api/tenant/inspections/route.ts
+++ b/app/api/tenant/inspections/route.ts
@@ -1,0 +1,212 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import type { TenantEDLListItem } from "@/lib/types/tenant";
+
+/**
+ * GET /api/tenant/inspections
+ *
+ * Liste des états des lieux (EDL) accessibles au locataire.
+ *
+ * Pourquoi une route API ?
+ * --------------------------
+ * Le hook client précédent (useTenantInspections) interrogeait directement
+ * Supabase via le client browser-side, avec un embed PostgREST profond
+ * (`edl_signatures → edl → lease → property` ET `edl → property_details`).
+ * Ce JOIN traversait plusieurs policies RLS et déclenchait des erreurs 500
+ * (recursion 42P17 ou ambiguïté de relation), rendant la page totalement
+ * inaccessible au locataire.
+ *
+ * On déplace la requête côté serveur en utilisant `getServiceClient()` :
+ * l'authentification est vérifiée via `createClient()` + `getUser()`, puis
+ * toutes les lectures de données passent par le service role qui bypasse
+ * les RLS sans risque de récursion.
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile) {
+      return NextResponse.json({ inspections: [] });
+    }
+
+    // 1. Récupérer toutes les signatures EDL où ce profil est signataire
+    //    (cast `any` car les colonnes signer_profile_id / property_id ont été
+    //    ajoutées par migration ultérieure et ne sont pas dans database.types.ts)
+    const { data: signaturesRaw, error: signaturesError } = await (serviceClient as any)
+      .from("edl_signatures")
+      .select(
+        "id, edl_id, signer_profile_id, signed_at, invitation_token, signer_role"
+      )
+      .eq("signer_profile_id", profile.id);
+
+    if (signaturesError) {
+      console.error(
+        "[GET /api/tenant/inspections] edl_signatures error:",
+        signaturesError.message
+      );
+      return NextResponse.json(
+        { error: "Erreur lors du chargement des états des lieux" },
+        { status: 500 }
+      );
+    }
+
+    const signatures = (signaturesRaw || []) as Array<{
+      id: string;
+      edl_id: string;
+      signer_profile_id: string | null;
+      signed_at: string | null;
+      invitation_token: string | null;
+      signer_role: string | null;
+    }>;
+
+    if (signatures.length === 0) {
+      return NextResponse.json({ inspections: [] });
+    }
+
+    const edlIds = Array.from(
+      new Set(signatures.map((s) => s.edl_id).filter(Boolean))
+    );
+
+    if (edlIds.length === 0) {
+      return NextResponse.json({ inspections: [] });
+    }
+
+    // 2. Récupérer les EDL associés (sans embed pour éviter toute recursion RLS)
+    const { data: edlsRaw, error: edlsError } = await (serviceClient as any)
+      .from("edl")
+      .select(
+        "id, type, status, scheduled_at, scheduled_date, created_at, lease_id, property_id"
+      )
+      .in("id", edlIds);
+
+    if (edlsError) {
+      console.error(
+        "[GET /api/tenant/inspections] edl error:",
+        edlsError.message
+      );
+      return NextResponse.json(
+        { error: "Erreur lors du chargement des états des lieux" },
+        { status: 500 }
+      );
+    }
+
+    const edlList = (edlsRaw || []) as Array<{
+      id: string;
+      type: string | null;
+      status: string | null;
+      scheduled_at: string | null;
+      scheduled_date: string | null;
+      created_at: string;
+      lease_id: string | null;
+      property_id: string | null;
+    }>;
+
+    // 3. Récupérer les propriétés (via property_id direct OU via lease_id)
+    const directPropertyIds = edlList
+      .map((e) => e.property_id)
+      .filter((id): id is string => !!id);
+
+    const leaseIds = edlList
+      .map((e) => e.lease_id)
+      .filter((id): id is string => !!id);
+
+    const leasePropertyMap = new Map<string, string>();
+    if (leaseIds.length > 0) {
+      const { data: leases } = await serviceClient
+        .from("leases")
+        .select("id, property_id")
+        .in("id", leaseIds);
+      if (leases) {
+        for (const l of leases as Array<{ id: string; property_id: string | null }>) {
+          if (l.property_id) leasePropertyMap.set(l.id, l.property_id);
+        }
+      }
+    }
+
+    const allPropertyIds = Array.from(
+      new Set([
+        ...directPropertyIds,
+        ...Array.from(leasePropertyMap.values()),
+      ])
+    );
+
+    const propertyMap = new Map<string, any>();
+    if (allPropertyIds.length > 0) {
+      const { data: properties } = await serviceClient
+        .from("properties")
+        .select(
+          "id, adresse_complete, ville, code_postal, type, surface_habitable_m2, nb_pieces"
+        )
+        .in("id", allPropertyIds);
+      if (properties) {
+        for (const p of properties as Array<{ id: string }>) {
+          propertyMap.set(p.id, p);
+        }
+      }
+    }
+
+    // 4. Construire la liste enrichie pour le client
+    const signatureByEdl = new Map<string, (typeof signatures)[number]>();
+    for (const sig of signatures) {
+      // Garder la signature la plus récemment signée si plusieurs existent
+      const existing = signatureByEdl.get(sig.edl_id);
+      if (
+        !existing ||
+        (sig.signed_at && (!existing.signed_at || sig.signed_at > existing.signed_at))
+      ) {
+        signatureByEdl.set(sig.edl_id, sig);
+      }
+    }
+
+    const inspections: TenantEDLListItem[] = edlList
+      .map((edl) => {
+        const sig = signatureByEdl.get(edl.id);
+        const propertyId =
+          edl.property_id || (edl.lease_id ? leasePropertyMap.get(edl.lease_id) : undefined);
+        const property = propertyId ? propertyMap.get(propertyId) ?? null : null;
+
+        return {
+          id: edl.id,
+          type: (edl.type as "entree" | "sortie") || "entree",
+          status: edl.status || "draft",
+          scheduled_at:
+            edl.scheduled_at || (edl.scheduled_date ? `${edl.scheduled_date}T00:00:00Z` : null),
+          created_at: edl.created_at,
+          invitation_token: sig?.invitation_token ?? undefined,
+          property,
+          isSigned: !!sig?.signed_at,
+          needsMySignature: !sig?.signed_at && edl.status !== "draft",
+        };
+      })
+      // En haut : ce qui nécessite une action du locataire
+      .sort((a, b) => Number(b.needsMySignature) - Number(a.needsMySignature));
+
+    return NextResponse.json({ inspections });
+  } catch (error: unknown) {
+    console.error("[GET /api/tenant/inspections] erreur:", error);
+    return NextResponse.json(
+      { error: "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/owner/invoices/[id]/page.tsx
+++ b/app/owner/invoices/[id]/page.tsx
@@ -329,6 +329,20 @@ export default function InvoiceDetailPage() {
                     <span className="text-muted-foreground">Charges</span>
                     <span className="font-medium">{invoice.montant_charges.toLocaleString("fr-FR")} €</span>
                   </div>
+                  {/* Bug 9 : afficher le dépôt de garantie comme ligne dédiée
+                      sur les factures initiales (sinon le total ne tombe pas juste). */}
+                  {(() => {
+                    const meta = (invoice as any).metadata || {};
+                    const includesDeposit = meta.includes_deposit === true || meta.includes_deposit === "true";
+                    const depositAmount = Number(meta.deposit_amount || 0);
+                    if (!includesDeposit || depositAmount <= 0) return null;
+                    return (
+                      <div className="flex justify-between items-center py-2">
+                        <span className="text-muted-foreground">Dépôt de garantie</span>
+                        <span className="font-medium">{depositAmount.toLocaleString("fr-FR")} €</span>
+                      </div>
+                    );
+                  })()}
                   <Separator />
                   <div className="flex justify-between items-center py-2">
                     <span className="font-semibold">Total</span>
@@ -380,14 +394,20 @@ export default function InvoiceDetailPage() {
                         <div className="text-right">
                           <Badge
                             className={cn(
-                              payment.statut === "succeeded" && "bg-green-100 text-green-700",
+                              (payment.statut === "succeeded" || payment.statut === "paid") && "bg-green-100 text-green-700",
                               payment.statut === "pending" && "bg-amber-100 text-amber-700",
-                              payment.statut === "failed" && "bg-red-100 text-red-700"
+                              payment.statut === "processing" && "bg-blue-100 text-blue-700",
+                              payment.statut === "failed" && "bg-red-100 text-red-700",
+                              payment.statut === "cancelled" && "bg-gray-100 text-gray-600",
+                              payment.statut === "refunded" && "bg-purple-100 text-purple-700"
                             )}
                           >
-                            {payment.statut === "succeeded" && "Réussi"}
+                            {(payment.statut === "succeeded" || payment.statut === "paid") && "Réussi"}
                             {payment.statut === "pending" && "En attente"}
+                            {payment.statut === "processing" && "En cours"}
                             {payment.statut === "failed" && "Échoué"}
+                            {payment.statut === "cancelled" && "Annulé"}
+                            {payment.statut === "refunded" && "Remboursé"}
                           </Badge>
                           <p className="text-xs text-muted-foreground mt-1">
                             {safeDateFormat(payment.date_paiement)}

--- a/app/tenant/_data/fetchTenantDashboard.ts
+++ b/app/tenant/_data/fetchTenantDashboard.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
 import { linkOrphanSigners } from "@/features/tenant/services/tenant-linking.service";
+import { computeUnpaidStats } from "@/lib/payments/unpaid-invoices";
 
 // Interface pour un bail avec propriété jointe
 export interface TenantLease {
@@ -654,7 +655,8 @@ async function fetchTenantDashboardDirect(
     };
   });
 
-  const unpaidInvoices = invoices.filter((i) => i.statut === "sent" || i.statut === "late");
+  // Source de vérité unique pour les impayés (cf. lib/payments/unpaid-invoices.ts)
+  const unpaidStats = computeUnpaidStats(invoices);
 
   // kyc_status est sur tenant_profiles, pas sur profiles
   let kycStatus: TenantDashboardData["kyc_status"] = "pending";
@@ -685,8 +687,8 @@ async function fetchTenantDashboardDirect(
       last_expiry_date: insuranceDoc?.expiry_date || undefined,
     },
     stats: {
-      unpaid_amount: unpaidInvoices.reduce((sum, i) => sum + Number(i.montant_total || 0), 0),
-      unpaid_count: unpaidInvoices.length,
+      unpaid_amount: unpaidStats.totalAmount,
+      unpaid_count: unpaidStats.count,
       total_monthly_rent: enrichedLeases.reduce((sum: number, l: any) => sum + Number(l.loyer || 0), 0),
       active_leases_count: enrichedLeases.filter((l: any) => l.statut === "active").length,
     },

--- a/app/tenant/dashboard/DashboardClient.tsx
+++ b/app/tenant/dashboard/DashboardClient.tsx
@@ -41,6 +41,10 @@ import {
 } from "lucide-react";
 import { differenceInMonths, differenceInDays } from "date-fns";
 import { formatCurrency, formatDateShort } from "@/lib/helpers/format";
+import {
+  computeUnpaidStats,
+  getNextUpcomingInvoice,
+} from "@/lib/payments/unpaid-invoices";
 import { Badge } from "@/components/ui/badge";
 import { PageTransition } from "@/components/ui/page-transition";
 import { GlassCard } from "@/components/ui/glass-card";
@@ -271,6 +275,15 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
     return tenantSigner?.signature_status === 'signed' || !!tenantSigner?.signed_at;
   }, [dashboard]);
 
+  // Source de vérité unique : calcul des impayés via helper centralisé.
+  // La RPC `tenant_dashboard` peut renvoyer des stats périmées (filtrées sur
+  // un sous-ensemble de statuts). On recalcule côté client à partir de la
+  // liste complète des factures pour garantir la cohérence avec /tenant/payments.
+  const unpaidSummary = useMemo(
+    () => computeUnpaidStats(dashboard?.invoices ?? []),
+    [dashboard?.invoices]
+  );
+
   // 2. Calcul des actions requises (Command Center)
   const pendingActions = useMemo(() => {
     if (!dashboard) return [];
@@ -292,11 +305,11 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
       });
     }
 
-    // Action 2 : Impayés
-    if (dashboard.stats?.unpaid_amount > 0) {
+    // Action 2 : Impayés (calcul centralisé pour cohérence avec /tenant/payments)
+    if (unpaidSummary.totalAmount > 0) {
       actions.push({
         id: 'payment',
-        label: `Régulariser ${formatCurrency(dashboard.stats.unpaid_amount)}`,
+        label: `Régulariser ${formatCurrency(unpaidSummary.totalAmount)}`,
         icon: CreditCard,
         color: 'text-red-600',
         bg: 'bg-red-50',
@@ -329,7 +342,7 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
     }
     
     return actions;
-  }, [dashboard, pendingEDLs, hasSignedLease]);
+  }, [dashboard, pendingEDLs, hasSignedLease, unpaidSummary.totalAmount]);
   const primaryPendingAction = pendingActions[0] ?? null;
   const secondaryPendingActions = pendingActions.slice(1, 3);
 
@@ -366,38 +379,29 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
     return { steps, completed, percentage: Math.round((completed / steps) * 100) };
   }, [hasLeaseData, dashboard?.kyc_status, currentLease?.statut, dashboard]);
 
-  // Prochaine échéance basée sur la prochaine invoice non payée (source de vérité)
-  // Fallback : calcul basé sur jour_paiement du bail si aucune invoice n'existe encore
-  // SOTA 2026 / Légal : Seules les vraies factures (sent, late, partial) déclenchent l'affichage
-  // d'un montant à payer. Pas de fallback frontend — la facture initiale est générée par le
-  // trigger DB generate_initial_signing_invoice() quand le bail passe à fully_signed.
+  // Prochaine échéance : la prochaine facture dont la date_echeance est >= aujourd'hui.
+  // Les factures passées impayées appartiennent à la section "impayés", pas ici.
   const nextDue = useMemo(() => {
     if (!currentLease) return null;
     const now = new Date();
 
-    const invoicesList = dashboard?.invoices || [];
-    const nextInvoice = invoicesList
-      .filter((i: any) => ['sent', 'late', 'partial', 'viewed'].includes(i.statut))
-      .sort((a: any, b: any) => {
-        const dateA = a.date_echeance || a.due_date || a.created_at;
-        const dateB = b.date_echeance || b.due_date || b.created_at;
-        return new Date(dateA).getTime() - new Date(dateB).getTime();
-      })[0];
+    const nextInvoice = getNextUpcomingInvoice(dashboard?.invoices ?? []);
+    if (!nextInvoice) return null;
 
-    if (nextInvoice) {
-      const effectiveDate = nextInvoice.date_echeance || nextInvoice.due_date || nextInvoice.created_at;
-      const dueDate = new Date(effectiveDate);
-      const daysLeft = Math.ceil((dueDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-      return {
-        date: dueDate,
-        amount: Number(nextInvoice.montant_total) || 0,
-        daysLeft,
-        invoiceId: nextInvoice.id,
-      };
-    }
-
-    // Pas de facture réelle à payer — ne pas afficher de montant fictif
-    return null;
+    const effectiveDate =
+      (nextInvoice as any).date_echeance ||
+      (nextInvoice as any).due_date ||
+      (nextInvoice as any).created_at;
+    const dueDate = new Date(effectiveDate);
+    const daysLeft = Math.ceil(
+      (dueDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+    );
+    return {
+      date: dueDate,
+      amount: Number((nextInvoice as any).montant_total) || 0,
+      daysLeft,
+      invoiceId: (nextInvoice as any).id,
+    };
   }, [currentLease, dashboard?.invoices]);
 
   if (error) {
@@ -662,7 +666,7 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
               asChild
               className={cn(
                 "h-14 rounded-2xl font-bold text-sm shadow-md transition-all hover:scale-[1.02]",
-                (dashboard.stats?.unpaid_amount > 0 || (nextDue && nextDue.daysLeft <= 7))
+                (unpaidSummary.totalAmount > 0 || (nextDue && nextDue.daysLeft <= 7))
                   ? "bg-primary hover:bg-primary/90 text-white"
                   : "bg-card border border-border text-foreground hover:bg-muted"
               )}
@@ -843,11 +847,14 @@ export function DashboardClient({ serverPendingEDLs = [] }: DashboardClientProps
                       </p>
                     </div>
                     
-                    {(realtime.unpaidAmount > 0 || dashboard.stats?.unpaid_amount > 0) ? (
+                    {unpaidSummary.totalAmount > 0 ? (
                       <div className="mt-6 p-4 rounded-2xl bg-red-50 border border-red-100">
                         <p className="text-xs font-bold text-red-600 uppercase">Impayé en cours</p>
                         <p className="text-2xl font-black text-red-700">
-                          {formatCurrency(realtime.unpaidAmount > 0 ? realtime.unpaidAmount : dashboard.stats?.unpaid_amount)}
+                          {formatCurrency(unpaidSummary.totalAmount)}
+                        </p>
+                        <p className="text-[11px] text-red-600/80 mt-1">
+                          {unpaidSummary.count} facture{unpaidSummary.count > 1 ? "s" : ""} à régulariser
                         </p>
                       </div>
                     ) : (!dashboard.invoices || dashboard.invoices.length === 0) && (currentLease?.statut === 'active' || currentLease?.statut === 'fully_signed') ? (

--- a/app/tenant/documents/page.tsx
+++ b/app/tenant/documents/page.tsx
@@ -262,7 +262,18 @@ export default function TenantDocumentsPage() {
   const keyDocuments = useMemo(() => {
     if (!documents.length) return { bail: null, quittance: null, edl: null, assurance: null };
 
-    const sorted = [...documents].sort((a, b) => safeTime(b.created_at) - safeTime(a.created_at));
+    // Bug 2 : ne pas considérer les documents sans type valide / "autre" pour
+    // les slots des documents essentiels. Sinon une capture d'écran uploadée
+    // sans type apparaît dans la grille des 4 cards essentielles.
+    const eligible = documents.filter((d: any) => {
+      const rawType = (d.type ?? "").toString().toLowerCase().trim();
+      const detected = (detectType(d) ?? "").toString().toLowerCase().trim();
+      if (!rawType && !detected) return false;
+      if (rawType === "autre" && detected === "autre") return false;
+      return true;
+    });
+
+    const sorted = [...eligible].sort((a, b) => safeTime(b.created_at) - safeTime(a.created_at));
 
     let bail: any = null;
     let quittance: any = null;

--- a/app/tenant/payments/TenantPaymentsClient.tsx
+++ b/app/tenant/payments/TenantPaymentsClient.tsx
@@ -35,6 +35,11 @@ import { useTenantRealtime } from "@/lib/hooks/use-realtime-tenant";
 import { useTenantPaymentMethodsDisplay } from "@/lib/hooks/use-tenant-payment-methods";
 import { useToast } from "@/components/ui/use-toast";
 import { isInvoicePayableStatus } from "@/lib/payments/tenant-payment-flow";
+import {
+  computeUnpaidStats,
+  computePunctualityScore,
+  getNextUpcomingInvoice,
+} from "@/lib/payments/unpaid-invoices";
 
 interface TenantPaymentsClientProps {
   invoices: any[];
@@ -61,32 +66,32 @@ export function TenantPaymentsClient({ invoices: initialInvoices }: TenantPaymen
     const now = new Date();
     const lease = dashboard?.lease ?? (dashboard?.leases && dashboard.leases.length > 0 ? dashboard.leases[0] : null);
 
-    // Chercher la prochaine facture non payée parmi les invoices
-    const nextInvoice = [...payableInvoices]
-      .sort((a: any, b: any) => {
-        const dateA = a.date_echeance || a.due_date || a.created_at;
-        const dateB = b.date_echeance || b.due_date || b.created_at;
-        return new Date(dateA).getTime() - new Date(dateB).getTime();
-      })[0];
+    // Source unique : prochaine facture dont la date d'échéance est >= aujourd'hui.
+    // Les factures passées impayées appartiennent à la section "Total à régulariser",
+    // pas à la section "Prochaine échéance" (corrige Bug 4).
+    const nextInvoice = getNextUpcomingInvoice(initialInvoices);
 
     if (nextInvoice) {
-      // Source de vérité : la facture réelle
-      const effectiveDate = nextInvoice.date_echeance || nextInvoice.due_date || nextInvoice.created_at;
+      const effectiveDate =
+        (nextInvoice as any).date_echeance ||
+        (nextInvoice as any).due_date ||
+        (nextInvoice as any).created_at;
       const dueDate = new Date(effectiveDate);
       const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
       const diffMs = dueDate.getTime() - today.getTime();
       const daysLeft = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
       return {
         date: dueDate,
-        amount: Number(nextInvoice.montant_total) || 0,
+        amount: Number((nextInvoice as any).montant_total) || 0,
         daysLeft,
         hasLease: !!lease,
-        loyer: Number(nextInvoice.montant_loyer) || 0,
-        charges: Number(nextInvoice.montant_charges) || 0,
+        loyer: Number((nextInvoice as any).montant_loyer) || 0,
+        charges: Number((nextInvoice as any).montant_charges) || 0,
+        invoice: nextInvoice,
       };
     }
 
-    // Fallback : calcul basé sur jour_paiement du bail
+    // Fallback : calcul basé sur jour_paiement du bail si aucune facture future
     const jourPaiement = (lease as any)?.jour_paiement ?? 5;
     let nextDate = new Date(now.getFullYear(), now.getMonth(), jourPaiement);
     if (nextDate <= now) {
@@ -103,8 +108,9 @@ export function TenantPaymentsClient({ invoices: initialInvoices }: TenantPaymen
       hasLease: !!lease,
       loyer: lease?.loyer ?? 0,
       charges: lease?.charges_forfaitaires ?? 0,
+      invoice: null,
     };
-  }, [dashboard?.lease, dashboard?.leases, payableInvoices]);
+  }, [dashboard?.lease, dashboard?.leases, initialInvoices]);
 
   // SOTA 2026: Temps réel pour synchronisation des factures avec le propriétaire
   const realtime = useTenantRealtime({ showToasts: true, enableSound: false });
@@ -159,43 +165,52 @@ export function TenantPaymentsClient({ invoices: initialInvoices }: TenantPaymen
     router.refresh(); 
   };
 
-  // Statistiques financières SOTA - score de ponctualité calculé réellement
-  // Exclure les factures initiales (type='initial_invoice') du score de ponctualité
+  // Statistiques financières SOTA — délègue aux helpers centralisés pour
+  // garantir la cohérence avec le dashboard et le bandeau d'actions documents.
   const stats = useMemo(() => {
-    const now = new Date();
-    const unpaid = invoices.filter(i =>
-      i.statut !== 'paid' && i.statut !== 'draft' && i.statut !== 'cancelled' &&
-      (!i.due_date || new Date(i.due_date) <= now)
-    );
-    const totalUnpaid = unpaid.reduce((acc, curr) => acc + (curr.montant_total || 0), 0);
+    // Total à régulariser (Bug 1)
+    const unpaidStats = computeUnpaidStats(invoices);
 
-    // Seules les factures de loyer comptent pour le score de ponctualité
-    const rentInvoices = invoices.filter(i => i.type !== 'initial_invoice' && i.statut !== 'cancelled');
-    const paidRentInvoices = rentInvoices.filter(i => i.statut === 'paid');
-    const paidCount = paidRentInvoices.length;
-    const totalCount = rentInvoices.length;
+    // Score de ponctualité (Bug 5) : null tant qu'aucun paiement n'est enregistré
+    const { score, paidCount, totalCount } = computePunctualityScore(invoices);
 
-    // Calcul du score de ponctualité réel (loyers uniquement)
-    const lateCount = rentInvoices.filter(i => i.statut === 'late' || i.statut === 'overdue' || i.statut === 'unpaid').length;
-    const punctualityScore = totalCount > 0
-      ? Math.round(((totalCount - lateCount) / totalCount) * 100)
-      : null;
-    const punctualityLabel = punctualityScore === null ? "En construction"
-      : punctualityScore >= 90 ? "Excellent"
-      : punctualityScore >= 70 ? "Bon"
-      : punctualityScore >= 50 ? "Moyen"
+    const punctualityLabel = score === null ? "En construction"
+      : score >= 90 ? "Excellent"
+      : score >= 70 ? "Bon"
+      : score >= 50 ? "Moyen"
       : "À améliorer";
 
-    return { totalUnpaid, unpaidCount: unpaid.length, paidCount, punctualityScore, punctualityLabel, totalCount };
+    return {
+      totalUnpaid: unpaidStats.totalAmount,
+      unpaidCount: unpaidStats.count,
+      paidCount,
+      punctualityScore: score,
+      punctualityLabel,
+      totalCount,
+    };
   }, [invoices]);
 
   const filteredInvoices = useMemo(() => {
-    return invoices.filter(inv =>
+    const filtered = invoices.filter(inv =>
       inv.statut !== 'cancelled' && (
         inv.periode?.toLowerCase().includes(searchQuery.toLowerCase()) ||
         formatCurrency(inv.montant_total).includes(searchQuery)
       )
     );
+
+    // Bug 6 : tri par date d'échéance descendante (plus récente en haut)
+    // Avant : tri par "periode" alphabétique qui mélangeait passé et futur.
+    return [...filtered].sort((a: any, b: any) => {
+      const dateA = a.date_echeance || a.due_date || a.created_at || a.periode;
+      const dateB = b.date_echeance || b.due_date || b.created_at || b.periode;
+      const tA = new Date(dateA).getTime();
+      const tB = new Date(dateB).getTime();
+      // Si les dates sont invalides, fallback sur periode
+      if (Number.isNaN(tA) || Number.isNaN(tB)) {
+        return (b.periode || "").localeCompare(a.periode || "");
+      }
+      return tB - tA;
+    });
   }, [invoices, searchQuery]);
 
   return (
@@ -314,13 +329,15 @@ export function TenantPaymentsClient({ invoices: initialInvoices }: TenantPaymen
                 <Button
                   className="rounded-xl font-bold bg-indigo-600 hover:bg-indigo-700"
                   onClick={() => {
-                    const firstPayable = payableInvoices[0];
-                    if (firstPayable) {
-                      setSelectedInvoice(firstPayable);
+                    // Préfère la facture "prochaine échéance" si elle est payable,
+                    // sinon retombe sur la première facture passée impayée.
+                    const target = (nextDue.invoice as any) || payableInvoices[0];
+                    if (target) {
+                      setSelectedInvoice(target);
                       setIsPaymentOpen(true);
                     }
                   }}
-                  disabled={payableInvoices.length === 0}
+                  disabled={!nextDue.invoice && payableInvoices.length === 0}
                 >
                   <CreditCard className="mr-2 h-4 w-4" /> Payer
                 </Button>
@@ -339,7 +356,7 @@ export function TenantPaymentsClient({ invoices: initialInvoices }: TenantPaymen
               <div className="relative z-10">
                 <p className="text-xs font-bold text-white/50 uppercase tracking-widest mb-1">Total à régulariser</p>
                 <p className="text-4xl font-black">
-                  {formatCurrency(realtime.unpaidAmount > 0 ? realtime.unpaidAmount : stats.totalUnpaid)}
+                  {formatCurrency(stats.totalUnpaid)}
                 </p>
                 <div className="mt-4 flex items-center gap-2">
                   <Badge className={cn("border-none", stats.totalUnpaid > 0 ? "bg-red-500" : "bg-emerald-500")}>

--- a/lib/hooks/queries/use-tenant-inspections.ts
+++ b/lib/hooks/queries/use-tenant-inspections.ts
@@ -1,59 +1,41 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { createClient } from "@/lib/supabase/client";
-import type { TenantEDLListItem, TenantEDLSignatureWithDetails } from "@/lib/types/tenant";
+import type { TenantEDLListItem } from "@/lib/types/tenant";
 
+/**
+ * Liste des EDL accessibles au locataire connecté.
+ *
+ * Délègue à `/api/tenant/inspections` qui utilise `getServiceClient()` côté
+ * serveur pour éviter les recursions RLS (42P17) déclenchées par les embeds
+ * PostgREST profonds en mode user-scoped.
+ */
 async function fetchTenantInspections(): Promise<TenantEDLListItem[]> {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return [];
+  const res = await fetch("/api/tenant/inspections", {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+  });
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("id")
-    .eq("user_id", user.id)
-    .single();
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const data = await res.json();
+      if (data?.error) message = data.error;
+    } catch {
+      /* ignore */
+    }
+    throw new Error(message);
+  }
 
-  if (!profile) return [];
-
-  const { data: signatures, error } = await supabase
-    .from("edl_signatures")
-    .select(`
-      *,
-      edl:edl_id(
-        *,
-        lease:lease_id(*, property:properties(*)),
-        property_details:property_id(*)
-      )
-    `)
-    .eq("signer_profile_id", profile.id);
-
-  if (error) throw new Error(error.message);
-
-  const formatted = (signatures as unknown as TenantEDLSignatureWithDetails[] | null)
-    ?.filter(
-      (sig): sig is TenantEDLSignatureWithDetails & { edl: NonNullable<TenantEDLSignatureWithDetails["edl"]> } =>
-        sig.edl !== null && sig.edl !== undefined
-    )
-    .map((sig) => ({
-      id: sig.edl.id,
-      type: sig.edl.type as "entree" | "sortie",
-      status: sig.edl.status,
-      scheduled_at: sig.edl.scheduled_at ?? null,
-      created_at: sig.edl.created_at,
-      invitation_token: sig.invitation_token,
-      property: sig.edl.lease?.property || sig.edl.property_details || null,
-      isSigned: !!sig.signed_at,
-      needsMySignature: !sig.signed_at && sig.edl.status !== "draft",
-    })) || [];
-
-  return formatted.sort((a, b) => (b.needsMySignature ? 1 : 0) - (a.needsMySignature ? 1 : 0));
+  const data = (await res.json()) as { inspections?: TenantEDLListItem[] };
+  return data.inspections ?? [];
 }
 
 export function useTenantInspections() {
   return useQuery({
     queryKey: ["tenant", "inspections"],
     queryFn: fetchTenantInspections,
+    staleTime: 60_000,
   });
 }

--- a/lib/hooks/use-realtime-tenant.ts
+++ b/lib/hooks/use-realtime-tenant.ts
@@ -20,6 +20,10 @@ import { createClient } from "@/lib/supabase/client";
 import { useAuth } from "@/lib/hooks/use-auth";
 import { useToast } from "@/components/ui/use-toast";
 import type { RealtimeChannel, RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import {
+  computeUnpaidStats,
+  UNPAID_INVOICE_STATUSES,
+} from "@/lib/payments/unpaid-invoices";
 
 export interface TenantRealtimeEvent {
   id: string;
@@ -198,12 +202,12 @@ export function useTenantRealtime(options: UseTenantRealtimeOptions = {}) {
           .from("leases")
           .select("id, loyer, charges_forfaitaires, statut, type_bail, property_id")
           .in("id", ids),
-        // Factures impayées
+        // Factures (toutes les statuts non finaux pour calculer correctement les impayés)
         supabaseRef.current
           .from("invoices")
-          .select("id, montant_total, statut, periode")
+          .select("id, montant_total, statut, periode, due_date, date_echeance, created_at, type")
           .in("lease_id", ids)
-          .in("statut", ["sent", "late"]),
+          .in("statut", UNPAID_INVOICE_STATUSES as unknown as string[]),
         // Tickets ouverts
         supabaseRef.current
           .from("tickets")
@@ -222,7 +226,9 @@ export function useTenantRealtime(options: UseTenantRealtimeOptions = {}) {
       const activeLease = leases?.find(l => l.statut === "active") || leases?.[0];
       const currentRent = activeLease?.loyer || 0;
       const currentCharges = activeLease?.charges_forfaitaires || 0;
-      const unpaidAmount = invoices?.reduce((sum, inv) => sum + (inv.montant_total || 0), 0) || 0;
+      // Source unique : helper centralisé qui filtre uniquement les factures
+      // dont la date d'échéance est passée (cohérent avec /tenant/payments).
+      const unpaidAmount = computeUnpaidStats(invoices || []).totalAmount;
       
       setData(prev => ({
         ...prev,

--- a/lib/payments/index.ts
+++ b/lib/payments/index.ts
@@ -36,3 +36,15 @@ export {
   type RentPaymentResult,
   type ConnectAccountInfo,
 } from "./rent-collection.service";
+
+export {
+  UNPAID_INVOICE_STATUSES,
+  isInvoiceUnpaid,
+  getInvoiceEffectiveDueDate,
+  computeUnpaidStats,
+  getNextUpcomingInvoice,
+  computePunctualityScore,
+  type InvoiceLike,
+  type UnpaidInvoiceStatus,
+  type UnpaidStats,
+} from "./unpaid-invoices";

--- a/lib/payments/unpaid-invoices.ts
+++ b/lib/payments/unpaid-invoices.ts
@@ -1,0 +1,215 @@
+/**
+ * Centralized helpers for "unpaid invoice" calculations.
+ *
+ * Source de vérité pour TOUTES les pages tenant qui affichent des montants
+ * impayés / à régulariser. Évite les divergences (35 € sur dashboard vs 105 €
+ * sur la page paiements) qui surgissent quand chaque écran réimplémente sa
+ * propre logique de filtrage.
+ */
+
+import { PAYABLE_INVOICE_STATUSES } from "./tenant-payment-flow";
+
+/**
+ * Statuts considérés comme "impayés" — agrégés depuis les statuts canoniques
+ * du state-machine + les statuts legacy encore présents en base.
+ *
+ * Une facture est "impayée" si :
+ *   - son statut est dans cette liste
+ *   - ET sa date d'échéance est passée (ou absente)
+ */
+export const UNPAID_INVOICE_STATUSES = [
+  ...PAYABLE_INVOICE_STATUSES,
+  "pending",
+  "reminder_sent",
+  "collection",
+  "viewed",
+] as const;
+
+export type UnpaidInvoiceStatus = (typeof UNPAID_INVOICE_STATUSES)[number];
+
+const UNPAID_STATUS_SET = new Set<string>(UNPAID_INVOICE_STATUSES);
+
+/**
+ * Forme minimale d'une facture pour les calculs côté client.
+ * Compatible avec les types Supabase générés et les structures legacy
+ * (TenantInvoice, InvoiceWithPayments, etc.).
+ */
+export interface InvoiceLike {
+  statut?: string | null;
+  montant_total?: number | string | null;
+  due_date?: string | null;
+  date_echeance?: string | null;
+  created_at?: string | null;
+  type?: string | null;
+}
+
+function toAmount(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function toDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Date d'échéance "effective" — `date_echeance` puis `due_date` puis `created_at`.
+ */
+export function getInvoiceEffectiveDueDate(
+  invoice: InvoiceLike
+): Date | null {
+  return (
+    toDate(invoice.date_echeance) ||
+    toDate(invoice.due_date) ||
+    toDate(invoice.created_at)
+  );
+}
+
+/**
+ * Une facture compte-t-elle dans le total "à régulariser" ?
+ *
+ * @param invoice  La facture à évaluer
+ * @param referenceDate  Date de référence (par défaut : maintenant)
+ */
+export function isInvoiceUnpaid(
+  invoice: InvoiceLike,
+  referenceDate: Date = new Date()
+): boolean {
+  const status = invoice.statut?.toString();
+  if (!status) return false;
+  if (!UNPAID_STATUS_SET.has(status)) return false;
+
+  const dueDate = getInvoiceEffectiveDueDate(invoice);
+  // Pas de date d'échéance → on considère qu'elle est due maintenant
+  if (!dueDate) return true;
+  // L'échéance est dans le futur → ce n'est pas (encore) un impayé
+  return dueDate.getTime() <= referenceDate.getTime();
+}
+
+export interface UnpaidStats<T extends InvoiceLike = InvoiceLike> {
+  /** Montant total à régulariser, arrondi au centime */
+  totalAmount: number;
+  /** Nombre de factures impayées */
+  count: number;
+  /** Liste des factures impayées (triées par date d'échéance ascendante) */
+  invoices: T[];
+}
+
+/**
+ * Calcule les statistiques d'impayés à partir d'une liste de factures.
+ * Utilisé par dashboard, page paiements et bandeau actions documents.
+ */
+export function computeUnpaidStats<T extends InvoiceLike>(
+  invoices: readonly T[] | null | undefined,
+  referenceDate: Date = new Date()
+): UnpaidStats<T> {
+  if (!invoices || invoices.length === 0) {
+    return { totalAmount: 0, count: 0, invoices: [] };
+  }
+
+  const unpaid = invoices.filter((inv) => isInvoiceUnpaid(inv, referenceDate));
+
+  unpaid.sort((a, b) => {
+    const dateA = getInvoiceEffectiveDueDate(a)?.getTime() ?? 0;
+    const dateB = getInvoiceEffectiveDueDate(b)?.getTime() ?? 0;
+    return dateA - dateB;
+  });
+
+  const totalAmount = unpaid.reduce(
+    (sum, inv) => sum + toAmount(inv.montant_total),
+    0
+  );
+
+  return {
+    totalAmount: Math.round(totalAmount * 100) / 100,
+    count: unpaid.length,
+    invoices: unpaid,
+  };
+}
+
+/**
+ * Récupère la prochaine facture à échéance future (date >= today).
+ *
+ * Utilisé par les widgets "Prochaine échéance". À la différence d'un simple
+ * `[...invoices].sort()[0]`, cette fonction écarte les factures dont
+ * l'échéance est passée — celles-ci appartiennent à la section "impayés".
+ */
+export function getNextUpcomingInvoice<T extends InvoiceLike>(
+  invoices: readonly T[] | null | undefined,
+  referenceDate: Date = new Date()
+): T | null {
+  if (!invoices || invoices.length === 0) return null;
+
+  const startOfToday = new Date(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth(),
+    referenceDate.getDate()
+  );
+
+  const upcoming = invoices
+    .filter((inv) => {
+      const status = inv.statut?.toString();
+      if (!status) return false;
+      // Doit pouvoir devenir un impayé futur
+      if (!UNPAID_STATUS_SET.has(status)) return false;
+      const dueDate = getInvoiceEffectiveDueDate(inv);
+      if (!dueDate) return false;
+      return dueDate.getTime() >= startOfToday.getTime();
+    })
+    .sort((a, b) => {
+      const dateA = getInvoiceEffectiveDueDate(a)!.getTime();
+      const dateB = getInvoiceEffectiveDueDate(b)!.getTime();
+      return dateA - dateB;
+    });
+
+  return upcoming[0] ?? null;
+}
+
+/**
+ * Calcule le score de ponctualité d'un locataire.
+ *
+ * @returns `null` si aucun paiement n'a encore été enregistré (pas de score),
+ *          sinon un pourcentage entre 0 et 100.
+ */
+export function computePunctualityScore<T extends InvoiceLike>(
+  invoices: readonly T[] | null | undefined
+): { score: number | null; paidCount: number; totalCount: number } {
+  if (!invoices || invoices.length === 0) {
+    return { score: null, paidCount: 0, totalCount: 0 };
+  }
+
+  // On n'évalue que les vraies factures de loyer, hors statuts neutres
+  const rentInvoices = invoices.filter(
+    (i) => i.type !== "initial_invoice" && i.statut !== "cancelled" && i.statut !== "draft"
+  );
+  if (rentInvoices.length === 0) {
+    return { score: null, paidCount: 0, totalCount: 0 };
+  }
+
+  const paidCount = rentInvoices.filter(
+    (i) => i.statut === "paid" || i.statut === "receipt_generated" || i.statut === "succeeded"
+  ).length;
+
+  // Pas un seul paiement enregistré → on ne peut pas calculer un score
+  if (paidCount === 0) {
+    return { score: null, paidCount: 0, totalCount: rentInvoices.length };
+  }
+
+  const lateCount = rentInvoices.filter((i) =>
+    i.statut === "late" ||
+    i.statut === "overdue" ||
+    i.statut === "unpaid" ||
+    i.statut === "reminder_sent" ||
+    i.statut === "collection" ||
+    i.statut === "written_off"
+  ).length;
+
+  const score = Math.round(
+    ((rentInvoices.length - lateCount) / rentInvoices.length) * 100
+  );
+
+  return { score, paidCount, totalCount: rentInvoices.length };
+}

--- a/lib/services/invoice-status.service.ts
+++ b/lib/services/invoice-status.service.ts
@@ -1,12 +1,8 @@
 import type { InvoiceRow } from "@/lib/supabase/database.types";
 
-type SupabaseLike = {
-  from: (table: string) => {
-    select: (...args: unknown[]) => any;
-    update: (values: Record<string, unknown>) => any;
-    order: (...args: unknown[]) => any;
-  };
-};
+// Type très permissif pour rester compatible avec createClient et getServiceClient
+// (le client réel est utilisé en production, ce type sert uniquement à éviter `any` brut)
+type SupabaseLike = any;
 
 export interface InvoiceSettlement {
   invoice: Pick<InvoiceRow, "id" | "montant_total" | "statut" | "date_paiement"> | null;
@@ -100,6 +96,26 @@ export async function syncInvoiceStatusFromPayments(
       date_paiement: nextPaymentDate,
     })
     .eq("id", invoiceId);
+
+  // Bug 11 : quand une facture est entièrement réglée, on annule les anciens
+  // Payment Intents `pending` orphelins liés à cette facture. Sans ce nettoyage,
+  // l'historique côté propriétaire continue d'afficher "55€ — En attente — Date
+  // non renseignée" alors que la facture est marquée "Payée".
+  if (settlement.isSettled) {
+    try {
+      await supabase
+        .from("payments")
+        .update({ statut: "cancelled" })
+        .eq("invoice_id", invoiceId)
+        .in("statut", ["pending", "processing"]);
+    } catch (cleanupError) {
+      // Non bloquant : la facture est déjà marquée payée, c'est l'essentiel
+      console.warn(
+        "[syncInvoiceStatusFromPayments] Cleanup pending payments failed:",
+        cleanupError
+      );
+    }
+  }
 
   return {
     ...settlement,


### PR DESCRIPTION
## Summary

This PR introduces a centralized source of truth for unpaid invoice calculations (`lib/payments/unpaid-invoices.ts`) and fixes multiple UI inconsistencies where different screens were computing unpaid amounts, punctuality scores, and upcoming invoices independently, leading to divergent values (e.g., €35 on dashboard vs €105 on payments page).

## Key Changes

### New Centralized Helpers (`lib/payments/unpaid-invoices.ts`)
- **`computeUnpaidStats()`**: Single source of truth for calculating total unpaid amount, count, and sorted list of unpaid invoices
- **`getNextUpcomingInvoice()`**: Returns the next invoice with due date >= today (excludes past-due invoices which belong in the unpaid section)
- **`computePunctualityScore()`**: Calculates tenant payment punctuality (0-100%), returns `null` if no payments recorded yet
- **`isInvoiceUnpaid()`**: Determines if an invoice counts as unpaid based on status and due date
- **`getInvoiceEffectiveDueDate()`**: Resolves due date from multiple possible fields (`date_echeance`, `due_date`, `created_at`)

### UI Consistency Fixes
- **Dashboard** (`DashboardClient.tsx`): Now uses `computeUnpaidStats()` instead of relying on potentially stale RPC stats
- **Payments page** (`TenantPaymentsClient.tsx`): Uses centralized helpers for unpaid total, punctuality score, and next upcoming invoice
- **Realtime sync** (`use-realtime-tenant.ts`): Updated to use `UNPAID_INVOICE_STATUSES` constant

### API & Data Fetching
- **New endpoint** (`/api/tenant/inspections`): Moves EDL (inspection) queries to server-side using `getServiceClient()` to avoid RLS recursion errors (42P17) that made the inspections page inaccessible
- **Hook refactor** (`use-tenant-inspections.ts`): Delegates to new API endpoint instead of direct Supabase queries with deep embeds

### Bug Fixes
- **Bug 1**: Unpaid amount now calculated consistently across all screens
- **Bug 2**: Documents page filters out invalid/untyped documents from essential document slots
- **Bug 4**: Next upcoming invoice now correctly excludes past-due invoices (which belong in "Total à régulariser")
- **Bug 5**: Punctuality score returns `null` until first payment is recorded (was incorrectly showing 0%)
- **Bug 6**: Invoice list on payments page now sorted by due date descending (most recent first)
- **Bug 7**: Receipt generation now ensures document is persisted even if webhook missed
- **Bug 9**: Initial invoices now display deposit amount as separate line item
- **Bug 10**: Invoice emission date clamped to not exceed due date (fixes retroactive invoice display)
- **Bug 11**: Orphaned pending payments cancelled when invoice fully settled

### Implementation Details
- `InvoiceLike` interface provides minimal shape for client-side calculations, compatible with both Supabase-generated types and legacy structures
- All date/amount conversions handle null/undefined gracefully with sensible defaults
- Unpaid status set includes both state-machine statuses and legacy statuses (`pending`, `reminder_sent`, `collection`, `viewed`)
- Sorting consistently uses effective due date across all helpers
- Rounding applied to unpaid totals (Math.round to nearest cent)

https://claude.ai/code/session_01LT4BiVe5bX5MUZ2oDoSYGE