### PR TITLE
Fix payment flow error handling and Stripe Connect banner RLS issues

### DIFF
--- a/app/api/invoices/[id]/mark-paid/route.ts
+++ b/app/api/invoices/[id]/mark-paid/route.ts
@@ -70,32 +70,53 @@ export async function POST(
 
     // Récupérer la facture — service client pour bypasser RLS ; l'autorisation
     // est vérifiée manuellement ci-dessous via owner_id.
+    //
+    // Étape 1 : lecture "plate" de l'invoice. Si le résultat est null, c'est
+    // que l'id n'existe pas — 404 légitime. Si une erreur est renvoyée, on
+    // remonte un 500 détaillé plutôt que de masquer la cause derrière un
+    // faux 404 (bug historique : un échec schema-cache / RLS / FK cassé
+    // donnait un 404 "Facture non trouvée" impossible à diagnostiquer côté
+    // front).
     const { data: invoice, error: invoiceError } = await serviceClient
       .from("invoices")
-      .select(`
-        *,
-        lease:leases(
-          id,
-          property:properties(
-            owner_id,
-            adresse_complete
-          )
-        )
-      `)
+      .select("*")
       .eq("id", invoiceId)
       .maybeSingle();
 
-    if (invoiceError || !invoice) {
-      if (invoiceError) {
-        console.error("[mark-paid] Erreur lecture facture:", invoiceError);
-      }
+    if (invoiceError) {
+      console.error("[mark-paid] Erreur lecture facture:", invoiceError);
+      return NextResponse.json(
+        {
+          error: `Erreur lecture facture: ${invoiceError.message}`,
+          code: invoiceError.code ?? null,
+        },
+        { status: 500 }
+      );
+    }
+
+    if (!invoice) {
       return NextResponse.json(
         { error: "Facture non trouvée" },
         { status: 404 }
       );
     }
 
+    // Étape 2 : résoudre l'owner + l'adresse via lease→property en
+    // requête séparée. Si le bail ou la property sont orphelins, on retombe
+    // sur `invoice.owner_id` dénormalisé sans renvoyer de 500. Le champ
+    // d'adresse alimente les événements outbox plus bas.
+    let ownerFromLease: string | null = null;
+    let propertyAddress: string | null = null;
     const invoiceData = invoice as any;
+    if (invoiceData.lease_id) {
+      const { data: leaseRow } = await serviceClient
+        .from("leases")
+        .select("property:properties(owner_id, adresse_complete)")
+        .eq("id", invoiceData.lease_id)
+        .maybeSingle();
+      ownerFromLease = (leaseRow as any)?.property?.owner_id ?? null;
+      propertyAddress = (leaseRow as any)?.property?.adresse_complete ?? null;
+    }
 
     // Vérifier les permissions via service client (évite 42P17 sur profiles)
     const { data: profile } = await serviceClient
@@ -108,7 +129,6 @@ export async function POST(
     const isAdmin = profileData?.role === "admin";
     // `owner_id` est dénormalisé sur invoices — le chemin lease→property sert
     // de defense-in-depth au cas où la dénormalisation n'aurait pas eu lieu.
-    const ownerFromLease = invoiceData.lease?.property?.owner_id;
     const invoiceOwnerId = invoiceData.owner_id ?? ownerFromLease;
     const isOwner = !!profileData?.id && invoiceOwnerId === profileData.id;
 
@@ -266,7 +286,7 @@ export async function POST(
           tenant_id: (tenantProfile as any)?.user_id || null,
           amount: paymentAmount,
           periode: invoiceData.periode,
-          property_address: invoiceData.lease?.property?.adresse_complete || null,
+          property_address: propertyAddress,
           receipt_generated: !!receiptDocumentId,
         },
       },
@@ -279,7 +299,7 @@ export async function POST(
           tenant_name: tenantDisplayName,
           amount: paymentAmount,
           periode: invoiceData.periode,
-          property_address: invoiceData.lease?.property?.adresse_complete || null,
+          property_address: propertyAddress,
         },
       },
     ];
@@ -302,24 +322,43 @@ export async function POST(
       });
     }
 
