### PR TITLE
claude/audit-building-module-ZhavK

### DIFF
--- a/app/api/buildings/[id]/route.ts
+++ b/app/api/buildings/[id]/route.ts
@@ -1,3 +1,14 @@
+/**
+ * /api/buildings/[id]
+ *
+ * - GET    : [NOT CONSUMED BY FRONTEND] conservé pour usage API externe.
+ *            Le hub `/owner/buildings/[id]` fait son fetch en SSR direct.
+ * - PATCH  : ACTIF — consommé par BuildingDetailClient (équipements, nom,
+ *            adresse, surface_totale, ownership_type, notes, etc.).
+ * - DELETE : ACTIF — garde baux actifs via building_active_lease_units.
+ *
+ * Voir docs/api-buildings.md.
+ */
 export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 

--- a/app/api/buildings/[id]/route.ts
+++ b/app/api/buildings/[id]/route.ts
@@ -8,19 +8,25 @@ import { handleApiError, ApiError } from "@/lib/helpers/api-error";
 import { getServiceClient } from "@/lib/supabase/service-client";
 
 const updateBuildingSchema = z.object({
-  name: z.string().min(1).max(100).optional(),
+  name: z.string().min(1).max(200).optional(),
   adresse_complete: z.string().min(1).optional(),
   code_postal: z.string().regex(/^(?:(?:0[1-9]|[1-8]\d|9[0-5])\d{3}|97[1-6]\d{2})$/).optional(),
   ville: z.string().min(1).optional(),
   departement: z.string().optional(),
   floors: z.number().int().min(1).max(50).optional(),
-  construction_year: z.number().int().min(1800).max(new Date().getFullYear() + 5).optional(),
+  construction_year: z.number().int().min(1800).max(new Date().getFullYear() + 5).optional().nullable(),
+  surface_totale: z.number().nonnegative().optional().nullable(),
+  notes: z.string().max(2000).optional().nullable(),
+  ownership_type: z.enum(["full", "partial"]).optional(),
+  total_lots_in_building: z.number().int().positive().optional().nullable(),
   has_ascenseur: z.boolean().optional(),
   has_gardien: z.boolean().optional(),
   has_interphone: z.boolean().optional(),
   has_digicode: z.boolean().optional(),
   has_local_velo: z.boolean().optional(),
   has_local_poubelles: z.boolean().optional(),
+  has_parking_commun: z.boolean().optional(),
+  has_jardin_commun: z.boolean().optional(),
 });
 
 interface RouteParams {
@@ -139,6 +145,32 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       }
     }
 
