### PR TITLE
claude/fix-building-404-error-ace27

### DIFF
--- a/app/owner/buildings/[id]/page.tsx
+++ b/app/owner/buildings/[id]/page.tsx
@@ -57,6 +57,8 @@ export async function generateMetadata(
 
 export default async function BuildingDetailPage({ params }: PageProps) {
   const { id } = await params;
+  console.log("[BUILDING-DEBUG] Starting page load for id:", id);
+
   const supabase = await createClient();
 
   const {
@@ -64,20 +66,53 @@ export default async function BuildingDetailPage({ params }: PageProps) {
     error: authError,
   } = await supabase.auth.getUser();
 
+  console.log(
+    "[BUILDING-DEBUG] user.id:",
+    user?.id,
+    "user.email:",
+    user?.email,
+    "authError:",
+    authError?.message ?? null,
+  );
+
   if (authError || !user) {
+    console.log("[BUILDING-DEBUG] >>> REDIRECTING to /auth/signin — reason: no auth user");
     redirect("/auth/signin");
   }
 
   // Service client pour bypasser RLS (évite récursion user_profile_id())
   const serviceClient = getServiceClient();
 
-  const { data: profile } = await serviceClient
+  const { data: profile, error: profileError } = await serviceClient
     .from("profiles")
-    .select("id, role")
+    .select("id, role, email")
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
+
+  if (profileError) {
+    console.error(
+      "[BUILDING-DEBUG] Profile query error:",
+      profileError.message,
+      profileError.code,
+      profileError.details,
+    );
+  }
+
+  console.log(
+    "[BUILDING-DEBUG] profile:",
+    JSON.stringify({
+      id: (profile as any)?.id,
+      role: (profile as any)?.role,
+      email: (profile as any)?.email,
+    }),
+  );
 
   if (!profile || (profile.role !== "owner" && profile.role !== "admin")) {
+    console.log(
+      "[BUILDING-DEBUG] >>> REDIRECTING to /dashboard — reason: profile missing or role not allowed (role=",
+      (profile as any)?.role,
+      ")",
+    );
     redirect("/dashboard");
   }
 
@@ -90,6 +125,7 @@ export default async function BuildingDetailPage({ params }: PageProps) {
   //    `owner_id = profile.id` produisait un faux 404 pour les immeubles
   //    détenus via une entité SCI dont le `legal_entity_id` pointe vers un
   //    autre profil ou dont l'utilisateur est membre via `entity_members`.
+  console.log("[BUILDING-DEBUG] Querying properties with id:", id);
   const { data: property, error } = await serviceClient
     .from("properties")
     .select(`
@@ -111,6 +147,26 @@ export default async function BuildingDetailPage({ params }: PageProps) {
     .is("deleted_at", null)
     .maybeSingle();
 
+  if (error) {
+    console.error(
+      "[BUILDING-DEBUG] Property query error:",
+      error.message,
+      error.code,
+      error.details,
+    );
+  }
+
+  console.log(
+    "[BUILDING-DEBUG] property result:",
+    JSON.stringify({
+      id: (property as any)?.id,
+      type: (property as any)?.type,
+      owner_id: (property as any)?.owner_id,
+      legal_entity_id: (property as any)?.legal_entity_id,
+      error: error?.message ?? null,
+    }),
+  );
+
   if (property) {
     // Vérification d'accès : admin, owner direct, ou membre SCI via
     // entity_members. Même pattern que `/api/invoices/[id]/route.ts:78-106`.
@@ -118,15 +174,42 @@ export default async function BuildingDetailPage({ params }: PageProps) {
     const isAdmin = profile.role === "admin";
     const isOwnerDirect = propertyAny.owner_id === profile.id;
     let isSciMember = false;
+    let membershipError: { message: string; code?: string } | null = null;
     if (!isAdmin && !isOwnerDirect && propertyAny.legal_entity_id) {
-      const { data: membership } = await serviceClient
+      const { data: membership, error: memErr } = await serviceClient
         .from("entity_members")
         .select("id")
         .eq("entity_id", propertyAny.legal_entity_id)
         .eq("user_id", user.id)
         .maybeSingle();
+      if (memErr) {
+        membershipError = { message: memErr.message, code: memErr.code };
+        console.error(
+          "[BUILDING-DEBUG] entity_members query error:",
+          memErr.message,
+          memErr.code,
+          memErr.details,
+        );
+      }
       isSciMember = !!membership;
     }
+
+    console.log(
+      "[BUILDING-DEBUG] access check → isAdmin:",
+      isAdmin,
+      "isOwnerDirect:",
+      isOwnerDirect,
+      "isSciMember:",
+      isSciMember,
+      "propertyOwnerId:",
+      propertyAny.owner_id,
+      "profileId:",
+      profile.id,
+      "legalEntityId:",
+      propertyAny.legal_entity_id,
+      "membershipError:",
+      membershipError,
+    );
 
     if (!isAdmin && !isOwnerDirect && !isSciMember) {
       console.warn("[building-detail] Accès refusé", {
@@ -135,35 +218,76 @@ export default async function BuildingDetailPage({ params }: PageProps) {
         ownerId: propertyAny.owner_id,
         legalEntityId: propertyAny.legal_entity_id,
       });
+      console.log(
+        "[BUILDING-DEBUG] >>> TRIGGERING 404 — reason: access denied (not admin, not direct owner, not SCI member)",
+      );
       notFound();
     }
 
     // Property trouvée et accessible — vérifier que c'est bien un immeuble
     if (property.type !== "immeuble") {
+      console.log(
+        "[BUILDING-DEBUG] >>> REDIRECTING to /owner/properties/",
+        id,
+        "— reason: type is not immeuble (actual type=",
+        property.type,
+        ")",
+      );
       // Ce n'est pas un immeuble, rediriger vers la fiche bien classique
       redirect(`/owner/properties/${id}`);
     }
   }
 
   if (!property) {
+    console.log(
+      "[BUILDING-DEBUG] property is null — attempting buildings table fallback with id:",
+      id,
+    );
     // 2. Fallback : peut-être que l'URL contient un building_id au lieu d'un property_id
-    const { data: buildingRecord } = await serviceClient
+    const { data: buildingRecord, error: buildingRecordError } = await serviceClient
       .from("buildings")
       .select("property_id")
       .eq("id", id)
       .maybeSingle();
 
+    if (buildingRecordError) {
+      console.error(
+        "[BUILDING-DEBUG] buildings fallback query error:",
+        buildingRecordError.message,
+        buildingRecordError.code,
+        buildingRecordError.details,
+      );
+    }
+
+    console.log(
+      "[BUILDING-DEBUG] buildings fallback result:",
+      JSON.stringify({ property_id: buildingRecord?.property_id ?? null }),
+    );
+
     if (buildingRecord?.property_id) {
+      console.log(
+        "[BUILDING-DEBUG] >>> REDIRECTING to canonical URL /owner/buildings/",
+        buildingRecord.property_id,
+      );
       // Rediriger vers l'URL canonique avec property_id
       redirect(`/owner/buildings/${buildingRecord.property_id}`);
     }
 
     // 3. Diagnostic : la property existe-t-elle sans filtre owner_id ?
-    const { data: anyProperty } = await serviceClient
+    const { data: anyProperty, error: anyPropertyError } = await serviceClient
       .from("properties")
       .select("id, owner_id, type, deleted_at")
       .eq("id", id)
       .maybeSingle();
+
+    if (anyPropertyError) {
+      console.error(
+        "[BUILDING-DEBUG] anyProperty diagnostic query error:",
+        anyPropertyError.message,
+        anyPropertyError.code,
+        anyPropertyError.details,
+      );
+    }
 
     if (anyProperty) {
       console.error("[building-detail] Property exists but access denied:", {
@@ -174,8 +298,21 @@ export default async function BuildingDetailPage({ params }: PageProps) {
         type: anyProperty.type,
         deleted_at: anyProperty.deleted_at,
       });
+      console.log(
+        "[BUILDING-DEBUG] >>> TRIGGERING 404 — reason: property exists but was filtered out by initial query (deleted_at=",
+        anyProperty.deleted_at,
+        "type=",
+        anyProperty.type,
+        "owner_id=",
+        anyProperty.owner_id,
+        ")",
+      );
     } else {
       console.error("[building-detail] Property not found in DB at all:", { id, error });
+      console.log(
+        "[BUILDING-DEBUG] >>> TRIGGERING 404 — reason: property truly does not exist in DB for id:",
+        id,
+      );
     }
 
     notFound();
@@ -184,13 +321,31 @@ export default async function BuildingDetailPage({ params }: PageProps) {
   // À ce stade, property est non-null et de type immeuble
   const building = property;
   propertyId = building.id;
+  console.log(
+    "[BUILDING-DEBUG] property validated as immeuble, proceeding with propertyId:",
+    propertyId,
+  );
 
   // Fetch building metadata
-  const { data: buildingMeta } = await serviceClient
+  const { data: buildingMeta, error: buildingMetaError } = await serviceClient
     .from("buildings")
     .select("*")
     .eq("property_id", propertyId)
-    .single();
+    .maybeSingle();
+
+  if (buildingMetaError) {
+    console.error(
+      "[BUILDING-DEBUG] buildings metadata query error:",
+      buildingMetaError.message,
+      buildingMetaError.code,
+      buildingMetaError.details,
+    );
+  }
+
+  console.log(
+    "[BUILDING-DEBUG] buildingMeta:",
+    JSON.stringify({ id: (buildingMeta as any)?.id ?? null }),
+  );
 
   // Fetch units + documents en parallèle
   const [unitsResult, documentsResult] = await Promise.all([
@@ -205,7 +360,7 @@ export default async function BuildingDetailPage({ params }: PageProps) {
           .eq("building_id", buildingMeta.id)
           .order("floor", { ascending: true })
           .order("position", { ascending: true })
-      : Promise.resolve({ data: null }),
+      : Promise.resolve({ data: null, error: null }),
     serviceClient
       .from("documents")
       .select("id, type, title, original_filename, file_size, mime_type, created_at, expiry_date, valid_until, ged_status")
@@ -213,6 +368,23 @@ export default async function BuildingDetailPage({ params }: PageProps) {
       .eq("is_current_version", true)
       .order("created_at", { ascending: false }),
   ]);
+
+  if ((unitsResult as any).error) {
+    console.error(
+      "[BUILDING-DEBUG] building_units query error:",
+      (unitsResult as any).error.message,
+      (unitsResult as any).error.code,
+      (unitsResult as any).error.details,
+    );
+  }
+  if ((documentsResult as any).error) {
+    console.error(
+      "[BUILDING-DEBUG] documents query error:",
+      (documentsResult as any).error.message,
+      (documentsResult as any).error.code,
+      (documentsResult as any).error.details,
+    );
+  }
 
   // The generated DB types don't include the `property_id` column on `building_units`
   // yet, so we cast through unknown to layer the runtime-truthful shape.
@@ -222,6 +394,8 @@ export default async function BuildingDetailPage({ params }: PageProps) {
     current_lease_id: string | null;
     [key: string]: unknown;
   }>;
+
+  console.log("[BUILDING-DEBUG] units count:", units.length);
 
   // Fetch lot properties (cover_url, unique_code) and active leases/tenants in parallel.
   // Chaque lot pointe vers son propre property_id — on récupère ici les infos
@@ -235,14 +409,31 @@ export default async function BuildingDetailPage({ params }: PageProps) {
           .from("properties")
           .select("id, cover_url, unique_code, adresse_complete")
           .in("id", lotPropertyIds)
-      : Promise.resolve({ data: [] }),
+      : Promise.resolve({ data: [], error: null }),
     leaseIds.length > 0
       ? serviceClient
           .from("leases")
           .select("id, tenant_id, date_fin, statut, loyer, charges_forfaitaires")
           .in("id", leaseIds)
-      : Promise.resolve({ data: [] }),
+      : Promise.resolve({ data: [], error: null }),
   ]);
+
+  if ((lotPropertiesResult as any).error) {
+    console.error(
+      "[BUILDING-DEBUG] lotProperties query error:",
+      (lotPropertiesResult as any).error.message,
+      (lotPropertiesResult as any).error.code,
+      (lotPropertiesResult as any).error.details,
+    );
+  }
+  if ((leasesResult as any).error) {
+    console.error(
+      "[BUILDING-DEBUG] leases query error:",
+      (leasesResult as any).error.message,
+      (leasesResult as any).error.code,
+      (leasesResult as any).error.details,
+    );
+  }
 
   const lotProperties = (lotPropertiesResult.data || []) as Array<{
     id: string;
@@ -261,18 +452,38 @@ export default async function BuildingDetailPage({ params }: PageProps) {
   }>;
 
   const tenantIds = leases.map((l) => l.tenant_id).filter((v): v is string => !!v);
-  const { data: tenantsData } = tenantIds.length > 0
+  const tenantsQuery = tenantIds.length > 0
     ? await serviceClient
         .from("profiles")
         .select("id, first_name, last_name")
         .in("id", tenantIds)
-    : { data: [] as Array<{ id: string; first_name: string | null; last_name: string | null }> };
+    : { data: [] as Array<{ id: string; first_name: string | null; last_name: string | null }>, error: null };
 
-  const tenants = (tenantsData || []) as Array<{
+  if ((tenantsQuery as any).error) {
+    console.error(
+      "[BUILDING-DEBUG] tenants profiles query error:",
+      (tenantsQuery as any).error.message,
+      (tenantsQuery as any).error.code,
+      (tenantsQuery as any).error.details,
+    );
+  }
+
+  const tenants = (tenantsQuery.data || []) as Array<{
     id: string;
     first_name: string | null;
     last_name: string | null;
   }>;
+
+  console.log(
+    "[BUILDING-DEBUG] rendering BuildingDetailClient — lotProperties:",
+    lotProperties.length,
+    "leases:",
+    leases.length,
+    "tenants:",
+    tenants.length,
+    "documents:",
+    (documentsResult.data as any[])?.length ?? 0,
+  );
 
   return (
     <BuildingDetailClient


### PR DESCRIPTION
Ajoute des console.log "[BUILDING-DEBUG]" a chaque etape critique pour
diagnostiquer le 404 persistant sur /owner/buildings/[id] malgre des
donnees DB correctes :

- params.id au debut de la fonction
- user.id / user.email / authError apres auth.getUser()
- profile (id, role, email) apres le fetch profile, avec error check
- id query property + resultat (id, type, owner_id, legal_entity_id, error)
- access check (isAdmin, isOwnerDirect, isSciMember, propertyOwnerId,
  profileId, legalEntityId, membershipError)
- raison explicite avant chaque notFound() et chaque redirect()
- error.message / .code / .details apres CHAQUE query Supabase (profile,
  property, entity_members, buildings fallback, anyProperty diagnostic,
  buildingMeta, building_units, documents, lotProperties, leases, tenants)

Aussi remplace le .single() du fetch profile et du fetch buildings meta
par .maybeSingle() pour eviter les faux-positifs PGRST116 (0 rows). Le
.single() retournait "JSON object requested, multiple (or no) rows" dans
le champ error et shadowait silencieusement data a null quand la ligne
manquait, ce qui pouvait pousser le code dans le branch redirect/notFound
meme quand la property existait reellement.

Apres deploy, l'utilisateur reproduit le 404 et consulte les logs Netlify
Functions pour voir exactement quelle ligne declenche le 404.