-    await serviceClient.from("outbox").insert(outboxEvents as any);
+    // Outbox + audit_log : non bloquants. Une insertion échouée ne doit
+    // JAMAIS faire retourner 500 alors que le paiement est déjà enregistré
+    // en base (sinon le front affiche "Erreur serveur" et l'utilisateur
+    // retente → doublon).
+    const { error: outboxError } = await serviceClient
+      .from("outbox")
+      .insert(outboxEvents as any);
+    if (outboxError) {
+      console.error(
+        "[mark-paid] Outbox insert failed (non bloquant):",
+        outboxError,
+      );
+    }
 
-    // Journaliser
-    await serviceClient.from("audit_log").insert({
-      user_id: user.id,
-      action: "invoice_marked_paid",
-      entity_type: "invoice",
-      entity_id: invoiceId,
-      metadata: {
-        lease_id: invoiceData.lease_id,
-        payment_id: payment?.id,
-        amount: paymentAmount,
-        payment_method: paymentMethod,
-        reference,
-        bank_name,
-        notes,
-      },
-    } as any);
+    const { error: auditError } = await serviceClient
+      .from("audit_log")
+      .insert({
+        user_id: user.id,
+        action: "invoice_marked_paid",
+        entity_type: "invoice",
+        entity_id: invoiceId,
+        metadata: {
+          lease_id: invoiceData.lease_id,
+          payment_id: payment?.id,
+          amount: paymentAmount,
+          payment_method: paymentMethod,
+          reference,
+          bank_name,
+          notes,
+        },
+      } as any);
+    if (auditError) {
+      console.error(
+        "[mark-paid] Audit log insert failed (non bloquant):",
+        auditError,
+      );
+    }
 
     return NextResponse.json({
       success: true,

--- a/app/api/owner/stripe-connect-status/route.ts
+++ b/app/api/owner/stripe-connect-status/route.ts
@@ -1,0 +1,107 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/owner/stripe-connect-status
+ *
+ * Endpoint minimal dédié au bandeau dashboard "Encaissement en ligne non
+ * configuré" (StripeConnectBanner). On ne veut surtout PAS que le
+ * composant lance deux requêtes directes Supabase (profiles +
+ * stripe_connect_accounts) depuis le navigateur avec le client anon,
+ * parce que toute récursion RLS 42P17 sur profiles faisait remonter
+ * deux des quatre GET 500 observés côté dashboard owner.
+ *
+ * On fait donc la lecture côté serveur avec le service client, et on
+ * retourne strictement ce dont le bandeau a besoin :
+ *   - configured: false     → afficher le bandeau
+ *   - configured: true      → ne rien afficher
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { NextResponse } from "next/server";
+
+interface StripeConnectStatusResponse {
+  configured: boolean;
+  charges_enabled: boolean;
+}
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile || (profile as { role?: string }).role !== "owner") {
+      // Non-owners don't see the banner — treat as "configured" so the
+      // client hides it without raising an error.
+      const payload: StripeConnectStatusResponse = {
+        configured: true,
+        charges_enabled: false,
+      };
+      return NextResponse.json(payload);
+    }
+
+    const profileId = (profile as { id: string }).id;
+
+    const { data: connectAccount, error: connectError } = await serviceClient
+      .from("stripe_connect_accounts")
+      .select("id, charges_enabled")
+      .eq("profile_id", profileId)
+      .maybeSingle();
+
+    if (connectError) {
+      console.error(
+        "[GET /api/owner/stripe-connect-status] Erreur lecture compte:",
+        connectError,
+      );
+      // On ne veut pas bloquer le dashboard sur ce bandeau cosmétique.
+      const payload: StripeConnectStatusResponse = {
+        configured: true,
+        charges_enabled: false,
+      };
+      return NextResponse.json(payload);
+    }
+
+    const chargesEnabled =
+      (connectAccount as { charges_enabled?: boolean } | null)
+        ?.charges_enabled === true;
+    const configured = !!connectAccount && chargesEnabled;
+
+    const payload: StripeConnectStatusResponse = {
+      configured,
+      charges_enabled: chargesEnabled,
+    };
+
+    return NextResponse.json(payload, {
+      headers: {
+        "Cache-Control": "private, s-maxage=60, stale-while-revalidate=300",
+      },
+    });
+  } catch (error: unknown) {
+    console.error(
+      "[GET /api/owner/stripe-connect-status] Erreur:",
+      error,
+    );
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Erreur serveur",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/owner/dashboard/stripe-connect-banner.tsx
+++ b/components/owner/dashboard/stripe-connect-banner.tsx
@@ -4,11 +4,17 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { AlertTriangle, CreditCard, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { createClient } from "@/lib/supabase/client";
 
 /**
  * Banner displayed on the owner dashboard when Stripe Connect is not configured.
  * Dismissible per session via localStorage.
+ *
+ * Historical note: this component used to query `profiles` and
+ * `stripe_connect_accounts` directly from the browser with the anon
+ * Supabase client. That triggered RLS 42P17 recursion on `profiles` in
+ * production, which was visible as two of the "4x GET Supabase 500"
+ * errors on the owner dashboard. We now hit a dedicated server route
+ * (`/api/owner/stripe-connect-status`) that uses the service client.
  */
 export function StripeConnectBanner() {
   const [show, setShow] = useState(false);
@@ -20,29 +26,32 @@ export function StripeConnectBanner() {
       return;
     }
 
-    const supabase = createClient();
-    supabase.auth.getUser().then(async ({ data: { user } }) => {
-      if (!user) return;
-
-      const { data: profile } = await supabase
-        .from("profiles")
-        .select("id")
-        .eq("user_id", user.id)
-        .single();
-
-      if (!profile) return;
-
-      const { data: connectAccount } = await supabase
-        .from("stripe_connect_accounts")
-        .select("id, charges_enabled")
-        .eq("profile_id", profile.id)
-        .maybeSingle();
-
-      // Show banner if no Stripe Connect account or charges not enabled
-      if (!connectAccount || !connectAccount.charges_enabled) {
-        setShow(true);
+    let aborted = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/owner/stripe-connect-status", {
+          method: "GET",
+          credentials: "include",
+        });
+        if (!res.ok || aborted) return;
+        const data = (await res.json()) as {
+          configured?: boolean;
+        };
+        if (!aborted && data.configured === false) {
+          setShow(true);
+        }
+      } catch (err) {
+        // Cosmetic banner — never crash the dashboard on failure.
+        console.error(
+          "[StripeConnectBanner] Failed to load status:",
+          err,
+        );
       }
-    });
+    })();
+
+    return () => {
+      aborted = true;
+    };
   }, []);
 
   if (!show || dismissed) return null;

