### PR TITLE
Improve lease preview error handling and DDT compliance logic

### DIFF
--- a/app/tenant/lease/page.tsx
+++ b/app/tenant/lease/page.tsx
@@ -164,6 +164,30 @@ export default function TenantLeasePage() {
   const isSent = lease.statut === 'sent';
   const isPropertyDeleted = !!(property as { deleted_at?: string; etat?: string } | null)?.deleted_at || (property as { deleted_at?: string; etat?: string } | null)?.etat === 'deleted';
 
+  // Conformité DDT : on accepte deux sources de vérité pour éviter les faux "En attente"
+  //  1. Un document diagnostic lié au bail (type dpe/plomb/electricite/gaz/erp…) — via /api/tenant/lease/[id]/documents
+  //  2. Les champs DPE remplis directement sur la propriété (dpe_classe_energie / dpe_consommation)
+  //     — fréquent car beaucoup de propriétaires saisissent les valeurs sans uploader le PDF
+  const propertyForDdt = property as {
+    dpe_classe_energie?: string | null;
+    dpe_consommation?: number | null;
+    energie?: string | null;
+  } | null;
+  const hasDiagnosticDocs = !!(docs?.diagnostics && docs.diagnostics.length > 0);
+  const hasDpeOnProperty = !!(
+    propertyForDdt?.dpe_classe_energie ||
+    propertyForDdt?.dpe_consommation ||
+    propertyForDdt?.energie
+  );
+  // Pendant le chargement initial des documents on reste neutre ("pending" sans note)
+  // pour ne pas faire clignoter la carte. Une fois chargé, on statue.
+  const ddtStatus: 'success' | 'pending' = (hasDiagnosticDocs || hasDpeOnProperty) ? 'success' : 'pending';
+  const ddtPendingNote: string | undefined = loadingDocs
+    ? undefined
+    : lease.statut === 'active' || lease.statut === 'fully_signed'
+      ? 'Le propriétaire n\'a pas encore partagé les diagnostics'
+      : 'En attente du propriétaire';
+
   if (isPropertyDeleted) {
     return (
       <PageTransition>
@@ -440,7 +464,11 @@ export default function TenantLeasePage() {
                           
                           <div className="space-y-4">
                             <CheckItem label="Contrat de bail signé" status={isFullySigned ? 'success' : 'pending'} />
-                            <CheckItem label="Dossier Diagnostics (DDT)" status={docs?.diagnostics && docs.diagnostics.length > 0 ? 'success' : 'pending'} pendingNote="En attente du propriétaire" />
+                            <CheckItem
+                              label="Dossier Diagnostics (DDT)"
+                              status={ddtStatus}
+                              pendingNote={ddtPendingNote}
+                            />
                             <CheckItem label="Attestation d'assurance" status={dashboard.insurance?.has_insurance ? 'success' : 'pending'} pendingCta={{ href: '/tenant/documents', label: 'Ajoutez votre attestation' }} />
                             <CheckItem label="État des lieux d'entrée" status={((lease as { has_signed_entry_edl?: boolean }).has_signed_entry_edl === true || lease.statut === 'active') ? 'success' : 'pending'} />
                           </div>

--- a/components/documents/LeasePreview.tsx
+++ b/components/documents/LeasePreview.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { FileText, Loader2, Maximize2, RefreshCw } from "lucide-react";
+import { FileText, Loader2, Maximize2, RefreshCw, Download } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -17,6 +17,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
   const [isSealed, setIsSealed] = useState(false);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [iframeFailed, setIframeFailed] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
   const [iframeKey, setIframeKey] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -27,6 +28,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
     try {
       setLoading(true);
       setFetchError(null);
+      setIframeFailed(false);
       const response = await fetch(`/api/leases/${leaseId}/html`);
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
@@ -39,10 +41,17 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
         setPdfUrl(data.pdfUrl);
         setIsSealed(true);
         setHtml("");
-      } else {
-        setHtml(typeof data.html === "string" ? data.html : "");
+      } else if (typeof data.html === "string" && data.html.length > 0) {
+        setHtml(data.html);
         setPdfUrl(null);
         setIsSealed(false);
+      } else {
+        // Ni PDF signé, ni HTML : impossible d'afficher l'aperçu
+        console.error("[LeasePreview] Réponse API vide — ni pdfUrl ni html", { leaseId, data });
+        setHtml("");
+        setPdfUrl(null);
+        setIsSealed(false);
+        setFetchError("Le document n'est pas encore disponible");
       }
       setIframeKey(prev => prev + 1);
     } catch (error) {
@@ -145,7 +154,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
               <Loader2 className="h-6 w-6 sm:h-8 sm:w-8 animate-spin text-blue-600 mb-2" />
               <p className="text-xs sm:text-sm text-white/80 text-center">Chargement du contrat...</p>
             </div>
-          ) : isSealed && pdfUrl ? (
+          ) : isSealed && pdfUrl && !iframeFailed ? (
             <div className="h-full overflow-y-auto flex justify-center py-4 px-2 sm:px-4">
               <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)] flex-shrink-0 h-fit">
                 <iframe
@@ -153,10 +162,14 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
                   className="w-full border-0 bg-white"
                   style={{ height: "calc(297mm * 1.5)" }}
                   title="Bail signé (document définitif)"
+                  onError={() => {
+                    console.error("[LeasePreview] iframe PDF failed to load", { leaseId, pdfUrl });
+                    setIframeFailed(true);
+                  }}
                 />
               </div>
             </div>
-          ) : html ? (
+          ) : html && !iframeFailed ? (
             <div className="h-full overflow-y-auto flex justify-center py-4 px-2 sm:px-4">
               <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)] flex-shrink-0 h-fit">
                 <iframe