+    // Cohérence ownership_type ↔ total_lots_in_building
+    if (
+      payload.ownership_type === "partial" &&
+      (payload.total_lots_in_building === null ||
+        (payload.total_lots_in_building === undefined &&
+          !("total_lots_in_building" in payload)))
+    ) {
+      // Si partial fourni sans total_lots, on n'exige pas nécessairement qu'il soit
+      // dans CE patch (il peut déjà exister). On vérifie en DB.
+      const { data: current } = await serviceClient
+        .from("buildings")
+        .select("total_lots_in_building")
+        .eq("id", id)
+        .single();
+      if (!current || current.total_lots_in_building == null) {
+        throw new ApiError(
+          400,
+          "Copropriété partielle : indiquez le nombre total de lots de l'immeuble physique."
+        );
+      }
+    }
+    if (payload.ownership_type === "full") {
+      // En mode full, total_lots_in_building doit être NULL (réinitialisation)
+      (payload as Record<string, unknown>).total_lots_in_building = null;
+    }
+
     const { data: building, error: updateError } = await serviceClient
       .from("buildings")
       .update({
@@ -195,6 +227,21 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       throw new ApiError(403, "Accès non autorisé à cet immeuble");
     }
 
+    // Garde : refuser la suppression si au moins un lot a un bail bloquant
+    // (status='occupe' OU current_lease_id != NULL OU bail actif via leases).
+    const { data: blocking } = await serviceClient.rpc(
+      "building_active_lease_units",
+      { p_building_id: id }
+    );
+    if (Array.isArray(blocking) && blocking.length > 0) {
+      throw new ApiError(
+        409,
+        `Impossible de supprimer l'immeuble : ${blocking.length} lot(s) ont un bail actif. Résilier les baux d'abord.`
+      );
+    }
+
+    // Fallback safety : garder la vérification status='occupe' au cas où
+    // `current_lease_id` n'est pas sync (anciens records).
     const { data: occupiedUnits, error: occupiedError } = await serviceClient
       .from("building_units")
       .select("id")

--- a/app/api/buildings/[id]/units/[unitId]/route.ts
+++ b/app/api/buildings/[id]/units/[unitId]/route.ts
@@ -1,3 +1,12 @@
+/**
+ * /api/buildings/[id]/units/[unitId]
+ *
+ * - GET    : [NOT CONSUMED BY FRONTEND] conservé pour usage API externe.
+ * - PATCH  : ACTIF — BuildingDetailClient (changement de status inline).
+ * - DELETE : ACTIF — BuildingDetailClient (suppression d'un lot).
+ *
+ * Voir docs/api-buildings.md.
+ */
 export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 

--- a/app/api/buildings/[id]/units/route.ts
+++ b/app/api/buildings/[id]/units/route.ts
@@ -1,3 +1,13 @@
+/**
+ * /api/buildings/[id]/units
+ *
+ * [NOT CONSUMED BY FRONTEND — kept for API programmatic use]
+ *
+ * Le wizard et la page de gestion des lots passent par
+ * POST /api/properties/[id]/building-units (RPC transactionnelle).
+ * Cette route reste disponible pour un usage API direct (tests, scripts,
+ * intégration future). Voir docs/api-buildings.md.
+ */
 export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 

--- a/app/api/buildings/route.ts
+++ b/app/api/buildings/route.ts
@@ -1,3 +1,11 @@
+/**
+ * [NOT CONSUMED BY FRONTEND — kept for API programmatic use]
+ *
+ * GET et POST de /api/buildings sont fonctionnels mais non appelés par
+ * l'UI Talok. Toute création d'immeuble passe par le wizard et la route
+ * POST /api/properties/[id]/building-units (RPC transactionnelle).
+ * Voir docs/api-buildings.md.
+ */
 export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 

--- a/app/api/properties/[id]/building-unit/route.ts
+++ b/app/api/properties/[id]/building-unit/route.ts
@@ -1,0 +1,83 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+/**
+ * GET /api/properties/[id]/building-unit
+ *
+ * Retourne le `building_unit` correspondant à la property (si c'est un lot
+ * d'immeuble), ou `{ unit: null }` sinon.
+ *
+ * Utilisé par LeaseWizard (item #12 de l'audit) pour prioriser les valeurs
+ * loyer_hc / charges / depot_garantie du lot sur celles de la property,
+ * qui peuvent diverger.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: propertyId } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      throw new ApiError(authError?.status || 401, authError?.message || "Non authentifié");
+    }
+
+    const serviceClient = getServiceClient();
+
+    // Auth : le user doit pouvoir voir la property (owner direct ou admin ou
+    // membre de l'entité légale). On laisse RLS gérer via une requête avec
+    // le client auth-scoped — ici on fait simple : service client + check owner.
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile) throw new ApiError(404, "Profil non trouvé");
+
+    const { data: property } = await serviceClient
+      .from("properties")
+      .select("id, owner_id, legal_entity_id")
+      .eq("id", propertyId)
+      .is("deleted_at", null)
+      .maybeSingle();
+
+    if (!property) {
+      return NextResponse.json({ unit: null });
+    }
+
+    // Check access: owner direct, admin, ou membre de l'entité
+    let hasAccess = profile.role === "admin" || property.owner_id === profile.id;
+    if (!hasAccess && property.legal_entity_id) {
+      const { data: membership } = await serviceClient
+        .from("entity_members")
+        .select("id")
+        .eq("entity_id", property.legal_entity_id)
+        .eq("user_id", user.id)
+        .maybeSingle();
+      hasAccess = !!membership;
+    }
+    if (!hasAccess) {
+      throw new ApiError(403, "Accès non autorisé");
+    }
+
+    // Lookup building_unit par property_id
+    const { data: unit } = await serviceClient
+      .from("building_units")
+      .select(
+        "id, building_id, floor, position, type, surface, nb_pieces, loyer_hc, charges, depot_garantie, status"
+      )
+      .eq("property_id", propertyId)
+      .is("deleted_at", null)
+      .maybeSingle();
+
+    return NextResponse.json({ unit: unit ?? null });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/properties/[id]/building-units/route.ts
+++ b/app/api/properties/[id]/building-units/route.ts
@@ -5,10 +5,12 @@ import { NextResponse } from "next/server";
 import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
 import { getServiceClient } from "@/lib/supabase/service-client";
 import { applyRateLimit } from "@/lib/middleware/rate-limit";
-import { generateCode } from "@/lib/helpers/code-generator";
-import type { BuildingUnitTemplate } from "@/lib/supabase/database.types";
 import { z } from "zod";
 
+/**
+ * Payload d'un lot envoyé par le wizard / UnitsManagement.
+ * `meuble` est explicite (Phase 2 — fin du hardcode type-based).
+ */
 const buildingUnitPayloadSchema = z.object({
   id: z.string().optional(),
   floor: z.number().int().min(-5).max(50),
@@ -21,30 +23,58 @@ const buildingUnitPayloadSchema = z.object({
   charges: z.number().min(0),
   depot_garantie: z.number().min(0),
   status: z.enum(["vacant", "occupe", "travaux", "reserve"]).optional(),
+  meuble: z.boolean().optional(),
 });
 
+/**
+ * Champs immeuble acceptés. Tous optionnels pour préserver la compat
+ * avec les appels legacy du wizard pré-Phase 3.
+ */
 const bodySchema = z.object({
+  // Identité
+  name: z.string().trim().min(1).max(200).optional(),
+
+  // Plan
   building_floors: z.number().int().min(1).max(50).optional(),
+  construction_year: z.number().int().min(1800).max(2100).optional(),
+  surface_totale: z.number().nonnegative().optional(),
+  notes: z.string().max(2000).optional(),
+
+  // Équipements communs
   has_ascenseur: z.boolean().optional(),
   has_gardien: z.boolean().optional(),
   has_interphone: z.boolean().optional(),
   has_digicode: z.boolean().optional(),
   has_local_velo: z.boolean().optional(),
   has_local_poubelles: z.boolean().optional(),
+  has_parking_commun: z.boolean().optional(),
+  has_jardin_commun: z.boolean().optional(),
+
+  // Mode de possession
+  ownership_type: z.enum(["full", "partial"]).optional(),
+  total_lots_in_building: z.number().int().positive().optional(),
+
+  // Lots
   units: z.array(buildingUnitPayloadSchema).min(1, "Au moins un lot requis"),
 });
 
-/** Étiquette étage lisible */
-function floorLabel(floor: number): string {
-  if (floor < 0) return `SS${Math.abs(floor)}`;
-  if (floor === 0) return "RDC";
-  return `Étage ${floor}`;
-}
+type BlockingUnit = {
+  unit_id: string;
+  floor: number;
+  position: string;
+  lease_id: string | null;
+  lease_statut: string | null;
+};
 
 /**
  * POST /api/properties/[id]/building-units
- * Crée ou met à jour l'immeuble et ses lots pour une propriété de type immeuble.
- * Sprint 1 : chaque lot génère une property indépendante (idempotent).
+ *
+ * Upsert atomique d'un immeuble et de ses lots pour une property de type immeuble.
+ * Toute la logique de DB (UPSERT building + DELETE/INSERT units + UPSERT lots)
+ * est encapsulée dans la RPC `upsert_building_with_units` (transaction SQL).
+ *
+ * Garde : refuse si au moins un lot a un bail bloquant (active / pending_signature
+ * / fully_signed / notice_given).
  */
 export async function POST(
   request: Request,
@@ -63,6 +93,7 @@ export async function POST(
 
     const serviceClient = getServiceClient();
 
+    // ─── Auth : profile owner ou admin ────────────────────────────────────
     const { data: profile } = await serviceClient
       .from("profiles")
       .select("id, role")
@@ -72,11 +103,12 @@ export async function POST(
       return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
     }
 
+    // ─── Property parent existe et appartient au user ────────────────────
     const { data: property, error: propErr } = await serviceClient
       .from("properties")
-      .select("id, owner_id, legal_entity_id, adresse_complete, code_postal, ville, departement")
+      .select("id, owner_id")
       .eq("id", propertyId)
-      .single();
+      .maybeSingle();
     if (propErr || !property) {
       return NextResponse.json({ error: "Propriété non trouvée" }, { status: 404 });
     }
@@ -84,6 +116,7 @@ export async function POST(
       return NextResponse.json({ error: "Vous n'êtes pas propriétaire de ce bien" }, { status: 403 });
     }
 
+    // ─── Validation Zod ──────────────────────────────────────────────────
     const body = await request.json();
     rawBody = body;
     const parsed = bodySchema.safeParse(body);
@@ -93,193 +126,112 @@ export async function POST(
         { status: 400 }
       );
     }
-    const { building_floors, has_ascenseur, has_gardien, has_interphone, has_digicode, has_local_velo, has_local_poubelles, units } = parsed.data;
 
-    // ─── 1. Upsert building ───────────────────────────────────────────
-    let buildingId: string;
+    // Cohérence ownership_type ↔ total_lots_in_building
+    if (
+      parsed.data.ownership_type === "partial" &&
+      parsed.data.total_lots_in_building == null
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Copropriété partielle : indiquez le nombre total de lots de l'immeuble physique.",
+        },
+        { status: 400 }
+      );
+    }
 
+    const { units, ...buildingData } = parsed.data;
+
+    // ─── Garde pré-remplacement : aucun lot n'a un bail bloquant ─────────
+    // On vérifie AVANT d'appeler la RPC pour pouvoir renvoyer un 409 lisible.
+    // La RPC refait la même vérification transactionnellement (ERRCODE P0002).
     const { data: existingBuilding } = await serviceClient
       .from("buildings")
       .select("id")
       .eq("property_id", propertyId)
+      .is("deleted_at", null)
       .maybeSingle();
 
     if (existingBuilding?.id) {
-      buildingId = existingBuilding.id;
-      await serviceClient
-        .from("buildings")
-        .update({
-          floors: building_floors ?? 1,
-          has_ascenseur: has_ascenseur ?? false,
-          has_gardien: has_gardien ?? false,
-          has_interphone: has_interphone ?? false,
-          has_digicode: has_digicode ?? false,
-          has_local_velo: has_local_velo ?? false,
-          has_local_poubelles: has_local_poubelles ?? false,
-          updated_at: new Date().toISOString(),
-        })
-        .eq("id", buildingId);
-    } else {
-      const { data: newBuilding, error: insertErr } = await serviceClient
-        .from("buildings")
-        .insert({
-          owner_id: property.owner_id,
-          property_id: propertyId,
-          name: property.adresse_complete?.slice(0, 200) ?? "Immeuble",
-          adresse_complete: property.adresse_complete ?? "",
-          code_postal: property.code_postal ?? "",
-          ville: property.ville ?? "",
-          departement: property.departement ?? null,
-          floors: building_floors ?? 1,
-          has_ascenseur: has_ascenseur ?? false,
-          has_gardien: has_gardien ?? false,
-          has_interphone: has_interphone ?? false,
-          has_digicode: has_digicode ?? false,
-          has_local_velo: has_local_velo ?? false,
-          has_local_poubelles: has_local_poubelles ?? false,
-        })
-        .select("id")
-        .single();
-      if (insertErr || !newBuilding?.id) {
-        console.error("[building-units] Erreur création building:", insertErr);
-        return NextResponse.json({ error: "Erreur lors de la création de l'immeuble" }, { status: 500 });
+      const { data: blocking, error: blockingErr } = await serviceClient.rpc(
+        "building_active_lease_units",
+        { p_building_id: existingBuilding.id }
+      );
+      if (blockingErr) {
+        console.error("[building-units] building_active_lease_units error:", blockingErr);
+        return NextResponse.json({ error: "Erreur de vérification des baux" }, { status: 500 });
       }
-      buildingId = newBuilding.id;
-    }
-
-    // ─── 2. Récupérer les units existants avec leur property_id ───────
-    const { data: existingUnits } = await serviceClient
-      .from("building_units")
-      .select("id, floor, position, property_id")
-      .eq("building_id", buildingId);
-
-    // Index des property_id existants par clé floor-position
-    const existingPropertyMap = new Map<string, string>();
-    if (existingUnits) {
-      for (const eu of existingUnits) {
-        if (eu.property_id) {
-          existingPropertyMap.set(`${eu.floor}-${eu.position}`, eu.property_id);
-        }
+      const blockingList = (blocking ?? []) as BlockingUnit[];
+      if (blockingList.length > 0) {
+        return NextResponse.json(
+          {
+            error:
+              "Impossible de modifier les lots : " +
+              blockingList.length +
+              " lot(s) ont un bail actif. Résilier les baux d'abord.",
+            blocking_units: blockingList.map((b) => ({
+              floor: b.floor,
+              position: b.position,
+              lease_id: b.lease_id,
+              lease_statut: b.lease_statut,
+            })),
+          },
+          { status: 409 }
+        );
       }
     }
 
-    // ─── 3. Supprimer les anciens units (les properties lots restent) ─
-    await serviceClient.from("building_units").delete().eq("building_id", buildingId);
+    // ─── Appel RPC transactionnelle ──────────────────────────────────────
+    const { data: rpcData, error: rpcErr } = await serviceClient.rpc(
+      "upsert_building_with_units",
+      {
+        p_property_id: propertyId,
+        p_building_data: buildingData,
+        p_units: units,
+      }
+    );
 
-    // ─── 4. Créer une property indépendante par lot ───────────────────
-    const unitRows: Array<{
+    if (rpcErr) {
+      // ERRCODE P0002 : garde baux actifs (fallback si la pré-vérif ci-dessus a raté)
+      if (
+        typeof rpcErr.message === "string" &&
+        rpcErr.message.includes("active_leases_blocking")
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "Impossible de modifier les lots : certains lots ont un bail actif. Résilier les baux d'abord.",
+            detail: rpcErr.message,
+          },
+          { status: 409 }
+        );
+      }
+      // ERRCODE P0001 : property introuvable
+      if (
+        typeof rpcErr.message === "string" &&
+        rpcErr.message.includes("property_not_found")
+      ) {
+        return NextResponse.json({ error: "Propriété non trouvée" }, { status: 404 });
+      }
+      console.error("[building-units] RPC error:", rpcErr);
+      return NextResponse.json(
+        { error: "Erreur lors de l'enregistrement de l'immeuble", detail: rpcErr.message },
+        { status: 500 }
+      );
+    }
+
+    const result = rpcData as {
       building_id: string;
-      floor: number;
-      position: string;
-      type: string;
-      surface: number;
-      nb_pieces: number;
-      template: BuildingUnitTemplate | null;
-      loyer_hc: number;
-      charges: number;
-      depot_garantie: number;
-      status: string;
-      property_id: string;
-    }> = [];
-
-    for (const u of units) {
-      const key = `${u.floor}-${u.position}`;
-      let lotPropertyId: string | undefined = existingPropertyMap.get(key);
-
-      if (lotPropertyId) {
-        // Lot existant — mettre à jour la property
-        await serviceClient
-          .from("properties")
-          .update({
-            type: u.type,
-            surface: u.surface,
-            nb_pieces: u.nb_pieces,
-            loyer_hc: u.loyer_hc,
-            charges_mensuelles: u.charges,
-            adresse_complete: `${property.adresse_complete ?? ""} - Lot ${u.position}, ${floorLabel(u.floor)}`,
-            updated_at: new Date().toISOString(),
-          })
-          .eq("id", lotPropertyId);
-      } else {
-        // Nouveau lot — créer la property indépendante
-        let uniqueCode: string;
-        let attempts = 0;
-        do {
-          uniqueCode = await generateCode();
-          const { data: existing } = await serviceClient
-            .from("properties")
-            .select("id")
-            .eq("unique_code", uniqueCode)
-            .maybeSingle();
-          if (!existing) break;
-          attempts++;
-        } while (attempts < 10);
-
-        const isMeuble = u.type === "studio" || u.type === "local_commercial";
-        const lotAddress = `${property.adresse_complete ?? ""} - Lot ${u.position}, ${floorLabel(u.floor)}`;
-
-        const { data: lotProperty, error: lotErr } = await serviceClient
-          .from("properties")
-          .insert({
-            owner_id: property.owner_id,
-            legal_entity_id: (property as any).legal_entity_id ?? null,
-            parent_property_id: propertyId,
-            type: u.type,
-            etat: "published",
-            unique_code: uniqueCode,
-            adresse_complete: lotAddress,
-            code_postal: property.code_postal ?? "",
-            ville: property.ville ?? "",
-            departement: property.departement ?? "",
-            surface: u.surface,
-            nb_pieces: u.nb_pieces,
-            nb_chambres: 0,
-            ascenseur: has_ascenseur ?? false,
-            meuble: isMeuble,
-            loyer_hc: u.loyer_hc,
-            charges_mensuelles: u.charges,
-          })
-          .select("id")
-          .single();
-
-        if (lotErr || !lotProperty) {
-          console.error(`[building-units] Erreur création property lot ${key}:`, lotErr);
-          return NextResponse.json(
-            { error: `Erreur lors de la création du lot ${u.position} (${floorLabel(u.floor)})` },
-            { status: 500 }
-          );
-        }
-        lotPropertyId = lotProperty.id;
-      }
-
-      unitRows.push({
-        building_id: buildingId,
-        floor: u.floor,
-        position: u.position,
-        type: u.type,
-        surface: u.surface,
-        nb_pieces: u.nb_pieces,
-        template: (u.template?.toLowerCase() ?? null) as BuildingUnitTemplate | null,
-        loyer_hc: u.loyer_hc,
-        charges: u.charges,
-        depot_garantie: u.depot_garantie,
-        status: u.status ?? "vacant",
-        property_id: lotPropertyId!,
-      });
-    }
-
-    // ─── 5. Insérer les building_units avec property_id ───────────────
-    const { error: unitsErr } = await serviceClient.from("building_units").insert(unitRows);
-    if (unitsErr) {
-      console.error("[building-units] Erreur insertion lots:", unitsErr);
-      return NextResponse.json({ error: "Erreur lors de l'enregistrement des lots" }, { status: 500 });
-    }
+      unit_count: number;
+      lot_property_ids: string[];
+    };
 
     return NextResponse.json({
       success: true,
-      building_id: buildingId,
-      count: unitRows.length,
-      lot_property_ids: unitRows.map((r) => r.property_id),
+      building_id: result.building_id,
+      count: result.unit_count,
+      lot_property_ids: result.lot_property_ids,
     });
   } catch (e) {
     const errObj = e instanceof Error ? { message: e.message, stack: e.stack, name: e.name } : e;

--- a/app/owner/buildings/[id]/BuildingDetailClient.tsx
+++ b/app/owner/buildings/[id]/BuildingDetailClient.tsx
@@ -25,6 +25,9 @@ import {
   Wrench,
   Eye,
   Trash2,
+  Sparkles,
+  Copy,
+  Loader2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -57,7 +60,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
+import { LotCharacteristicsDrawer } from "./LotCharacteristicsDrawer";
 import Link from "next/link";
 import Image from "next/image";
 import type { BuildingRow, BuildingUnitRow } from "@/lib/supabase/database.types";
@@ -309,7 +322,54 @@ export function BuildingDetailClient({
     has_digicode: buildingMeta?.has_digicode ?? false,
     has_local_velo: buildingMeta?.has_local_velo ?? false,
     has_local_poubelles: buildingMeta?.has_local_poubelles ?? false,
+    has_parking_commun: (buildingMeta as any)?.has_parking_commun ?? false,
+    has_jardin_commun: (buildingMeta as any)?.has_jardin_commun ?? false,
   });
+
+  // Détails immeuble (name, construction_year, surface_totale, notes)
+  const [buildingName, setBuildingName] = useState<string>(
+    (buildingMeta as any)?.name ?? ""
+  );
+  const [constructionYear, setConstructionYear] = useState<number | "">(
+    (buildingMeta as any)?.construction_year ?? ""
+  );
+  const [surfaceTotale, setSurfaceTotale] = useState<number | "">(
+    (buildingMeta as any)?.surface_totale ?? ""
+  );
+  const [buildingNotes, setBuildingNotes] = useState<string>(
+    (buildingMeta as any)?.notes ?? ""
+  );
+
+  // Mode de possession
+  const [ownershipType, setOwnershipType] = useState<"full" | "partial">(
+    ((buildingMeta as any)?.ownership_type as "full" | "partial") ?? "full"
+  );
+  const [totalLotsInBuilding, setTotalLotsInBuilding] = useState<number | "">(
+    (buildingMeta as any)?.total_lots_in_building ?? ""
+  );
+
+  // Drawer caractéristiques lot (item #5)
+  const [drawerLot, setDrawerLot] = useState<{
+    propertyId: string;
+    label: string;
+  } | null>(null);
+
+  // Dialog duplication lot (item #25)
+  const [duplicateSource, setDuplicateSource] = useState<{
+    unitId: string;
+    sourceFloor: number;
+  } | null>(null);
+  const [duplicateTargetFloors, setDuplicateTargetFloors] = useState<number[]>([]);
+  const [duplicating, setDuplicating] = useState(false);
+
+  // Stats officielles via /api/buildings/[id]/stats (item #15)
+  const [serverStats, setServerStats] = useState<{
+    occupancy_rate: number | null;
+    revenus_actuels: number | null;
+    revenus_potentiels: number | null;
+    occupied_units: number | null;
+    total_units: number | null;
+  } | null>(null);
 
   // ── Documents state ──
   const [documents, setDocuments] = useState<BuildingDocument[]>(initialDocuments || []);
@@ -400,6 +460,77 @@ export function BuildingDetailClient({
     const ok = await patchBuilding({ [key]: val });
     if (!ok) setEquipment(prev => ({ ...prev, [key]: !val }));
   }, [patchBuilding]);
+
+  // Fetch server stats (building_stats view) — fallback silencieux sur calcul inline
+  useEffect(() => {
+    if (!buildingId) return;
+    let cancelled = false;
+    fetch(`/api/buildings/${buildingId}/stats`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const s = data.stats || data;
+        if (s && typeof s === "object") {
+          setServerStats({
+            occupancy_rate:
+              typeof s.occupancy_rate === "number" ? s.occupancy_rate : null,
+            revenus_actuels:
+              typeof s.revenus_actuels === "number" ? s.revenus_actuels : null,
+            revenus_potentiels:
+              typeof s.revenus_potentiels === "number" ? s.revenus_potentiels : null,
+            occupied_units:
+              typeof s.occupied_units === "number" ? s.occupied_units : null,
+            total_units:
+              typeof s.total_units === "number" ? s.total_units : null,
+          });
+        }
+      })
+      .catch(() => {
+        /* silencieux — fallback sur calcul inline */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [buildingId]);
+
+  // Duplication lot (item #25)
+  const handleDuplicateSubmit = useCallback(async () => {
+    if (!buildingId || !duplicateSource) return;
+    if (duplicateTargetFloors.length === 0) return;
+    setDuplicating(true);
+    try {
+      const res = await fetch(
+        `/api/buildings/${buildingId}/units/${duplicateSource.unitId}/duplicate`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ target_floors: duplicateTargetFloors }),
+        }
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.error || "Erreur duplication");
+      }
+      const data = await res.json();
+      toast({
+        title: `${data.count ?? duplicateTargetFloors.length} lot(s) créé(s)`,
+        description: "Rechargement…",
+      });
+      // Rafraîchir pour charger les nouveaux lots
+      setTimeout(() => {
+        if (typeof window !== "undefined") window.location.reload();
+      }, 600);
+      setDuplicateSource(null);
+      setDuplicateTargetFloors([]);
+    } catch (e) {
+      toast({
+        title: e instanceof Error ? e.message : "Erreur",
+        variant: "destructive",
+      });
+    } finally {
+      setDuplicating(false);
+    }
+  }, [buildingId, duplicateSource, duplicateTargetFloors, toast]);
 
   // ── Unit actions ──
   const [unitStatuses, setUnitStatuses] = useState<Record<string, string>>(() => {
@@ -510,11 +641,27 @@ export function BuildingDetailClient({
   const parkingUnits = liveUnits.filter((u) => u.type === "parking" || u.type === "cave").length;
   const habitableUnits = totalUnits - parkingUnits;
   const vacantUnits = liveUnits.filter((u) => u.status === "vacant" && u.type !== "parking" && u.type !== "cave").length;
-  const occupiedUnits = liveUnits.filter((u) => u.status === "occupe" && u.type !== "parking" && u.type !== "cave").length;
-  const occupancyRate = habitableUnits > 0 ? Math.round((occupiedUnits / habitableUnits) * 100) : 0;
-  const revenuActuel = liveUnits.filter((u) => u.status === "occupe").reduce((sum, u) => sum + (u.loyer_hc || 0) + (u.charges || 0), 0);
-  const revenuPotentiel = liveUnits.reduce((sum, u) => sum + (u.loyer_hc || 0) + (u.charges || 0), 0);
+  const occupiedUnitsInline = liveUnits.filter((u) => u.status === "occupe" && u.type !== "parking" && u.type !== "cave").length;
+  const revenuActuelInline = liveUnits.filter((u) => u.status === "occupe").reduce((sum, u) => sum + (u.loyer_hc || 0) + (u.charges || 0), 0);
+  const revenuPotentielInline = liveUnits.reduce((sum, u) => sum + (u.loyer_hc || 0) + (u.charges || 0), 0);
+
+  // Stats finales : priorité à serverStats (vue building_stats) sinon calcul inline
+  const occupiedUnits = serverStats?.occupied_units ?? occupiedUnitsInline;
+  const occupancyRate =
+    serverStats?.occupancy_rate ??
+    (habitableUnits > 0 ? Math.round((occupiedUnitsInline / habitableUnits) * 100) : 0);
+  const revenuActuel = serverStats?.revenus_actuels ?? revenuActuelInline;
+  const revenuPotentiel = serverStats?.revenus_potentiels ?? revenuPotentielInline;
+
   const hasActiveFilters = filterFloor !== "all" || filterType !== "all" || filterStatus !== "all";
+
+  // Liste des étages possibles pour la duplication (tous sauf celui du lot source)
+  const duplicateCandidateFloors = useMemo(() => {
+    const floorsCount = buildingMeta?.floors ?? 1;
+    const all = Array.from({ length: floorsCount }, (_, i) => i);
+    if (duplicateSource) return all.filter((f) => f !== duplicateSource.sourceFloor);
+    return all;
+  }, [buildingMeta, duplicateSource]);
 
   // Group documents by type
   const documentsByType = useMemo(() => {
@@ -590,18 +737,36 @@ export function BuildingDetailClient({
           <div className="flex items-center gap-3 mb-2 flex-wrap">
             <h1 className="text-2xl md:text-3xl font-bold font-[family-name:var(--font-manrope)]">
               <EditableField
-                value={building.adresse_complete}
-                onSave={(val) => patchBuilding({ adresse_complete: val })}
+                value={buildingName || building.adresse_complete}
+                onSave={(val) => {
+                  setBuildingName(val);
+                  void patchBuilding({ name: val });
+                }}
                 className="text-white"
               />
             </h1>
             <Badge className="bg-[#2563EB] text-white shrink-0">
               Immeuble &bull; {totalUnits} lot{totalUnits > 1 ? "s" : ""}
             </Badge>
+            {/* Badge ownership_type (item #14) */}
+            {ownershipType === "full" ? (
+              <Badge className="bg-emerald-600 text-white shrink-0">
+                Propriété complète
+              </Badge>
+            ) : (
+              <Badge className="bg-amber-600 text-white shrink-0">
+                Copropriété &bull; {totalUnits} lot(s) sur {totalLotsInBuilding || "?"}
+              </Badge>
+            )}
           </div>
           <div className="flex items-center gap-4 text-white/80 flex-wrap">
             <span className="flex items-center gap-1">
               <MapPin className="h-4 w-4" />
+              <EditableField
+                value={building.adresse_complete}
+                onSave={(val) => patchBuilding({ adresse_complete: val })}
+                className="text-white/80"
+              />
               <EditableField
                 value={building.code_postal}
                 onSave={(val) => patchBuilding({ code_postal: val })}
@@ -675,7 +840,160 @@ export function BuildingDetailClient({
         </Card>
       </div>
 
-      {/* Equipment — Toggles */}
+      {/* Détails de l'immeuble (item #17) */}
+      <Card className="mb-6 bg-card">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Détails de l'immeuble</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="hub-construction-year" className="text-xs">
+                Année de construction
+              </Label>
+              <Input
+                id="hub-construction-year"
+                type="number"
+                min={1800}
+                max={new Date().getFullYear() + 5}
+                value={constructionYear}
+                onChange={(e) => {
+                  const v = e.target.value === "" ? "" : Number(e.target.value);
+                  setConstructionYear(v);
+                }}
+                onBlur={() => {
+                  patchBuilding({
+                    construction_year:
+                      constructionYear === "" ? null : constructionYear,
+                  });
+                }}
+                placeholder="1960"
+                className="h-9 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="hub-surface-totale" className="text-xs">
+                Surface totale (m²)
+              </Label>
+              <Input
+                id="hub-surface-totale"
+                type="number"
+                min={0}
+                step="0.01"
+                value={surfaceTotale}
+                onChange={(e) => {
+                  const v = e.target.value === "" ? "" : Number(e.target.value);
+                  setSurfaceTotale(v);
+                }}
+                onBlur={() => {
+                  patchBuilding({
+                    surface_totale: surfaceTotale === "" ? null : surfaceTotale,
+                  });
+                }}
+                placeholder="280"
+                className="h-9 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="hub-floors" className="text-xs">
+                Nombre d'étages
+              </Label>
+              <Input
+                id="hub-floors"
+                type="number"
+                min={1}
+                max={50}
+                value={buildingMeta?.floors ?? ""}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  if (!Number.isNaN(v) && v >= 1 && v <= 50) {
+                    patchBuilding({ floors: v });
+                  }
+                }}
+                placeholder="4"
+                className="h-9 text-sm"
+              />
+            </div>
+          </div>
+          <div className="mt-4 space-y-1">
+            <Label htmlFor="hub-notes" className="text-xs">
+              Notes internes
+            </Label>
+            <Textarea
+              id="hub-notes"
+              value={buildingNotes}
+              onChange={(e) => setBuildingNotes(e.target.value)}
+              onBlur={() => patchBuilding({ notes: buildingNotes || null })}
+              placeholder="Informations internes sur l'immeuble…"
+              rows={2}
+              maxLength={2000}
+              className="text-sm"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Mode de possession (item #14 édition) */}
+      <Card className="mb-6 bg-card">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Mode de possession</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="hub-ownership" className="text-xs">
+                Type de propriété
+              </Label>
+              <Select
+                value={ownershipType}
+                onValueChange={(v) => {
+                  const next = v as "full" | "partial";
+                  setOwnershipType(next);
+                  patchBuilding({
+                    ownership_type: next,
+                    ...(next === "full" ? { total_lots_in_building: null } : {}),
+                  });
+                  if (next === "full") setTotalLotsInBuilding("");
+                }}
+              >
+                <SelectTrigger id="hub-ownership" className="h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="full">Immeuble entier</SelectItem>
+                  <SelectItem value="partial">Copropriété partielle</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {ownershipType === "partial" && (
+              <div className="space-y-1">
+                <Label htmlFor="hub-total-lots" className="text-xs">
+                  Nombre total de lots de l'immeuble physique
+                </Label>
+                <Input
+                  id="hub-total-lots"
+                  type="number"
+                  min={1}
+                  value={totalLotsInBuilding}
+                  onChange={(e) => {
+                    const v = e.target.value === "" ? "" : Number(e.target.value);
+                    setTotalLotsInBuilding(v);
+                  }}
+                  onBlur={() => {
+                    if (totalLotsInBuilding !== "") {
+                      patchBuilding({ total_lots_in_building: totalLotsInBuilding });
+                    }
+                  }}
+                  placeholder="Ex: 12"
+                  className="h-9 text-sm"
+                />
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Equipment — Toggles (items #16 : + parking_commun, jardin_commun) */}
       <Card className="mb-8 bg-card">
         <CardHeader className="pb-2">
           <CardTitle className="text-base">Équipements</CardTitle>
@@ -688,6 +1006,8 @@ export function BuildingDetailClient({
             <EquipmentToggle label="Digicode" checked={equipment.has_digicode} onToggle={(v) => handleEquipmentToggle("has_digicode", v)} saving={saving} />
             <EquipmentToggle label="Local vélos" checked={equipment.has_local_velo} onToggle={(v) => handleEquipmentToggle("has_local_velo", v)} saving={saving} />
             <EquipmentToggle label="Local poubelles" checked={equipment.has_local_poubelles} onToggle={(v) => handleEquipmentToggle("has_local_poubelles", v)} saving={saving} />
+            <EquipmentToggle label="Parking commun" checked={equipment.has_parking_commun} onToggle={(v) => handleEquipmentToggle("has_parking_commun", v)} saving={saving} />
+            <EquipmentToggle label="Jardin commun" checked={equipment.has_jardin_commun} onToggle={(v) => handleEquipmentToggle("has_jardin_commun", v)} saving={saving} />
           </div>
           {buildingMeta?.floors && (
             <div className="mt-3 pt-3 border-t">
@@ -878,6 +1198,20 @@ export function BuildingDetailClient({
                                       </Link>
                                     </DropdownMenuItem>
                                   )}
+                                  {/* Item #5 : Drawer caractéristiques lot (DPE, chauffage, équipements, meublé) */}
+                                  {unit.property_id && (
+                                    <DropdownMenuItem
+                                      onClick={() =>
+                                        setDrawerLot({
+                                          propertyId: unit.property_id as string,
+                                          label: `Lot ${unit.position ?? ""} · ${floorLabel((unit.floor as number) ?? 0)}`,
+                                        })
+                                      }
+                                    >
+                                      <Sparkles className="h-3.5 w-3.5 mr-2" />
+                                      Caractéristiques (DPE, chauffage…)
+                                    </DropdownMenuItem>
+                                  )}
                                   {status === "occupe" && unit.current_lease_id && (
                                     <DropdownMenuItem asChild>
                                       <Link href={`/owner/leases/${unit.current_lease_id}`}>
@@ -895,6 +1229,20 @@ export function BuildingDetailClient({
                                     </DropdownMenuItem>
                                   )}
                                   <DropdownMenuSeparator />
+                                  {/* Item #25 : Dupliquer sur d'autres étages */}
+                                  <DropdownMenuItem
+                                    onClick={() => {
+                                      if (!unit.id) return;
+                                      setDuplicateSource({
+                                        unitId: unit.id,
+                                        sourceFloor: (unit.floor as number) ?? 0,
+                                      });
+                                      setDuplicateTargetFloors([]);
+                                    }}
+                                  >
+                                    <Copy className="h-3.5 w-3.5 mr-2" />
+                                    Dupliquer sur d'autres étages
+                                  </DropdownMenuItem>
                                   {status !== "travaux" && (
                                     <DropdownMenuItem onClick={() => unit.id && handleUnitStatusChange(unit.id, "travaux")}>
                                       <Wrench className="h-3.5 w-3.5 mr-2" />
@@ -1122,6 +1470,119 @@ export function BuildingDetailClient({
         </section>
 
       </div>
+
+      {/* Drawer caractéristiques lot (item #5) */}
+      {drawerLot && (
+        <LotCharacteristicsDrawer
+          open={!!drawerLot}
+          onOpenChange={(o) => {
+            if (!o) setDrawerLot(null);
+          }}
+          propertyId={drawerLot.propertyId}
+          unitLabel={drawerLot.label}
+        />
+      )}
+
+      {/* Dialog de duplication lot (item #25) */}
+      <Dialog
+        open={!!duplicateSource}
+        onOpenChange={(o) => {
+          if (!o) {
+            setDuplicateSource(null);
+            setDuplicateTargetFloors([]);
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Copy className="h-5 w-5 text-blue-500" />
+              Dupliquer ce lot
+            </DialogTitle>
+            <DialogDescription>
+              Sélectionnez les étages sur lesquels recréer ce lot. Les nouveaux lots
+              seront créés à la prochaine position disponible, avec le même loyer,
+              la même surface et le statut <em>vacant</em>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-3">
+            <Label className="text-xs mb-2 block">Étages cibles</Label>
+            <div className="flex flex-wrap gap-2">
+              {duplicateCandidateFloors.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  Aucun autre étage disponible. Ajoutez un étage dans les détails
+                  de l'immeuble pour en créer.
+                </p>
+              ) : (
+                duplicateCandidateFloors.map((f) => {
+                  const isSelected = duplicateTargetFloors.includes(f);
+                  return (
+                    <Button
+                      key={f}
+                      type="button"
+                      size="sm"
+                      variant={isSelected ? "default" : "outline"}
+                      onClick={() => {
+                        setDuplicateTargetFloors((prev) =>
+                          prev.includes(f) ? prev.filter((x) => x !== f) : [...prev, f]
+                        );
+                      }}
+                    >
+                      {floorLabel(f)}
+                    </Button>
+                  );
+                })
+              )}
+            </div>
+            {duplicateCandidateFloors.length > 0 && (
+              <div className="flex gap-2 mt-3">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setDuplicateTargetFloors(duplicateCandidateFloors)}
+                >
+                  Tous
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setDuplicateTargetFloors([])}
+                >
+                  Aucun
+                </Button>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDuplicateSource(null);
+                setDuplicateTargetFloors([]);
+              }}
+              disabled={duplicating}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleDuplicateSubmit}
+              disabled={duplicating || duplicateTargetFloors.length === 0}
+            >
+              {duplicating ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Duplication…
+                </>
+              ) : (
+                <>
+                  <Copy className="h-4 w-4 mr-2" />
+                  Dupliquer ({duplicateTargetFloors.length})
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/owner/buildings/[id]/LotCharacteristicsDrawer.tsx
+++ b/app/owner/buildings/[id]/LotCharacteristicsDrawer.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { useToast } from "@/components/ui/use-toast";
+import { Loader2, Sparkles, Thermometer, Home, Zap } from "lucide-react";
+
+const DPE_CLASSES = ["A", "B", "C", "D", "E", "F", "G"] as const;
+type DpeClass = (typeof DPE_CLASSES)[number];
+
+const HEATING_TYPES = [
+  { value: "individuel", label: "Individuel" },
+  { value: "collectif", label: "Collectif" },
+  { value: "aucun", label: "Aucun" },
+] as const;
+
+const HEATING_ENERGIES = [
+  { value: "electricite", label: "Électricité" },
+  { value: "gaz", label: "Gaz" },
+  { value: "fioul", label: "Fioul" },
+  { value: "bois", label: "Bois" },
+  { value: "reseau_urbain", label: "Réseau urbain" },
+  { value: "autre", label: "Autre" },
+] as const;
+
+const HOT_WATER_TYPES = [
+  { value: "electrique_indiv", label: "Électrique indiv." },
+  { value: "gaz_indiv", label: "Gaz individuel" },
+  { value: "collectif", label: "Collectif" },
+  { value: "solaire", label: "Solaire" },
+  { value: "autre", label: "Autre" },
+] as const;
+
+/**
+ * Équipements checkboxes (subset des EquipmentV3 les plus courants).
+ * Couvre les besoins DPE/description locative sans surcharger l'UI.
+ */
+const LOT_EQUIPMENTS: Array<{ key: string; label: string; icon?: string }> = [
+  { key: "wifi", label: "Wifi" },
+  { key: "television", label: "TV" },
+  { key: "cuisine_equipee", label: "Cuisine équipée" },
+  { key: "lave_linge", label: "Lave-linge" },
+  { key: "lave_vaisselle", label: "Lave-vaisselle" },
+  { key: "micro_ondes", label: "Micro-ondes" },
+  { key: "climatisation", label: "Climatisation" },
+  { key: "balcon", label: "Balcon" },
+  { key: "terrasse", label: "Terrasse" },
+  { key: "jardin", label: "Jardin" },
+];
+
+export interface LotCharacteristicsDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  propertyId: string; // id de la property du lot
+  unitLabel: string; // affiche "Lot A - Étage 1"
+  onSaved?: () => void;
+}
+
+interface LotDraft {
+  dpe_classe_energie: DpeClass | "";
+  dpe_classe_climat: DpeClass | "";
+  chauffage_type: "individuel" | "collectif" | "aucun" | "";
+  chauffage_energie: string;
+  eau_chaude_type: string;
+  nb_chambres: number | "";
+  meuble: boolean;
+  equipments: string[];
+  // Flag : true tant qu'on n'a pas fetch les valeurs actuelles
+  _loaded: boolean;
+}
+
+const EMPTY_DRAFT: LotDraft = {
+  dpe_classe_energie: "",
+  dpe_classe_climat: "",
+  chauffage_type: "",
+  chauffage_energie: "",
+  eau_chaude_type: "",
+  nb_chambres: "",
+  meuble: false,
+  equipments: [],
+  _loaded: false,
+};
+
+export function LotCharacteristicsDrawer({
+  open,
+  onOpenChange,
+  propertyId,
+  unitLabel,
+  onSaved,
+}: LotCharacteristicsDrawerProps) {
+  const { toast } = useToast();
+  const [draft, setDraft] = useState<LotDraft>(EMPTY_DRAFT);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Charger les caractéristiques actuelles de la property lot quand le drawer s'ouvre
+  useEffect(() => {
+    if (!open || !propertyId) return;
+    let cancelled = false;
+    setLoading(true);
+    fetch(`/api/properties/${propertyId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        const p = (data?.property || data) as Record<string, unknown>;
+        setDraft({
+          dpe_classe_energie: ((p.dpe_classe_energie as string) || "") as DpeClass | "",
+          dpe_classe_climat: ((p.dpe_classe_climat as string) || "") as DpeClass | "",
+          chauffage_type: ((p.chauffage_type as string) || "") as LotDraft["chauffage_type"],
+          chauffage_energie: (p.chauffage_energie as string) || "",
+          eau_chaude_type: (p.eau_chaude_type as string) || "",
+          nb_chambres: typeof p.nb_chambres === "number" ? p.nb_chambres : "",
+          meuble: Boolean(p.meuble),
+          equipments: Array.isArray(p.equipments) ? (p.equipments as string[]) : [],
+          _loaded: true,
+        });
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          toast({
+            title: "Erreur de chargement",
+            description: e instanceof Error ? e.message : "Impossible de charger le lot",
+            variant: "destructive",
+          });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, propertyId, toast]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const payload = {
+        dpe_classe_energie: draft.dpe_classe_energie || null,
+        dpe_classe_climat: draft.dpe_classe_climat || null,
+        chauffage_type: draft.chauffage_type || null,
+        chauffage_energie: draft.chauffage_energie || null,
+        eau_chaude_type: draft.eau_chaude_type || null,
+        nb_chambres: draft.nb_chambres === "" ? null : draft.nb_chambres,
+        meuble: draft.meuble,
+        equipments: draft.equipments,
+      };
+      const res = await fetch(`/api/properties/${propertyId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.error || "Erreur lors de la sauvegarde");
+      }
+      toast({ title: "Caractéristiques enregistrées" });
+      onSaved?.();
+      onOpenChange(false);
+    } catch (e) {
+      toast({
+        title: e instanceof Error ? e.message : "Erreur",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleEquipment = (key: string) => {
+    setDraft((d) => ({
+      ...d,
+      equipments: d.equipments.includes(key)
+        ? d.equipments.filter((e) => e !== key)
+        : [...d.equipments, key],
+    }));
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="sm:max-w-md overflow-hidden flex flex-col">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-[#2563EB]" />
+            Caractéristiques du lot
+          </SheetTitle>
+          <SheetDescription>
+            <Badge variant="secondary" className="mt-1">
+              {unitLabel}
+            </Badge>
+          </SheetDescription>
+        </SheetHeader>
+
+        {loading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <ScrollArea className="flex-1 my-4 pr-3">
+            <div className="space-y-6">
+              {/* DPE */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <Zap className="h-4 w-4 text-amber-500" />
+                  Diagnostic de performance énergétique
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <Label className="text-xs">DPE (énergie)</Label>
+                    <Select
+                      value={draft.dpe_classe_energie || ""}
+                      onValueChange={(v) =>
+                        setDraft((d) => ({
+                          ...d,
+                          dpe_classe_energie: v as DpeClass | "",
+                        }))
+                      }
+                    >
+                      <SelectTrigger className="h-9 text-sm">
+                        <SelectValue placeholder="Non renseigné" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {DPE_CLASSES.map((c) => (
+                          <SelectItem key={c} value={c}>
+                            {c}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">GES (climat)</Label>
+                    <Select
+                      value={draft.dpe_classe_climat || ""}
+                      onValueChange={(v) =>
+                        setDraft((d) => ({
+                          ...d,
+                          dpe_classe_climat: v as DpeClass | "",
+                        }))
+                      }
+                    >
+                      <SelectTrigger className="h-9 text-sm">
+                        <SelectValue placeholder="Non renseigné" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {DPE_CLASSES.map((c) => (
+                          <SelectItem key={c} value={c}>
+                            {c}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </section>
+
+              <Separator />
+
+              {/* Chauffage */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <Thermometer className="h-4 w-4 text-red-500" />
+                  Chauffage &amp; eau chaude
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <Label className="text-xs">Type</Label>
+                    <Select
+                      value={draft.chauffage_type || ""}
+                      onValueChange={(v) =>
+                        setDraft((d) => ({
+                          ...d,
+                          chauffage_type: v as LotDraft["chauffage_type"],
+                        }))
+                      }
+                    >
+                      <SelectTrigger className="h-9 text-sm">
+                        <SelectValue placeholder="Non renseigné" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {HEATING_TYPES.map((t) => (
+                          <SelectItem key={t.value} value={t.value}>
+                            {t.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Énergie</Label>
+                    <Select
+                      value={draft.chauffage_energie || ""}
+                      onValueChange={(v) =>
+                        setDraft((d) => ({ ...d, chauffage_energie: v }))
+                      }
+                    >
+                      <SelectTrigger className="h-9 text-sm">
+                        <SelectValue placeholder="Non renseigné" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {HEATING_ENERGIES.map((e) => (
+                          <SelectItem key={e.value} value={e.value}>
+                            {e.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Eau chaude sanitaire</Label>
+                  <Select
+                    value={draft.eau_chaude_type || ""}
+                    onValueChange={(v) =>
+                      setDraft((d) => ({ ...d, eau_chaude_type: v }))
+                    }
+                  >
+                    <SelectTrigger className="h-9 text-sm">
+                      <SelectValue placeholder="Non renseigné" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {HOT_WATER_TYPES.map((t) => (
+                        <SelectItem key={t.value} value={t.value}>
+                          {t.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </section>
+
+              <Separator />
+
+              {/* Pièces & meublé */}
+              <section className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <Home className="h-4 w-4 text-emerald-500" />
+                  Agencement
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="nb_chambres" className="text-xs">
+                    Nombre de chambres
+                  </Label>
+                  <Input
+                    id="nb_chambres"
+                    type="number"
+                    min={0}
+                    max={20}
+                    value={draft.nb_chambres}
+                    onChange={(e) =>
+                      setDraft((d) => ({
+                        ...d,
+                        nb_chambres:
+                          e.target.value === "" ? "" : Number(e.target.value),
+                      }))
+                    }
+                    placeholder="0"
+                    className="h-9 text-sm"
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="meuble" className="text-sm">
+                    Lot meublé
+                  </Label>
+                  <Switch
+                    id="meuble"
+                    checked={draft.meuble}
+                    onCheckedChange={(v) => setDraft((d) => ({ ...d, meuble: v }))}
+                  />
+                </div>
+              </section>
+
+              <Separator />
+
+              {/* Équipements */}
+              <section className="space-y-3">
+                <div className="text-sm font-semibold">Équipements</div>
+                <div className="grid grid-cols-2 gap-2">
+                  {LOT_EQUIPMENTS.map((eq) => {
+                    const selected = draft.equipments.includes(eq.key);
+                    return (
+                      <button
+                        key={eq.key}
+                        type="button"
+                        onClick={() => toggleEquipment(eq.key)}
+                        className={
+                          "text-left px-3 py-2 rounded-md border text-xs transition-colors " +
+                          (selected
+                            ? "border-[#2563EB] bg-[#2563EB]/10 text-[#2563EB] font-medium"
+                            : "border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-500")
+                        }
+                      >
+                        {eq.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            </div>
+          </ScrollArea>
+        )}
+
+        <SheetFooter className="pt-4 border-t">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Annuler
+          </Button>
+          <Button onClick={handleSave} disabled={saving || loading}>
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Enregistrement…
+              </>
+            ) : (
+              "Enregistrer"
+            )}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/app/owner/leases/new/LeaseWizard.tsx
+++ b/app/owner/leases/new/LeaseWizard.tsx
@@ -594,34 +594,86 @@ export function LeaseWizard({ properties, initialPropertyId, initialBuildingUnit
   const handlePropertySelect = useCallback((property: Property) => {
     setSelectedPropertyId(property.id);
     const propAny = property as any;
-    
+
     const loyerValue = propAny.loyer_hc ?? propAny.loyer_base ?? 0;
     setPropertyLoyer(loyerValue);
     if (loyerValue > 0) setLoyer(loyerValue);
-    
+
     // Charges : charges_mensuelles (propriété) → charges_forfaitaires (bail)
     const chargesValue = propAny.charges_mensuelles ?? propAny.charges_forfaitaires ?? 0;
     if (chargesValue > 0) setCharges(chargesValue);
-    
+
     // Dépôt : calculer selon le type de bail
     const depotMonths = selectedType ? LEASE_TYPE_CONFIGS[selectedType].maxDepositMonths : 1;
     if (loyerValue > 0) setDepot(loyerValue * depotMonths);
-    
+
     // ✅ SOTA 2026: Toast de confirmation
     const address = property.adresse_complete || property.adresse || "Bien";
     toast({
       title: `✓ ${address.substring(0, 30)}${address.length > 30 ? "..." : ""}`,
-      description: loyerValue > 0 
-        ? `Loyer pré-rempli : ${loyerValue.toLocaleString("fr-FR")} €` 
+      description: loyerValue > 0
+        ? `Loyer pré-rempli : ${loyerValue.toLocaleString("fr-FR")} €`
         : "⚠️ Renseignez le loyer ci-dessous",
       duration: 2000,
     });
-    
+
     // ✅ Pré-remplir digicode/interphone depuis la propriété
     setWizardDigicode(propAny.digicode || "");
     setWizardInterphone(propAny.interphone || "");
     setDigicodeModified(false);
     setInterphoneModified(false);
+
+    // ─── Item #12 : prioriser building_unit.loyer_hc si c'est un lot d'immeuble ──
+    // Fetch async en arrière-plan — ne bloque pas l'UX.
+    // Si la property a un parent_property_id, elle est un lot → on fetch le
+    // building_unit associé et on override loyer/charges/dépôt si les valeurs
+    // diffèrent (le lot est la source de vérité pour ces champs).
+    if (propAny.parent_property_id) {
+      fetch(`/api/properties/${property.id}/building-unit`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          const unit = data?.unit;
+          if (!unit) return;
+
+          // Override uniquement si le building_unit a des valeurs significatives
+          // ET qu'elles différent de la property.
+          const unitLoyer = Number(unit.loyer_hc) || 0;
+          const unitCharges = Number(unit.charges) || 0;
+          const unitDepot = Number(unit.depot_garantie) || 0;
+
+          let overridden = false;
+          if (unitLoyer > 0 && unitLoyer !== loyerValue) {
+            setPropertyLoyer(unitLoyer);
+            setLoyer(unitLoyer);
+            const depMonths = selectedType ? LEASE_TYPE_CONFIGS[selectedType].maxDepositMonths : 1;
+            setDepot(unitDepot > 0 ? unitDepot : unitLoyer * depMonths);
+            overridden = true;
+          } else if (unitDepot > 0) {
+            setDepot(unitDepot);
+          }
+          if (unitCharges > 0 && unitCharges !== chargesValue) {
+            setCharges(unitCharges);
+            overridden = true;
+          }
+
+          if (overridden) {
+            const floorLabel =
+              unit.floor < 0
+                ? `SS${Math.abs(unit.floor)}`
+                : unit.floor === 0
+                ? "RDC"
+                : `Étage ${unit.floor}`;
+            toast({
+              title: "Loyer issu du lot",
+              description: `Lot ${unit.position} · ${floorLabel} — valeurs alignées sur building_units.`,
+              duration: 2500,
+            });
+          }
+        })
+        .catch(() => {
+          /* silencieux — on garde les valeurs property */
+        });
+    }
 
     // ✅ SOTA 2026: Auto-scroll vers la section financière
     setTimeout(() => {
@@ -653,6 +705,26 @@ export function LeaseWizard({ properties, initialPropertyId, initialBuildingUnit
         if (loyerValue > 0) setDepot(loyerValue);
         if (propAny.digicode) setWizardDigicode(propAny.digicode);
         if (propAny.interphone) setWizardInterphone(propAny.interphone);
+
+        // Item #12 : override async depuis le building_unit si c'est un lot.
+        if (propAny.parent_property_id) {
+          fetch(`/api/properties/${property.id}/building-unit`)
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+              const unit = data?.unit;
+              if (!unit) return;
+              const unitLoyer = Number(unit.loyer_hc) || 0;
+              const unitCharges = Number(unit.charges) || 0;
+              const unitDepot = Number(unit.depot_garantie) || 0;
+              if (unitLoyer > 0) setLoyer(unitLoyer);
+              if (unitCharges > 0) setCharges(unitCharges);
+              if (unitDepot > 0) setDepot(unitDepot);
+              else if (unitLoyer > 0) setDepot(unitLoyer);
+            })
+            .catch(() => {
+              /* silencieux */
+            });
+        }
       }
     }
   }, [initialPropertyId, properties, loyer]);

--- a/app/owner/properties/[id]/PropertyDetailsClient.tsx
+++ b/app/owner/properties/[id]/PropertyDetailsClient.tsx
@@ -76,6 +76,11 @@ const PropertyMap = dynamic(
 interface PropertyDetailsClientProps {
   details: PropertyDetails;
   propertyId: string;
+  /**
+   * Item #13 : contexte parent pour breadcrumb "Mes biens > Immeuble > Lot"
+   * et badge cliquable. Null si la property n'est pas un lot d'immeuble.
+   */
+  parentBuilding?: { id: string; adresse_complete: string | null } | null;
 }
 
 // Mapping type de bien → label CTA bail adapté + route
@@ -129,7 +134,7 @@ function getLeaseCtaForPropertyType(propertyType: string | undefined, propertyId
   }
 }
 
-export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsClientProps) {
+export function PropertyDetailsClient({ details, propertyId, parentBuilding }: PropertyDetailsClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
@@ -622,17 +627,46 @@ export function PropertyDetailsClient({ details, propertyId }: PropertyDetailsCl
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isGalleryOpen, handleKeyDown]);
 
+  // Item #13 : breadcrumb et badge contextualisés pour un lot d'immeuble.
+  const breadcrumbItems = parentBuilding
+    ? [
+        { label: "Mes biens", href: "/owner/properties?tab=immeubles" },
+        {
+          label: `Immeuble ${parentBuilding.adresse_complete ?? ""}`.trim(),
+          href: `/owner/buildings/${parentBuilding.id}`,
+        },
+        { label: property.adresse_complete || "Lot" },
+      ]
+    : [
+        { label: "Mes biens", href: "/owner/properties" },
+        { label: property.adresse_complete || "Détails du bien" },
+      ];
+
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
-      {/* Breadcrumb */}
+      {/* Breadcrumb (contextualisé pour les lots d'immeuble — item #13) */}
       <Breadcrumb
-        items={[
-          { label: "Mes biens", href: "/owner/properties" },
-          { label: property.adresse_complete || "Détails du bien" }
-        ]}
+        items={breadcrumbItems}
         homeHref="/owner/dashboard"
         className="mb-4"
       />
+
+      {/* Badge parent cliquable — visible uniquement pour les lots d'immeuble */}
+      {parentBuilding && (
+        <Link
+          href={`/owner/buildings/${parentBuilding.id}`}
+          className="inline-flex items-center gap-2 px-3 py-1.5 mb-4 rounded-full bg-blue-50 hover:bg-blue-100 border border-blue-200 text-[#2563EB] text-sm transition-colors"
+        >
+          <Building2 className="h-3.5 w-3.5" />
+          <span>
+            Lot dans l'immeuble
+            {parentBuilding.adresse_complete
+              ? ` · ${parentBuilding.adresse_complete}`
+              : ""}
+          </span>
+          <ArrowLeft className="h-3.5 w-3.5 rotate-180 opacity-60" />
+        </Link>
+      )}
 
       {/* Bouton retour */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">

--- a/app/owner/properties/[id]/page.tsx
+++ b/app/owner/properties/[id]/page.tsx
@@ -85,7 +85,33 @@ export default async function OwnerPropertyDetailPage({ params }: PageProps) {
       redirect(`/owner/buildings/${id}`);
     }
 
-    return <PropertyDetailsClient details={details} propertyId={id} />;
+    // Item #13 : si la property est un lot d'immeuble, enrichir le contexte
+    // avec l'adresse du parent pour afficher un breadcrumb "Mes biens >
+    // Immeuble [X] > Lot [Y]" et un badge cliquable vers le hub immeuble.
+    let parentBuilding: { id: string; adresse_complete: string | null } | null = null;
+    const parentPropertyId = (details as any).parent_property_id as string | null | undefined;
+    if (parentPropertyId) {
+      const { data: parent } = await serviceClient
+        .from("properties")
+        .select("id, adresse_complete")
+        .eq("id", parentPropertyId)
+        .is("deleted_at", null)
+        .maybeSingle();
+      if (parent) {
+        parentBuilding = {
+          id: parent.id,
+          adresse_complete: parent.adresse_complete ?? null,
+        };
+      }
+    }
+
+    return (
+      <PropertyDetailsClient
+        details={details}
+        propertyId={id}
+        parentBuilding={parentBuilding}
+      />
+    );
   } catch (error) {
     console.error("Error loading property details:", error);
     return (

--- a/docs/api-buildings.md
+++ b/docs/api-buildings.md
@@ -1,0 +1,113 @@
+# API Buildings — Référence
+
+> Module immeubles et lots. Mise à jour Phase 5 audit building-module (2026-04).
+
+## Endpoint canonique (wizard + hub)
+
+### `POST /api/properties/[id]/building-units`
+
+**Statut** : actif — source de vérité du module immeuble côté client.
+
+Upsert atomique (via RPC `upsert_building_with_units`) de l'immeuble + lots
+d'un `property.type='immeuble'`. Utilisé par :
+
+- `property-wizard-v3.tsx` (création initiale)
+- `UnitsManagementClient.tsx` (édition groupée)
+
+**Body** (Zod) :
+
+```ts
+{
+  name?: string;
+  building_floors?: number;
+  construction_year?: number;
+  surface_totale?: number;
+  notes?: string;
+  ownership_type?: 'full' | 'partial';
+  total_lots_in_building?: number; // obligatoire si ownership_type='partial'
+  has_ascenseur?: boolean;
+  has_gardien?: boolean;
+  has_interphone?: boolean;
+  has_digicode?: boolean;
+  has_local_velo?: boolean;
+  has_local_poubelles?: boolean;
+  has_parking_commun?: boolean;
+  has_jardin_commun?: boolean;
+  units: Array<{
+    floor: number;      // -5..50
+    position: string;   // "A", "B", ...
+    type: 'appartement'|'studio'|'local_commercial'|'parking'|'cave'|'bureau';
+    surface: number;
+    nb_pieces: number;
+    template?: string | null;
+    loyer_hc: number;
+    charges: number;
+    depot_garantie: number;
+    status?: 'vacant'|'occupe'|'travaux'|'reserve';
+    meuble?: boolean;
+  }>;
+}
+```
+
+**Garde** : refuse (409) si au moins un lot a un bail bloquant (statut
+`active`, `pending_signature`, `fully_signed`, `notice_given`).
+
+---
+
+## Endpoints actifs sur le hub
+
+| Endpoint | Méthodes | Consommé par |
+|---|---|---|
+| `/api/buildings/[id]` | `PATCH`, `DELETE` | `BuildingDetailClient.tsx` |
+| `/api/buildings/[id]/units/[unitId]` | `PATCH`, `DELETE` | `BuildingDetailClient.tsx` (status + delete) |
+| `/api/buildings/[id]/units/[unitId]/duplicate` | `POST` | `BuildingDetailClient.tsx` (dialog Phase 4) |
+| `/api/buildings/[id]/stats` | `GET` | `BuildingDetailClient.tsx` (Phase 4) |
+| `/api/properties/[id]/building-unit` | `GET` | `LeaseWizard.tsx` (priorité loyer lot, Phase 5) |
+| `/api/properties/[id]/building` | `GET` | `buildings.service.ts` (loadProperty wizard) |
+| `/api/properties/[id]/building-units` | `POST` | wizard + UnitsManagement |
+
+---
+
+## Endpoints conservés mais non consommés par le frontend
+
+Ces endpoints sont fonctionnels et restent disponibles pour :
+- usage programmatique externe (scripts, intégrations futures)
+- tests E2E
+- évolution vers une API publique
+
+Ils sont marqués par un commentaire en tête `// NOT CONSUMED BY FRONTEND —
+kept for API programmatic use`.
+
+| Endpoint | Méthodes | Pourquoi non consommé ? |
+|---|---|---|
+| `/api/buildings` | `GET` | Remplacé par query directe côté SSR via `/api/buildings/[id]/stats` et page SSR |
+| `/api/buildings` | `POST` | Remplacé par `POST /api/properties/[id]/building-units` (wizard) |
+| `/api/buildings/[id]` | `GET` | Remplacé par fetch SSR dans `app/owner/buildings/[id]/page.tsx` |
+| `/api/buildings/[id]/units` | `GET` | Remplacé par fetch SSR |
+| `/api/buildings/[id]/units` | `POST` (single + bulk) | Remplacé par `POST /api/properties/[id]/building-units` |
+| `/api/buildings/[id]/units/[unitId]` | `GET` | Remplacé par fetch SSR |
+
+---
+
+## Règles de développement
+
+1. **Toute mutation building/units passe par la RPC transactionnelle** (via
+   `POST /api/properties/[id]/building-units`). Ne PAS appeler
+   `POST /api/buildings` ou `POST /api/buildings/[id]/units` depuis le wizard.
+
+2. **Garde baux actifs** : toute route qui remplace ou supprime des `building_units`
+   doit appeler `public.building_active_lease_units(buildingId)` avant. La RPC
+   et `DELETE /api/buildings/[id]` le font déjà.
+
+3. **Service client** : toutes les lectures/écritures côté API utilisent
+   `getServiceClient()` (bypass RLS). Pas de `createClient()` user-scoped
+   dans les routes building.
+
+4. **RLS** : les policies `buildings_owner_*` et `building_units_owner_*`
+   incluent maintenant le support `entity_members` (Phase 5). Un membre SCI
+   a accès aux immeubles de son entité via
+   `public.user_in_entity_of_property(property_id)`.
+
+5. **URL `/owner/buildings/[id]`** : utilise `property_id` du wrapper (pas
+   `building_id`). Le server component résout `building_id` via
+   `buildings.property_id`.

--- a/docs/buildings-backlog.md
+++ b/docs/buildings-backlog.md
@@ -1,0 +1,108 @@
+# Module Buildings — Backlog différé (post audit 2026-04)
+
+> Items identifiés par l'audit mais **volontairement non implémentés** par
+> les phases 1-5 parce que :
+> - le besoin métier n'est pas encore confirmé (#19), OU
+> - le ROI MVP est trop faible (#23).
+>
+> À reprendre si les conditions de déclenchement listées ci-dessous sont
+> atteintes.
+
+---
+
+## #19 — Route `POST /api/properties/[id]/associate-building`
+
+**Effort estimé** : M (0.5–1j)
+**Priorité audit** : P2
+**Statut** : ❌ Non implémenté — **en attente de confirmation métier**
+
+### Description
+
+Permettre de rattacher une `property` existante (un bien unitaire déjà créé)
+à un immeuble existant, transformant la property en lot. Concrètement :
+- Body : `{ building_id: string }`
+- Crée un `building_unit` lié au building + à la property source
+- Met à jour `buildings.property_id` si c'est le premier rattachement
+- Positionne `properties.parent_property_id` vers le wrapper de l'immeuble
+
+### Conditions de déclenchement
+
+Implémenter si **au moins un** de ces signaux émerge :
+1. Un propriétaire demande à regrouper ses biens éparpillés dans une vue
+   "immeuble" a posteriori (pas lors de la création)
+2. Import d'un portefeuille existant depuis un concurrent qui expose les
+   biens comme unitaires mais réellement groupés
+3. Migration SCI : un propriétaire crée sa SCI après avoir déjà saisi ses
+   biens en direct et veut les rattacher
+
+### Risques / complexité
+
+- **RLS** : la property source peut avoir un `owner_id` différent du
+  `building.owner_id` → refuser le rattachement dans ce cas
+- **Quota** : la property reste comptée dans le quota même après
+  rattachement (les lots comptent dans le quota — cf. `check-limit.ts`)
+- **Baux actifs** : si la property source a un bail actif, il faut
+  décider si on le conserve et le lier au nouveau `building_unit.id`
+  via `leases.building_unit_id`, ou si on refuse l'association
+
+### Alternatives déjà en place
+
+- Le workflow actuel suffit : créer l'immeuble, puis ajouter les lots
+  via `/owner/buildings/[id]/units` (`UnitsManagementClient`)
+- Pas de demande utilisateur remontée à date (avril 2026)
+
+---
+
+## #23 — Draft serveur pour édition lots
+
+**Effort estimé** : L (1–3j)
+**Priorité audit** : P2
+**Statut** : ❌ Reporté — ROI MVP trop faible
+
+### Description
+
+Aujourd'hui, `UnitsManagementClient` garde les modifications en mémoire
+React tant que l'utilisateur n'a pas cliqué "Enregistrer". Si la page est
+fermée / rafraîchie / si le navigateur crashe, les modifications en cours
+sont perdues.
+
+La feature consisterait à :
+- Auto-saver dans une table `building_drafts` à chaque changement
+  (debounced), avec un état par `building_id` + `user_id`
+- Proposer de restaurer le draft à l'ouverture de
+  `/owner/buildings/[id]/units`
+- Option "Abandonner le draft" pour nettoyer
+
+### Conditions de déclenchement
+
+Implémenter si **au moins un** de ces signaux :
+1. Les utilisateurs rapportent des pertes de modifications (ticket
+   support, NPS, analytics `page_abandonment_during_edit`)
+2. Les sessions d'édition dépassent régulièrement 10 minutes (→ risque
+   de perte plus élevé)
+3. Demande récurrente en retours utilisateurs sur le hub immeuble
+
+### Alternatives déjà en place
+
+- Pour créer un immeuble complet : le wizard a déjà son propre draft
+  serveur (via `initializeDraft` + `updateFormData` debounce dans
+  `wizard-store.ts`)
+- L'édition des lots via `UnitsManagementClient` reste relativement
+  rapide (moins de 3 minutes pour 10 lots)
+- Le risque de perte est tangible mais limité aux modifications
+  pendant la session d'édition
+
+---
+
+## Note sur les items non-phasés
+
+Tous les autres items du tableau Axe 6 de l'audit ont été livrés via les
+Phases 1 à 5. Voir :
+- Migrations : `supabase/migrations/20260415140000_*`,
+  `20260415150000_*`, `20260415160000_*`
+- Routes API : `app/api/properties/[id]/building-units/route.ts` (RPC),
+  `app/api/properties/[id]/building-unit/route.ts` (Phase 5)
+- Frontend : `BuildingConfigStep.tsx`, `BuildingDetailClient.tsx`,
+  `LotCharacteristicsDrawer.tsx`, `LeaseWizard.tsx`,
+  `PropertyDetailsClient.tsx`
+- Doc : `docs/api-buildings.md`

--- a/features/properties/components/v3/immersive/steps/BuildingConfigStep.tsx
+++ b/features/properties/components/v3/immersive/steps/BuildingConfigStep.tsx
@@ -2,9 +2,10 @@
 
 import React, { useState, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { 
-  Building2, Plus, Copy, Trash2, Sparkles, Wand2, 
-  Globe, ChevronRight, Home, Car, Warehouse
+import {
+  Building2, Plus, Copy, Trash2, Sparkles, Wand2,
+  Globe, ChevronRight, ChevronDown, Home, Car, Warehouse,
+  Euro, Users, Calendar, Ruler
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,6 +14,9 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
+import {
+  RadioGroup, RadioGroupItem,
+} from "@/components/ui/radio-group";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
@@ -23,8 +27,9 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { usePropertyWizardStore } from "@/features/properties/stores/wizard-store";
 import { cn } from "@/lib/utils";
 import { BuildingVisualizer } from "./BuildingVisualizer";
-import { 
-  type BuildingUnit, 
+import {
+  type BuildingUnit,
+  type BuildingOwnershipType,
   type UnitTemplateConfig,
   UNIT_TEMPLATES,
   generateUnitId,
@@ -61,21 +66,67 @@ export function BuildingConfigStep() {
   const [hasGardien, setHasGardien] = useState(formData.has_gardien || false);
   const [hasInterphone, setHasInterphone] = useState(formData.has_interphone || false);
   const [hasDigicode, setHasDigicode] = useState(formData.has_digicode || false);
+  const [hasLocalVelo, setHasLocalVelo] = useState(formData.has_local_velo || false);
+  const [hasLocalPoubelles, setHasLocalPoubelles] = useState(formData.has_local_poubelles || false);
+  const [hasParkingCommun, setHasParkingCommun] = useState(formData.has_parking_commun || false);
+  const [hasJardinCommun, setHasJardinCommun] = useState(formData.has_jardin_commun || false);
   const [digicodeValue, setDigicodeValue] = useState((formData as any).digicode || "");
   const [interphoneValue, setInterphoneValue] = useState((formData as any).interphone || "");
 
-  // Sync avec le store
+  // Détails immeuble (SOTA 2026)
+  const [buildingName, setBuildingName] = useState(formData.building_name || "");
+  const [constructionYear, setConstructionYear] = useState<number | "">(
+    formData.construction_year ?? ""
+  );
+  const [surfaceTotale, setSurfaceTotale] = useState<number | "">(
+    formData.surface_totale ?? ""
+  );
+
+  // Mode de possession (SOTA 2026)
+  const [ownershipType, setOwnershipType] = useState<BuildingOwnershipType>(
+    formData.ownership_type ?? "full"
+  );
+  const [totalLotsInBuilding, setTotalLotsInBuilding] = useState<number | "">(
+    formData.total_lots_in_building ?? ""
+  );
+
+  // Expand édition inline d'un lot (loyer/charges/dépôt/meublé)
+  const [expandedUnitId, setExpandedUnitId] = useState<string | null>(null);
+
+  // Sync avec le store (lots + floors + équipements communs)
   const syncToStore = useCallback((newUnits: BuildingUnit[], newFloors?: number) => {
     setUnits(newUnits);
-    updateFormData({ 
+    updateFormData({
       building_units: newUnits,
       building_floors: newFloors ?? floors,
       has_ascenseur: hasAscenseur,
       has_gardien: hasGardien,
       has_interphone: hasInterphone,
       has_digicode: hasDigicode,
+      has_local_velo: hasLocalVelo,
+      has_local_poubelles: hasLocalPoubelles,
+      has_parking_commun: hasParkingCommun,
+      has_jardin_commun: hasJardinCommun,
     });
-  }, [floors, hasAscenseur, hasGardien, hasInterphone, hasDigicode, updateFormData]);
+  }, [
+    floors,
+    hasAscenseur, hasGardien, hasInterphone, hasDigicode,
+    hasLocalVelo, hasLocalPoubelles, hasParkingCommun, hasJardinCommun,
+    updateFormData,
+  ]);
+
+  // Mettre à jour un seul champ d'un lot donné (loyer, charges, dépôt, meublé)
+  const updateUnit = useCallback(
+    (unitId: string, patch: Partial<BuildingUnit>) => {
+      const next = units.map((u) =>
+        u.id === unitId
+          ? { ...u, ...patch, updated_at: new Date().toISOString() }
+          : u
+      );
+      syncToStore(next);
+    },
+    [units, syncToStore]
+  );
 
   // Ajouter un lot
   const addUnit = useCallback((floor: number, template: UnitTemplateConfig) => {
@@ -359,6 +410,150 @@ export function BuildingConfigStep() {
           </CardContent>
         </Card>
 
+        {/* Détails de l'immeuble */}
+        <Card>
+          <CardHeader className="pb-2 pt-3 px-4">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Building2 className="h-4 w-4 text-blue-500" />
+              Détails de l'immeuble
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 pb-4 space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="building_name" className="text-xs">Nom (optionnel)</Label>
+              <Input
+                id="building_name"
+                value={buildingName}
+                onChange={(e) => {
+                  setBuildingName(e.target.value);
+                  updateFormData({ building_name: e.target.value });
+                }}
+                placeholder="Résidence Les Oliviers"
+                className="h-8 text-sm"
+                maxLength={200}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label htmlFor="construction_year" className="text-xs flex items-center gap-1">
+                  <Calendar className="h-3 w-3" />
+                  Année
+                </Label>
+                <Input
+                  id="construction_year"
+                  type="number"
+                  min={1800}
+                  max={2100}
+                  value={constructionYear}
+                  onChange={(e) => {
+                    const v = e.target.value === "" ? "" : Number(e.target.value);
+                    setConstructionYear(v);
+                    updateFormData({
+                      construction_year: v === "" ? undefined : v,
+                    });
+                  }}
+                  placeholder="1960"
+                  className="h-8 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="surface_totale" className="text-xs flex items-center gap-1">
+                  <Ruler className="h-3 w-3" />
+                  Surface m²
+                </Label>
+                <Input
+                  id="surface_totale"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={surfaceTotale}
+                  onChange={(e) => {
+                    const v = e.target.value === "" ? "" : Number(e.target.value);
+                    setSurfaceTotale(v);
+                    updateFormData({
+                      surface_totale: v === "" ? undefined : v,
+                    });
+                  }}
+                  placeholder="280"
+                  className="h-8 text-sm"
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Mode de possession */}
+        <Card>
+          <CardHeader className="pb-2 pt-3 px-4">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Users className="h-4 w-4 text-purple-500" />
+              Mode de possession
+            </CardTitle>
+            <CardDescription className="text-[11px]">
+              Possédez-vous l'immeuble en totalité, ou seulement certains lots ?
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="px-4 pb-4 space-y-3">
+            <RadioGroup
+              value={ownershipType}
+              onValueChange={(v) => {
+                const next = (v as BuildingOwnershipType) ?? "full";
+                setOwnershipType(next);
+                updateFormData({
+                  ownership_type: next,
+                  total_lots_in_building:
+                    next === "full" ? undefined : (typeof totalLotsInBuilding === "number" ? totalLotsInBuilding : undefined),
+                });
+              }}
+              className="space-y-2"
+            >
+              <div className="flex items-start gap-2 p-2 rounded-md border hover:border-blue-400 cursor-pointer">
+                <RadioGroupItem value="full" id="own-full" className="mt-0.5" />
+                <Label htmlFor="own-full" className="flex-1 cursor-pointer">
+                  <div className="text-sm font-medium">Immeuble entier</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Vous possédez tous les lots.
+                  </div>
+                </Label>
+              </div>
+              <div className="flex items-start gap-2 p-2 rounded-md border hover:border-blue-400 cursor-pointer">
+                <RadioGroupItem value="partial" id="own-partial" className="mt-0.5" />
+                <Label htmlFor="own-partial" className="flex-1 cursor-pointer">
+                  <div className="text-sm font-medium">Copropriété partielle</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Vous ne possédez qu'une partie des lots (les autres sont à d'autres copropriétaires).
+                  </div>
+                </Label>
+              </div>
+            </RadioGroup>
+            {ownershipType === "partial" && (
+              <div className="space-y-1 pl-2 border-l-2 border-purple-200">
+                <Label htmlFor="total_lots" className="text-xs">
+                  Nombre total de lots de l'immeuble physique
+                </Label>
+                <Input
+                  id="total_lots"
+                  type="number"
+                  min={1}
+                  value={totalLotsInBuilding}
+                  onChange={(e) => {
+                    const v = e.target.value === "" ? "" : Number(e.target.value);
+                    setTotalLotsInBuilding(v);
+                    updateFormData({
+                      total_lots_in_building: v === "" ? undefined : v,
+                    });
+                  }}
+                  placeholder="Ex: 12"
+                  className="h-8 text-sm"
+                />
+                <p className="text-[11px] text-muted-foreground">
+                  Incluez tous les lots, y compris ceux qui ne vous appartiennent pas.
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
         {/* Parties communes */}
         <Card>
           <CardHeader className="pb-2 pt-3 px-4">
@@ -367,9 +562,9 @@ export function BuildingConfigStep() {
           <CardContent className="px-4 pb-4 space-y-3">
             <div className="flex items-center justify-between">
               <Label htmlFor="ascenseur" className="text-sm">Ascenseur</Label>
-              <Switch 
-                id="ascenseur" 
-                checked={hasAscenseur} 
+              <Switch
+                id="ascenseur"
+                checked={hasAscenseur}
                 onCheckedChange={(v) => {
                   setHasAscenseur(v);
                   updateFormData({ has_ascenseur: v });
@@ -378,12 +573,56 @@ export function BuildingConfigStep() {
             </div>
             <div className="flex items-center justify-between">
               <Label htmlFor="gardien" className="text-sm">Gardien</Label>
-              <Switch 
-                id="gardien" 
-                checked={hasGardien} 
+              <Switch
+                id="gardien"
+                checked={hasGardien}
                 onCheckedChange={(v) => {
                   setHasGardien(v);
                   updateFormData({ has_gardien: v });
+                }}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="local_velo" className="text-sm">Local vélo</Label>
+              <Switch
+                id="local_velo"
+                checked={hasLocalVelo}
+                onCheckedChange={(v) => {
+                  setHasLocalVelo(v);
+                  updateFormData({ has_local_velo: v });
+                }}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="local_poubelles" className="text-sm">Local poubelles</Label>
+              <Switch
+                id="local_poubelles"
+                checked={hasLocalPoubelles}
+                onCheckedChange={(v) => {
+                  setHasLocalPoubelles(v);
+                  updateFormData({ has_local_poubelles: v });
+                }}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="parking_commun" className="text-sm">Parking commun</Label>
+              <Switch
+                id="parking_commun"
+                checked={hasParkingCommun}
+                onCheckedChange={(v) => {
+                  setHasParkingCommun(v);
+                  updateFormData({ has_parking_commun: v });
+                }}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="jardin_commun" className="text-sm">Jardin commun</Label>
+              <Switch
+                id="jardin_commun"
+                checked={hasJardinCommun}
+                onCheckedChange={(v) => {
+                  setHasJardinCommun(v);
+                  updateFormData({ has_jardin_commun: v });
                 }}
               />
             </div>
@@ -461,54 +700,186 @@ export function BuildingConfigStep() {
               <ScrollArea className="max-h-48">
                 <div className="space-y-2">
                   <AnimatePresence mode="popLayout">
-                    {selectedFloorUnits.map((unit) => (
-                      <motion.div
-                        key={unit.id}
-                        layout
-                        initial={{ opacity: 0, scale: 0.9 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        exit={{ opacity: 0, scale: 0.9 }}
-                        className="flex items-center gap-2 p-2 bg-slate-50 dark:bg-slate-800 rounded-lg border"
-                      >
-                        <div className={cn(
-                          "w-8 h-8 rounded-md flex items-center justify-center text-lg",
-                          unit.type === "parking" && "bg-blue-100 dark:bg-blue-900",
-                          unit.type === "cave" && "bg-amber-100 dark:bg-amber-900",
-                          unit.type !== "parking" && unit.type !== "cave" && "bg-emerald-100 dark:bg-emerald-900"
-                        )}>
-                          {unit.type === "parking" ? "🚗" : unit.type === "cave" ? "🪨" : "🏠"}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <p className="font-medium text-sm truncate">
-                            Lot {unit.position} • {unit.template?.toUpperCase() || unit.type}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {unit.surface} m² • {unit.nb_pieces > 0 ? `${unit.nb_pieces} pièce${unit.nb_pieces > 1 ? "s" : ""}` : ""}
-                          </p>
-                        </div>
-                        <div className="flex gap-1">
-                          <Button 
-                            size="icon" 
-                            variant="ghost" 
-                            className="h-7 w-7 text-slate-400 hover:text-blue-500"
-                            onClick={() => {
-                              setUnitToDuplicate(unit);
-                              setShowDuplicateDialog(true);
-                            }}
-                          >
-                            <Copy className="h-3.5 w-3.5" />
-                          </Button>
-                          <Button 
-                            size="icon" 
-                            variant="ghost" 
-                            className="h-7 w-7 text-slate-400 hover:text-red-500"
-                            onClick={() => removeUnit(unit.id)}
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </Button>
-                        </div>
-                      </motion.div>
-                    ))}
+                    {selectedFloorUnits.map((unit) => {
+                      const isExpanded = expandedUnitId === unit.id;
+                      const isHabitable = unit.type !== "parking" && unit.type !== "cave";
+                      return (
+                        <motion.div
+                          key={unit.id}
+                          layout
+                          initial={{ opacity: 0, scale: 0.9 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          exit={{ opacity: 0, scale: 0.9 }}
+                          className="bg-slate-50 dark:bg-slate-800 rounded-lg border overflow-hidden"
+                        >
+                          {/* Ligne compacte */}
+                          <div className="flex items-center gap-2 p-2">
+                            <button
+                              type="button"
+                              className={cn(
+                                "w-8 h-8 rounded-md flex items-center justify-center text-lg shrink-0",
+                                unit.type === "parking" && "bg-blue-100 dark:bg-blue-900",
+                                unit.type === "cave" && "bg-amber-100 dark:bg-amber-900",
+                                unit.type !== "parking" && unit.type !== "cave" && "bg-emerald-100 dark:bg-emerald-900"
+                              )}
+                              onClick={() => setExpandedUnitId(isExpanded ? null : unit.id)}
+                              aria-label={isExpanded ? "Réduire" : "Modifier"}
+                            >
+                              {unit.type === "parking" ? "🚗" : unit.type === "cave" ? "🪨" : "🏠"}
+                            </button>
+                            <button
+                              type="button"
+                              className="flex-1 min-w-0 text-left"
+                              onClick={() => setExpandedUnitId(isExpanded ? null : unit.id)}
+                            >
+                              <p className="font-medium text-sm truncate">
+                                Lot {unit.position} • {unit.template?.toUpperCase() || unit.type}
+                                {unit.loyer_hc > 0 && (
+                                  <span className="ml-2 text-xs text-emerald-600 font-normal">
+                                    {unit.loyer_hc}€ HC
+                                  </span>
+                                )}
+                              </p>
+                              <p className="text-xs text-muted-foreground">
+                                {unit.surface} m² • {unit.nb_pieces > 0 ? `${unit.nb_pieces} pièce${unit.nb_pieces > 1 ? "s" : ""}` : ""}
+                              </p>
+                            </button>
+                            <div className="flex gap-1">
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7 text-slate-400 hover:text-blue-500"
+                                onClick={() => setExpandedUnitId(isExpanded ? null : unit.id)}
+                                aria-label="Éditer le lot"
+                              >
+                                {isExpanded
+                                  ? <ChevronDown className="h-3.5 w-3.5" />
+                                  : <ChevronRight className="h-3.5 w-3.5" />}
+                              </Button>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7 text-slate-400 hover:text-blue-500"
+                                onClick={() => {
+                                  setUnitToDuplicate(unit);
+                                  setShowDuplicateDialog(true);
+                                }}
+                              >
+                                <Copy className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7 text-slate-400 hover:text-red-500"
+                                onClick={() => removeUnit(unit.id)}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          </div>
+
+                          {/* Zone éditable (loyer / charges / dépôt / meublé) */}
+                          <AnimatePresence initial={false}>
+                            {isExpanded && (
+                              <motion.div
+                                initial={{ height: 0, opacity: 0 }}
+                                animate={{ height: "auto", opacity: 1 }}
+                                exit={{ height: 0, opacity: 0 }}
+                                className="border-t border-slate-200 dark:border-slate-700 bg-white/60 dark:bg-slate-900/40"
+                              >
+                                <div className="p-3 space-y-3">
+                                  <div className="grid grid-cols-3 gap-2">
+                                    <div className="space-y-1">
+                                      <Label
+                                        htmlFor={`loyer-${unit.id}`}
+                                        className="text-[11px] flex items-center gap-1"
+                                      >
+                                        <Euro className="h-3 w-3" />
+                                        Loyer HC
+                                      </Label>
+                                      <Input
+                                        id={`loyer-${unit.id}`}
+                                        type="number"
+                                        min={0}
+                                        step="0.01"
+                                        value={unit.loyer_hc || ""}
+                                        onChange={(e) =>
+                                          updateUnit(unit.id, {
+                                            loyer_hc: e.target.value === "" ? 0 : Number(e.target.value),
+                                          })
+                                        }
+                                        placeholder="650"
+                                        className="h-8 text-sm"
+                                      />
+                                    </div>
+                                    <div className="space-y-1">
+                                      <Label
+                                        htmlFor={`charges-${unit.id}`}
+                                        className="text-[11px]"
+                                      >
+                                        Charges
+                                      </Label>
+                                      <Input
+                                        id={`charges-${unit.id}`}
+                                        type="number"
+                                        min={0}
+                                        step="0.01"
+                                        value={unit.charges || ""}
+                                        onChange={(e) =>
+                                          updateUnit(unit.id, {
+                                            charges: e.target.value === "" ? 0 : Number(e.target.value),
+                                          })
+                                        }
+                                        placeholder="50"
+                                        className="h-8 text-sm"
+                                      />
+                                    </div>
+                                    <div className="space-y-1">
+                                      <Label
+                                        htmlFor={`depot-${unit.id}`}
+                                        className="text-[11px]"
+                                      >
+                                        Dépôt
+                                      </Label>
+                                      <Input
+                                        id={`depot-${unit.id}`}
+                                        type="number"
+                                        min={0}
+                                        step="0.01"
+                                        value={unit.depot_garantie || ""}
+                                        onChange={(e) =>
+                                          updateUnit(unit.id, {
+                                            depot_garantie: e.target.value === "" ? 0 : Number(e.target.value),
+                                          })
+                                        }
+                                        placeholder="650"
+                                        className="h-8 text-sm"
+                                      />
+                                    </div>
+                                  </div>
+
+                                  {isHabitable && (
+                                    <div className="flex items-center justify-between">
+                                      <Label
+                                        htmlFor={`meuble-${unit.id}`}
+                                        className="text-[12px]"
+                                      >
+                                        Lot meublé
+                                      </Label>
+                                      <Switch
+                                        id={`meuble-${unit.id}`}
+                                        checked={unit.meuble ?? false}
+                                        onCheckedChange={(v) => updateUnit(unit.id, { meuble: v })}
+                                      />
+                                    </div>
+                                  )}
+                                </div>
+                              </motion.div>
+                            )}
+                          </AnimatePresence>
+                        </motion.div>
+                      );
+                    })}
                   </AnimatePresence>
                   
                   {selectedFloorUnits.length === 0 && (

--- a/features/properties/components/v3/property-wizard-v3.tsx
+++ b/features/properties/components/v3/property-wizard-v3.tsx
@@ -420,19 +420,30 @@ export function PropertyWizardV3({ propertyId, initialData, onSuccess, onCancel 
 
     // SOTA 2026: Persister les lots d'immeuble avant publication
     if (formData.type === "immeuble" && (formData.building_units as unknown[] | undefined)?.length) {
-      const units = (formData.building_units as Array<{ floor: number; position: string; type: string; surface: number; nb_pieces: number; loyer_hc: number; charges: number; depot_garantie: number; status?: string; template?: string }>) ?? [];
+      const units = (formData.building_units as Array<{ floor: number; position: string; type: string; surface: number; nb_pieces: number; loyer_hc: number; charges: number; depot_garantie: number; status?: string; template?: string; meuble?: boolean }>) ?? [];
       try {
         const res = await fetch(`/api/properties/${storePropertyId}/building-units`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
+            // Identité + structure
+            name: formData.building_name,
             building_floors: formData.building_floors ?? 1,
+            construction_year: formData.construction_year,
+            surface_totale: formData.surface_totale,
+            // Mode de possession
+            ownership_type: formData.ownership_type ?? "full",
+            total_lots_in_building: formData.total_lots_in_building,
+            // Parties communes
             has_ascenseur: formData.has_ascenseur,
             has_gardien: formData.has_gardien,
             has_interphone: formData.has_interphone,
             has_digicode: formData.has_digicode,
             has_local_velo: formData.has_local_velo,
             has_local_poubelles: formData.has_local_poubelles,
+            has_parking_commun: formData.has_parking_commun,
+            has_jardin_commun: formData.has_jardin_commun,
+            // Lots
             units: units.map((u) => ({
               floor: u.floor,
               position: u.position ?? "A",
@@ -444,6 +455,7 @@ export function PropertyWizardV3({ propertyId, initialData, onSuccess, onCancel 
               depot_garantie: u.depot_garantie ?? 0,
               status: u.status ?? "vacant",
               template: u.template ?? null,
+              meuble: u.meuble ?? false,
             })),
           }),
         });

--- a/features/properties/stores/wizard-store.ts
+++ b/features/properties/stores/wizard-store.ts
@@ -112,12 +112,19 @@ export interface WizardFormData {
   // SOTA 2026 - Champs spécifiques immeuble
   building_floors?: number;
   building_units?: BuildingUnit[];
+  building_name?: string;
+  construction_year?: number;
+  surface_totale?: number;
+  ownership_type?: 'full' | 'partial';
+  total_lots_in_building?: number;
   has_ascenseur?: boolean;
   has_gardien?: boolean;
   has_interphone?: boolean;
   has_digicode?: boolean;
   has_local_velo?: boolean;
   has_local_poubelles?: boolean;
+  has_parking_commun?: boolean;
+  has_jardin_commun?: boolean;
   digicode?: string;
   interphone?: string;
 }
@@ -243,10 +250,15 @@ const INITIAL_STATE: Omit<WizardState, 'reset' | 'initializeDraft' | 'loadProper
     // Valeurs par défaut immeuble
     building_floors: 4,
     building_units: [],
+    ownership_type: 'full',
     has_ascenseur: false,
     has_gardien: false,
     has_interphone: false,
     has_digicode: false,
+    has_local_velo: false,
+    has_local_poubelles: false,
+    has_parking_commun: false,
+    has_jardin_commun: false,
     digicode: "",
     interphone: "",
   },
@@ -401,12 +413,20 @@ export const usePropertyWizardStore = create<WizardState>()(
           buildingId = buildingData.building.id;
           buildingFormData = {
             building_floors: buildingData.building.floors ?? 4,
+            building_name: buildingData.building.name ?? undefined,
+            construction_year: (buildingData.building as any).construction_year ?? undefined,
+            surface_totale: (buildingData.building as any).surface_totale ?? undefined,
+            ownership_type: (buildingData.building as any).ownership_type ?? 'full',
+            total_lots_in_building:
+              (buildingData.building as any).total_lots_in_building ?? undefined,
             has_ascenseur: buildingData.building.has_ascenseur ?? false,
             has_gardien: buildingData.building.has_gardien ?? false,
             has_interphone: buildingData.building.has_interphone ?? false,
             has_digicode: buildingData.building.has_digicode ?? false,
             has_local_velo: buildingData.building.has_local_velo ?? false,
             has_local_poubelles: buildingData.building.has_local_poubelles ?? false,
+            has_parking_commun: (buildingData.building as any).has_parking_commun ?? false,
+            has_jardin_commun: (buildingData.building as any).has_jardin_commun ?? false,
             building_units: (buildingData.units ?? []).map((u: any) => ({
               id: u.id,
               floor: u.floor,
@@ -415,6 +435,7 @@ export const usePropertyWizardStore = create<WizardState>()(
               surface: u.surface,
               nb_pieces: u.nb_pieces,
               template: u.template,
+              meuble: u.meuble ?? false,
               loyer_hc: u.loyer_hc,
               charges: u.charges,
               depot_garantie: u.depot_garantie,

--- a/lib/types/building-v3.ts
+++ b/lib/types/building-v3.ts
@@ -42,22 +42,23 @@ export type UnitTemplate =
 export interface BuildingUnit {
   id: string;
   building_id: string;
-  
+
   // Position dans l'immeuble
   floor: number;              // 0 = RDC, 1 = 1er étage, etc.
   position: string;           // "A", "B", "gauche", "droite", etc.
-  
+
   // Type et caractéristiques
   type: BuildingUnitType;
   surface: number;
   nb_pieces: number;
   template?: UnitTemplate;
-  
+  meuble?: boolean;           // SOTA 2026 — fin du hardcode studio/local
+
   // Conditions de location
   loyer_hc: number;
   charges: number;
   depot_garantie: number;
-  
+
   // Statut actuel
   status: BuildingUnitStatus;
   
@@ -156,11 +157,16 @@ export interface BuildingFormData {
   code_postal: string;
   ville: string;
   departement?: string;
-  
+
   // Structure
   building_floors: number;
   construction_year?: number;
-  
+  surface_totale?: number;
+
+  // Mode de possession (SOTA 2026)
+  ownership_type?: 'full' | 'partial';
+  total_lots_in_building?: number;
+
   // Parties communes
   has_ascenseur: boolean;
   has_gardien: boolean;
@@ -168,10 +174,14 @@ export interface BuildingFormData {
   has_digicode: boolean;
   has_local_velo: boolean;
   has_local_poubelles: boolean;
-  
+  has_parking_commun?: boolean;
+  has_jardin_commun?: boolean;
+
   // Lots (état temporaire du wizard)
   building_units: BuildingUnit[];
 }
+
+export type BuildingOwnershipType = 'full' | 'partial';
 
 // ============================================
 // 6. TYPES POUR ACTIONS/API

--- a/supabase/migrations/20260415140000_buildings_sota_fix_wave1.sql
+++ b/supabase/migrations/20260415140000_buildings_sota_fix_wave1.sql
@@ -1,0 +1,444 @@
+-- ============================================================================
+-- Migration : Buildings SOTA Fix — Vague 1 (Sécurité & intégrité)
+--
+-- Consolide les items P0 de l'audit building-module :
+--   #22 — DROP policies "Service role full access" (dangereuses)
+--   #7  — ADD COLUMN ownership_type + total_lots_in_building
+--   #9  — ADD COLUMN deleted_at (buildings + building_units)
+--   #11 — Étendre le trigger sync lease → building_unit.status à INSERT
+--         + backfill des building_units déjà liés à des baux actifs
+--   #21 — UNIQUE INDEX partiel sur building_units.property_id
+--   #8  — Helper SQL `building_has_active_leases(building_id)` réutilisé
+--         par la RPC transactionnelle de la Phase 2
+--
+-- La vue `building_stats` est aussi étendue pour exposer ownership_type /
+-- total_lots_in_building et filtrer les soft-deleted.
+-- ============================================================================
+
+-- ============================================================================
+-- 1. [#22] Supprimer les policies "Service role full access" sur buildings
+--    et building_units (court-circuit RLS dangereux en production).
+--    Les API routes utilisent déjà createServiceRoleClient() qui bypass RLS
+--    nativement via le service_role JWT — aucune policy n'est nécessaire.
+-- ============================================================================
+DROP POLICY IF EXISTS "Service role full access buildings" ON buildings;
+DROP POLICY IF EXISTS "Service role full access building_units" ON building_units;
+
+-- ============================================================================
+-- 2. [#7] ownership_type + total_lots_in_building sur buildings
+--    full    = le propriétaire possède tous les lots physiques
+--    partial = copropriété (quelques lots dans un immeuble plus grand)
+--    total_lots_in_building n'a de sens que si ownership_type = 'partial'
+-- ============================================================================
+ALTER TABLE buildings
+  ADD COLUMN IF NOT EXISTS ownership_type TEXT NOT NULL DEFAULT 'full'
+    CHECK (ownership_type IN ('full', 'partial'));
+
+ALTER TABLE buildings
+  ADD COLUMN IF NOT EXISTS total_lots_in_building INTEGER
+    CHECK (total_lots_in_building IS NULL OR total_lots_in_building > 0);
+
+-- Cohérence : si full → total_lots_in_building doit être NULL
+-- (un immeuble "full" ne dépend pas d'un nombre de lots extérieurs).
+-- On ne pose pas de contrainte stricte NULL=full pour ne pas bloquer les
+-- backfills futurs — les API/UI doivent enforce. Un commentaire documente.
+COMMENT ON COLUMN buildings.ownership_type IS
+  'full = immeuble entier possédé, partial = quelques lots dans une copropriété';
+COMMENT ON COLUMN buildings.total_lots_in_building IS
+  'Nombre total de lots dans l''immeuble physique (renseigné uniquement si ownership_type = partial)';
+
+-- ============================================================================
+-- 3. [#9] Soft-delete sur buildings ET building_units
+--    La route DELETE /api/buildings/[id] tentait déjà `SET deleted_at = NOW()`
+--    mais la colonne n'existait pas → fallback hard-delete silencieux.
+-- ============================================================================
+ALTER TABLE buildings
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ DEFAULT NULL;
+
+ALTER TABLE building_units
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ DEFAULT NULL;
+
+-- Index partiels : la majorité des records ont deleted_at = NULL.
+-- Un index partiel est bien plus efficace qu'un index plein.
+CREATE INDEX IF NOT EXISTS idx_buildings_active
+  ON buildings (id) WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_building_units_active
+  ON building_units (building_id) WHERE deleted_at IS NULL;
+
+COMMENT ON COLUMN buildings.deleted_at IS
+  'Soft-delete timestamp. Les records non-null sont filtrés des queries applicatives et RLS.';
+COMMENT ON COLUMN building_units.deleted_at IS
+  'Soft-delete timestamp. Cascade depuis buildings.deleted_at.';
+
+-- ============================================================================
+-- 4. [#21] Index UNIQUE partiel sur building_units.property_id
+--    Empêche qu'un même lot-property soit lié à plusieurs building_units.
+--    L'index est partiel (WHERE property_id IS NOT NULL) car les parkings /
+--    caves / lots pas encore individualisés peuvent ne pas avoir de property.
+--
+--    Détection préalable des doublons (fail loud si incohérence existante).
+-- ============================================================================
+DO $$
+DECLARE
+  dup_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT property_id
+    FROM building_units
+    WHERE property_id IS NOT NULL AND deleted_at IS NULL
+    GROUP BY property_id
+    HAVING COUNT(*) > 1
+  ) d;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION
+      'Cannot add UNIQUE index : % property_id(s) are linked to multiple building_units. Resolve manually before rerunning.',
+      dup_count;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_building_units_property_id
+  ON building_units (property_id)
+  WHERE property_id IS NOT NULL AND deleted_at IS NULL;
+
+-- ============================================================================
+-- 5. [#8] Helper SQL réutilisable : compter / lister les lots d'un immeuble
+--    qui ont un bail actif. Utilisé par la RPC transactionnelle de Phase 2
+--    (upsert_building_with_units) et par l'API route DELETE.
+--
+--    Statuts considérés comme "actifs" (doivent bloquer DELETE/REPLACE) :
+--      active, pending_signature, fully_signed, notice_given
+--    Statuts NON bloquants : draft, cancelled, terminated, archived
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.building_active_lease_units(p_building_id UUID)
+RETURNS TABLE (
+  unit_id UUID,
+  floor INTEGER,
+  "position" TEXT,
+  lease_id UUID,
+  lease_statut TEXT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    bu.id AS unit_id,
+    bu.floor,
+    bu.position,
+    l.id AS lease_id,
+    l.statut::TEXT AS lease_statut
+  FROM building_units bu
+  LEFT JOIN leases l
+    ON l.building_unit_id = bu.id
+   AND l.statut IN ('active', 'pending_signature', 'fully_signed', 'notice_given')
+  WHERE bu.building_id = p_building_id
+    AND bu.deleted_at IS NULL
+    AND (
+      bu.current_lease_id IS NOT NULL
+      OR l.id IS NOT NULL
+    )
+$$;
+
+COMMENT ON FUNCTION public.building_active_lease_units(UUID) IS
+  'Retourne les building_units d''un immeuble qui ont un bail bloquant (active / pending_signature / fully_signed / notice_given). Utilisé pour garder DELETE/REPLACE.';
+
+-- ============================================================================
+-- 6. [#11] Étendre le trigger sync_building_unit_status_from_lease à INSERT
+--    + backfill des building_units dont le bail actif n'était pas synchronisé.
+--
+--    Comportement :
+--      INSERT lease (statut='active', building_unit_id != NULL)
+--         → UPDATE building_units.status='occupe', current_lease_id=lease.id
+--      UPDATE lease.statut : draft/... → active
+--         → UPDATE building_units.status='occupe', current_lease_id=lease.id
+--      UPDATE lease.statut : active → terminated/archived/cancelled
+--         → UPDATE building_units.status='vacant', current_lease_id=NULL
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.sync_building_unit_status_from_lease()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- INSERT : un bail est créé directement actif avec un lot associé
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.building_unit_id IS NOT NULL AND NEW.statut = 'active' THEN
+      UPDATE building_units
+         SET status = 'occupe',
+             current_lease_id = NEW.id
+       WHERE id = NEW.building_unit_id
+         AND deleted_at IS NULL;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- UPDATE : traiter les transitions de statut
+  IF TG_OP = 'UPDATE' THEN
+    -- Transition vers 'active'
+    IF NEW.statut = 'active'
+       AND (OLD.statut IS DISTINCT FROM NEW.statut)
+       AND NEW.building_unit_id IS NOT NULL THEN
+      UPDATE building_units
+         SET status = 'occupe',
+             current_lease_id = NEW.id
+       WHERE id = NEW.building_unit_id
+         AND deleted_at IS NULL;
+    END IF;
+
+    -- Transition sortant de 'active' vers terminaison
+    IF OLD.statut = 'active'
+       AND NEW.statut IN ('terminated', 'archived', 'cancelled')
+       AND NEW.building_unit_id IS NOT NULL THEN
+      UPDATE building_units
+         SET status = 'vacant',
+             current_lease_id = NULL
+       WHERE id = NEW.building_unit_id
+         AND current_lease_id = NEW.id
+         AND deleted_at IS NULL;
+    END IF;
+
+    -- Réassignation : le bail change de building_unit_id
+    IF OLD.building_unit_id IS DISTINCT FROM NEW.building_unit_id THEN
+      -- Ancien lot : libérer si c'était ce bail qui l'occupait
+      IF OLD.building_unit_id IS NOT NULL THEN
+        UPDATE building_units
+           SET status = 'vacant',
+               current_lease_id = NULL
+         WHERE id = OLD.building_unit_id
+           AND current_lease_id = NEW.id
+           AND deleted_at IS NULL;
+      END IF;
+      -- Nouveau lot : occuper si bail actif
+      IF NEW.building_unit_id IS NOT NULL AND NEW.statut = 'active' THEN
+        UPDATE building_units
+           SET status = 'occupe',
+               current_lease_id = NEW.id
+         WHERE id = NEW.building_unit_id
+           AND deleted_at IS NULL;
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recréer le trigger pour couvrir INSERT + UPDATE
+DROP TRIGGER IF EXISTS trigger_sync_unit_status_on_lease ON leases;
+CREATE TRIGGER trigger_sync_unit_status_on_lease
+  AFTER INSERT OR UPDATE ON leases
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_building_unit_status_from_lease();
+
+-- Backfill : synchroniser les building_units dont un bail actif existe déjà
+-- mais dont le status / current_lease_id n'a pas été mis à jour.
+UPDATE building_units bu
+   SET status = 'occupe',
+       current_lease_id = l.id
+  FROM leases l
+ WHERE l.building_unit_id = bu.id
+   AND l.statut = 'active'
+   AND bu.deleted_at IS NULL
+   AND (bu.status IS DISTINCT FROM 'occupe' OR bu.current_lease_id IS DISTINCT FROM l.id);
+
+-- Backfill inverse : libérer les building_units dont le bail n'est plus actif
+UPDATE building_units bu
+   SET status = 'vacant',
+       current_lease_id = NULL
+  FROM leases l
+ WHERE bu.current_lease_id = l.id
+   AND l.statut IN ('terminated', 'archived', 'cancelled')
+   AND bu.deleted_at IS NULL;
+
+-- ============================================================================
+-- 7. Étendre les RLS policies pour filtrer les soft-deleted
+--    Les policies owner_* existantes (migration 20260318020000) sont
+--    reconstruites pour inclure `AND deleted_at IS NULL`.
+--    Les admin_all et tenant_select laissent voir le soft-deleted (audit).
+-- ============================================================================
+
+-- buildings : recréer les policies owner avec filtre deleted_at
+DROP POLICY IF EXISTS "buildings_owner_select" ON buildings;
+CREATE POLICY "buildings_owner_select" ON buildings
+  FOR SELECT TO authenticated
+  USING (
+    owner_id = public.user_profile_id()
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS "buildings_owner_update" ON buildings;
+CREATE POLICY "buildings_owner_update" ON buildings
+  FOR UPDATE TO authenticated
+  USING (
+    owner_id = public.user_profile_id()
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS "buildings_owner_delete" ON buildings;
+CREATE POLICY "buildings_owner_delete" ON buildings
+  FOR DELETE TO authenticated
+  USING (
+    owner_id = public.user_profile_id()
+    AND deleted_at IS NULL
+  );
+-- INSERT policy inchangée (un nouveau record a forcément deleted_at = NULL).
+
+-- building_units : filtrer via le building parent non-soft-deleted
+DROP POLICY IF EXISTS "building_units_owner_select" ON building_units;
+CREATE POLICY "building_units_owner_select" ON building_units
+  FOR SELECT TO authenticated
+  USING (
+    building_units.deleted_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.owner_id = public.user_profile_id()
+         AND b.deleted_at IS NULL
+    )
+  );
+
+DROP POLICY IF EXISTS "building_units_owner_update" ON building_units;
+CREATE POLICY "building_units_owner_update" ON building_units
+  FOR UPDATE TO authenticated
+  USING (
+    building_units.deleted_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.owner_id = public.user_profile_id()
+         AND b.deleted_at IS NULL
+    )
+  );
+
+DROP POLICY IF EXISTS "building_units_owner_delete" ON building_units;
+CREATE POLICY "building_units_owner_delete" ON building_units
+  FOR DELETE TO authenticated
+  USING (
+    building_units.deleted_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.owner_id = public.user_profile_id()
+         AND b.deleted_at IS NULL
+    )
+  );
+
+-- INSERT policy : idem, filtrer via building non-soft-deleted
+DROP POLICY IF EXISTS "building_units_owner_insert" ON building_units;
+CREATE POLICY "building_units_owner_insert" ON building_units
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.owner_id = public.user_profile_id()
+         AND b.deleted_at IS NULL
+    )
+  );
+
+-- ============================================================================
+-- 8. Mettre à jour la vue building_stats pour exposer ownership_type
+--    et filtrer les soft-deleted.
+-- ============================================================================
+CREATE OR REPLACE VIEW building_stats AS
+SELECT
+  b.id,
+  b.name,
+  b.owner_id,
+  b.adresse_complete,
+  b.ville,
+  b.floors,
+  b.ownership_type,
+  b.total_lots_in_building,
+
+  -- Comptages par type (uniquement lots actifs)
+  COUNT(bu.id) FILTER (WHERE bu.type NOT IN ('parking', 'cave') AND bu.deleted_at IS NULL) AS total_units,
+  COUNT(bu.id) FILTER (WHERE bu.type = 'parking' AND bu.deleted_at IS NULL) AS total_parkings,
+  COUNT(bu.id) FILTER (WHERE bu.type = 'cave' AND bu.deleted_at IS NULL) AS total_caves,
+
+  -- Surface
+  COALESCE(SUM(bu.surface) FILTER (WHERE bu.deleted_at IS NULL), 0) AS surface_totale,
+
+  -- Revenus
+  COALESCE(SUM(bu.loyer_hc + bu.charges) FILTER (WHERE bu.deleted_at IS NULL), 0) AS revenus_potentiels,
+  COALESCE(
+    SUM(bu.loyer_hc + bu.charges) FILTER (WHERE bu.status = 'occupe' AND bu.deleted_at IS NULL),
+    0
+  ) AS revenus_actuels,
+
+  -- Taux d'occupation (uniquement logements habitables, hors parking/cave)
+  ROUND(
+    COUNT(bu.id) FILTER (
+      WHERE bu.status = 'occupe'
+        AND bu.type NOT IN ('parking', 'cave')
+        AND bu.deleted_at IS NULL
+    )::DECIMAL /
+    NULLIF(
+      COUNT(bu.id) FILTER (
+        WHERE bu.type NOT IN ('parking', 'cave')
+          AND bu.deleted_at IS NULL
+      ),
+      0
+    ) * 100,
+    1
+  ) AS occupancy_rate,
+
+  COUNT(bu.id) FILTER (
+    WHERE bu.status = 'vacant'
+      AND bu.type NOT IN ('parking', 'cave')
+      AND bu.deleted_at IS NULL
+  ) AS vacant_units,
+  COUNT(bu.id) FILTER (
+    WHERE bu.status = 'occupe'
+      AND bu.type NOT IN ('parking', 'cave')
+      AND bu.deleted_at IS NULL
+  ) AS occupied_units,
+  COUNT(bu.id) FILTER (WHERE bu.status = 'travaux' AND bu.deleted_at IS NULL) AS units_en_travaux
+
+FROM buildings b
+LEFT JOIN building_units bu ON bu.building_id = b.id
+WHERE b.deleted_at IS NULL
+GROUP BY b.id;
+
+COMMENT ON VIEW building_stats IS
+  'Vue agrégée des stats par immeuble. Expose ownership_type et total_lots_in_building. Exclut les soft-deleted.';
+
+-- ============================================================================
+-- 9. Ajuster get_building_stats() pour filtrer les soft-deleted
+-- ============================================================================
+CREATE OR REPLACE FUNCTION get_building_stats(p_building_id UUID)
+RETURNS TABLE (
+  total_units INTEGER,
+  total_parkings INTEGER,
+  total_caves INTEGER,
+  surface_totale DECIMAL,
+  revenus_potentiels DECIMAL,
+  revenus_actuels DECIMAL,
+  occupancy_rate DECIMAL,
+  vacant_units INTEGER,
+  occupied_units INTEGER
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    COUNT(bu.id) FILTER (WHERE bu.type NOT IN ('parking', 'cave'))::INTEGER,
+    COUNT(bu.id) FILTER (WHERE bu.type = 'parking')::INTEGER,
+    COUNT(bu.id) FILTER (WHERE bu.type = 'cave')::INTEGER,
+    COALESCE(SUM(bu.surface), 0)::DECIMAL,
+    COALESCE(SUM(bu.loyer_hc + bu.charges), 0)::DECIMAL,
+    COALESCE(SUM(bu.loyer_hc + bu.charges) FILTER (WHERE bu.status = 'occupe'), 0)::DECIMAL,
+    ROUND(
+      COUNT(bu.id) FILTER (WHERE bu.status = 'occupe' AND bu.type NOT IN ('parking', 'cave'))::DECIMAL /
+      NULLIF(COUNT(bu.id) FILTER (WHERE bu.type NOT IN ('parking', 'cave')), 0) * 100,
+      1
+    )::DECIMAL,
+    COUNT(bu.id) FILTER (WHERE bu.status = 'vacant' AND bu.type NOT IN ('parking', 'cave'))::INTEGER,
+    COUNT(bu.id) FILTER (WHERE bu.status = 'occupe' AND bu.type NOT IN ('parking', 'cave'))::INTEGER
+  FROM building_units bu
+  WHERE bu.building_id = p_building_id
+    AND bu.deleted_at IS NULL;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION get_building_stats IS
+  'Stats détaillées d''un immeuble — exclut les lots soft-deleted (deleted_at IS NULL).';

--- a/supabase/migrations/20260415150000_upsert_building_with_units_rpc.sql
+++ b/supabase/migrations/20260415150000_upsert_building_with_units_rpc.sql
@@ -1,0 +1,319 @@
+-- ============================================================================
+-- Migration : RPC transactionnelle upsert_building_with_units
+--
+-- Encapsule en une seule transaction SQL l'ensemble des opérations de
+-- création/mise à jour d'un immeuble et de ses lots :
+--   1. UPSERT du record buildings
+--   2. Garde baux actifs (via building_active_lease_units)
+--   3. UPSERT des properties lots (préserve les IDs existants via floor-position)
+--   4. DELETE + INSERT des building_units (atomiquement dans la même fonction)
+--
+-- Items de l'audit adressés :
+--   #4  — Transaction SQL pour POST /building-units
+--   #8  — Garde baux actifs avant DELETE
+--   #10 — UPDATE du `name` dans UPSERT (pas figé à la création)
+--   #24 — Supprime le hardcode `meuble = studio||local_commercial`
+--   #6  — Propagation loyer/charges/depot_garantie vers properties lots
+--         (y compris depot_garantie qui manquait)
+-- ============================================================================
+
+-- ============================================================================
+-- 1. Fonction utilitaire permanente : génération de unique_code property
+--    Format : PROP-XXXX-XXXX (8 caractères random, charset alphanum majuscule)
+--    Identique à lib/helpers/code-generator.ts côté app.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public._gen_prop_code()
+RETURNS TEXT
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  charset TEXT := '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  result TEXT;
+  i INT;
+  max_attempts INT := 20;
+  attempt INT := 0;
+BEGIN
+  LOOP
+    attempt := attempt + 1;
+    result := 'PROP-';
+    FOR i IN 1..4 LOOP
+      result := result || substr(charset, floor(random() * length(charset) + 1)::int, 1);
+    END LOOP;
+    result := result || '-';
+    FOR i IN 1..4 LOOP
+      result := result || substr(charset, floor(random() * length(charset) + 1)::int, 1);
+    END LOOP;
+    EXIT WHEN NOT EXISTS (SELECT 1 FROM properties WHERE unique_code = result);
+    IF attempt >= max_attempts THEN
+      RAISE EXCEPTION 'gen_prop_code_max_attempts_exceeded';
+    END IF;
+  END LOOP;
+  RETURN result;
+END;
+$$;
+
+COMMENT ON FUNCTION public._gen_prop_code() IS
+  'Génère un unique_code PROP-XXXX-XXXX unique dans la table properties.';
+
+-- ============================================================================
+-- 2. RPC transactionnelle : upsert_building_with_units
+--    Signature :
+--      upsert_building_with_units(
+--        p_property_id UUID,          -- property wrapper (type='immeuble')
+--        p_building_data JSONB,       -- champs building (tous optionnels)
+--        p_units JSONB                -- array des lots (obligatoire)
+--      ) RETURNS JSONB
+--
+--    Retour :
+--      { "building_id": UUID, "unit_count": INT, "lot_property_ids": [UUID] }
+--
+--    Exceptions :
+--      P0001 'property_not_found'      — property parent introuvable
+--      P0002 'active_leases_blocking:<list>' — baux actifs bloquent le remplacement
+--      23505 (unique_violation)        — contrainte UNIQUE violée (collision floor/position)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.upsert_building_with_units(
+  p_property_id UUID,
+  p_building_data JSONB,
+  p_units JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_owner_id UUID;
+  v_legal_entity_id UUID;
+  v_adresse TEXT;
+  v_cp TEXT;
+  v_ville TEXT;
+  v_dept TEXT;
+  v_building_id UUID;
+  v_active_count INTEGER;
+  v_active_list TEXT;
+  v_existing_prop_map JSONB := '{}'::JSONB;
+  v_unit JSONB;
+  v_key TEXT;
+  v_lot_prop_id UUID;
+  v_lot_prop_ids UUID[] := ARRAY[]::UUID[];
+  v_new_code TEXT;
+  v_floor_label TEXT;
+  v_floor INTEGER;
+  v_pos TEXT;
+  v_type TEXT;
+  v_template TEXT;
+  v_unit_count INTEGER := 0;
+  v_has_ascenseur BOOLEAN;
+BEGIN
+  -- ─── 1. Valider la property parent ────────────────────────────────────────
+  SELECT owner_id, legal_entity_id, adresse_complete, code_postal, ville, departement
+    INTO v_owner_id, v_legal_entity_id, v_adresse, v_cp, v_ville, v_dept
+    FROM properties
+   WHERE id = p_property_id
+     AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'property_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  v_has_ascenseur := COALESCE((p_building_data->>'has_ascenseur')::BOOLEAN, false);
+
+  -- ─── 2. Upsert building ───────────────────────────────────────────────────
+  SELECT id INTO v_building_id
+    FROM buildings
+   WHERE property_id = p_property_id
+     AND deleted_at IS NULL
+   LIMIT 1;
+
+  IF v_building_id IS NOT NULL THEN
+    -- Garde baux actifs avant tout replacement
+    SELECT COUNT(*), string_agg('Lot ' || "position" || ' (étage ' || floor || ')', ', ')
+      INTO v_active_count, v_active_list
+      FROM public.building_active_lease_units(v_building_id);
+
+    IF v_active_count > 0 THEN
+      RAISE EXCEPTION 'active_leases_blocking:%', v_active_list
+        USING ERRCODE = 'P0002';
+    END IF;
+
+    -- UPDATE building (COALESCE pour ne pas écraser avec NULL si non fourni)
+    UPDATE buildings SET
+      name = COALESCE(NULLIF(p_building_data->>'name', ''), name),
+      floors = COALESCE((p_building_data->>'floors')::INTEGER, floors),
+      has_ascenseur = COALESCE((p_building_data->>'has_ascenseur')::BOOLEAN, has_ascenseur),
+      has_gardien = COALESCE((p_building_data->>'has_gardien')::BOOLEAN, has_gardien),
+      has_interphone = COALESCE((p_building_data->>'has_interphone')::BOOLEAN, has_interphone),
+      has_digicode = COALESCE((p_building_data->>'has_digicode')::BOOLEAN, has_digicode),
+      has_local_velo = COALESCE((p_building_data->>'has_local_velo')::BOOLEAN, has_local_velo),
+      has_local_poubelles = COALESCE((p_building_data->>'has_local_poubelles')::BOOLEAN, has_local_poubelles),
+      has_parking_commun = COALESCE((p_building_data->>'has_parking_commun')::BOOLEAN, has_parking_commun),
+      has_jardin_commun = COALESCE((p_building_data->>'has_jardin_commun')::BOOLEAN, has_jardin_commun),
+      ownership_type = COALESCE(NULLIF(p_building_data->>'ownership_type', ''), ownership_type),
+      total_lots_in_building = CASE
+        WHEN p_building_data ? 'total_lots_in_building'
+             AND p_building_data->>'total_lots_in_building' IS NOT NULL
+          THEN (p_building_data->>'total_lots_in_building')::INTEGER
+        ELSE total_lots_in_building
+      END,
+      construction_year = CASE
+        WHEN p_building_data ? 'construction_year'
+             AND p_building_data->>'construction_year' IS NOT NULL
+          THEN (p_building_data->>'construction_year')::INTEGER
+        ELSE construction_year
+      END,
+      surface_totale = CASE
+        WHEN p_building_data ? 'surface_totale'
+             AND p_building_data->>'surface_totale' IS NOT NULL
+          THEN (p_building_data->>'surface_totale')::DECIMAL
+        ELSE surface_totale
+      END,
+      notes = COALESCE(p_building_data->>'notes', notes),
+      updated_at = NOW()
+    WHERE id = v_building_id;
+  ELSE
+    -- INSERT building
+    INSERT INTO buildings (
+      owner_id, property_id, name,
+      adresse_complete, code_postal, ville, departement,
+      floors,
+      has_ascenseur, has_gardien, has_interphone, has_digicode,
+      has_local_velo, has_local_poubelles, has_parking_commun, has_jardin_commun,
+      ownership_type, total_lots_in_building,
+      construction_year, surface_totale, notes
+    ) VALUES (
+      v_owner_id, p_property_id,
+      COALESCE(NULLIF(p_building_data->>'name', ''), LEFT(COALESCE(v_adresse, 'Immeuble'), 200)),
+      v_adresse, v_cp, v_ville, v_dept,
+      COALESCE((p_building_data->>'floors')::INTEGER, 1),
+      COALESCE((p_building_data->>'has_ascenseur')::BOOLEAN, false),
+      COALESCE((p_building_data->>'has_gardien')::BOOLEAN, false),
+      COALESCE((p_building_data->>'has_interphone')::BOOLEAN, false),
+      COALESCE((p_building_data->>'has_digicode')::BOOLEAN, false),
+      COALESCE((p_building_data->>'has_local_velo')::BOOLEAN, false),
+      COALESCE((p_building_data->>'has_local_poubelles')::BOOLEAN, false),
+      COALESCE((p_building_data->>'has_parking_commun')::BOOLEAN, false),
+      COALESCE((p_building_data->>'has_jardin_commun')::BOOLEAN, false),
+      COALESCE(NULLIF(p_building_data->>'ownership_type', ''), 'full'),
+      NULLIF(p_building_data->>'total_lots_in_building', '')::INTEGER,
+      NULLIF(p_building_data->>'construction_year', '')::INTEGER,
+      NULLIF(p_building_data->>'surface_totale', '')::DECIMAL,
+      NULLIF(p_building_data->>'notes', '')
+    )
+    RETURNING id INTO v_building_id;
+  END IF;
+
+  -- ─── 3. Map des property_id existantes par floor-position ─────────────────
+  SELECT COALESCE(
+           jsonb_object_agg(floor::TEXT || '-' || position, property_id),
+           '{}'::JSONB
+         )
+    INTO v_existing_prop_map
+    FROM building_units
+   WHERE building_id = v_building_id
+     AND property_id IS NOT NULL
+     AND deleted_at IS NULL;
+
+  -- ─── 4. DELETE des building_units (les properties lots restent) ───────────
+  DELETE FROM building_units WHERE building_id = v_building_id;
+
+  -- ─── 5. Pour chaque unit du payload : upsert property lot + insert unit ───
+  FOR v_unit IN SELECT * FROM jsonb_array_elements(p_units) LOOP
+    v_floor := (v_unit->>'floor')::INTEGER;
+    v_pos := v_unit->>'position';
+    v_type := v_unit->>'type';
+    v_template := NULLIF(lower(COALESCE(v_unit->>'template', '')), '');
+    v_key := v_floor::TEXT || '-' || v_pos;
+
+    -- Label étage
+    IF v_floor < 0 THEN v_floor_label := 'SS' || abs(v_floor);
+    ELSIF v_floor = 0 THEN v_floor_label := 'RDC';
+    ELSE v_floor_label := 'Étage ' || v_floor;
+    END IF;
+
+    v_lot_prop_id := NULL;
+    IF v_existing_prop_map ? v_key THEN
+      v_lot_prop_id := (v_existing_prop_map->>v_key)::UUID;
+
+      -- UPDATE property lot existante
+      -- meuble : on respecte le payload si fourni, sinon on garde la valeur actuelle
+      UPDATE properties SET
+        type = v_type,
+        surface = (v_unit->>'surface')::DECIMAL,
+        nb_pieces = (v_unit->>'nb_pieces')::INTEGER,
+        loyer_hc = (v_unit->>'loyer_hc')::DECIMAL,
+        charges_mensuelles = (v_unit->>'charges')::DECIMAL,
+        depot_garantie = (v_unit->>'depot_garantie')::DECIMAL,
+        meuble = CASE
+          WHEN v_unit ? 'meuble' AND v_unit->>'meuble' IS NOT NULL
+            THEN (v_unit->>'meuble')::BOOLEAN
+          ELSE meuble
+        END,
+        ascenseur = v_has_ascenseur,
+        adresse_complete = COALESCE(v_adresse, '')
+                           || ' - Lot ' || v_pos
+                           || ', ' || v_floor_label,
+        updated_at = NOW()
+      WHERE id = v_lot_prop_id;
+    ELSE
+      -- INSERT property lot
+      v_new_code := public._gen_prop_code();
+
+      INSERT INTO properties (
+        owner_id, legal_entity_id, parent_property_id,
+        type, etat, unique_code,
+        adresse_complete, code_postal, ville, departement,
+        surface, nb_pieces, nb_chambres,
+        ascenseur, meuble,
+        loyer_hc, charges_mensuelles, depot_garantie
+      ) VALUES (
+        v_owner_id, v_legal_entity_id, p_property_id,
+        v_type, 'published', v_new_code,
+        COALESCE(v_adresse, '') || ' - Lot ' || v_pos || ', ' || v_floor_label,
+        COALESCE(v_cp, ''), COALESCE(v_ville, ''), COALESCE(v_dept, ''),
+        (v_unit->>'surface')::DECIMAL,
+        (v_unit->>'nb_pieces')::INTEGER,
+        0,
+        v_has_ascenseur,
+        COALESCE((v_unit->>'meuble')::BOOLEAN, false),
+        (v_unit->>'loyer_hc')::DECIMAL,
+        (v_unit->>'charges')::DECIMAL,
+        (v_unit->>'depot_garantie')::DECIMAL
+      )
+      RETURNING id INTO v_lot_prop_id;
+    END IF;
+
+    -- INSERT building_unit
+    INSERT INTO building_units (
+      building_id, floor, position, type, template,
+      surface, nb_pieces,
+      loyer_hc, charges, depot_garantie,
+      status, property_id
+    ) VALUES (
+      v_building_id, v_floor, v_pos, v_type, v_template,
+      (v_unit->>'surface')::DECIMAL,
+      (v_unit->>'nb_pieces')::INTEGER,
+      (v_unit->>'loyer_hc')::DECIMAL,
+      (v_unit->>'charges')::DECIMAL,
+      (v_unit->>'depot_garantie')::DECIMAL,
+      COALESCE(NULLIF(v_unit->>'status', ''), 'vacant'),
+      v_lot_prop_id
+    );
+
+    v_lot_prop_ids := array_append(v_lot_prop_ids, v_lot_prop_id);
+    v_unit_count := v_unit_count + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'building_id', v_building_id,
+    'unit_count', v_unit_count,
+    'lot_property_ids', to_jsonb(v_lot_prop_ids)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_building_with_units(UUID, JSONB, JSONB) IS
+  'Upsert atomique d''un immeuble + lots + properties lots. Refuse si au moins un lot a un bail bloquant. Renvoie { building_id, unit_count, lot_property_ids }.';

--- a/supabase/migrations/20260415160000_buildings_rls_entity_members_support.sql
+++ b/supabase/migrations/20260415160000_buildings_rls_entity_members_support.sql
@@ -1,0 +1,171 @@
+-- ============================================================================
+-- Migration : RLS Support entity_members pour buildings et building_units
+--
+-- Item #18 de l'audit building-module : actuellement les policies owner_* sur
+-- buildings et building_units ne vérifient que `owner_id = user_profile_id()`.
+-- Les membres d'une SCI (via entity_members) n'ont pas accès aux immeubles
+-- de leur entité, alors que la page /owner/buildings/[id] les autorise déjà
+-- au niveau SSR.
+--
+-- Cette migration étend les policies pour inclure ce cas :
+--   Un user est autorisé sur un building si :
+--     (a) il est l'owner direct (pattern existant)
+--     (b) OU il est membre de l'entité légale associée à la property parent
+--         (via entity_members.user_id = auth.uid())
+--
+-- Les policies tenant/admin ne sont pas touchées.
+-- ============================================================================
+
+-- ============================================================================
+-- 1. Fonction helper : user_in_entity_of_property(property_id)
+--    Retourne true si l'utilisateur courant est membre de l'entité légale
+--    rattachée à la property. Encapsule le pattern pour éviter les sous-
+--    requêtes répétées dans chaque policy.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.user_in_entity_of_property(p_property_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM properties p
+    JOIN entity_members em ON em.entity_id = p.legal_entity_id
+    WHERE p.id = p_property_id
+      AND p.legal_entity_id IS NOT NULL
+      AND em.user_id = auth.uid()
+  );
+$$;
+
+COMMENT ON FUNCTION public.user_in_entity_of_property(UUID) IS
+  'Retourne true si auth.uid() est membre (entity_members) de l''entité légale de la property. Utilisé par les RLS policies buildings/building_units pour le cas SCI.';
+
+-- ============================================================================
+-- 2. Recréer les policies owner sur buildings pour inclure entity_members
+-- ============================================================================
+DROP POLICY IF EXISTS "buildings_owner_select" ON buildings;
+CREATE POLICY "buildings_owner_select" ON buildings
+  FOR SELECT TO authenticated
+  USING (
+    buildings.deleted_at IS NULL
+    AND (
+      owner_id = public.user_profile_id()
+      OR (
+        property_id IS NOT NULL
+        AND public.user_in_entity_of_property(property_id)
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "buildings_owner_update" ON buildings;
+CREATE POLICY "buildings_owner_update" ON buildings
+  FOR UPDATE TO authenticated
+  USING (
+    buildings.deleted_at IS NULL
+    AND (
+      owner_id = public.user_profile_id()
+      OR (
+        property_id IS NOT NULL
+        AND public.user_in_entity_of_property(property_id)
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "buildings_owner_delete" ON buildings;
+CREATE POLICY "buildings_owner_delete" ON buildings
+  FOR DELETE TO authenticated
+  USING (
+    buildings.deleted_at IS NULL
+    AND (
+      owner_id = public.user_profile_id()
+      OR (
+        property_id IS NOT NULL
+        AND public.user_in_entity_of_property(property_id)
+      )
+    )
+  );
+
+-- INSERT : seul le propriétaire direct peut créer un building. Un membre SCI
+-- ne doit pas pouvoir créer un building hors du flux wizard. On garde la
+-- contrainte restrictive sur INSERT (owner_id = user_profile_id()).
+
+-- ============================================================================
+-- 3. Recréer les policies owner sur building_units pour inclure entity_members
+--    via buildings.property_id → properties.legal_entity_id
+-- ============================================================================
+DROP POLICY IF EXISTS "building_units_owner_select" ON building_units;
+CREATE POLICY "building_units_owner_select" ON building_units
+  FOR SELECT TO authenticated
+  USING (
+    building_units.deleted_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.deleted_at IS NULL
+         AND (
+           b.owner_id = public.user_profile_id()
+           OR (
+             b.property_id IS NOT NULL
+             AND public.user_in_entity_of_property(b.property_id)
+           )
+         )
+    )
+  );
+
+DROP POLICY IF EXISTS "building_units_owner_update" ON building_units;
+CREATE POLICY "building_units_owner_update" ON building_units
+  FOR UPDATE TO authenticated
+  USING (
+    building_units.deleted_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.deleted_at IS NULL
+         AND (
+           b.owner_id = public.user_profile_id()
+           OR (
+             b.property_id IS NOT NULL
+             AND public.user_in_entity_of_property(b.property_id)
+           )
+         )
+    )
+  );
+
+DROP POLICY IF EXISTS "building_units_owner_delete" ON building_units;
+CREATE POLICY "building_units_owner_delete" ON building_units
+  FOR DELETE TO authenticated
+  USING (
+    building_units.deleted_at IS NULL
+    AND EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.deleted_at IS NULL
+         AND (
+           b.owner_id = public.user_profile_id()
+           OR (
+             b.property_id IS NOT NULL
+             AND public.user_in_entity_of_property(b.property_id)
+           )
+         )
+    )
+  );
+
+DROP POLICY IF EXISTS "building_units_owner_insert" ON building_units;
+CREATE POLICY "building_units_owner_insert" ON building_units
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM buildings b
+       WHERE b.id = building_units.building_id
+         AND b.deleted_at IS NULL
+         AND (
+           b.owner_id = public.user_profile_id()
+           OR (
+             b.property_id IS NOT NULL
+             AND public.user_in_entity_of_property(b.property_id)
+           )
+         )
+    )
+  );


### PR DESCRIPTION
Consolide les items P0 de l'audit building-module :

- #22 : DROP policies "Service role full access buildings/building_units"
  (court-circuit RLS dangereux — les API utilisent déjà le service role JWT)
- #7  : ADD COLUMN ownership_type ('full'|'partial') + total_lots_in_building
  sur buildings (base pour la distinction copropriété partielle)
- #9  : ADD COLUMN deleted_at sur buildings + building_units + index partiels
  (la route DELETE tentait un UPDATE sur cette colonne inexistante)
- #11 : Trigger sync_building_unit_status_from_lease étendu à INSERT,
  gère la réassignation building_unit_id, + backfill des units désynchronisés
- #21 : UNIQUE INDEX partiel sur building_units.property_id (avec garde
  préalable qui fail si doublons existants)
- #8  : Helper public.building_active_lease_units(building_id) réutilisé
  par la RPC transactionnelle de la Phase 2

Bonus :
- RLS policies owner_* recréées pour filtrer deleted_at IS NULL
- Vue building_stats étendue : expose ownership_type, total_lots_in_building,
  exclut les soft-deleted
- get_building_stats() filtre les lots soft-deleted

https://claude.ai/code/session_01NLEkrJJAQtBVjqUZgyERt3