### PR TITLE
Replace component-based logos with horizontal PNG assets

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,9 +12,8 @@ export default function NotFound() {
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 p-4">
       <div className="text-center max-w-md">
         {/* Logo */}
-        <Link href="/" className="inline-flex items-center gap-2 mb-8">
-          <img src="/images/talok-icon.png" alt="TALOK" className="h-8 w-8 rounded-lg object-contain" />
-          <span className="text-lg font-bold text-slate-900 dark:text-white font-display">TALOK</span>
+        <Link href="/" className="inline-flex items-center mb-8">
+          <img src="/images/talok-logo-horizontal.png" alt="TALOK" className="h-10 w-auto object-contain" />
         </Link>
 
         {/* 404 Illustration */}

--- a/components/layout/core-shell-header.tsx
+++ b/components/layout/core-shell-header.tsx
@@ -48,9 +48,11 @@ export function CoreShellHeader({
             </Button>
           ) : null}
 
-          <span className="font-bold text-lg bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent md:hidden">
-            {mobileBrand}
-          </span>
+          <img
+            src="/images/talok-logo-horizontal.png"
+            alt={mobileBrand}
+            className="h-8 w-auto object-contain md:hidden"
+          />
 
           <div className="hidden min-w-0 md:block">
             <div className="flex items-center gap-2">

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -496,13 +496,12 @@ export function Navbar() {
           <div className="container mx-auto px-4">
             <div className="flex h-16 items-center justify-between">
               <div className="flex items-center gap-6">
-                <div className="flex items-center gap-2">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-                    <Building2 className="h-5 w-5" />
-                  </div>
-                  <span className="text-xl font-bold hidden sm:inline-block">
-                    Talok
-                  </span>
+                <div className="flex items-center">
+                  <img
+                    src="/images/talok-logo-horizontal.png"
+                    alt="TALOK"
+                    className="h-10 w-auto object-contain"
+                  />
                 </div>
               </div>
               <div className="flex items-center gap-3">
@@ -530,13 +529,12 @@ export function Navbar() {
           <div className="flex h-16 items-center justify-between">
             {/* Logo & Brand */}
             <div className="flex items-center gap-6">
-              <Link href={user ? "/dashboard" : "/"} className="flex items-center gap-2">
-                <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-                  <Building2 className="h-5 w-5" />
-                </div>
-                <span className="text-xl font-extrabold tracking-tight hidden sm:inline-block" style={{ color: "#1B2A6B" }}>
-                  TALOK
-                </span>
+              <Link href={user ? "/dashboard" : "/"} className="flex items-center">
+                <img
+                  src="/images/talok-logo-horizontal.png"
+                  alt="TALOK"
+                  className="h-10 w-auto object-contain"
+                />
               </Link>
 
               {/* Desktop Navigation - Authenticated */}

--- a/components/layout/owner-app-layout.tsx
+++ b/components/layout/owner-app-layout.tsx
@@ -189,9 +189,11 @@ export function OwnerAppLayout({ children, profile: serverProfile }: OwnerAppLay
         >
           {/* Logo compact */}
           <div className="flex h-14 shrink-0 items-center justify-center border-b border-border">
-            <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-600 to-indigo-600 flex items-center justify-center">
-              <Building2 className="h-5 w-5 text-white" />
-            </div>
+            <img
+              src="/images/talok-icon.png"
+              alt="TALOK"
+              className="h-8 w-8 rounded-lg object-contain"
+            />
           </div>
 
           {/* Navigation icônes avec tooltips, groupées */}
@@ -263,14 +265,15 @@ export function OwnerAppLayout({ children, profile: serverProfile }: OwnerAppLay
           className="hidden lg:fixed lg:inset-y-0 lg:z-40 lg:flex lg:w-64 xl:w-72 lg:flex-col"
         >
           <div className="flex grow flex-col gap-y-4 lg:gap-y-5 overflow-y-auto bg-card border-r border-border px-4 lg:px-6 pb-4">
-            <div className="flex h-16 shrink-0 items-center gap-2">
-              <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-600 to-indigo-600 flex items-center justify-center">
-                <Building2 className="h-5 w-5 text-white" />
-              </div>
-              <div>
-                <h1 className="text-lg font-bold text-foreground">Talok</h1>
-                <p className="text-xs text-muted-foreground">Compte Propriétaire</p>
-              </div>
+            <div className="flex h-16 shrink-0 items-center gap-3">
+              <img
+                src="/images/talok-logo-horizontal.png"
+                alt="TALOK"
+                className="h-9 w-auto object-contain"
+              />
+              <p className="text-xs text-muted-foreground border-l border-border pl-3">
+                Compte<br />Propriétaire
+              </p>
             </div>
 
             {/* Company Switcher */}

--- a/components/layout/public-footer.tsx
+++ b/components/layout/public-footer.tsx
@@ -68,13 +68,8 @@ export function PublicFooter({
         <div className="container mx-auto px-4">
           <div className="flex flex-col md:flex-row items-center justify-between gap-4">
             {/* Logo */}
-            <div className="flex items-center gap-2">
-              <img src="/images/talok-icon.png" alt="TALOK" className="h-8 w-8 rounded-lg object-contain" />
-              <span
-                className={`font-bold ${isDark ? "text-white" : "text-slate-900"}`}
-              >
-                TALOK
-              </span>
+            <div className="flex items-center">
+              <img src="/images/talok-logo-horizontal.png" alt="TALOK" className="h-8 w-auto object-contain" />
             </div>
 
             {/* Links */}
@@ -131,13 +126,8 @@ export function PublicFooter({
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-12">
           {/* Brand Column */}
           <div className="col-span-2 md:col-span-1">
-            <div className="flex items-center gap-2 mb-4">
-              <img src="/images/talok-icon.png" alt="TALOK" className="h-10 w-10 rounded-xl object-contain" />
-              <span
-                className={`text-xl font-bold ${isDark ? "text-white" : "text-slate-900"}`}
-              >
-                TALOK
-              </span>
+            <div className="flex items-center mb-4">
+              <img src="/images/talok-logo-horizontal.png" alt="TALOK" className="h-10 w-auto object-contain" />
             </div>
             <p
               className={`text-sm mb-4 ${isDark ? "text-slate-400" : "text-slate-600"}`}

--- a/components/layout/tenant-app-layout.tsx
+++ b/components/layout/tenant-app-layout.tsx
@@ -150,9 +150,11 @@ export function TenantAppLayout({ children, profile: serverProfile }: TenantAppL
       >
         {/* Logo compact */}
         <div className="flex h-14 shrink-0 items-center justify-center border-b border-border">
-          <span className="text-lg font-bold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
-            T
-          </span>
+          <img
+            src="/images/talok-icon.png"
+            alt="TALOK"
+            className="h-8 w-8 rounded-lg object-contain"
+          />
         </div>
 
         {/* Navigation icônes avec tooltips */}
@@ -222,9 +224,11 @@ export function TenantAppLayout({ children, profile: serverProfile }: TenantAppL
         {/* Logo */}
         <div className="h-16 flex items-center px-6 border-b shrink-0">
           <Link href="/tenant/dashboard" className="flex items-center gap-2">
-            <span className="text-xl font-bold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
-              Talok
-            </span>
+            <img
+              src="/images/talok-logo-horizontal.png"
+              alt="TALOK"
+              className="h-9 w-auto object-contain"
+            />
             <Badge variant="secondary" className="text-xs bg-blue-100 text-blue-700">
               Locataire
             </Badge>

--- a/components/marketing/DashboardMockup.tsx
+++ b/components/marketing/DashboardMockup.tsx
@@ -87,9 +87,8 @@ export function DashboardMockup() {
         <div className="flex">
           {/* Sidebar */}
           <div className="hidden w-[140px] shrink-0 bg-[#1E293B] p-3 sm:block">
-            <div className="mb-4 flex items-center gap-2">
-              <img src="/images/talok-icon.png" alt="TALOK" className="h-7 w-7 rounded-lg object-contain" />
-              <span className="text-[10px] font-bold text-white">TALOK</span>
+            <div className="mb-4 flex items-center">
+              <img src="/images/talok-logo-horizontal.png" alt="TALOK" className="h-7 w-auto object-contain" />
             </div>
             {sidebarItems.map((item, i) => (
               <motion.div

--- a/components/marketing/Footer.tsx
+++ b/components/marketing/Footer.tsx
@@ -49,9 +49,8 @@ export function MarketingFooter() {
         <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-5">
           {/* Brand column */}
           <div className="lg:col-span-1">
-            <Link href="/" className="mb-4 flex items-center gap-2">
-              <img src="/images/talok-icon.png" alt="TALOK" className="h-8 w-8 rounded-lg object-contain" />
-              <span className="text-lg font-bold text-white font-display">TALOK</span>
+            <Link href="/" className="mb-4 flex items-center">
+              <img src="/images/talok-logo-horizontal.png" alt="TALOK" className="h-10 w-auto object-contain" />
             </Link>
             <p className="text-sm leading-relaxed text-slate-400">
               LE Logiciel de Gestion Locative

--- a/components/marketing/TalokLogo.tsx
+++ b/components/marketing/TalokLogo.tsx
@@ -5,43 +5,31 @@ import Image from "next/image";
 import { cn } from "@/lib/utils";
 
 interface TalokLogoProps {
-  /** "light" = texte sombre sur fond clair, "dark" = texte blanc sur fond sombre */
+  /** Conservé pour compatibilité API — le logo horizontal intègre son propre badge, fonctionne sur fond clair & sombre */
   variant?: "light" | "dark";
-  /** Taille du logo */
+  /** Taille du logo (hauteur) */
   size?: "sm" | "md" | "lg";
   /** Desactiver le lien vers l'accueil */
   noLink?: boolean;
   className?: string;
 }
 
-const SIZE_MAP = {
-  sm: { img: "h-7 w-7", text: "text-base" },
-  md: { img: "h-9 w-9", text: "text-lg" },
-  lg: { img: "h-12 w-12", text: "text-xl" },
+const SIZE_CLS = {
+  sm: "h-8 w-auto",
+  md: "h-10 w-auto",
+  lg: "h-14 w-auto",
 };
 
-export function TalokLogo({ variant = "dark", size = "md", noLink = false, className }: TalokLogoProps) {
-  const s = SIZE_MAP[size];
-
+export function TalokLogo({ size = "md", noLink = false, className }: TalokLogoProps) {
   const content = (
-    <span className={cn("inline-flex items-center gap-2", className)}>
-      <Image
-        src="/images/talok-icon.png"
-        alt="TALOK"
-        width={48}
-        height={48}
-        className={cn("object-contain rounded-lg", s.img)}
-      />
-      <span
-        className={cn(
-          "font-bold tracking-tight",
-          s.text,
-          variant === "dark" ? "text-white" : "text-foreground"
-        )}
-      >
-        TALOK
-      </span>
-    </span>
+    <Image
+      src="/images/talok-logo-horizontal.png"
+      alt="TALOK"
+      width={160}
+      height={64}
+      className={cn("object-contain", SIZE_CLS[size], className)}
+      priority
+    />
   );
 
   if (noLink) return content;

--- a/components/ui/talok-logo.tsx
+++ b/components/ui/talok-logo.tsx
@@ -22,14 +22,6 @@ const IMG_CLS: Record<Size, string> = {
   xl: "h-12 w-12",
 };
 
-const TEXT_CLS: Record<Size, string> = {
-  xs: "text-sm",
-  sm: "text-lg",
-  md: "text-xl",
-  lg: "text-2xl",
-  xl: "text-3xl",
-};
-
 // ── TalokMark (icon only) ──────────────────────────────────
 interface MarkProps {
   size?: Size;
@@ -69,44 +61,39 @@ export function TalokBadge({ size = "md", className }: BadgeProps) {
   );
 }
 
-// ── TalokLogo (horizontal: badge + text) ───────────────────
+// ── TalokLogo (horizontal logo PNG — badge intégré + texte) ─
 interface LogoProps {
   size?: Size;
-  variant?: Variant;
+  /** Conservé pour compatibilité — si false, affiche uniquement le badge carré */
   showText?: boolean;
   className?: string;
-  textClassName?: string;
 }
+
+const LOGO_CLS: Record<Size, string> = {
+  xs: "h-5 w-auto",
+  sm: "h-7 w-auto",
+  md: "h-9 w-auto",
+  lg: "h-12 w-auto",
+  xl: "h-14 w-auto",
+};
 
 export function TalokLogo({
   size = "md",
-  variant = "color",
   showText = true,
   className,
-  textClassName,
 }: LogoProps) {
-  const textColor =
-    variant === "inverse"
-      ? "text-white"
-      : variant === "mono"
-        ? ""
-        : "text-foreground";
+  // Si showText=false, on affiche uniquement le badge (icône carrée)
+  if (!showText) {
+    return <TalokBadge size={size} className={className} />;
+  }
 
   return (
-    <span className={cn("inline-flex items-center gap-2", className)}>
-      <TalokBadge size={size} />
-      {showText && (
-        <span
-          className={cn(
-            "font-display font-extrabold tracking-tight",
-            TEXT_CLS[size],
-            textColor,
-            textClassName,
-          )}
-        >
-          TALOK
-        </span>
-      )}
-    </span>
+    <Image
+      src="/images/talok-logo-horizontal.png"
+      alt="TALOK"
+      width={160}
+      height={64}
+      className={cn("shrink-0 object-contain", LOGO_CLS[size], className)}
+    />
   );
 }


### PR DESCRIPTION
## Summary
Unified logo implementation across the application by replacing custom-built component-based logos with a single horizontal PNG asset (`talok-logo-horizontal.png`). This simplifies the codebase, improves consistency, and reduces maintenance overhead.

## Key Changes

- **Removed TEXT_CLS mapping** from `talok-logo.tsx` — no longer needed for text rendering
- **Refactored TalokLogo component** to use PNG image instead of composing badge + text elements
  - Removed `variant` and `textClassName` props (no longer applicable)
  - Kept `showText` prop for backward compatibility (falls back to TalokBadge when false)
  - Added `LOGO_CLS` mapping for responsive sizing based on size prop
- **Updated TalokLogo in marketing** (`components/marketing/TalokLogo.tsx`)
  - Removed `variant` prop usage (logo now works on both light and dark backgrounds)
  - Simplified size mapping to use `w-auto` for proper aspect ratio
  - Added `priority` flag to Image component
- **Replaced all logo instances** across layout components:
  - `navbar.tsx`: Replaced icon + text with horizontal logo image
  - `owner-app-layout.tsx`: Updated sidebar logo to use PNG assets
  - `tenant-app-layout.tsx`: Replaced gradient text branding with PNG logo
  - `core-shell-header.tsx`: Updated mobile brand display
  - `public-footer.tsx`: Consolidated footer logos to use horizontal asset
- **Updated marketing components**:
  - `DashboardMockup.tsx`: Sidebar logo now uses horizontal PNG
  - `Footer.tsx`: Brand column logo updated
  - `not-found.tsx`: 404 page logo updated
- **Simplified styling** by removing conditional color logic and text sizing — the PNG asset handles visual presentation

## Implementation Details

- All logo images use `object-contain` for proper scaling
- Height-based sizing with `w-auto` maintains aspect ratio across all breakpoints
- Backward compatibility maintained through optional props in component interfaces
- Consistent alt text ("TALOK") across all image instances

https://claude.ai/code/session_01Lyf7VJbcmkVmwE7JMXtiuH