@@ -166,28 +179,49 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
                   className="w-full border-0 bg-white"
                   style={{ height: "calc(297mm * 1.5)" }}
                   title="Aperçu du bail"
+                  onError={() => {
+                    console.error("[LeasePreview] iframe HTML failed to load", { leaseId });
+                    setIframeFailed(true);
+                  }}
                 />
               </div>
             </div>
           ) : (
             <div className="absolute inset-0 flex flex-col items-center justify-center px-4 text-center">
-              <FileText className="h-8 w-8 text-white/40" />
-              <p className="text-xs text-white/70 mt-2 font-medium">
-                {fetchError ? "Aperçu indisponible" : "Aucun aperçu disponible"}
+              <FileText className="h-10 w-10 text-white/40" />
+              <p className="text-sm text-white/90 mt-3 font-semibold">
+                Document non disponible
               </p>
-              {fetchError && (
-                <p className="text-[10px] text-white/50 mt-1 max-w-xs font-mono">
-                  {fetchError}
-                </p>
-              )}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={fetchLeaseHtml}
-                className="mt-3 text-white/80 hover:text-white hover:bg-white/10 text-xs h-7"
-              >
-                <RefreshCw className="h-3 w-3 mr-1" /> Réessayer
-              </Button>
+              <p className="text-[11px] text-white/60 mt-1 max-w-xs">
+                {fetchError
+                  ? "L'aperçu du bail n'a pas pu être chargé."
+                  : "L'aperçu n'est pas disponible pour le moment."}
+              </p>
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  asChild
+                  className="h-8 text-xs font-bold"
+                >
+                  <a
+                    href={`/api/leases/${leaseId}/pdf`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Download className="h-3.5 w-3.5 mr-1.5" />
+                    Télécharger le bail
+                  </a>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={fetchLeaseHtml}
+                  className="text-white/80 hover:text-white hover:bg-white/10 text-xs h-8"
+                >
+                  <RefreshCw className="h-3.5 w-3.5 mr-1.5" /> Réessayer
+                </Button>
+              </div>
             </div>
           )}
         </div>

