### PR TITLE
Fix property display logic and French accents across app

### DIFF
--- a/app/owner/properties/page.tsx
+++ b/app/owner/properties/page.tsx
@@ -335,16 +335,18 @@ export default function OwnerPropertiesPage() {
       return badges;
     }
 
-    // Surface (toujours affichée)
-    badges.push({
-      label: `${property.surface || "?"} m²`,
-      variant: "secondary" as const
-    });
+    // Surface : masquée pour parking/box/etc. si absente
+    if (!TYPES_WITHOUT_ROOMS.includes(property.type) || property.surface) {
+      badges.push({
+        label: property.surface ? `${property.surface} m²` : "? m²",
+        variant: "secondary" as const
+      });
+    }
 
     // Pièces : seulement pour les biens d'habitation
     if (!TYPES_WITHOUT_ROOMS.includes(property.type)) {
       badges.push({
-        label: `${property.nb_pieces || "?"} pièces`,
+        label: property.nb_pieces ? `${property.nb_pieces} pièce${property.nb_pieces > 1 ? "s" : ""}` : "? pièces",
         variant: "secondary" as const
       });
     } else if (property.type === "parking" || property.type === "box") {
@@ -357,11 +359,18 @@ export default function OwnerPropertiesPage() {
       }
     }
 
-    // Loyer (toujours affiché)
-    badges.push({
-      label: formatCurrency(property.monthlyRent),
-      variant: "default" as const
-    });
+    // Loyer : "Non renseigné" si 0 ou absent
+    if (property.monthlyRent && property.monthlyRent > 0) {
+      badges.push({
+        label: formatCurrency(property.monthlyRent),
+        variant: "default" as const
+      });
+    } else {
+      badges.push({
+        label: "Non renseigné",
+        variant: "outline" as const
+      });
+    }
 
     return badges;
   };
@@ -418,11 +427,13 @@ export default function OwnerPropertiesPage() {
       cell: (property: any) => (
         <div className="text-right">
           <span className="font-medium block">
-            {formatCurrency(property.monthlyRent)}
+            {property.monthlyRent && property.monthlyRent > 0 ? formatCurrency(property.monthlyRent) : "Non renseigné"}
           </span>
-          <span className="text-xs text-muted-foreground">
-            {property.currentLease ? "Loyer actuel" : "Loyer estimé"}
-          </span>
+          {property.monthlyRent && property.monthlyRent > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {property.currentLease ? "Loyer actuel" : "Loyer estimé"}
+            </span>
+          )}
         </div>
       )
     },
