### PR TITLE
feat(syndic): LRAR dispatch, Stripe Connect multi-entity, Sentry + UI fixes

### DIFF
--- a/app/api/copro/assemblies/[assemblyId]/send-convocations/route.ts
+++ b/app/api/copro/assemblies/[assemblyId]/send-convocations/route.ts
@@ -1,0 +1,337 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/copro/assemblies/[assemblyId]/send-convocations
+ *
+ * Dispatch les convocations en attente (status='pending') pour une AG.
+ *
+ * Body: { convocationIds?: string[] }
+ *   - Si fourni : envoie uniquement ces convocations
+ *   - Si omis : envoie toutes les convocations pending de l'AG
+ *
+ * Par convocation :
+ *   - email → Resend (template copro-ag-convocation)
+ *   - lrar/postal_recommande/lre_numerique/postal_simple → LRAR provider
+ *   - hand_delivered → marqué comme envoyé sans dispatch
+ *
+ * Un échec sur une convocation ne bloque pas les autres.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAssemblyAccess } from "@/lib/helpers/syndic-auth";
+import { sendEmail } from "@/lib/emails/resend.service";
+import { coproAgConvocationEmail } from "@/lib/emails/templates/copro-ag-convocation";
+import { getLRARProvider } from "@/lib/services/lrar.service";
+import type { LRARSender, LRARRecipient, LRARDocument, LRARSendOptions } from "@/lib/services/lrar.service";
+
+interface RouteParams {
+  params: { assemblyId: string };
+}
+
+interface SendResult {
+  convocationId: string;
+  recipientName: string;
+  method: string;
+  success: boolean;
+  trackingNumber?: string;
+  error?: string;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const access = await requireAssemblyAccess(request, params.assemblyId);
+  if (access instanceof NextResponse) return access;
+
+  const { auth, assembly } = access;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const convocationIds: string[] | undefined = body.convocationIds;
+
+    // 1. Charger les convocations à envoyer
+    let query = auth.serviceClient
+      .from("copro_convocations")
+      .select("*")
+      .eq("assembly_id", assembly.id)
+      .eq("status", "pending");
+
+    if (convocationIds && convocationIds.length > 0) {
+      query = query.in("id", convocationIds);
+    }
+
+    const { data: convocations, error: fetchError } = await query;
+    if (fetchError) throw fetchError;
+
+    if (!convocations || convocations.length === 0) {
+      return NextResponse.json(
+        { error: "Aucune convocation en attente à envoyer" },
+        { status: 404 }
+      );
+    }
+
+    // 2. Charger les données contextuelles (AG, site, syndic)
+    const { data: assemblyData } = await auth.serviceClient
+      .from("copro_assemblies")
+      .select("*")
+      .eq("id", assembly.id)
+      .single();
+
+    if (!assemblyData) {
+      return NextResponse.json({ error: "Assemblée introuvable" }, { status: 404 });
+    }
+
+    const ag = assemblyData as any;
+
+    const { data: site } = await auth.serviceClient
+      .from("sites")
+      .select("name, address_line1, postal_code, city, syndic_profile_id, syndic_company_name, syndic_address, syndic_email, syndic_phone")
+      .eq("id", ag.site_id)
+      .single();
+
+    if (!site) {
+      return NextResponse.json({ error: "Site introuvable" }, { status: 404 });
+    }
+
+    const siteAny = site as any;
+
+    // Charger les infos syndic pour le template email
+    let syndicDisplayName = siteAny.syndic_company_name || "Syndic";
+    let syndicTypeSyndic: "professionnel" | "benevole" | "cooperatif" = "benevole";
+    let syndicCartePro: string | null = null;
+
+    if (siteAny.syndic_profile_id) {
+      const { data: syndicProfile } = await auth.serviceClient
+        .from("profiles")
+        .select("prenom, nom")
+        .eq("id", siteAny.syndic_profile_id)
+        .maybeSingle();
+
+      if (syndicProfile) {
+        const sp = syndicProfile as any;
+        syndicDisplayName = siteAny.syndic_company_name || `${sp.prenom || ""} ${sp.nom || ""}`.trim() || "Syndic";
+      }
+
+      const { data: syndicPro } = await auth.serviceClient
+        .from("syndic_profiles")
+        .select("type_syndic, numero_carte_pro")
+        .eq("profile_id", siteAny.syndic_profile_id)
+        .maybeSingle();
+
+      if (syndicPro) {
+        const spp = syndicPro as any;
+        syndicTypeSyndic = spp.type_syndic || "benevole";
+        syndicCartePro = spp.numero_carte_pro || null;
+      }
+    }
+
+    // Charger le nombre de résolutions pour le template email
+    const { count: resolutionsCount } = await auth.serviceClient
+      .from("copro_resolutions")
+      .select("id", { count: "exact", head: true })
+      .eq("assembly_id", assembly.id);
+
+    // 3. Dispatcher chaque convocation
+    const results: SendResult[] = [];
+    const now = new Date().toISOString();
+
+    for (const conv of convocations as any[]) {
+      const result: SendResult = {
+        convocationId: conv.id,
+        recipientName: conv.recipient_name,
+        method: conv.delivery_method,
+        success: false,
+      };
+
+      try {
+        if (conv.delivery_method === "email") {
+          // --- Email via Resend ---
+          if (!conv.recipient_email) {
+            result.error = "Pas d'adresse email pour ce copropriétaire";
+            results.push(result);
+            continue;
+          }
+
+          const email = coproAgConvocationEmail({
+            recipientName: conv.recipient_name,
+            assemblyId: assembly.id,
+            assemblyDate: ag.scheduled_at,
+            assemblyLocation: ag.location,
+            assemblyType: ag.assembly_type === "AGE" ? "extraordinaire" : "ordinaire",
+            referenceNumber: ag.reference_number,
+            resolutionsCount: resolutionsCount || 0,
+            site: {
+              name: siteAny.name,
+              address: `${siteAny.address_line1}, ${siteAny.postal_code} ${siteAny.city}`,
+            },
+            syndic: {
+              displayName: syndicDisplayName,
+              typeSyndic: syndicTypeSyndic,
+              numeroCartePro: syndicCartePro,
+              emailContact: siteAny.syndic_email,
+              telephone: siteAny.syndic_phone,
+              adresse: siteAny.syndic_address,
+            },
+          });
+
+          const emailResult = await sendEmail({
+            to: conv.recipient_email,
+            subject: email.subject,
+            html: email.html,
+            tags: [
+              { name: "type", value: "copro-ag-convocation" },
+              { name: "assembly_id", value: assembly.id },
+            ],
+            idempotencyKey: `convocation-${conv.id}`,
+          });
+
+          if (!emailResult.success) {
+            result.error = emailResult.error || "Erreur Resend";
+            results.push(result);
+            continue;
+          }
+
+          // Marquer comme envoyé
+          await auth.serviceClient
+            .from("copro_convocations")
+            .update({ status: "sent", sent_at: now, updated_at: now })
+            .eq("id", conv.id);
+
+          result.success = true;
+
+        } else if (conv.delivery_method === "hand_delivered") {
+          // --- Remise en main propre ---
+          await auth.serviceClient
+            .from("copro_convocations")
+            .update({ status: "sent", sent_at: now, updated_at: now })
+            .eq("id", conv.id);
+
+          result.success = true;
+
+        } else {
+          // --- LRAR / postal / LRE ---
+          const lrar = getLRARProvider();
+
+          if (!lrar.isConfigured()) {
+            result.error = "Service LRAR non configuré (clé API manquante)";
+            results.push(result);
+            continue;
+          }
+
+          // Récupérer le document PDF à envoyer
+          let pdfBuffer: Buffer | null = null;
+
+          if (conv.convocation_document_url) {
+            try {
+              const pdfRes = await fetch(conv.convocation_document_url);
+              if (pdfRes.ok) {
+                const arrayBuf = await pdfRes.arrayBuffer();
+                pdfBuffer = Buffer.from(arrayBuf);
+              }
+            } catch {
+              // URL inaccessible — on continue sans document
+            }
+          }
+
+          if (!pdfBuffer) {
+            result.error = "Aucun document PDF de convocation fourni. Uploadez un PDF avant l'envoi LRAR.";
+            results.push(result);
+            continue;
+          }
+
+          // Construire l'adresse de l'expéditeur (syndic)
+          const senderAddress = siteAny.syndic_address || `${siteAny.address_line1}, ${siteAny.postal_code} ${siteAny.city}`;
+          const senderParts = parseFrenchAddress(senderAddress);
+
+          // Adresse du destinataire
+          const recipientAddress = conv.recipient_address || "";
+          const recipientParts = parseFrenchAddress(recipientAddress);
+
+          const sender: LRARSender = {
+            name: syndicDisplayName,
+            address: senderParts.street,
+            postalCode: senderParts.postalCode || siteAny.postal_code || "",
+            city: senderParts.city || siteAny.city || "",
+          };
+
+          const recipient: LRARRecipient = {
+            name: conv.recipient_name,
+            address: recipientParts.street,
+            postalCode: recipientParts.postalCode || "",
+            city: recipientParts.city || "",
+          };
+
+          const documents: LRARDocument[] = [
+            {
+              filename: `convocation-${ag.reference_number || assembly.id}.pdf`,
+              content: pdfBuffer,
+              mimeType: "application/pdf",
+            },
+          ];
+
+          const options: LRARSendOptions = {
+            deliveryType: conv.delivery_method as LRARSendOptions["deliveryType"],
+            acknowledgment: conv.delivery_method !== "postal_simple",
+            internalReference: `conv-${conv.id}`,
+          };
+
+          const lrarResult = await lrar.sendLetter({ sender, recipient, documents, options });
+
+          // Mettre à jour avec tracking
+          await auth.serviceClient
+            .from("copro_convocations")
+            .update({
+              status: "sent",
+              sent_at: now,
+              tracking_number: lrarResult.trackingNumber || null,
+              updated_at: now,
+            })
+            .eq("id", conv.id);
+
+          result.success = true;
+          result.trackingNumber = lrarResult.trackingNumber;
+        }
+      } catch (err) {
+        result.error = err instanceof Error ? err.message : "Erreur inattendue";
+      }
+
+      results.push(result);
+    }
+
+    const sent = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+
+    return NextResponse.json({
+      total: results.length,
+      sent,
+      failed,
+      results,
+    });
+  } catch (error) {
+    console.error("[send-convocations:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Parse une adresse française libre en composants (rue, CP, ville).
+ * Heuristique simple : cherche un code postal 5 chiffres.
+ */
+function parseFrenchAddress(raw: string): {
+  street: string;
+  postalCode: string;
+  city: string;
+} {
+  const match = raw.match(/(\d{5})\s+(.+)/);
+  if (match) {
+    const beforeCp = raw.substring(0, raw.indexOf(match[1])).replace(/,\s*$/, "").trim();
+    return {
+      street: beforeCp || raw,
+      postalCode: match[1],
+      city: match[2].trim(),
+    };
+  }
+  return { street: raw, postalCode: "", city: "" };
+}

--- a/app/api/stripe/connect/balance/route.ts
+++ b/app/api/stripe/connect/balance/route.ts
@@ -6,7 +6,7 @@ export const runtime = "nodejs";
  * GET /api/stripe/connect/balance - Récupère le solde disponible et en attente
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient, createServiceRoleClient } from "@/lib/supabase/server";
 import { connectService } from "@/lib/stripe/connect.service";
 import { isStripeConfigurationError } from "@/lib/helpers/api-error";
@@ -15,7 +15,7 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const supabase = await createRouteHandlerClient();
     const serviceClient = createServiceRoleClient();
@@ -35,22 +35,30 @@ export async function GET() {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "owner") {
+    if (!profile || !["owner", "syndic"].includes(profile.role)) {
       return NextResponse.json(
-        { error: "Seuls les propriétaires peuvent consulter leur solde" },
+        { error: "Seuls les propriétaires et syndics peuvent consulter leur solde" },
         { status: 403 }
       );
     }
 
-    // Récupérer le compte Connect personnel (S2-2 : entity_id IS NULL)
-    const { data: connectAccount, error: connectAccountError } = await serviceClient
+    const entityId = new URL(request.url).searchParams.get("entityId") || undefined;
+
+    // Récupérer le compte Connect (personnel ou scopé par entité)
+    let connectQuery = serviceClient
       .from("stripe_connect_accounts")
       .select(
         "stripe_account_id, charges_enabled, payouts_enabled, details_submitted, requirements_currently_due, requirements_past_due, requirements_disabled_reason"
       )
-      .eq("profile_id", profile.id)
-      .is("entity_id", null)
-      .maybeSingle();
+      .eq("profile_id", profile.id);
+
+    if (entityId) {
+      connectQuery = connectQuery.eq("entity_id", entityId);
+    } else {
+      connectQuery = connectQuery.is("entity_id", null);
+    }
+
+    const { data: connectAccount, error: connectAccountError } = await connectQuery.maybeSingle();
 
     if (connectAccountError) {
       throw new Error(`Erreur lecture compte Connect: ${connectAccountError.message}`);

--- a/app/api/stripe/connect/dashboard/route.ts
+++ b/app/api/stripe/connect/dashboard/route.ts
@@ -6,11 +6,11 @@ export const runtime = "nodejs";
  * POST /api/stripe/connect/dashboard - Génère un lien vers le dashboard Stripe
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient, createServiceRoleClient } from "@/lib/supabase/server";
 import { connectService } from "@/lib/stripe/connect.service";
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
     const supabase = await createRouteHandlerClient();
     const serviceClient = createServiceRoleClient();
@@ -30,22 +30,31 @@ export async function POST() {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "owner") {
+    if (!profile || !["owner", "syndic"].includes(profile.role)) {
       return NextResponse.json(
-        { error: "Seuls les propriétaires peuvent accéder au dashboard" },
+        { error: "Seuls les propriétaires et syndics peuvent accéder au dashboard" },
         { status: 403 }
       );
     }
 
-    // Récupérer le compte Connect personnel (S2-2 : entity_id IS NULL)
-    const { data: connectAccount } = await serviceClient
+    const body = await request.json().catch(() => ({}));
+    const entityId: string | undefined = body.entityId || undefined;
+
+    // Récupérer le compte Connect (personnel ou scopé par entité)
+    let connectQuery = serviceClient
       .from("stripe_connect_accounts")
       .select(
         "stripe_account_id, charges_enabled, payouts_enabled, details_submitted, requirements_currently_due, requirements_past_due, requirements_disabled_reason"
       )
-      .eq("profile_id", profile.id)
-      .is("entity_id", null)
-      .maybeSingle();
+      .eq("profile_id", profile.id);
+
+    if (entityId) {
+      connectQuery = connectQuery.eq("entity_id", entityId);
+    } else {
+      connectQuery = connectQuery.is("entity_id", null);
+    }
+
+    const { data: connectAccount } = await connectQuery.maybeSingle();
 
     if (!connectAccount) {
       return NextResponse.json(

--- a/app/api/stripe/connect/route.ts
+++ b/app/api/stripe/connect/route.ts
@@ -112,10 +112,10 @@ async function getAuthenticatedOwnerProfile() {
     .eq("user_id", user.id)
     .single();
 
-  if (!profile || profile.role !== "owner") {
+  if (!profile || !["owner", "syndic"].includes(profile.role)) {
     return {
       error: NextResponse.json(
-        { error: "Seuls les propriétaires peuvent avoir un compte Connect" },
+        { error: "Seuls les propriétaires et syndics peuvent avoir un compte Connect" },
         { status: 403 }
       ),
     };
@@ -126,19 +126,24 @@ async function getAuthenticatedOwnerProfile() {
 
 async function getStoredConnectAccountReference(
   serviceClient: ReturnType<typeof createServiceRoleClient>,
-  profileId: string
+  profileId: string,
+  entityId?: string | null
 ): Promise<StoredConnectAccountReference | null> {
-  // S2-2 : filtrer explicitement sur le compte personnel (entity_id IS NULL).
+  // S2-2 : filtrer par entité juridique si fournie, sinon compte personnel.
   // Depuis la migration 20260412100000 un même profile_id peut avoir plusieurs
   // comptes Connect (un personnel + plusieurs scopés par entité juridique).
-  // Cette route sert historiquement aux propriétaires, on veut donc le compte
-  // personnel.
-  const { data, error } = await serviceClient
+  let query = serviceClient
     .from("stripe_connect_accounts")
     .select("id, stripe_account_id")
-    .eq("profile_id", profileId)
-    .is("entity_id", null)
-    .maybeSingle();
+    .eq("profile_id", profileId);
+
+  if (entityId) {
+    query = query.eq("entity_id", entityId);
+  } else {
+    query = query.is("entity_id", null);
+  }
+
+  const { data, error } = await query.maybeSingle();
 
   if (error) {
     throw new Error(`Erreur lecture compte Connect: ${error.message}`);
@@ -157,7 +162,7 @@ async function getStoredConnectAccountReference(
 /**
  * GET - Récupérer le compte Connect de l'utilisateur
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const auth = await getAuthenticatedOwnerProfile();
     if (auth.error) {
@@ -166,14 +171,21 @@ export async function GET() {
 
     const { profile } = auth;
     const serviceClient = createServiceRoleClient();
+    const entityId = new URL(request.url).searchParams.get("entityId") || undefined;
 
-    // Récupérer le compte Connect personnel (S2-2 : entity_id IS NULL)
-    const { data: connectAccount } = await serviceClient
+    // Récupérer le compte Connect (personnel ou scopé par entité)
+    let connectQuery = serviceClient
       .from("stripe_connect_accounts")
       .select("*")
-      .eq("profile_id", profile.id)
-      .is("entity_id", null)
-      .maybeSingle();
+      .eq("profile_id", profile.id);
+
+    if (entityId) {
+      connectQuery = connectQuery.eq("entity_id", entityId);
+    } else {
+      connectQuery = connectQuery.is("entity_id", null);
+    }
+
+    const { data: connectAccount } = await connectQuery.maybeSingle();
 
     if (!connectAccount) {
       return NextResponse.json({
@@ -269,10 +281,14 @@ export async function POST(request: NextRequest) {
     const { profile, user } = auth;
     const serviceClient = createServiceRoleClient();
 
-    // Vérifier si un compte existe déjà
+    const body = await request.json().catch(() => ({}));
+    const entityId: string | undefined = body.entityId || undefined;
+
+    // Vérifier si un compte existe déjà (personnel ou scopé par entité)
     const existingAccount = await getStoredConnectAccountReference(
       serviceClient,
-      profile.id
+      profile.id,
+      entityId
     );
 
     let stripeAccountId: string;
@@ -284,7 +300,6 @@ export async function POST(request: NextRequest) {
       stripeAccountId = existingAccount.stripe_account_id as string;
     } else {
       // Créer un nouveau compte Stripe Connect
-      const body = await request.json().catch(() => ({}));
       const businessType = body.business_type || "individual";
 
       const stripeAccount = await connectService.createConnectAccount({
@@ -295,22 +310,29 @@ export async function POST(request: NextRequest) {
           profile_id: profile.id,
           talok_user_id: user.id,
         },
-        idempotencyKey: `owner-connect-account:${profile.id}`,
+        idempotencyKey: entityId
+          ? `connect-account:${profile.id}:${entityId}`
+          : `owner-connect-account:${profile.id}`,
       });
 
       stripeAccountId = stripeAccount.id;
       createdStripeAccountId = stripeAccount.id;
 
-      // Enregistrer en base de données
+      // Enregistrer en base de données (personnel ou scopé par entité)
+      const insertPayload: Record<string, any> = {
+        profile_id: profile.id,
+        stripe_account_id: stripeAccountId,
+        account_type: "express",
+        business_type: businessType,
+        country: "FR",
+      };
+      if (entityId) {
+        insertPayload.entity_id = entityId;
+      }
+
       const { error: insertError } = await serviceClient
         .from("stripe_connect_accounts")
-        .insert({
-          profile_id: profile.id,
-          stripe_account_id: stripeAccountId,
-          account_type: "express",
-          business_type: businessType,
-          country: "FR",
-        });
+        .insert(insertPayload);
 
       if (insertError) {
         if (isUniqueProfileConflict(insertError)) {
@@ -324,7 +346,8 @@ export async function POST(request: NextRequest) {
 
       const persistedAccount = await getStoredConnectAccountReference(
         serviceClient,
-        profile.id
+        profile.id,
+        entityId
       );
 
       if (!persistedAccount?.stripe_account_id) {
@@ -361,10 +384,13 @@ export async function POST(request: NextRequest) {
     }
 
     // Créer le lien d'onboarding
+    const returnBase = entityId
+      ? `${APP_URL}/syndic/settings/connect`
+      : `${APP_URL}/owner/money?tab=banque`;
     const accountLink = await connectService.createAccountLink({
       accountId: stripeAccountId,
-      refreshUrl: `${APP_URL}/owner/money?tab=banque&refresh=true`,
-      returnUrl: `${APP_URL}/owner/money?tab=banque&success=true`,
+      refreshUrl: `${returnBase}${entityId ? "?" : "&"}refresh=true`,
+      returnUrl: `${returnBase}${entityId ? "?" : "&"}success=true`,
       type: hasExistingAccount ? "account_update" : "account_onboarding",
     });
 

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
 
 /**
  * Page d'erreur globale pour les erreurs au niveau du root layout
  * Cette page doit inclure les balises html et body car le layout peut être cassé
+ * Utilise des inline styles car Tailwind n'est pas garanti ici
  */
 export default function GlobalError({
   error,
@@ -14,8 +16,9 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    // En production, envoyer à Sentry ou autre service de monitoring
-    console.error("Critical global error:", error);
+    Sentry.captureException(error, {
+      tags: { boundary: "root-layout", digest: error.digest },
+    });
   }, [error]);
 
   return (
@@ -157,7 +160,7 @@ export default function GlobalError({
                   padding: "0.625rem 1.25rem",
                   borderRadius: "0.5rem",
                   border: "none",
-                  background: "#6366f1",
+                  background: "#2563EB",
                   color: "white",
                   fontWeight: "500",
                   cursor: "pointer",

--- a/app/syndic/assemblies/[id]/_components/SendConvocationsDialog.tsx
+++ b/app/syndic/assemblies/[id]/_components/SendConvocationsDialog.tsx
@@ -19,12 +19,21 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useToast } from "@/components/ui/use-toast";
-import { Loader2, Send, AlertCircle } from "lucide-react";
+import { Loader2, Send, AlertCircle, CheckCircle2, XCircle, Mail } from "lucide-react";
 
 interface SendConvocationsDialogProps {
   assemblyId: string;
   onClose: () => void;
   onSent: () => void;
+}
+
+interface SendResultItem {
+  convocationId: string;
+  recipientName: string;
+  method: string;
+  success: boolean;
+  trackingNumber?: string;
+  error?: string;
 }
 
 const DELIVERY_METHODS = [
@@ -63,16 +72,30 @@ export function SendConvocationsDialog({
   const { toast } = useToast();
   const isSubmittingRef = useRef(false);
   const [submitting, setSubmitting] = useState(false);
+  const [step, setStep] = useState<"form" | "sending" | "results">("form");
+  const [sendResults, setSendResults] = useState<SendResultItem[]>([]);
+  const [sendSummary, setSendSummary] = useState({ total: 0, sent: 0, failed: 0 });
 
   const [form, setForm] = useState({
-    delivery_method: "lre_numerique",
+    delivery_method: "email",
     convocation_document_url: "",
     ordre_du_jour_document_url: "",
   });
 
+  const needsDocument = ["lrar", "lre_numerique", "postal_recommande", "postal_simple"].includes(form.delivery_method);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isSubmittingRef.current) return;
+
+    if (needsDocument && !form.convocation_document_url.trim()) {
+      toast({
+        title: "Document requis",
+        description: "Un PDF de convocation est obligatoire pour l'envoi postal ou recommandé.",
+        variant: "destructive",
+      });
+      return;
+    }
 
     if (
       !confirm(
@@ -84,36 +107,68 @@ export function SendConvocationsDialog({
 
     isSubmittingRef.current = true;
     setSubmitting(true);
+    setStep("sending");
 
     try {
-      const payload: Record<string, any> = {
+      // Étape 1 : Créer les convocations en base (status='pending')
+      const createPayload: Record<string, any> = {
         delivery_method: form.delivery_method,
       };
 
       if (form.convocation_document_url.trim()) {
-        payload.convocation_document_url = form.convocation_document_url.trim();
+        createPayload.convocation_document_url = form.convocation_document_url.trim();
       }
       if (form.ordre_du_jour_document_url.trim()) {
-        payload.ordre_du_jour_document_url = form.ordre_du_jour_document_url.trim();
+        createPayload.ordre_du_jour_document_url = form.ordre_du_jour_document_url.trim();
       }
 
-      const res = await fetch(`/api/copro/assemblies/${assemblyId}/convocations`, {
+      const createRes = await fetch(`/api/copro/assemblies/${assemblyId}/convocations`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(createPayload),
       });
 
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.error || "Erreur lors de l'envoi");
+      if (!createRes.ok) {
+        const err = await createRes.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la création des convocations");
       }
 
-      const data = await res.json();
+      const createData = await createRes.json();
+      const convocationIds = (createData.convocations || []).map((c: any) => c.id);
 
-      toast({
-        title: "Convocations créées",
-        description: `${data.count} convocation(s) en attente d'envoi. L'assemblée est convoquée.`,
+      if (convocationIds.length === 0) {
+        throw new Error("Aucune convocation créée");
+      }
+
+      // Étape 2 : Dispatcher les convocations (envoi réel)
+      const sendRes = await fetch(`/api/copro/assemblies/${assemblyId}/send-convocations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ convocationIds }),
       });
+
+      if (!sendRes.ok) {
+        const err = await sendRes.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de l'envoi des convocations");
+      }
+
+      const sendData = await sendRes.json();
+      setSendResults(sendData.results || []);
+      setSendSummary({ total: sendData.total, sent: sendData.sent, failed: sendData.failed });
+      setStep("results");
+
+      if (sendData.failed === 0) {
+        toast({
+          title: "Convocations envoyées",
+          description: `${sendData.sent} convocation(s) envoyée(s) avec succès.`,
+        });
+      } else {
+        toast({
+          title: "Envoi partiel",
+          description: `${sendData.sent} envoyée(s), ${sendData.failed} en échec.`,
+          variant: "destructive",
+        });
+      }
 
       onSent();
     } catch (error) {
@@ -122,6 +177,7 @@ export function SendConvocationsDialog({
         description: error instanceof Error ? error.message : "Impossible d'envoyer les convocations",
         variant: "destructive",
       });
+      setStep("form");
     } finally {
       setSubmitting(false);
       isSubmittingRef.current = false;
@@ -130,104 +186,181 @@ export function SendConvocationsDialog({
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-xl bg-slate-900 border-white/10 text-white">
+      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto bg-slate-900 border-white/10 text-white">
         <DialogHeader>
           <DialogTitle className="text-xl flex items-center gap-2">
             <Send className="h-5 w-5 text-blue-400" />
             Envoyer les convocations
           </DialogTitle>
           <DialogDescription className="text-slate-400">
-            Les convocations seront créées pour tous les lots actifs du site et prêtes à être envoyées.
+            {step === "results"
+              ? "Résultat de l'envoi des convocations"
+              : "Les convocations seront envoyées à tous les copropriétaires du site."}
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="rounded-xl border border-amber-400/30 bg-amber-500/10 p-3 text-sm text-amber-100 flex items-start gap-3">
-            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-            <p>
-              Loi du 10 juillet 1965 : les convocations doivent être envoyées au moins{" "}
-              <strong>21 jours</strong> avant la date de l'assemblée (sauf urgence justifiée).
-            </p>
+        {step === "sending" && (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="h-10 w-10 animate-spin text-blue-400" />
+            <p className="text-slate-300">Envoi des convocations en cours...</p>
           </div>
+        )}
 
-          <div className="space-y-2">
-            <Label className="text-slate-300">Mode d'envoi *</Label>
-            <Select
-              value={form.delivery_method}
-              onValueChange={(value) => setForm({ ...form, delivery_method: value })}
-              disabled={submitting}
-            >
-              <SelectTrigger className="bg-white/5 border-white/10 text-white">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {DELIVERY_METHODS.map((method) => (
-                  <SelectItem key={method.value} value={method.value}>
-                    <div>
-                      <div className="font-medium">{method.label}</div>
-                      <div className="text-xs text-slate-500">{method.description}</div>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+        {step === "results" && (
+          <div className="space-y-3">
+            <div className="flex gap-3 text-sm">
+              <span className="px-2 py-1 rounded bg-emerald-500/20 text-emerald-300">
+                {sendSummary.sent} envoyée{sendSummary.sent > 1 ? "s" : ""}
+              </span>
+              {sendSummary.failed > 0 && (
+                <span className="px-2 py-1 rounded bg-red-500/20 text-red-300">
+                  {sendSummary.failed} en échec
+                </span>
+              )}
+            </div>
+            <div className="max-h-60 overflow-y-auto space-y-2">
+              {sendResults.map((r) => (
+                <div
+                  key={r.convocationId}
+                  className="flex items-start gap-2 p-2 rounded-lg bg-white/5 text-sm"
+                >
+                  {r.success ? (
+                    <CheckCircle2 className="h-4 w-4 mt-0.5 text-emerald-400 shrink-0" />
+                  ) : (
+                    <XCircle className="h-4 w-4 mt-0.5 text-red-400 shrink-0" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium truncate">{r.recipientName}</p>
+                    {r.success && r.trackingNumber && (
+                      <p className="text-xs text-slate-400 mt-0.5">
+                        N° suivi : {r.trackingNumber}
+                      </p>
+                    )}
+                    {!r.success && r.error && (
+                      <p className="text-xs text-red-400 mt-0.5">{r.error}</p>
+                    )}
+                  </div>
+                  <span className="text-xs text-slate-500 shrink-0">
+                    {r.method === "email" ? "Email" : r.method === "hand_delivered" ? "Main propre" : "LRAR"}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
+        )}
 
-          <div className="space-y-2">
-            <Label className="text-slate-300">URL du document convocation (optionnel)</Label>
-            <input
-              type="url"
-              placeholder="https://..."
-              value={form.convocation_document_url}
-              onChange={(e) => setForm({ ...form, convocation_document_url: e.target.value })}
-              disabled={submitting}
-              className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-400/50"
-            />
-            <p className="text-xs text-slate-500">PDF de la convocation (sera attaché aux envois)</p>
-          </div>
+        {step === "form" && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="rounded-xl border border-amber-400/30 bg-amber-500/10 p-3 text-sm text-amber-100 flex items-start gap-3">
+              <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+              <p>
+                Loi du 10 juillet 1965 : les convocations doivent être envoyées au moins{" "}
+                <strong>21 jours</strong> avant la date de l'assemblée (sauf urgence justifiée).
+              </p>
+            </div>
 
-          <div className="space-y-2">
-            <Label className="text-slate-300">URL de l'ordre du jour (optionnel)</Label>
-            <input
-              type="url"
-              placeholder="https://..."
-              value={form.ordre_du_jour_document_url}
-              onChange={(e) => setForm({ ...form, ordre_du_jour_document_url: e.target.value })}
-              disabled={submitting}
-              className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-400/50"
-            />
-            <p className="text-xs text-slate-500">PDF de l'ordre du jour avec les résolutions</p>
-          </div>
+            <div className="space-y-2">
+              <Label className="text-slate-300">Mode d'envoi *</Label>
+              <Select
+                value={form.delivery_method}
+                onValueChange={(value) => setForm({ ...form, delivery_method: value })}
+                disabled={submitting}
+              >
+                <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DELIVERY_METHODS.map((method) => (
+                    <SelectItem key={method.value} value={method.value}>
+                      <div>
+                        <div className="font-medium">{method.label}</div>
+                        <div className="text-xs text-slate-500">{method.description}</div>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
 
+            {needsDocument && (
+              <div className="space-y-2">
+                <Label className="text-slate-300">URL du document convocation (PDF) *</Label>
+                <input
+                  type="url"
+                  placeholder="https://..."
+                  value={form.convocation_document_url}
+                  onChange={(e) => setForm({ ...form, convocation_document_url: e.target.value })}
+                  disabled={submitting}
+                  required={needsDocument}
+                  className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-400/50"
+                />
+                <p className="text-xs text-slate-500">PDF de la convocation qui sera envoyé par courrier</p>
+              </div>
+            )}
+
+            {!needsDocument && (
+              <div className="rounded-lg border border-blue-400/20 bg-blue-500/10 p-3 text-sm text-blue-200 flex items-start gap-3">
+                <Mail className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <p>
+                  La convocation sera envoyée par email avec l'ordre du jour et un lien vers l'espace copropriétaire.
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label className="text-slate-300">URL de l'ordre du jour (optionnel)</Label>
+              <input
+                type="url"
+                placeholder="https://..."
+                value={form.ordre_du_jour_document_url}
+                onChange={(e) => setForm({ ...form, ordre_du_jour_document_url: e.target.value })}
+                disabled={submitting}
+                className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-400/50"
+              />
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={submitting}
+                className="border-white/20 text-white hover:bg-white/10"
+              >
+                Annuler
+              </Button>
+              <Button
+                type="submit"
+                disabled={submitting}
+                className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700"
+              >
+                {submitting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Envoi...
+                  </>
+                ) : (
+                  <>
+                    <Send className="h-4 w-4 mr-2" />
+                    Envoyer les convocations
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+
+        {step === "results" && (
           <DialogFooter>
             <Button
-              type="button"
               variant="outline"
               onClick={onClose}
-              disabled={submitting}
               className="border-white/20 text-white hover:bg-white/10"
             >
-              Annuler
-            </Button>
-            <Button
-              type="submit"
-              disabled={submitting}
-              className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700"
-            >
-              {submitting ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Envoi...
-                </>
-              ) : (
-                <>
-                  <Send className="h-4 w-4 mr-2" />
-                  Envoyer les convocations
-                </>
-              )}
+              Fermer
             </Button>
           </DialogFooter>
-        </form>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/syndic/settings/connect/page.tsx
+++ b/app/syndic/settings/connect/page.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Building2,
+  CreditCard,
+  ExternalLink,
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+import { ProtectedRoute } from "@/components/protected-route";
+
+interface CoproSite {
+  id: string;
+  name: string;
+  city: string;
+  entity_id: string | null;
+}
+
+interface ConnectStatus {
+  siteId: string;
+  entityId: string | null;
+  hasAccount: boolean;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+  bankLast4?: string;
+  loading: boolean;
+}
+
+export default function SyndicConnectSettingsPage() {
+  const { toast } = useToast();
+  const [sites, setSites] = useState<CoproSite[]>([]);
+  const [connectStatuses, setConnectStatuses] = useState<Map<string, ConnectStatus>>(new Map());
+  const [loadingSites, setLoadingSites] = useState(true);
+  const [onboardingEntityId, setOnboardingEntityId] = useState<string | null>(null);
+
+  // Charger les sites du syndic
+  useEffect(() => {
+    async function loadSites() {
+      try {
+        const res = await fetch("/api/copro/sites", { credentials: "include" });
+        if (!res.ok) return;
+        const data = await res.json();
+        const siteList = (data.sites || data || []).map((s: any) => ({
+          id: s.id,
+          name: s.name || "Copropriété sans nom",
+          city: s.city || "",
+          entity_id: s.legal_entity_id || s.entity_id || null,
+        }));
+        setSites(siteList);
+      } catch {
+        // silently fail
+      } finally {
+        setLoadingSites(false);
+      }
+    }
+    loadSites();
+  }, []);
+
+  // Charger le statut Connect pour chaque entité
+  const loadConnectStatus = useCallback(
+    async (site: CoproSite) => {
+      const key = site.entity_id || "personal";
+      setConnectStatuses((prev) => {
+        const next = new Map(prev);
+        next.set(key, {
+          siteId: site.id,
+          entityId: site.entity_id,
+          hasAccount: false,
+          chargesEnabled: false,
+          payoutsEnabled: false,
+          detailsSubmitted: false,
+          loading: true,
+        });
+        return next;
+      });
+
+      try {
+        const params = site.entity_id ? `?entityId=${site.entity_id}` : "";
+        const res = await fetch(`/api/stripe/connect${params}`, { credentials: "include" });
+        if (!res.ok) return;
+        const data = await res.json();
+
+        setConnectStatuses((prev) => {
+          const next = new Map(prev);
+          next.set(key, {
+            siteId: site.id,
+            entityId: site.entity_id,
+            hasAccount: data.has_account || false,
+            chargesEnabled: data.account?.charges_enabled || false,
+            payoutsEnabled: data.account?.payouts_enabled || false,
+            detailsSubmitted: data.account?.details_submitted || false,
+            bankLast4: data.account?.bank_account_last4 || undefined,
+            loading: false,
+          });
+          return next;
+        });
+      } catch {
+        setConnectStatuses((prev) => {
+          const next = new Map(prev);
+          const existing = next.get(key);
+          if (existing) next.set(key, { ...existing, loading: false });
+          return next;
+        });
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (sites.length > 0) {
+      // Dédupliquer par entity_id (plusieurs sites peuvent partager une entité)
+      const seen = new Set<string>();
+      for (const site of sites) {
+        const key = site.entity_id || "personal";
+        if (!seen.has(key)) {
+          seen.add(key);
+          loadConnectStatus(site);
+        }
+      }
+    }
+  }, [sites, loadConnectStatus]);
+
+  const handleOnboard = async (entityId: string | null) => {
+    setOnboardingEntityId(entityId);
+    try {
+      const res = await fetch("/api/stripe/connect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entityId }),
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur lors de la configuration");
+      }
+
+      const data = await res.json();
+      if (data.onboarding_url) {
+        window.location.href = data.onboarding_url;
+      }
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de configurer le compte",
+        variant: "destructive",
+      });
+      setOnboardingEntityId(null);
+    }
+  };
+
+  const handleDashboard = async (entityId: string | null) => {
+    try {
+      const res = await fetch("/api/stripe/connect/dashboard", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entityId }),
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Erreur");
+      }
+
+      const data = await res.json();
+      if (data.dashboard_url) {
+        window.open(data.dashboard_url, "_blank");
+      }
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible d'ouvrir le tableau de bord",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const getStatusBadge = (status: ConnectStatus) => {
+    if (status.loading) return <Skeleton className="h-5 w-20" />;
+    if (!status.hasAccount) {
+      return <Badge variant="outline" className="text-slate-400 border-slate-700">Non connecté</Badge>;
+    }
+    if (status.chargesEnabled && status.payoutsEnabled) {
+      return <Badge className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30">Connecté</Badge>;
+    }
+    return <Badge className="bg-amber-500/20 text-amber-400 border-amber-500/30">En cours</Badge>;
+  };
+
+  return (
+    <ProtectedRoute allowedRoles={["syndic", "admin"]}>
+      <div className="container mx-auto px-4 py-6 max-w-3xl">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-foreground">Comptes bancaires</h1>
+          <p className="text-muted-foreground mt-1">
+            Configurez un compte bancaire par copropriété pour recevoir les appels de fonds.
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-blue-400/20 bg-blue-500/10 p-4 mb-6 text-sm text-blue-200 flex items-start gap-3">
+          <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <p>
+            <strong>Obligation légale :</strong> chaque copropriété doit disposer d'un compte bancaire
+            séparé au nom du syndicat des copropriétaires (loi ALUR, art. 18 loi du 10 juillet 1965).
+          </p>
+        </div>
+
+        {loadingSites ? (
+          <div className="space-y-4">
+            {[1, 2].map((i) => (
+              <Card key={i} className="bg-card border-border">
+                <CardHeader>
+                  <Skeleton className="h-5 w-48" />
+                  <Skeleton className="h-4 w-32 mt-1" />
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+        ) : sites.length === 0 ? (
+          <Card className="bg-card border-border">
+            <CardContent className="py-8 text-center text-muted-foreground">
+              <Building2 className="h-10 w-10 mx-auto mb-3 opacity-50" />
+              <p>Aucune copropriété trouvée. Créez un site depuis l'onboarding syndic.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {sites.map((site) => {
+              const key = site.entity_id || "personal";
+              const status = connectStatuses.get(key);
+              const isOnboarding = onboardingEntityId === site.entity_id;
+              const isConnected = status?.chargesEnabled && status?.payoutsEnabled;
+              const isPending = status?.hasAccount && !isConnected;
+
+              return (
+                <Card key={site.id} className="bg-card border-border">
+                  <CardHeader className="pb-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <CardTitle className="text-base flex items-center gap-2">
+                          <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <span className="truncate">{site.name}</span>
+                        </CardTitle>
+                        {site.city && (
+                          <CardDescription className="mt-0.5">{site.city}</CardDescription>
+                        )}
+                      </div>
+                      {status && getStatusBadge(status)}
+                    </div>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    {status?.loading ? (
+                      <Skeleton className="h-9 w-full" />
+                    ) : isConnected ? (
+                      <div className="space-y-3">
+                        <div className="flex items-center gap-4 text-sm">
+                          <div className="flex items-center gap-1.5 text-emerald-500">
+                            <CheckCircle2 className="h-3.5 w-3.5" />
+                            <span>Paiements activés</span>
+                          </div>
+                          {status?.bankLast4 && (
+                            <div className="flex items-center gap-1.5 text-muted-foreground">
+                              <CreditCard className="h-3.5 w-3.5" />
+                              <span>•••• {status.bankLast4}</span>
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleDashboard(site.entity_id)}
+                          >
+                            <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+                            Tableau de bord
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => loadConnectStatus(site)}
+                          >
+                            <RefreshCw className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </div>
+                    ) : isPending ? (
+                      <div className="space-y-3">
+                        <p className="text-sm text-amber-400">
+                          La configuration du compte n'est pas terminée. Complétez l'onboarding.
+                        </p>
+                        <Button
+                          size="sm"
+                          onClick={() => handleOnboard(site.entity_id)}
+                          disabled={isOnboarding}
+                          className="bg-gradient-to-r from-blue-500 to-blue-600"
+                        >
+                          {isOnboarding ? (
+                            <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                          ) : (
+                            <CreditCard className="h-4 w-4 mr-1.5" />
+                          )}
+                          Reprendre la configuration
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button
+                        size="sm"
+                        onClick={() => handleOnboard(site.entity_id)}
+                        disabled={isOnboarding}
+                        className="bg-gradient-to-r from-blue-500 to-blue-600"
+                      >
+                        {isOnboarding ? (
+                          <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                        ) : (
+                          <CreditCard className="h-4 w-4 mr-1.5" />
+                        )}
+                        Connecter un compte bancaire
+                      </Button>
+                    )}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const { withSentryConfig } = require('@sentry/nextjs');
+
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
@@ -281,4 +283,12 @@ const nextConfig = {
   },
 };
 
-module.exports = withBundleAnalyzer(withSerwist(nextConfig));
+module.exports = withSentryConfig(withBundleAnalyzer(withSerwist(nextConfig)), {
+  // Supprime les logs Sentry pendant le build
+  silent: true,
+  // Ne pas uploader les source maps sans SENTRY_AUTH_TOKEN
+  disableServerWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
+  disableClientWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
+  // Masquer les source maps en production
+  hideSourceMaps: true,
+});

--- a/next.config.js
+++ b/next.config.js
@@ -283,12 +283,14 @@ const nextConfig = {
   },
 };
 
-module.exports = withSentryConfig(withBundleAnalyzer(withSerwist(nextConfig)), {
-  // Supprime les logs Sentry pendant le build
-  silent: true,
-  // Ne pas uploader les source maps sans SENTRY_AUTH_TOKEN
-  disableServerWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
-  disableClientWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
-  // Masquer les source maps en production
-  hideSourceMaps: true,
-});
+const baseConfig = withBundleAnalyzer(withSerwist(nextConfig));
+
+// Wrapper Sentry UNIQUEMENT si SENTRY_AUTH_TOKEN est défini.
+// Sans le token, withSentryConfig peut échouer au build sur Netlify
+// (tentative d'upload de source maps sans credentials).
+module.exports = process.env.SENTRY_AUTH_TOKEN
+  ? withSentryConfig(baseConfig, {
+      silent: true,
+      hideSourceMaps: true,
+    })
+  : baseConfig;


### PR DESCRIPTION
## Summary

- **5 UI bugs Mes biens** : accents FR, pluriel pièces, routing immeuble table view, surface parking masquée, loyer 0€ → "Non renseigné"
- **Sentry error-boundary** : `global-error.tsx` branché sur `Sentry.captureException` + `withSentryConfig` wrapper dans `next.config.js`
- **LRAR SendConvocationsDialog** : nouvelle route `POST /send-convocations` qui dispatch réellement les convocations (email via Resend, LRAR via Merci Facteur, main propre). Dialog 3 états : formulaire → spinner → résultats par destinataire
- **Stripe Connect multi-entity** : API routes acceptent `entityId` (owner+syndic), nouvelle page `/syndic/settings/connect` avec statut Connect par copropriété

## Test plan

- [ ] Page "Mes biens" : vérifier accents dans la bannière, "1 pièce" singulier, parking sans "? m²", loyer "Non renseigné" si 0
- [ ] Clic immeuble en vue liste → doit naviguer vers `/owner/buildings/{id}` (pas 404)
- [ ] Page d'erreur globale : vérifier que `Sentry.captureException` est appelé (bouton couleur #2563EB)
- [ ] Syndic > Assemblées > Envoyer convocations : sélectionner email, vérifier envoi réel via Resend
- [ ] Syndic > Paramètres > Comptes bancaires : liste des copros avec statut Connect
- [ ] Owner existant sans entityId : Stripe Connect fonctionne comme avant (backward compatible)

https://claude.ai/code/session_011MArZSiDQWgba3Nq7DAGCf