--- a/lib/services/invoice-status.service.ts
+++ b/lib/services/invoice-status.service.ts
@@ -89,7 +89,7 @@ export async function syncInvoiceStatusFromPayments(
     ? paidAt || settlement.invoice?.date_paiement || new Date().toISOString()
     : null;
 
-  await supabase
+  const { error: invoiceUpdateError } = await supabase
     .from("invoices")
     .update({
       statut: nextStatus,
@@ -97,22 +97,35 @@ export async function syncInvoiceStatusFromPayments(
     })
     .eq("id", invoiceId);
 
+  if (invoiceUpdateError) {
+    console.error(
+      "[syncInvoiceStatusFromPayments] Invoice status update failed:",
+      invoiceUpdateError,
+    );
+  }
+
   // Bug 11 : quand une facture est entièrement réglée, on annule les anciens
   // Payment Intents `pending` orphelins liés à cette facture. Sans ce nettoyage,
   // l'historique côté propriétaire continue d'afficher "55€ — En attente — Date
   // non renseignée" alors que la facture est marquée "Payée".
+  //
+  // NB : le statut `cancelled` sur payments est autorisé depuis la
+  // migration 20260411120000_harden_payments_check_constraints.sql.
+  // Avant cette migration, cette update échouait silencieusement sur
+  // la CHECK (ancien set = pending|succeeded|failed|refunded).
   if (settlement.isSettled) {
-    try {
-      await supabase
-        .from("payments")
-        .update({ statut: "cancelled" })
-        .eq("invoice_id", invoiceId)
-        .in("statut", ["pending", "processing"]);
-    } catch (cleanupError) {
-      // Non bloquant : la facture est déjà marquée payée, c'est l'essentiel
+    const { error: cleanupError } = await supabase
+      .from("payments")
+      .update({ statut: "cancelled" })
+      .eq("invoice_id", invoiceId)
+      .in("statut", ["pending", "processing"]);
+
+    if (cleanupError) {
+      // Non bloquant : la facture est déjà marquée payée, c'est l'essentiel.
+      // On log quand même pour ne plus perdre silencieusement les échecs.
       console.warn(
         "[syncInvoiceStatusFromPayments] Cleanup pending payments failed:",
-        cleanupError
+        cleanupError,
       );
     }
   }

--- a/supabase/migrations/20260411120000_harden_payments_check_constraints.sql
+++ b/supabase/migrations/20260411120000_harden_payments_check_constraints.sql
@@ -1,0 +1,93 @@
+-- =====================================================
+-- Migration: Harden payments CHECK constraints for manual flows
+-- Date: 2026-04-11
+--
+-- CONTEXT:
+-- The manual payment modal (`ManualPaymentDialog.tsx`) POSTs to
+-- /api/invoices/[id]/mark-paid with `moyen` ∈ {especes, cheque, virement,
+-- autre}. The corresponding CHECK on `payments.moyen` was updated to
+-- this set by 20241129000002_cash_payments.sql, but the block was
+-- wrapped in `EXCEPTION WHEN others THEN NULL` — meaning if the ALTER
+-- failed for any reason (e.g. unnamed legacy constraint, parallel
+-- migration race, existing row violation), the DB silently kept the
+-- original check `('cb', 'virement', 'prelevement')`. On an environment
+-- where the update never landed, inserting a `moyen = 'cheque'` row
+-- raises:
+--
+--     new row for relation "payments" violates check constraint
+--     "payments_moyen_check"
+--
+-- …which in mark-paid bubbles up to the outer catch and returns a
+-- plain 500 "Erreur serveur" — exactly what the user sees on the
+-- chèque / virement / espèces flows.
+--
+-- Similarly, `syncInvoiceStatusFromPayments` (lib/services/invoice-
+-- status.service.ts) cancels stale pending payments by setting
+-- `statut = 'cancelled'`, but the current CHECK only allows
+-- ('pending', 'succeeded', 'failed', 'refunded'). The update silently
+-- fails because the JS client doesn't throw on constraint errors for
+-- bulk updates — we've been leaking orphan `pending` rows in the
+-- background.
+--
+-- FIX:
+-- Re-assert both constraints with the canonical allowed sets. No
+-- EXCEPTION catch-all this time: if this ALTER fails, we want to know
+-- loudly (the prior silent path is precisely why the prod DB drifted
+-- from the migration history in the first place).
+--
+-- Safe to re-run: the DROP is IF EXISTS and the ADD is idempotent in
+-- the sense that re-running the migration against an already-good DB
+-- simply replaces the constraint with an equivalent one.
+-- =====================================================
+
+BEGIN;
+
+-- ============================================
+-- 1. payments.moyen — all manual + provider methods
+-- ============================================
+--
+-- Allowed:
+--   cb           Stripe card (tenant)
+--   virement     Manual bank transfer (owner marks paid) OR Stripe SEPA
+--   prelevement  SEPA Direct Debit
+--   especes      Cash receipt (two-step signature flow)
+--   cheque       Paper cheque (owner marks paid)
+--   autre        Fallback (no specific method)
+--
+ALTER TABLE public.payments
+  DROP CONSTRAINT IF EXISTS payments_moyen_check;
+
+ALTER TABLE public.payments
+  ADD CONSTRAINT payments_moyen_check
+  CHECK (moyen IN ('cb', 'virement', 'prelevement', 'especes', 'cheque', 'autre'));
+
+-- ============================================
+-- 2. payments.statut — include 'cancelled' for pending cleanup
+-- ============================================
+--
+-- Allowed:
+--   pending      Created, awaiting provider confirmation
+--   processing   Provider is processing (e.g. SEPA in flight)
+--   succeeded    Settled
+--   failed       Provider rejected
+--   refunded     Chargeback / manual refund
+--   cancelled    Superseded by another payment (used by
+--                syncInvoiceStatusFromPayments when a full manual
+--                payment makes a Stripe PaymentIntent orphaned)
+--
+ALTER TABLE public.payments
+  DROP CONSTRAINT IF EXISTS payments_statut_check;
+
+ALTER TABLE public.payments
+  ADD CONSTRAINT payments_statut_check
+  CHECK (statut IN ('pending', 'processing', 'succeeded', 'failed', 'refunded', 'cancelled'));
+
+-- ============================================
+-- 3. Reload PostgREST schema cache
+-- ============================================
+-- Required for existing PostgREST workers to pick up the new
+-- constraint definitions without a restart.
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

This PR hardens error handling in the invoice payment flow and fixes RLS recursion issues that were causing 500 errors on the owner dashboard. It separates concerns by moving Stripe Connect status checks to a dedicated server endpoint and improves observability by distinguishing between legitimate 404s and actual server errors.

## Key Changes

### 1. **Invoice Mark-Paid Endpoint (`/api/invoices/[id]/mark-paid`)**
   - **Separated error handling**: Now distinguishes between "invoice not found" (404) and actual read errors (500 with detailed error info)
   - **Two-phase data fetching**: 
     - Phase 1: Fetch invoice with minimal fields to detect existence
     - Phase 2: Separately resolve owner and property address via lease relationship
   - **Non-blocking outbox/audit**: Made outbox and audit_log inserts non-blocking to prevent 500 responses when payment is already recorded (prevents duplicate payment attempts on retry)
   - **Better error diagnostics**: Returns detailed error messages and codes instead of masking failures behind generic 404s

### 2. **New Stripe Connect Status Endpoint (`/api/owner/stripe-connect-status`)**
   - Created dedicated server-side endpoint to replace direct browser queries
   - Eliminates RLS 42P17 recursion on `profiles` table that was causing 2 of 4 dashboard 500 errors
   - Returns minimal payload: `{ configured: boolean, charges_enabled: boolean }`
   - Includes cache headers (60s max-age, 300s stale-while-revalidate)
   - Gracefully degrades on errors (treats failures as "configured" to avoid blocking dashboard)

### 3. **StripeConnectBanner Component**
   - Migrated from direct Supabase client queries to server endpoint
   - Implements proper cleanup with abort flag to prevent state updates after unmount
   - Improved error handling with console logging instead of silent failures

### 4. **Invoice Status Sync Service**
   - Added error logging for invoice status updates
   - Added error logging for pending payment cleanup (previously silent failures)
   - Documented that `cancelled` status is now allowed on payments (via new migration)

### 5. **Database Migration (`20260411120000_harden_payments_check_constraints.sql`)**
   - Re-asserts `payments.moyen` CHECK constraint to include manual payment methods: `especes`, `cheque`, `autre`
   - Re-asserts `payments.statut` CHECK constraint to include `cancelled` status for orphaned payment cleanup
   - Removes silent exception handling to surface constraint drift issues
   - Triggers PostgREST schema cache reload

## Notable Implementation Details

- **Error vs. Not Found**: The mark-paid endpoint now properly returns 500 with error details when database operations fail, rather than masking all failures as 404 "Facture non trouvée"
- **Defense-in-depth**: Maintains denormalized `owner_id` on invoices as primary source, with lease→property lookup as fallback
- **Non-blocking writes**: Outbox and audit_log failures don't prevent successful payment responses, reducing duplicate payment risk
- **Graceful degradation**: Stripe Connect banner hides on errors rather than crashing the dashboard
- **Observability**: All error paths now log to console for debugging production issues

https://claude.ai/code/session_01SYctWDNjcZaWV3Tyo3VZLF