--- a/components/layout/unified-fab.tsx
+++ b/components/layout/unified-fab.tsx
@@ -35,7 +35,19 @@ export function UnifiedFAB({ className }: UnifiedFABProps) {
   const pathname = usePathname();
   const { currentPlan } = useSubscription();
 
+  // Les locataires et garants ne souscrivent pas : aucun upgrade ne doit leur être proposé.
+  // Cela évite que le modal d'upgrade (qui mentionne le prestataire de paiement) s'affiche
+  // dans leur UI — conforme à la règle produit "jamais de branding Stripe côté locataire".
+  const isNonSubscriberRole =
+    pathname?.startsWith("/tenant") ||
+    pathname?.startsWith("/guarantor") ||
+    pathname?.startsWith("/provider");
+
   const getUpgradeTarget = (): { plan: PlanSlug; label: string } | null => {
+    if (isNonSubscriberRole) {
+      return null;
+    }
+
     if (pathname?.startsWith("/owner/providers")) {
       return { plan: "pro", label: `Passer ${PLANS.pro.name}` };
     }

--- a/components/subscription/upgrade-modal.tsx
+++ b/components/subscription/upgrade-modal.tsx
@@ -434,7 +434,7 @@ export function UpgradeModal({ open, onClose, feature, requiredPlan, context }: 
           <div className="text-center text-xs text-slate-500 space-y-1">
             <p>
               {billing === "yearly" && "Économisez jusqu'à 20% avec le paiement annuel — "}
-              1er mois offert — Paiement sécurisé par Stripe
+              1er mois offert — Paiement 100 % sécurisé
             </p>
             <p>
               Prix HT. TVA {TVA_RATE}% en sus.{" "}

--- a/features/billing/components/v2/SepaMandateSetup.tsx
+++ b/features/billing/components/v2/SepaMandateSetup.tsx
@@ -148,7 +148,7 @@ export function SepaMandateSetup({ onSuccess }: SepaMandateSetupProps) {
               <div className="flex items-start gap-2">
                 <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
                 <p>
-                  Le prélèvement est traité par Stripe SEPA Debit pour le compte de la plateforme. Les informations bancaires sont tokenisées et ne transitent pas en clair par l&apos;application.
+                  Le prélèvement automatique est traité de façon sécurisée pour le compte de la plateforme. Les informations bancaires sont tokenisées et ne transitent pas en clair par l&apos;application.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
This PR enhances the lease preview component's robustness and refines the DDT (Dossier de Diagnostics Techniques) compliance status logic for tenants. It also removes Stripe branding from non-subscriber user interfaces to maintain consistent product messaging.

## Key Changes

### LeasePreview Component (`components/documents/LeasePreview.tsx`)
- Added `iframeFailed` state to track iframe loading failures independently from fetch errors
- Improved error handling with `onError` callbacks on both PDF and HTML iframes to gracefully handle load failures
- Enhanced the empty state UI with:
  - Better visual hierarchy and messaging for unavailable documents
  - New "Download lease" button linking to `/api/leases/{leaseId}/pdf` for direct PDF access
  - Improved "Retry" button styling and layout
- Refined API response handling to explicitly check for valid HTML content before rendering
- Added detailed console logging for debugging iframe and API failures

### Tenant Lease Page (`app/tenant/lease/page.tsx`)
- Implemented dual-source DDT compliance verification:
  - Accepts diagnostic documents uploaded via the documents API
  - Also recognizes DPE data filled directly on the property (dpe_classe_energie, dpe_consommation, energie fields)
  - Prevents false "pending" states when property owners enter diagnostic values without uploading PDFs
- Added loading state awareness to prevent UI flickering during initial document fetch
- Improved pending note messaging based on lease status (active/fully_signed vs. other states)

### Subscription & Billing Components
- **UnifiedFAB** (`components/layout/unified-fab.tsx`): Disabled upgrade prompts for non-subscriber roles (tenant, guarantor, provider) to prevent Stripe branding exposure in their UI
- **UpgradeModal** (`components/subscription/upgrade-modal.tsx`): Removed explicit "Stripe" mention, changed to generic "Paiement 100 % sécurisé"
- **SepaMandateSetup** (`features/billing/components/v2/SepaMandateSetup.tsx`): Removed "Stripe SEPA Debit" branding, replaced with generic "Le prélèvement automatique est traité de façon sécurisée"

## Implementation Details
- The lease preview now gracefully degrades when iframes fail to load, showing a helpful empty state with download and retry options
- DDT status is computed dynamically based on both document presence and property field values, improving accuracy for properties with manually entered diagnostic data
- Non-subscriber users no longer see payment provider branding, maintaining a cleaner, more professional UI experience

https://claude.ai/code/session_01HVx4WbC7Ke1WxBjTtgs89H