### PR TITLE
fix(payments): resolve manual payment 404 + dashboard RLS 500s

### DIFF
--- a/app/api/invoices/[id]/mark-paid/route.ts
+++ b/app/api/invoices/[id]/mark-paid/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { AccountingIntegrationService } from "@/features/accounting/services/accounting-integration.service";
 import { applyRateLimit } from "@/lib/middleware/rate-limit";
@@ -13,6 +14,11 @@ import { syncInvoiceStatusFromPayments } from "@/lib/services/invoice-status.ser
  *
  * Utilisé par les propriétaires pour enregistrer un paiement reçu
  * (espèces, chèque, virement manuel, etc.)
+ *
+ * Auth via user-scoped client, DB reads/writes via service client pour
+ * éviter la récursion RLS 42P17 sur profiles/leases/properties qui faisait
+ * remonter `!inner` joins à vide → 404 "Facture non trouvée" pour des
+ * factures pourtant existantes.
  * @version 2026-01-22 - Fix: Next.js 15 params Promise pattern
  */
 export async function POST(
@@ -36,6 +42,8 @@ export async function POST(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
+    const serviceClient = getServiceClient();
+
     const invoiceId = id;
 
     // Récupérer les données optionnelles du body
@@ -48,35 +56,39 @@ export async function POST(
       bank_name?: string;
       notes?: string;
     }
-    
+
     let body: MarkPaidBody = {};
     try {
       body = await request.json();
     } catch {
       // Body vide, c'est OK
     }
-    
+
     // Support both "moyen" and "payment_method" for backward compatibility
     const paymentMethod = body.moyen || body.payment_method || "autre";
     const { reference, bank_name, notes, date_paiement } = body;
 
-    // Récupérer la facture avec vérification d'accès
-    const { data: invoice, error: invoiceError } = await supabase
+    // Récupérer la facture — service client pour bypasser RLS ; l'autorisation
+    // est vérifiée manuellement ci-dessous via owner_id.
+    const { data: invoice, error: invoiceError } = await serviceClient
       .from("invoices")
       .select(`
         *,
-        lease:leases!inner(
+        lease:leases(
           id,
-          property:properties!inner(
+          property:properties(
             owner_id,
             adresse_complete
           )
         )
       `)
       .eq("id", invoiceId)
-      .single();
+      .maybeSingle();
 
     if (invoiceError || !invoice) {
+      if (invoiceError) {
+        console.error("[mark-paid] Erreur lecture facture:", invoiceError);
+      }
       return NextResponse.json(
         { error: "Facture non trouvée" },
         { status: 404 }
@@ -85,8 +97,8 @@ export async function POST(
 
     const invoiceData = invoice as any;
 
-    // Vérifier les permissions
-    const { data: profile } = await supabase
+    // Vérifier les permissions via service client (évite 42P17 sur profiles)
+    const { data: profile } = await serviceClient
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
@@ -94,7 +106,11 @@ export async function POST(
 
     const profileData = profile as any;
     const isAdmin = profileData?.role === "admin";
-    const isOwner = invoiceData.lease?.property?.owner_id === profileData?.id;
+    // `owner_id` est dénormalisé sur invoices — le chemin lease→property sert
+    // de defense-in-depth au cas où la dénormalisation n'aurait pas eu lieu.
+    const ownerFromLease = invoiceData.lease?.property?.owner_id;
+    const invoiceOwnerId = invoiceData.owner_id ?? ownerFromLease;
+    const isOwner = !!profileData?.id && invoiceOwnerId === profileData.id;
 
     if (!isOwner && !isAdmin) {
       return NextResponse.json(
@@ -120,10 +136,10 @@ export async function POST(
     }
 
     // Déterminer le montant (utiliser celui fourni ou le total de la facture)
-    const paymentAmount = body.amount && body.amount > 0 
-      ? body.amount 
+    const paymentAmount = body.amount && body.amount > 0
+      ? body.amount
       : invoiceData.montant_total;
-    
+
     // Créer le paiement avec toutes les métadonnées
     const paymentData: Record<string, unknown> = {
       invoice_id: invoiceId,
@@ -132,7 +148,7 @@ export async function POST(
       date_paiement: date_paiement || new Date().toISOString().split("T")[0],
       statut: "succeeded",
     };
-    
+
     // Ajouter les métadonnées optionnelles si présentes
     // Ces données seront stockées dans provider_ref ou un champ metadata
     if (reference || bank_name || notes) {
@@ -142,10 +158,10 @@ export async function POST(
         notes: notes || null,
       });
     }
-    
-    const { data: payment, error: paymentError } = await supabase
+
+    const { data: payment, error: paymentError } = await serviceClient
       .from("payments")
-      .insert(paymentData)
+      .insert(paymentData as any)
       .select()
       .single();
 
@@ -155,7 +171,7 @@ export async function POST(
     }
 
     const settlement = await syncInvoiceStatusFromPayments(
-      supabase as any,
+      serviceClient as any,
       invoiceId,
       paymentData.date_paiement as string
     );
@@ -168,15 +184,15 @@ export async function POST(
     // INTÉGRATION COMPTABLE
     // =============================================
     try {
-      const accountingService = new AccountingIntegrationService(supabase);
+      const accountingService = new AccountingIntegrationService(serviceClient as any);
 
       // Récupérer les informations nécessaires pour la comptabilité
-      const { data: leaseDetails } = await supabase
+      const { data: leaseDetails } = await serviceClient
         .from("leases")
         .select(`
           id,
           tenant_id,
-          property:properties!inner(
+          property:properties(
             owner_id,
             code_postal,
             adresse_complete
@@ -186,19 +202,19 @@ export async function POST(
         .single();
 
       if (leaseDetails) {
-        const propertyData = leaseDetails.property as any;
+        const propertyData = (leaseDetails as any).property;
 
         await accountingService.recordRentPayment({
           invoiceId,
-          leaseId: leaseDetails.id,
-          ownerId: propertyData.owner_id,
-          tenantId: leaseDetails.tenant_id || "",
+          leaseId: (leaseDetails as any).id,
+          ownerId: propertyData?.owner_id,
+          tenantId: (leaseDetails as any).tenant_id || "",
           periode: invoiceData.periode,
           montantLoyer: invoiceData.montant_loyer || 0,
           montantCharges: invoiceData.montant_charges || 0,
           montantTotal: paymentAmount,
           paymentDate: paymentData.date_paiement as string,
-          propertyCodePostal: propertyData.code_postal || "75000",
+          propertyCodePostal: propertyData?.code_postal || "75000",
         });
 
       }
@@ -210,7 +226,7 @@ export async function POST(
     let receiptDocumentId: string | null = null;
     if (settlement.isSettled && payment?.id) {
       try {
-        const receiptResult = await ensureReceiptDocument(supabase as any, payment.id);
+        const receiptResult = await ensureReceiptDocument(serviceClient as any, payment.id);
         receiptDocumentId = receiptResult?.documentId || null;
       } catch (receiptError) {
         console.error("[mark-paid] Erreur génération quittance:", receiptError);
@@ -224,7 +240,7 @@ export async function POST(
         const { ensureReceiptAccountingEntry } = await import(
           "@/lib/accounting/receipt-entry"
         );
-        await ensureReceiptAccountingEntry(supabase as any, payment.id);
+        await ensureReceiptAccountingEntry(serviceClient as any, payment.id);
       } catch (entryError) {
         console.error(
           "[mark-paid] Écriture comptable (non bloquante):",
@@ -234,12 +250,12 @@ export async function POST(
     }
 
     const [{ data: tenantProfile }, { data: ownerProfile }] = await Promise.all([
-      supabase.from("profiles").select("user_id, prenom, nom").eq("id", invoiceData.tenant_id).maybeSingle(),
-      supabase.from("profiles").select("user_id").eq("id", invoiceData.lease?.property?.owner_id).maybeSingle(),
+      serviceClient.from("profiles").select("user_id, prenom, nom").eq("id", invoiceData.tenant_id).maybeSingle(),
+      serviceClient.from("profiles").select("user_id").eq("id", invoiceOwnerId).maybeSingle(),
     ]);
 
     const tenantDisplayName =
-      `${tenantProfile?.prenom || ""} ${tenantProfile?.nom || ""}`.trim() || "Le locataire";
+      `${(tenantProfile as any)?.prenom || ""} ${(tenantProfile as any)?.nom || ""}`.trim() || "Le locataire";
 
     const outboxEvents: Array<Record<string, unknown>> = [
       {
@@ -247,7 +263,7 @@ export async function POST(
         payload: {
           payment_id: payment?.id,
           invoice_id: invoiceId,
-          tenant_id: tenantProfile?.user_id || null,
+          tenant_id: (tenantProfile as any)?.user_id || null,
           amount: paymentAmount,
           periode: invoiceData.periode,
           property_address: invoiceData.lease?.property?.adresse_complete || null,
@@ -259,7 +275,7 @@ export async function POST(
         payload: {
           payment_id: payment?.id,
           invoice_id: invoiceId,
-          owner_id: ownerProfile?.user_id || null,
+          owner_id: (ownerProfile as any)?.user_id || null,
           tenant_name: tenantDisplayName,
           amount: paymentAmount,
           periode: invoiceData.periode,
@@ -286,10 +302,10 @@ export async function POST(
       });
     }
 
-    await supabase.from("outbox").insert(outboxEvents as any);
+    await serviceClient.from("outbox").insert(outboxEvents as any);
 
     // Journaliser
-    await supabase.from("audit_log").insert({
+    await serviceClient.from("audit_log").insert({
       user_id: user.id,
       action: "invoice_marked_paid",
       entity_type: "invoice",

--- a/app/api/owner/dashboard/counts/route.ts
+++ b/app/api/owner/dashboard/counts/route.ts
@@ -1,0 +1,168 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/owner/dashboard/counts
+ *
+ * Compteurs live affichés dans le `useRealtimeDashboard` du dashboard
+ * propriétaire. Auth via user-scoped client, lectures DB via service client
+ * pour éviter la récursion RLS 42P17 sur profiles/leases/properties qui
+ * produisait 4x GET 500 dans la console quand l'utilisateur ouvrait le
+ * dashboard.
+ *
+ * Les subscriptions realtime restent côté navigateur (anon client) — seul
+ * le fetch initial passe par ce route handler.
+ */
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { NextResponse } from "next/server";
+
+interface DashboardCountsResponse {
+  totalRevenue: number;
+  pendingPayments: number;
+  latePayments: number;
+  activeLeases: number;
+  pendingSignatures: number;
+  openTickets: number;
+}
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 403 });
+    }
+
+    const ownerId = (profile as { id: string }).id;
+
+    // Récupérer les propriétés du propriétaire pour filtrer les tables
+    // scopées par property_id (leases, tickets, lease_signers via leases).
+    const { data: properties } = await serviceClient
+      .from("properties")
+      .select("id")
+      .eq("owner_id", ownerId);
+
+    const propertyIds = (properties || []).map(
+      (p) => (p as { id: string }).id,
+    );
+
+    if (propertyIds.length === 0) {
+      const empty: DashboardCountsResponse = {
+        totalRevenue: 0,
+        pendingPayments: 0,
+        latePayments: 0,
+        activeLeases: 0,
+        pendingSignatures: 0,
+        openTickets: 0,
+      };
+      return NextResponse.json(empty);
+    }
+
+    const currentPeriod = `${new Date().getFullYear()}-${String(
+      new Date().getMonth() + 1,
+    ).padStart(2, "0")}`;
+
+    const [
+      invoicesResult,
+      leasesResult,
+      signersResult,
+      ticketsResult,
+    ] = await Promise.all([
+      serviceClient
+        .from("invoices")
+        .select("montant_total, statut")
+        .eq("owner_id", ownerId)
+        .eq("periode", currentPeriod),
+      serviceClient
+        .from("leases")
+        .select("id, statut")
+        .in("property_id", propertyIds),
+      serviceClient
+        .from("lease_signers")
+        .select("id, signature_status, lease:leases!inner(property_id)")
+        .eq("signature_status", "pending"),
+      serviceClient
+        .from("tickets")
+        .select("id, statut")
+        .in("property_id", propertyIds)
+        .in("statut", ["open", "in_progress"]),
+    ]);
+
+    const invoices =
+      (invoicesResult.data as Array<{
+        montant_total: number | null;
+        statut: string | null;
+      }> | null) || [];
+    const leases =
+      (leasesResult.data as Array<{ id: string; statut: string | null }> | null) ||
+      [];
+    const signers =
+      (signersResult.data as Array<{
+        id: string;
+        signature_status: string | null;
+        lease: { property_id: string | null } | null;
+      }> | null) || [];
+    const tickets =
+      (ticketsResult.data as Array<{ id: string; statut: string | null }> | null) ||
+      [];
+
+    const paidInvoices = invoices.filter((i) => i.statut === "paid");
+    const totalRevenue = paidInvoices.reduce(
+      (sum, i) => sum + (Number(i.montant_total) || 0),
+      0,
+    );
+    const pendingPayments = invoices.filter(
+      (i) => i.statut === "sent" || i.statut === "draft",
+    ).length;
+    const latePayments = invoices.filter((i) => i.statut === "late").length;
+    const activeLeases = leases.filter((l) => l.statut === "active").length;
+
+    // Filtrer les signataires pour les propriétés du propriétaire
+    const propertyIdSet = new Set(propertyIds);
+    const pendingSignatures = signers.filter((s) =>
+      s.lease?.property_id ? propertyIdSet.has(s.lease.property_id) : false,
+    ).length;
+
+    const openTickets = tickets.length;
+
+    const payload: DashboardCountsResponse = {
+      totalRevenue,
+      pendingPayments,
+      latePayments,
+      activeLeases,
+      pendingSignatures,
+      openTickets,
+    };
+
+    return NextResponse.json(payload, {
+      headers: {
+        "Cache-Control": "private, s-maxage=30, stale-while-revalidate=60",
+      },
+    });
+  } catch (error: unknown) {
+    console.error("[GET /api/owner/dashboard/counts] Erreur:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Erreur serveur",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/hooks/use-realtime-dashboard.ts
+++ b/lib/hooks/use-realtime-dashboard.ts
@@ -105,90 +105,55 @@ export function useRealtimeDashboard(options: UseRealtimeDashboardOptions = {}) 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [maxEvents, showToasts]);
 
-  // Charger les données initiales
+  // Charger les données initiales via l'API route (service client côté
+  // serveur pour éviter la récursion RLS 42P17 qui produisait 4x GET 500
+  // quand les queries étaient émises directement depuis le navigateur).
   const fetchInitialData = useCallback(async () => {
     if (!ownerId) return;
-    
+
     setLoading(true);
-    
+
     try {
-      // Récupérer les propriétés du propriétaire
-      const { data: properties } = await supabase
-        .from("properties")
-        .select("id")
-        .eq("owner_id", ownerId);
-      
-      const propertyIds = properties?.map(p => p.id) || [];
-      
-      if (propertyIds.length === 0) {
-        setLoading(false);
+      const res = await fetch("/api/owner/dashboard/counts", {
+        method: "GET",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        console.error(
+          "[useRealtimeDashboard] /api/owner/dashboard/counts",
+          res.status,
+        );
         return;
       }
-      
-      // Récupérer les stats en parallèle
-      // Calculer la période du mois en cours au format YYYY-MM pour le filtre sur invoices
-      const currentPeriod = `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}`;
-      
-      const [
-        { data: invoices },
-        { data: leases },
-        { data: signers },
-        { data: tickets },
-      ] = await Promise.all([
-        // Factures du mois en cours (utiliser owner_id et periode, pas property_id/created_at)
-        supabase
-          .from("invoices")
-          .select("montant_total, statut")
-          .eq("owner_id", ownerId)
-          .eq("periode", currentPeriod),
-        // Baux actifs
-        supabase
-          .from("leases")
-          .select("id, statut")
-          .in("property_id", propertyIds),
-        // Signatures en attente
-        supabase
-          .from("lease_signers")
-          .select("id, signature_status, lease:leases!inner(property_id)")
-          .eq("signature_status", "pending"),
-        // Tickets ouverts
-        supabase
-          .from("tickets")
-          .select("id, statut")
-          .in("property_id", propertyIds)
-          .in("statut", ["open", "in_progress"]),
-      ]);
-      
-      // Calculer les stats
-      const paidInvoices = invoices?.filter(i => i.statut === "paid") || [];
-      const totalRevenue = paidInvoices.reduce((sum, i) => sum + (i.montant_total || 0), 0);
-      const pendingPayments = invoices?.filter(i => i.statut === "sent" || i.statut === "draft").length || 0;
-      const latePayments = invoices?.filter(i => i.statut === "late").length || 0;
-      const activeLeases = leases?.filter(l => l.statut === "active").length || 0;
-      
-      // Filtrer les signataires pour les propriétés du propriétaire
-      const pendingSignatures = signers?.filter(s => 
-        propertyIds.includes((s.lease as any)?.property_id)
-      ).length || 0;
-      
-      const openTickets = tickets?.length || 0;
-      
-      setData(prev => ({
+
+      const counts = (await res.json()) as {
+        totalRevenue?: number;
+        pendingPayments?: number;
+        latePayments?: number;
+        activeLeases?: number;
+        pendingSignatures?: number;
+        openTickets?: number;
+      };
+
+      setData((prev) => ({
         ...prev,
-        totalRevenue,
-        pendingPayments,
-        latePayments,
-        activeLeases,
-        pendingSignatures,
-        openTickets,
+        totalRevenue: counts.totalRevenue ?? 0,
+        pendingPayments: counts.pendingPayments ?? 0,
+        latePayments: counts.latePayments ?? 0,
+        activeLeases: counts.activeLeases ?? 0,
+        pendingSignatures: counts.pendingSignatures ?? 0,
+        openTickets: counts.openTickets ?? 0,
         lastUpdate: new Date(),
       }));
     } catch (error) {
-      console.error("[useRealtimeDashboard] Error fetching initial data:", error);
+      console.error(
+        "[useRealtimeDashboard] Error fetching initial data:",
+        error,
+      );
     } finally {
       setLoading(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ownerId]);
 
   // Charger les données au montage


### PR DESCRIPTION
## Summary

Two residual bugs on the owner stack, same RLS 42P17 recursion root cause as PR #393:

- **Chèque / virement → 404 "Facture non trouvée"** — `POST /api/invoices/[id]/mark-paid` queried Supabase with the user-scoped client and `!inner` joins on leases/properties. When RLS recursion hits `profiles` (referenced by leases/properties policies), the inner-join rows are filtered out and `.single()` returns null → 404 for invoices that actually exist. Broke both chèque and virement flows from `ManualPaymentDialog`.
- **4× GET Supabase 500 in the console** — `useRealtimeDashboard.fetchInitialData` fired 4 parallel Supabase queries from the browser (invoices, leases, lease_signers inner join, tickets) + a properties prelude, all on the anon client → same RLS recursion → 4× 500 visible in DevTools on every dashboard mount.

## Changes

- `app/api/invoices/[id]/mark-paid/route.ts`: migrate DB reads/writes to `getServiceClient()`; authorization is now checked manually via `invoice.owner_id` (dénormalisé) with a lease→property fallback. `!inner` joins relaxed to tolerate orphans.
- `app/api/owner/dashboard/counts/route.ts` **(new)**: server route that computes the 6 realtime counters (`totalRevenue`, `pendingPayments`, `latePayments`, `activeLeases`, `pendingSignatures`, `openTickets`) using the service client.
- `lib/hooks/use-realtime-dashboard.ts`: `fetchInitialData` now calls `/api/owner/dashboard/counts` instead of querying Supabase directly. Realtime subscriptions stay on the browser anon client (channel auth is independent of RLS).

## Note on cash payments (espèces)

The espèces flow still depends on `create_cash_receipt` RPC shipped in `20260411000000_create_cash_receipt_function.sql` (PR #382). The migration includes `NOTIFY pgrst, 'reload schema'`. If the RPC is still missing from the schema cache in prod, it's a migration deployment issue — no code change needed here.

## Test plan

- [ ] Owner dashboard loads without any 500 in the Network tab
- [ ] `POST /api/invoices/[id]/mark-paid` with a chèque body returns 200 + creates a payment row
- [ ] Same test with a virement body returns 200 + creates a payment row
- [ ] Non-owner calling the route still gets 403
- [ ] Invoice already-paid returns 400 (not 404)
- [ ] `GET /api/owner/dashboard/counts` returns the expected 6-counter payload

https://claude.ai/code/session_01Q2Ur1VN44J4YgFeqjutVEx