@@ -625,7 +636,7 @@ export default function OwnerPropertiesPage() {
                   {isAtLimit && !canNavigateToNew && (
                     <Button variant="outline" onClick={() => setShowUpgradeModal(true)}>
                       <Sparkles className="mr-2 h-4 w-4" />
-                      Debloquer plus de biens
+                      Débloquer plus de biens
                     </Button>
                   )}
                 </CardContent>
@@ -806,7 +817,7 @@ export default function OwnerPropertiesPage() {
                       data={filteredProperties}
                       columns={columns}
                       keyExtractor={(item: any) => item.id}
-                      onRowClick={(item: any) => router.push(`/owner/properties/${item.id}`)}
+                      onRowClick={(item: any) => router.push(item.type === "immeuble" ? `/owner/buildings/${item.id}` : `/owner/properties/${item.id}`)}
                     />
                   </motion.div>
                 )

--- a/components/layout/owner-app-layout.tsx
+++ b/components/layout/owner-app-layout.tsx
@@ -360,7 +360,7 @@ export function OwnerAppLayout({ children, profile: serverProfile }: OwnerAppLay
               ============================================ */}
           <CoreShellHeader
             title={shellMeta.title}
-            description={isDashboardPage ? shellMeta.description : "Concentrez-vous sur la tache qui debloque votre gestion."}
+            description={isDashboardPage ? shellMeta.description : "Concentrez-vous sur la tâche qui débloque votre gestion."}
             roleLabel={shellMeta.roleLabel}
             isDetailPage={isDetailPage}
             onBack={() => router.back()}

--- a/lib/navigation/core-shell-metadata.ts
+++ b/lib/navigation/core-shell-metadata.ts
@@ -19,43 +19,43 @@ export interface CoreShellMetadata {
 }
 
 const ROLE_LABELS: Record<CoreShellRole, string> = {
-  owner: "Proprietaire",
+  owner: "Propriétaire",
   tenant: "Locataire",
   admin: "Admin",
   provider: "Prestataire",
 };
 
 const DEFAULT_DESCRIPTIONS: Record<CoreShellRole, string> = {
-  owner: "Concentrez-vous sur la tache qui debloque votre gestion.",
+  owner: "Concentrez-vous sur la tâche qui débloque votre gestion.",
   tenant: "Concentrez-vous sur votre prochaine action utile.",
   admin: "Traitez d'abord les sujets bloquants avant d'analyser les tendances.",
-  provider: "Concentrez-vous sur la prochaine intervention a traiter.",
+  provider: "Concentrez-vous sur la prochaine intervention à traiter.",
 };
 
 const ROLE_MATCHERS: Record<CoreShellRole, CoreShellMatch[]> = {
   owner: [
     { pattern: "/owner/dashboard", description: "Priorisez vos prochaines actions sans vous disperser." },
-    { pattern: "/owner/properties", description: "Gardez une vue claire sur votre portefeuille et ses priorites." },
-    { pattern: "/owner/leases", description: "Suivez les signatures, entrees et sorties sans perdre le fil." },
+    { pattern: "/owner/properties", description: "Gardez une vue claire sur votre portefeuille et ses priorités." },
+    { pattern: "/owner/leases", description: "Suivez les signatures, entrées et sorties sans perdre le fil." },
     { pattern: "/owner/money", description: "Concentrez-vous sur les encaissements, relances et arbitrages utiles." },
-    { pattern: "/owner/onboarding", description: "Terminez les reglages essentiels pour gerer sereinement vos locations." },
+    { pattern: "/owner/onboarding", description: "Terminez les réglages essentiels pour gérer sereinement vos locations." },
   ],
   tenant: [
     { pattern: "/tenant/dashboard", description: "Retrouvez vos actions importantes en un coup d'oeil." },
-    { pattern: "/tenant/lease", description: "Retrouvez l'essentiel de votre logement sans chercher dans plusieurs ecrans." },
-    { pattern: "/tenant/payments", description: "Reglez vos echeances et suivez votre situation sans ambiguite." },
-    { pattern: "/tenant/documents", description: "Accedez a vos documents utiles et deposez ceux qui manquent." },
-    { pattern: "/tenant/onboarding", description: "Finalisez les etapes qui rendent votre espace vraiment utilisable." },
+    { pattern: "/tenant/lease", description: "Retrouvez l'essentiel de votre logement sans chercher dans plusieurs écrans." },
+    { pattern: "/tenant/payments", description: "Réglez vos échéances et suivez votre situation sans ambiguïté." },
+    { pattern: "/tenant/documents", description: "Accédez à vos documents utiles et déposez ceux qui manquent." },
+    { pattern: "/tenant/onboarding", description: "Finalisez les étapes qui rendent votre espace vraiment utilisable." },
   ],
   admin: [
     { pattern: "/admin/dashboard", description: "Commencez par les sujets bloquants de la plateforme, puis ouvrez les analyses utiles." },
-    { pattern: "/admin/people", description: "Traitez d'abord les profils a verifier avant d'explorer l'annuaire complet." },
+    { pattern: "/admin/people", description: "Traitez d'abord les profils à vérifier avant d'explorer l'annuaire complet." },
     { pattern: "/admin/properties", description: "Surveillez les anomalies du parc avant les volumes globaux." },
-    { pattern: "/admin/reports", description: "Utilisez les rapports pour confirmer les tendances apres traitement des alertes." },
+    { pattern: "/admin/reports", description: "Utilisez les rapports pour confirmer les tendances après traitement des alertes." },
     { pattern: "/admin/moderation", description: "Faites remonter les cas sensibles avant la moderation de routine." },
   ],
   provider: [
-    { pattern: "/provider/dashboard", description: "Priorisez les missions qui demandent une reponse rapide." },
+    { pattern: "/provider/dashboard", description: "Priorisez les missions qui demandent une réponse rapide." },
   ],
 };
 


### PR DESCRIPTION
## Summary
This PR improves property display logic in the owner properties page and fixes French language accents throughout the application for better consistency and user experience.

## Key Changes

### Property Display Logic (`app/owner/properties/page.tsx`)
- **Surface badge**: Now conditionally displayed - hidden for parking/box types when surface is absent, shown otherwise
- **Rooms badge**: Added proper French pluralization (`pièce` vs `pièces`) based on count
- **Monthly rent badge**: 
  - Changed to show "Non renseigné" (with outline variant) when rent is 0 or absent
  - Only displays formatted currency when rent value exists and is greater than 0
  - Updated rent column to match this logic and conditionally show lease type label
- **Building navigation**: Row clicks now route to `/owner/buildings/{id}` for "immeuble" type properties instead of properties detail page

### Entity Filtering for Dashboard Counts (`app/api/owner/dashboard/counts/route.ts` & `app/owner/_data/OwnerDataProvider.tsx`)
- Added `entityId` query parameter support to filter properties by legal entity
- Implemented entity resolution logic: "particulier" (individual) maps to "personal" filter (properties with `legal_entity_id IS NULL`)
- Updated `OwnerDataProvider` to resolve entity type before API calls
- Connected realtime dashboard hooks to pass resolved entity ID for accurate counter filtering

### Realtime Dashboard Updates (`lib/hooks/use-realtime-dashboard.ts` & related components)
- Added `entityId` parameter to `useRealtimeDashboard` hook options
- Updated `RealtimeRevenueWidget` and `DashboardClient` to resolve and pass entity ID
- Ensures dashboard counters reflect only properties for the active entity

### French Language Corrections
- Fixed accents in role labels and descriptions across `lib/navigation/core-shell-metadata.ts`:
  - "Proprietaire" → "Propriétaire"
  - "tache" → "tâche", "debloque" → "débloque"
  - "priorites" → "priorités", "entrees" → "entrées"
  - "reglages" → "réglages", "gerer" → "gérer"
  - "ecrans" → "écrans", "echeances" → "échéances", "ambiguite" → "ambiguïté"
  - "Accedez" → "Accédez", "deposez" → "déposez", "etapes" → "étapes"
  - "verifier" → "vérifier", "apres" → "après", "reponse" → "réponse"
- Fixed "Debloquer" → "Débloquer" in button text
- Fixed generic description in `OwnerAppLayout`

## Implementation Details
- Entity filtering uses a callback pattern (`resolveEntityFilter`) to avoid stale closures
- The "personal" entity type is a special case that filters for properties with NULL legal_entity_id
- Realtime dashboard updates are triggered when entity changes via dependency arrays
- Property badges now provide better UX by hiding irrelevant information while maintaining clarity

https://claude.ai/code/session_011MArZSiDQWgba3Nq7DAGCf