### PR TITLE
docs(skills): add talok-buildings skill + sync property system doc

### DIFF
--- a/.claude/skills/talok-buildings/SKILL.md
+++ b/.claude/skills/talok-buildings/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: talok-buildings
+description: >
+  Architecture complète de la gestion des immeubles et lots Talok côté propriétaire :
+  modèle données (buildings, building_units, properties), ownership_type full/partial,
+  wizard de création, page hub managérial, routes UI et API, distinction avec le module
+  syndic, règles de scoping baux/factures/tickets. Déclenche dès que la tâche touche à
+  immeuble, lot, building, copropriétaire partiel, plan des lots, fiche immeuble,
+  wizard building_config, BuildingVisualizer, ou route /owner/buildings.
+---
+
+# Talok — Gestion des immeubles et lots (SOTA 2026)
+
+## 1. Modèle mental
+
+Talok distingue trois concepts strictement séparés :
+
+| Concept | Définition | Exemples |
+|---|---|---|
+| **Bien unitaire** | Une property standalone sans parent | Un appart isolé, une maison, un studio |
+| **Lot d'immeuble** | Une property avec `parent_property_id` pointant vers un immeuble wrapper | Un appart dans une SCI qui possède plusieurs apparts au même endroit |
+| **Immeuble conteneur** | Une property `type='immeuble'` + un record `buildings` + N `building_units` | La SCI Route du Phare, 4 apparts |
+
+**Règle d'or** : le propriétaire ne voit **jamais** le wrapper `type='immeuble'` comme un bien dans la liste "Mes biens". Il voit ses lots individuellement (avec un badge vers l'immeuble parent) **et** l'immeuble comme un hub managérial dans l'onglet "Immeubles".
+
+## 2. Modèle de données
+
+### Tables
+
+```
+properties                             — Tous les biens (lots + unitaires + wrappers)
+├── id (UUID PK)
+├── owner_id (FK profiles)
+├── type (enum 14 types — inclut 'immeuble' pour le wrapper)
+├── parent_property_id (UUID, FK properties) — non-null pour les lots, pointe vers le wrapper
+├── legal_entity_id (FK legal_entities) — entité SCI/EIRL/etc.
+├── adresse_complete, code_postal, ville, ...
+├── loyer_hc, charges, depot_garantie, ...
+└── etat, deleted_at
+
+buildings                              — Métadonnées physiques + équipements communs
+├── id (UUID PK)
+├── owner_id (FK profiles) NOT NULL
+├── property_id (FK properties) — pointe vers le wrapper type='immeuble', nullable
+├── ownership_type (ENUM: 'full' | 'partial') DEFAULT 'full'  ← à ajouter
+├── total_lots_in_building (INTEGER nullable)  ← à ajouter (informatif si partial)
+├── name, adresse_complete, code_postal, ville, departement
+├── floors, construction_year, surface_totale
+├── has_ascenseur, has_gardien, has_interphone, has_digicode
+├── has_local_velo, has_local_poubelles, has_parking_commun, has_jardin_commun
+├── notes, deleted_at
+└── created_at, updated_at
+
+building_units                         — Plan d'étage (floor/position) + ref lot
+├── id (UUID PK)
+├── building_id (FK buildings) ON DELETE CASCADE NOT NULL
+├── property_id (FK properties) NULLABLE — la property lot correspondante
+├── floor, position (UNIQUE per building)
+├── type (appartement|studio|local_commercial|parking|cave|bureau)
+├── template (studio|t1|t2|t3|t4|t5|local|parking|cave)
+├── surface, nb_pieces, loyer_hc, charges, depot_garantie
+├── status (vacant|occupe|travaux|reserve)
+├── current_lease_id (FK leases) ON DELETE SET NULL
+└── created_at, updated_at
+```
+
+### Relations
+
+```
+properties (type='immeuble', wrapper)
+    ↑ property_id
+    ↑
+buildings
+    ↓ id
+    ↓
+building_units
+    ↓ property_id
+    ↓
+properties (type≠'immeuble', le lot réel)
+    ↑ parent_property_id → wrapper
+```
+
+Le wrapper property existe pour faire la jointure entre `buildings` et les lots. Il n'est **jamais** exposé comme un bien dans les listes utilisateur.
+
+### `ownership_type` (à ajouter)
+
+| Valeur | Signification |
+|---|---|
+| `'full'` | Le propriétaire possède TOUS les lots de l'immeuble physique. Talok gère tout. |
+| `'partial'` | Le propriétaire possède seulement CERTAINS lots (copropriété avec d'autres propriétaires). Talok ne gère que ses lots à lui, les parties communes sont en lecture-seule, la gouvernance est externe (syndic). |
+
+Backfill : tous les records existants → `'full'` (comportement actuel).
+
+## 3. Quota forfait
+
+Un immeuble = **N biens dans le quota** où N est le nombre de lots du user.
+
+```
+buildings                 → ne consomme pas de slot
+properties type=immeuble  → ne consomme pas de slot (wrapper technique)
+properties (lots)         → consomme 1 slot chacun
+properties (unitaires)    → consomme 1 slot chacun
+```
+
+Fichier : `lib/subscriptions/check-limit.ts` — filtre `neq('type', 'immeuble')`.
+
+**Exemple** : SCI Marie-Line possède 2 lots dans Route du Phare (`ownership_type='partial'`, total=6) + 1 maison standalone = **3 biens dans le quota**.
+
+## 4. Wizard de création
+
+### Étapes pour `type='immeuble'`
+
+```
+1. type_bien              — sélection "Immeuble (entier ou partiel)"
+2. address                — adresse du bâtiment
+3. ownership_type         — NEW : radio full/partial + total_lots_in_building
+4. building_config        — BuildingVisualizer + lots de l'utilisateur
+5. photos                 — photos extérieures + parties communes
+6. recap                  — récapitulatif + submit
+```
+
+### Submit → INSERTs atomiques
+
+`POST /api/properties/[id]/building-units` fait en transaction :
+1. Upsert 1 ligne `buildings` (avec `ownership_type`, `total_lots_in_building`)
+2. Pour chaque lot : INSERT 1 ligne `properties` (`type != 'immeuble'`, `parent_property_id = wrapper.id`, `etat='published'`)
+3. BULK INSERT N lignes `building_units` (avec `property_id` pointant vers chaque lot)
+
+Source : `app/api/properties/[id]/building-units/route.ts:49-269`.
+
+### Mode `partial`
+- L'utilisateur configure uniquement **ses propres lots** (pas les 6 de l'immeuble physique s'il n'en possède que 2)
+- Le visualiseur affiche les emplacements des autres lots en **grisé non-interactif** avec label "Appartient à un autre copropriétaire"
+- Les équipements parties communes (ascenseur, gardien, ...) deviennent informatifs : "Géré par le syndic"
+
+## 5. Routes
+
+### UI (pages)
+
+| Route | Fichier | Description |
+|---|---|---|
+| `/owner/properties` | `app/owner/properties/page.tsx` | Liste unifiée avec tabs `Mes biens` / `Immeubles` |
+| `/owner/properties?tab=immeubles` | idem | Vue managériale des immeubles conteneurs |
+| `/owner/properties/new` | `app/owner/properties/new/NewPropertyClient.tsx` | Wizard (inclut branche immeuble) |
+| `/owner/properties/[id]` | `app/owner/properties/[id]/page.tsx` | Fiche d'un lot OU d'un bien unitaire |
+| `/owner/buildings` | `app/owner/buildings/page.tsx` | Redirect 301 → `/owner/properties?tab=immeubles` |
+| `/owner/buildings/[id]` | `app/owner/buildings/[id]/page.tsx` | **Hub managérial** (plan + cards lots + docs) |
+| `/owner/buildings/[id]/units` | `app/owner/buildings/[id]/units/page.tsx` | Édition des lots (CRUD inline) |
+| `/owner/buildings/[id]/not-found.tsx` | `app/owner/buildings/[id]/not-found.tsx` | 404 dédié (à distinguer de 403) |
+
+**URL pattern** : `/owner/buildings/[id]` utilise `id = property_id` du wrapper (**pas** `building_id`). Le server component résout le `building_id` via `buildings.property_id`.
+
+### API
+
+| Endpoint | Méthode | Description |
+|---|---|---|
+| `/api/buildings` | GET, POST | Liste + création |
+| `/api/buildings/[id]` | GET, PATCH, DELETE | Détail + update + soft-delete (fallback hard) |
+| `/api/buildings/[id]/units` | GET, POST | Liste + création bulk de lots |
+| `/api/buildings/[id]/units/[unitId]` | DELETE | Supprimer un lot |
+| `/api/properties/[id]/building` | GET | Récupère building + units pour une property type=immeuble |
+| `/api/properties/[id]/building-units` | POST | Upsert building + lots en une transaction (wizard) |
+| `/api/properties/[id]/associate-building` | POST | **À créer** — rattacher une property existante à un immeuble parent |
+
+## 6. Page `/owner/buildings/[id]` — structure
+
+La page est un **hub managérial** à 3 sections stackées verticalement (pas de tabs) :
+
+```
+┌─────────────────────────────────────────────────┐
+│ HEADER                                          │
+│   Nom immeuble · adresse · année · surface      │
+│   Badge ownership : "Propriétaire unique" ou    │
+│                     "Copropriétaire · X/M lots" │
+│   CTA : Modifier | Gérer les lots              │
+├─────────────────────────────────────────────────┤
+│ SECTION 1 — Plan des lots                       │
+│   <BuildingVisualizer readOnly />               │
+│   Lots user = cliquables (→ détail du lot)     │
+│   Lots externes (partial) = grisés              │
+├─────────────────────────────────────────────────┤
+│ SECTION 2 — Lots                                │
+│   Grille <BuildingLotCard /> réutilisable       │
+│   Par card : photo, étage/position, type,       │
+│   surface, loyer, statut, nom locataire, bail   │
+│   Clic → /owner/properties/[lot.property_id]   │
+├─────────────────────────────────────────────────┤
+│ SECTION 3 — Documents de gestion                │
+│   DPE collectif, règlement copro, PV AG,        │
+│   attestation PNO, contrats entretien, devis    │
+│   Upload / aperçu / suppression                 │
+└─────────────────────────────────────────────────┘
+```
+
+**Composant `BuildingLotCard`** (à créer dans `components/buildings/BuildingLotCard.tsx`) :
+- Props : `{ lot: PropertyRow, unit: BuildingUnitRow, lease?: LeaseRow, tenant?: ProfileRow }`
+- Clic → `Link` vers `/owner/properties/${lot.id}` (pas `/owner/buildings/${building_id}/units/${unit_id}` — on veut la vraie fiche du bien)
+- Toujours afficher la pastille statut (vacant/occupé/travaux/réserve)
+
+## 7. Page `/owner/properties/[id]` pour un lot
+
+Même composant que pour un bien unitaire, mais avec différences :
+- Breadcrumb : `Mes biens → Immeuble [X] → Lot [Y]`
+- Header : badge "Lot dans immeuble · [adresse]" cliquable → `/owner/buildings/[parent_property_id]`
+- Toutes les tabs existantes fonctionnent (bail, finance, documents, tickets, etc.)
+
+Le lot est traité comme un bien autonome pour tout ce qui est bail/locataire/factures — seul le "wrapping" managérial est groupé.
+
+## 8. Check d'accès — fix 404 "Immeuble introuvable"
+
+**Bug connu** : `app/owner/buildings/[id]/page.tsx:89-116` filtre `owner_id = profile.id` sans tenir compte des membres SCI (`entity_members`) ni du cas `building.property_id IS NULL`. Résultat : 404 pour des immeubles qui existent et sont légitimement accessibles.
+
+**Fix** : copier le pattern de `app/api/invoices/[id]/route.ts:78-106` :
+
+```
+1. Query property/building SANS filtre owner (service client)
+2. Autoriser si :
+   - property.owner_id === profile.id
+   - OU profile.id ∈ (SELECT user_id FROM entity_members WHERE entity_id = property.legal_entity_id)
+3. Sinon → 403 access-denied (page dédiée distincte du 404 not-found)
+4. Si building.property_id IS NULL → rendre quand même avec buildingRecord direct
+```
+
+## 9. Surfacer les lots dans "Mes biens"
+
+Filtre actuel (`app/owner/properties/page.tsx:181`) :
+```ts
+filtered = filtered.filter(p => p.type !== "immeuble" && !p.parent_property_id);
+```
+
+**À remplacer par** :
+```ts
+filtered = filtered.filter(p => p.type !== "immeuble");
+// Les lots avec parent_property_id apparaissent maintenant comme des biens
+```
+
+Le badge "Immeuble · [adresse]" est ajouté dans `PropertyCard` :
+- Condition : `property.parent_property_id != null`
+- Fetch léger en batch : `SELECT id, adresse_complete FROM properties WHERE id IN (distinct parent_property_ids)` au niveau de la page (pas N+1)
+- Link vers `/owner/buildings/${parent_property_id}`
+
+## 10. Gestion locative — scoping
+
+| Entité | Scope | FK canonique |
+|---|---|---|
+| **Bail** | Toujours au lot | `leases.property_id = lot.id` (+ `leases.building_unit_id` pour le trigger sync) |
+| **Facture** | Via bail | `invoices.lease_id` (remonte au lot via `leases.property_id`) |
+| **Ticket privatif** | Lot | `tickets.property_id = lot.id` |
+| **Ticket commun** (parties communes) | Immeuble | `tickets.building_id` (colonne à ajouter, phase ultérieure) |
+| **Document privatif** (EDL, quittance, etc.) | Lot | `documents.property_id = lot.id` |
+| **Document commun** (DPE collectif, PV AG, PNO) | Immeuble | `documents.building_id` OU `documents.property_id = wrapper.id` |
+
+**Règle** : un bail ne pointe jamais directement vers le wrapper `type='immeuble'`. Il pointe toujours vers un lot réel ou un bien unitaire.
+
+## 11. Suppression (cascade)
+
+### Contraintes SQL actuelles
+- `building_units.building_id` → `buildings.id` **ON DELETE CASCADE**
+- `buildings.property_id` → `properties.id` **ON DELETE SET NULL**
+- `building_units.current_lease_id` → `leases.id` **ON DELETE SET NULL**
+
+### Comportement DELETE immeuble
+`app/api/buildings/[id]/route.ts:163-235` :
+1. Refuse si au moins 1 lot occupé
+2. Soft-delete (`deleted_at = NOW()`) préféré, fallback hard-delete
+3. **Ne supprime pas** les properties lots enfants → orphelines
+
+### Comportement DELETE lot
+`app/api/buildings/[id]/units/[unitId]/route.ts` :
+1. `.delete()` physique sur `building_units`
+2. **Ne supprime pas** la property liée via `parent_property_id`
+
+**TODO** : ajouter un trigger de cleanup ou un soft-delete cascade sur les properties lots.
+
+## 12. Distinction stricte avec le module `/syndic`
+
+| `/owner/buildings` | `/syndic` |
+|---|---|
+| Vue propriétaire bailleur | Vue syndic / conseil syndical |
+| Scopée aux lots possédés | Gouvernance de toute la copro |
+| Obligations individuelles du user | Obligations collectives de la copro |
+| Documents reçus du syndic | Documents émis par le syndic |
+| Pas d'AG, pas de votes, pas d'appels de fonds émis | AG, convocations, votes, appels de fonds, mandats |
+
+Un utilisateur peut avoir les deux rôles (syndic bénévole d'une copro dont il est aussi copropriétaire), mais les modules restent strictement séparés pour ne pas mélanger responsabilités légales.
+
+## 13. Règles dev obligatoires
+
+1. **Check d'accès** : jamais de filtre `owner_id` seul sur les pages/routes building — toujours copier le pattern entity_members.
+2. **Service client** : toutes les lectures DB côté SSR/API utilisent `getServiceClient()`, jamais `createClient()` user-scoped (évite récursion RLS 42P17).
+3. **URL pattern** : `/owner/buildings/[id]` utilise `property_id` du wrapper, pas `building_id`. Le server component résout via `buildings.property_id = property_id`.
+4. **BuildingLotCard** : lien vers `/owner/properties/[lot.property_id]`, jamais vers une fiche "lot" dédiée (qui n'existe pas).
+5. **Wizard** : le type `immeuble` déclenche `BUILDING_STEPS` à la place de `DEFAULT_STEPS`. L'étape `building_config` utilise `BuildingVisualizer` + `BuildingConfigStep`.
+6. **Quota** : les lots comptent, le wrapper ne compte pas. Filtre `.neq('type', 'immeuble')` dans `check-limit.ts`.
+7. **RLS** : toutes les policies sur `buildings`, `building_units`, `properties` utilisent `public.user_profile_id()` — jamais `auth.uid()`.
+8. **Regen types** : après toute migration buildings, lancer `npx supabase gen types typescript` et commit `lib/supabase/database.types.ts`.
+
+## 14. Fichiers clés
+
+| Domaine | Fichier |
+|---|---|
+| Types DB | `lib/supabase/database.types.ts` |
+| Types building | `lib/types/building-v3.ts` |
+| Wizard store | `features/properties/stores/wizard-store.ts` |
+| Wizard UI | `features/properties/components/v3/property-wizard-v3.tsx` |
+| Étape building config | `features/properties/components/v3/immersive/steps/BuildingConfigStep.tsx` |
+| Visualiseur | `features/properties/components/v3/immersive/steps/BuildingVisualizer.tsx` |
+| Page détail immeuble | `app/owner/buildings/[id]/page.tsx` + `BuildingDetailClient.tsx` |
+| Page édition lots | `app/owner/buildings/[id]/units/UnitsManagementClient.tsx` |
+| Not-found immeuble | `app/owner/buildings/[id]/not-found.tsx` |
+| Liste immeubles | `app/owner/properties/page.tsx` (onglet `immeubles`) |
+| API buildings | `app/api/buildings/route.ts`, `app/api/buildings/[id]/**` |
+| API building-units (wizard) | `app/api/properties/[id]/building-units/route.ts` |
+| API building lookup | `app/api/properties/[id]/building/route.ts` |
+| Service | `features/properties/services/buildings.service.ts` |
+| Quota | `lib/subscriptions/check-limit.ts` (exclusion wrapper) |
+| RLS | `supabase/migrations/20260318020000_buildings_rls_sota2026.sql` |
+| Table création | `supabase/migrations/20260107000000_building_support.sql` |
+| Backfill lots | `supabase/migrations/20260409170000_backfill_building_unit_properties.sql` |
+| Lease building_unit_id | `supabase/migrations/20260409160000_building_unit_lease_document_fk.sql` |
+
+## 15. Skill sibling (Cursor)
+
+Pour les règles de prévention de régressions spécifiques au property system (RLS, types, rate limiting, Zod enums), voir aussi `.cursor/skills/property-building-guard/SKILL.md` et `.cursor/skills/sota-property-system/SKILL.md`.

--- a/.cursor/skills/sota-property-system/SKILL.md
+++ b/.cursor/skills/sota-property-system/SKILL.md
@@ -62,6 +62,8 @@ buildings
 ├── id (UUID, PK)
 ├── owner_id (FK profiles)
 ├── property_id (FK properties, type=immeuble)
+├── ownership_type ('full' | 'partial')    ← SOTA 2026
+├── total_lots_in_building (INTEGER, nullable, informatif si partial)
 ├── floors, construction_year, surface_totale
 ├── has_ascenseur, has_gardien, has_interphone, has_digicode
 ├── has_local_velo, has_local_poubelles, has_parking_commun
@@ -241,17 +243,77 @@ Every API route verifies:
 
 ## 7. Building System (Immeuble)
 
+### Mental Model
+
+Talok distingue trois concepts strictement séparés :
+- **Bien unitaire** : une `property` standalone (appart isolé, maison)
+- **Lot d'immeuble** : une `property` avec `parent_property_id` pointant vers un
+  wrapper immeuble. Apparaît dans "Mes biens" avec un badge "Immeuble parent".
+- **Immeuble conteneur** : une `property` `type='immeuble'` (wrapper technique) +
+  un record `buildings` + N `building_units`. Visible dans l'onglet "Immeubles",
+  sert de hub managérial (plan + cards lots + documents).
+
+**Règle d'or** : le wrapper `type='immeuble'` n'est JAMAIS affiché comme un bien
+dans "Mes biens". Il est filtré via `p.type !== 'immeuble'`. Les lots enfants
+(avec `parent_property_id`) SONT affichés dans "Mes biens" au même titre que
+les biens unitaires — chacun compte pour 1 dans le quota.
+
+### Ownership Types (SOTA 2026)
+
+| Type | Signification |
+|------|---------------|
+| `full` | Propriétaire unique : possède tous les lots de l'immeuble physique |
+| `partial` | Copropriétaire : possède seulement certains lots dans une copro |
+
+En mode `partial`, le wizard ne configure que les lots du user ; les autres
+emplacements sont grisés dans le visualiseur ; les équipements communs sont en
+lecture seule ("Géré par le syndic").
+
+**Distinction stricte** : `/owner/buildings` = vue propriétaire bailleur (scopée
+aux lots possédés). `/syndic` = vue syndic (gouvernance de toute la copro, AG,
+votes, appels de fonds). Les deux modules ne se recouvrent jamais.
+
 ### Creation Flow
 
 1. Wizard creates property with `type = "immeuble"`
-2. `BuildingConfigStep` configures floors, communal features, and lots
-3. `POST /api/properties/[id]/building-units` creates/replaces all units
+2. Étape `ownership_type` (full/partial + total_lots_in_building si partial)
+3. `BuildingConfigStep` configures floors, communal features, and lots
+4. `POST /api/properties/[id]/building-units` creates/replaces all units
 
 ### URL Pattern
 
 `/owner/buildings/[id]` where `id` = **property_id** (not `building_id`).
 
-Server components resolve the actual `building_id` from the `buildings` table.
+Server components resolve the actual `building_id` from the `buildings` table
+via `buildings.property_id = property_id`.
+
+### Access Check (fix 404)
+
+La page `/owner/buildings/[id]` doit vérifier l'accès via `entity_members` SCI
+en plus de `owner_id`, sinon les immeubles détenus via SCI déclenchent un 404
+injustifié. Pattern à copier depuis `app/api/invoices/[id]/route.ts:78-106` :
+
+1. Query sans filtre owner (service client)
+2. Autoriser si `owner_id === profile.id` OU `profile ∈ entity_members(legal_entity_id)`
+3. Sinon 403 access-denied (distinct du 404 not-found)
+4. Si `building.property_id IS NULL`, rendre quand même avec buildingRecord
+
+### Detail Page Structure
+
+`/owner/buildings/[id]` = **hub managérial** à 3 sections stackées (pas de tabs) :
+
+```
+HEADER          : nom, adresse, badge ownership (full/partial · X/M lots)
+SECTION 1       : Plan des lots (<BuildingVisualizer readOnly />)
+                  Lots user = cliquables → /owner/properties/[lot_id]
+                  Lots externes (partial) = grisés non-interactifs
+SECTION 2       : Grille <BuildingLotCard /> (photo, étage, loyer, statut, tenant)
+                  Clic → /owner/properties/[lot.property_id]
+SECTION 3       : Documents de gestion (DPE collectif, règlement copro, PV AG, PNO)
+```
+
+Le bail, les quittances, les tickets privatifs et les factures restent sur la
+page du **lot** (`/owner/properties/[lot_id]`), pas sur la page immeuble.
 
 ### Templates
 


### PR DESCRIPTION
## Summary

Documentation-only update. Adds a dedicated `talok-buildings` skill covering the full owner-side building/lot management architecture, and syncs the Cursor `sota-property-system` skill with the same source of truth.

Prepares the ground for the upcoming Phase 1 PR that will fix the 404 "Immeuble introuvable" bug and surface the lots in the "Mes biens" list.

## Changes

- **`.claude/skills/talok-buildings/SKILL.md` (new, +338 lines)** — 15-section reference:
  - Mental model : bien unitaire / lot / immeuble + règle d'or (le wrapper `type='immeuble'` n'est jamais affiché comme un bien)
  - DB schema (`properties` + `buildings` + `building_units`) with the proposed `ownership_type` and `total_lots_in_building` columns
  - Quota rules (lots count, wrapper doesn't)
  - Wizard flow with the new `ownership_type` step (full / partial)
  - All UI and API routes (pages + endpoints)
  - 3-section stacked structure for `/owner/buildings/[id]` (plan, lots grid, documents)
  - Access check pattern (fix 404 via `entity_members`, copy from `/api/invoices/[id]/route.ts:78-106`)
  - Lease / invoice / ticket / document scoping rules
  - Strict distinction with the `/syndic` module
  - Mandatory dev rules (service client, URL pattern, RLS, regen types)
  - 22 key file references

- **`.cursor/skills/sota-property-system/SKILL.md` (+55 / -3)** :
  - Added `ownership_type` and `total_lots_in_building` to the `buildings` schema block
  - New "Mental Model" paragraph
  - New "Ownership Types" (full/partial) section
  - New "Access Check" pattern section
  - New "Detail Page Structure" section with the 3-section layout

## Non-scope

- **No application code change** — no new route, no migration, no component modification
- **No TS error introduced** — baseline unchanged
- **No breaking change** — these are markdown files consumed by the Claude Code / Cursor harness

## Why now

During the buildings audit (previous session), we mapped the full surface of the feature and identified 3 architectural decisions that needed to be inscribed before writing any fix code:
1. The wrapper `type='immeuble'` is a technical joint, not a bien — must never leak into user-facing lists
2. Lots count in the quota, the wrapper does not — the previous "quota faussé" label was incorrect
3. `ownership_type` must support both mono-propriétaire and copropriétaire partiel (common French SCI case where the user owns 2 lots out of 6)

Having these rules in the skill file ensures the next agent working on this area (this session or any future one) starts from the right mental model instead of re-debating the architecture.

## Test plan

- [ ] Skill file is picked up by the Claude Code harness (verified in the current session — `talok-buildings` appears in the available skills list)
- [ ] No broken markdown link (checked manually)
- [ ] `.cursor/skills/sota-property-system/SKILL.md` still renders cleanly

https://claude.ai/code/session_01Q2Ur1VN44J4YgFeqjutVEx