### PR TITLE
Remove screenshots from web app manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -62,22 +62,6 @@
       "purpose": "maskable any"
     }
   ],
-  "screenshots": [
-    {
-      "src": "/screenshots/dashboard-wide.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "Tableau de bord propriétaire"
-    },
-    {
-      "src": "/screenshots/mobile-home.png",
-      "sizes": "750x1334",
-      "type": "image/png",
-      "form_factor": "narrow",
-      "label": "Vue mobile"
-    }
-  ],
   "shortcuts": [
     {
       "name": "Tableau de bord",


### PR DESCRIPTION
## Summary
Removed the `screenshots` array from the web app manifest configuration. This array previously defined two screenshot entries for the progressive web app (PWA).

## Changes
- Removed the entire `screenshots` section from `public/manifest.json`
- This included two screenshot definitions:
  - Dashboard wide screenshot (1280x720) for wide form factor
  - Mobile home screenshot (750x1334) for narrow form factor

## Notes
This change removes PWA screenshot metadata that was previously used for app store listings and installation prompts. The application will no longer display these screenshots in PWA installation dialogs or app store presentations.

https://claude.ai/code/session_01TJwFZm7j5jKCTWswkrmgTF