### PR TITLE
Add defensive validation for cash receipt IDs and handle missing receipt numbers

### DIFF
--- a/app/api/payments/cash-receipt/[id]/pdf/route.ts
+++ b/app/api/payments/cash-receipt/[id]/pdf/route.ts
@@ -19,6 +19,9 @@ import { PDFDocument, PDFImage, StandardFonts, rgb } from "pdf-lib";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function sanitizeText(input: string | null | undefined): string {
   // pdf-lib/WinAnsi ne supporte pas tous les caractères unicode (emoji, etc.)
   // On strip les non-printables et on garde les caractères latin-1.
@@ -78,6 +81,16 @@ export async function GET(
 ) {
   try {
     const { id: receiptId } = await params;
+
+    // Filet défensif : un id non-UUID (ex. "undefined") ferait échouer
+    // la requête Postgres (22P02) et remonterait en 500. On retourne un
+    // 404 clair et on évite une trace d'erreur inutile.
+    if (!receiptId || !UUID_REGEX.test(receiptId)) {
+      return NextResponse.json(
+        { error: "Identifiant de reçu invalide" },
+        { status: 404 }
+      );
+    }
 
     const supabase = await createClient();
     const {

--- a/app/api/payments/cash-receipt/[id]/route.ts
+++ b/app/api/payments/cash-receipt/[id]/route.ts
@@ -11,12 +11,25 @@ import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const { id } = await params;
+
+    // Filet défensif : un id non-UUID (ex. "undefined" suite à un bug côté
+    // client) ferait remonter une erreur Postgres 22P02 qui serait ensuite
+    // encapsulée en 500. On retourne un 404 clair à la place.
+    if (!id || !UUID_REGEX.test(id)) {
+      return NextResponse.json(
+        { error: "Identifiant de reçu invalide" },
+        { status: 404 }
+      );
+    }
 
     const supabase = await createClient();
     const {

--- a/app/api/payments/cash-receipt/[id]/tenant-sign/route.ts
+++ b/app/api/payments/cash-receipt/[id]/tenant-sign/route.ts
@@ -13,12 +13,24 @@ import { NextResponse } from "next/server";
 import { cashReceiptTenantSignatureSchema } from "@/lib/validations";
 import { sendPushNotification } from "@/lib/push/send";
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const { id: receiptId } = await params;
+
+    // Filet défensif : un id non-UUID produirait une erreur Postgres 22P02
+    // encapsulée en 500. On retourne un 404 clair à la place.
+    if (!receiptId || !UUID_REGEX.test(receiptId)) {
+      return NextResponse.json(
+        { error: "Identifiant de reçu invalide" },
+        { status: 404 }
+      );
+    }
 
     const supabase = await createClient();
     const {

--- a/app/tenant/payments/TenantPaymentsClient.tsx
+++ b/app/tenant/payments/TenantPaymentsClient.tsx
@@ -300,50 +300,63 @@ export function TenantPaymentsClient({
         )}
 
         {/* Reçus espèces en attente de contresignature — SOTA 2026 */}
-        {pendingCashReceipts.length > 0 && (
+        {pendingCashReceipts.filter((cr) => !!cr.id).length > 0 && (
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.02 }}
             className="space-y-3"
           >
-            {pendingCashReceipts.map((cr) => (
-              <GlassCard
-                key={cr.id}
-                className="p-5 border-amber-200 dark:border-amber-900/50 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-950/30 dark:to-orange-950/30 shadow-lg"
-              >
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                  <div className="flex items-start gap-4">
-                    <div className="h-12 w-12 rounded-2xl bg-amber-600 flex items-center justify-center text-white shadow-md shrink-0">
-                      <Banknote className="h-6 w-6" />
-                    </div>
-                    <div>
-                      <p className="text-xs font-bold text-amber-700 dark:text-amber-400 uppercase tracking-widest mb-1">
-                        Signature requise — Reçu espèces
-                      </p>
-                      <p className="text-lg font-black text-foreground">
-                        {formatCurrency(cr.amount)} · {cr.owner_name}
-                      </p>
-                      <p className="text-sm text-muted-foreground mt-0.5">
-                        {cr.periode ? `Période ${cr.periode}` : "Paiement en espèces"}
-                        {cr.property_address ? ` · ${cr.property_address}` : ""}
-                      </p>
-                      <p className="text-xs text-muted-foreground/80 mt-1">
-                        Référence : {cr.receipt_number}
-                      </p>
-                    </div>
-                  </div>
-                  <Button
-                    asChild
-                    className="rounded-xl font-bold bg-amber-600 hover:bg-amber-700 shrink-0"
+            {pendingCashReceipts
+              .filter((cr) => !!cr.id)
+              .map((cr) => {
+                // Référence affichée : numéro REC-YYYY-MM-XXXX si présent,
+                // sinon fallback sur les 8 premiers caractères de l'id
+                // (évite un "Référence : " vide si le trigger DB n'a pas
+                // généré le numéro).
+                const referenceLabel =
+                  cr.receipt_number && cr.receipt_number.length > 0
+                    ? cr.receipt_number
+                    : cr.id.slice(0, 8).toUpperCase();
+
+                return (
+                  <GlassCard
+                    key={cr.id}
+                    className="p-5 border-amber-200 dark:border-amber-900/50 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-950/30 dark:to-orange-950/30 shadow-lg"
                   >
-                    <Link href={`/tenant/payments/cash-receipt/${cr.id}`}>
-                      <PenLine className="mr-2 h-4 w-4" /> Signer le reçu
-                    </Link>
-                  </Button>
-                </div>
-              </GlassCard>
-            ))}
+                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                      <div className="flex items-start gap-4">
+                        <div className="h-12 w-12 rounded-2xl bg-amber-600 flex items-center justify-center text-white shadow-md shrink-0">
+                          <Banknote className="h-6 w-6" />
+                        </div>
+                        <div>
+                          <p className="text-xs font-bold text-amber-700 dark:text-amber-400 uppercase tracking-widest mb-1">
+                            Signature requise — Reçu espèces
+                          </p>
+                          <p className="text-lg font-black text-foreground">
+                            {formatCurrency(cr.amount)} · {cr.owner_name}
+                          </p>
+                          <p className="text-sm text-muted-foreground mt-0.5">
+                            {cr.periode ? `Période ${cr.periode}` : "Paiement en espèces"}
+                            {cr.property_address ? ` · ${cr.property_address}` : ""}
+                          </p>
+                          <p className="text-xs text-muted-foreground/80 mt-1">
+                            Référence : {referenceLabel}
+                          </p>
+                        </div>
+                      </div>
+                      <Button
+                        asChild
+                        className="rounded-xl font-bold bg-amber-600 hover:bg-amber-700 shrink-0"
+                      >
+                        <Link href={`/tenant/payments/cash-receipt/${cr.id}`}>
+                          <PenLine className="mr-2 h-4 w-4" /> Signer le reçu
+                        </Link>
+                      </Button>
+                    </div>
+                  </GlassCard>
+                );
+              })}
           </motion.div>
         )}
 

--- a/app/tenant/payments/cash-receipt/[id]/page.tsx
+++ b/app/tenant/payments/cash-receipt/[id]/page.tsx
@@ -6,12 +6,22 @@ import { TenantCashReceiptSignatureClient } from "./TenantCashReceiptSignatureCl
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
 export default async function TenantCashReceiptSignaturePage({ params }: PageProps) {
   const { id } = await params;
+
+  // Filet défensif : un id non-UUID (ex. "undefined" propagé depuis une URL
+  // malformée) produirait une erreur Postgres 22P02 sur le .eq("id", id)
+  // ci-dessous, remontée en 500 par Next. On retourne un 404 propre.
+  if (!id || !UUID_REGEX.test(id)) {
+    notFound();
+  }
 
   const supabase = await createClient();
   const {
@@ -69,11 +79,18 @@ export default async function TenantCashReceiptSignaturePage({ params }: PagePro
 
   const ownerName = `${receiptAny.owner?.prenom ?? ""} ${receiptAny.owner?.nom ?? ""}`.trim() || "Propriétaire";
   const tenantName = `${profile.prenom ?? ""} ${profile.nom ?? ""}`.trim() || "Locataire";
+  // Fallback si le trigger DB n'a pas (encore) généré de receipt_number —
+  // on retombe sur les 8 premiers caractères de l'id pour éviter une
+  // référence vide dans l'UI et dans le nom de fichier du PDF.
+  const displayReceiptNumber: string =
+    typeof receiptAny.receipt_number === "string" && receiptAny.receipt_number.length > 0
+      ? receiptAny.receipt_number
+      : String(receiptAny.id).slice(0, 8).toUpperCase();
 
   return (
     <TenantCashReceiptSignatureClient
       receiptId={receiptAny.id}
-      receiptNumber={receiptAny.receipt_number}
+      receiptNumber={displayReceiptNumber}
       amount={Number(receiptAny.amount)}
       amountWords={receiptAny.amount_words}
       periode={receiptAny.periode}

--- a/features/billing/server/data-fetching.ts
+++ b/features/billing/server/data-fetching.ts
@@ -3,7 +3,12 @@ import { getServiceClient } from "@/lib/supabase/service-client";
 
 export interface TenantPendingCashReceipt {
   id: string;
-  receipt_number: string;
+  /**
+   * Numéro "REC-YYYY-MM-XXXX" auto-généré par trigger côté DB.
+   * Peut être null si le trigger n'a pas encore été (re)déployé —
+   * l'UI retombe alors sur les 8 premiers caractères de l'id.
+   */
+  receipt_number: string | null;
   amount: number;
   periode: string | null;
   owner_signed_at: string | null;
@@ -43,16 +48,21 @@ export async function getTenantPendingCashReceipts(): Promise<TenantPendingCashR
 
   if (error || !data) return [];
 
-  return data.map((r: any) => ({
-    id: r.id,
-    receipt_number: r.receipt_number,
-    amount: Number(r.amount),
-    periode: r.periode,
-    owner_signed_at: r.owner_signed_at,
-    created_at: r.created_at,
-    property_address: r.property?.adresse_complete ?? null,
-    owner_name: `${r.owner?.prenom ?? ""} ${r.owner?.nom ?? ""}`.trim() || "Propriétaire",
-  }));
+  // Filet défensif : on écarte toute ligne sans id pour éviter des CTA
+  // pointant vers /tenant/payments/cash-receipt/undefined et des 500 en
+  // cascade sur les routes API correspondantes.
+  return data
+    .filter((r: any) => typeof r?.id === "string" && r.id.length > 0)
+    .map((r: any) => ({
+      id: r.id,
+      receipt_number: r.receipt_number ?? null,
+      amount: Number(r.amount),
+      periode: r.periode,
+      owner_signed_at: r.owner_signed_at,
+      created_at: r.created_at,
+      property_address: r.property?.adresse_complete ?? null,
+      owner_name: `${r.owner?.prenom ?? ""} ${r.owner?.nom ?? ""}`.trim() || "Propriétaire",
+    }));
 }
 
 export async function getOwnerInvoices(limit = 50) {


### PR DESCRIPTION
## Summary
This PR adds defensive validation for cash receipt identifiers across the application and improves handling of missing receipt numbers that may occur when database triggers haven't been deployed yet.

## Key Changes

- **UUID validation on API routes**: Added UUID regex validation to `/api/payments/cash-receipt/[id]/*` routes to prevent Postgres errors (22P02) when invalid IDs are passed, returning clean 404 responses instead of 500 errors
  - Applied to: `route.ts`, `pdf/route.ts`, and `tenant-sign/route.ts`

- **UUID validation on page routes**: Added UUID validation to the cash receipt signature page to catch malformed IDs early and return proper 404 responses

- **Nullable receipt_number handling**: Updated `TenantPendingCashReceipt` interface to allow `receipt_number` to be `null`, reflecting that the database trigger may not have generated it yet

- **Fallback reference display**: Implemented fallback logic to display the first 8 characters of the receipt ID (uppercase) when `receipt_number` is missing or empty, preventing empty "Référence:" labels in the UI

- **Data fetching safety**: Added defensive filtering in `getTenantPendingCashReceipts()` to exclude records without valid IDs before mapping, preventing undefined values from propagating to the UI

- **UI filtering**: Updated the pending cash receipts list rendering to filter out records without IDs before display and mapping

## Implementation Details

- UUID regex pattern: `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`
- Fallback reference uses `id.slice(0, 8).toUpperCase()` for consistency across UI and PDF generation
- All defensive checks include explanatory comments about the rationale (database trigger deployment timing, preventing cascading 500 errors)

https://claude.ai/code/session_01UDvY2n2ua4UhoWdfZhyihK