### PR TITLE
claude/cascade-delete-building-5YBYi

### DIFF
--- a/app/api/properties/[id]/can-delete/route.ts
+++ b/app/api/properties/[id]/can-delete/route.ts
@@ -1,0 +1,49 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { propertyIdParamSchema } from "@/lib/validations/params";
+import { canDeleteProperty } from "@/lib/properties/guards";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+/**
+ * GET /api/properties/[id]/can-delete
+ *
+ * Pre-flight check before deleting a property. Returns blockers, warnings,
+ * and linked-data counts. For immeubles, also returns per-lot info.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const propertyId = propertyIdParamSchema.parse(id);
+
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      throw new ApiError(authError?.status || 401, authError?.message || "Non authentifié");
+    }
+
+    const serviceClient = getServiceClient();
+
+    // Resolve profile to get owner_id
+    const { data: profile, error: profileError } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (profileError || !profile) {
+      throw new ApiError(404, "Profil non trouvé", profileError);
+    }
+
+    const result = await canDeleteProperty(serviceClient, propertyId, profile.id);
+
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/properties/[id]/route.ts
+++ b/app/api/properties/[id]/route.ts
@@ -630,13 +630,13 @@ export async function DELETE(
     });
 
     // ✅ RÉCUPÉRATION: Vérifier que l'utilisateur est propriétaire de la propriété
-    // Essayer d'abord avec etat, puis sans si la colonne n'existe pas
-    let property: { owner_id: string; etat?: string } | null = null;
+    // Essayer d'abord avec etat+type, puis sans si la colonne n'existe pas
+    let property: { owner_id: string; etat?: string; type?: string | null } | null = null;
     let propertyError: unknown = null;
-    
+
     const { data: propertyWithEtat, error: errorWithEtat } = await serviceClient
       .from("properties")
-      .select("owner_id, etat")
+      .select("owner_id, etat, type")
       .eq("id", propertyId)
       .maybeSingle();
 
@@ -648,7 +648,7 @@ export async function DELETE(
           .select("owner_id")
           .eq("id", propertyId)
           .maybeSingle();
-        
+
         if (errorWithoutEtat) {
           propertyError = errorWithoutEtat;
         } else {
@@ -656,6 +656,7 @@ export async function DELETE(
           // Si etat n'existe pas, on considère que c'est un draft par défaut
           if (property) {
             property.etat = "draft";
+            property.type = null;
           }
         }
       } else {
@@ -771,6 +772,64 @@ export async function DELETE(
       );
     }
 
+    // ✅ CASCADE IMMEUBLE: Vérifier les baux actifs sur les lots enfants
+    let lots: { id: string; adresse_complete?: string | null }[] = [];
+    if (property.type === "immeuble") {
+      const { data: childLots } = await serviceClient
+        .from("properties")
+        .select("id, adresse_complete")
+        .eq("parent_property_id", propertyId)
+        .is("deleted_at", null);
+
+      lots = childLots ?? [];
+
+      if (!isAdmin && lots.length > 0) {
+        const lotIds = lots.map((l) => l.id);
+        const { data: lotBlockingLeases } = await serviceClient
+          .from("leases")
+          .select(`
+            id,
+            statut,
+            property_id,
+            signers:lease_signers(
+              profile_id,
+              role,
+              signature_status,
+              invited_email,
+              invited_name,
+              profile:profiles(id, prenom, nom, email)
+            )
+          `)
+          .in("property_id", lotIds)
+          .not("statut", "in", '("terminated","archived","cancelled")');
+
+        if (lotBlockingLeases && lotBlockingLeases.length > 0) {
+          const lease = lotBlockingLeases[0] as any;
+          const lot = lots.find((l) => l.id === lease.property_id);
+          const lotLabel = lot?.adresse_complete || lot?.id || "un lot";
+          const tenantSigner = lease.signers?.find((s: any) =>
+            s.role === "locataire_principal" || s.role === "colocataire"
+          );
+          const tenantName = tenantSigner?.profile
+            ? `${tenantSigner.profile.prenom || ""} ${tenantSigner.profile.nom || ""}`.trim() || tenantSigner.profile.email
+            : "un locataire";
+
+          throw new ApiError(
+            400,
+            `Impossible de supprimer l'immeuble : le lot "${lotLabel}" a un bail actif avec ${tenantName}. Résiliez-le d'abord.`,
+            {
+              leaseId: lease.id,
+              leaseStatus: lease.statut,
+              lotId: lot?.id,
+              lotLabel,
+              tenantName,
+              actionHint: "terminate",
+            }
+          );
+        }
+      }
+    }
+
     // ✅ SOTA 2026: Récupérer l'adresse pour les notifications
     const { data: propertyDetails } = await serviceClient
       .from("properties")
@@ -779,10 +838,13 @@ export async function DELETE(
       .single();
 
     // ✅ SOTA 2026: Notifier les locataires des baux (même terminés) avant suppression
+    // Inclure les baux de l'immeuble parent + tous ses lots
+    const allPropertyIds = [propertyId, ...lots.map((l) => l.id)];
     const { data: allLeases } = await serviceClient
       .from("leases")
       .select(`
         id,
+        property_id,
         signers:lease_signers(
           profile_id,
           role,
@@ -790,11 +852,11 @@ export async function DELETE(
           invited_name
         )
       `)
-      .eq("property_id", propertyId);
+      .in("property_id", allPropertyIds);
 
     if (allLeases && allLeases.length > 0) {
       const tenantProfileIds = new Set<string>();
-      
+
       for (const lease of allLeases) {
         const leaseData = lease as any;
         if (leaseData.signers) {
@@ -809,7 +871,7 @@ export async function DELETE(
       // Créer les notifications pour chaque locataire
       const address = propertyDetails?.adresse_complete || "Adresse inconnue";
       const city = propertyDetails?.ville || "";
-      
+
       for (const tenantId of tenantProfileIds) {
         await serviceClient
           .from("notifications")
@@ -830,13 +892,36 @@ export async function DELETE(
       }
     }
 
+    const now = new Date().toISOString();
+
+    // ✅ CASCADE IMMEUBLE: Soft-delete les lots enfants avant l'immeuble parent
+    let lotsSoftDeleted = 0;
+    if (property.type === "immeuble" && lots.length > 0) {
+      const lotIds = lots.map((l) => l.id);
+      const { error: lotDeleteError, count } = await serviceClient
+        .from("properties")
+        .update({
+          etat: "archived",
+          deleted_at: now,
+          deleted_by: profile.id,
+        })
+        .in("id", lotIds)
+        .is("deleted_at", null);
+
+      if (lotDeleteError) {
+        console.error("[DELETE Property] Erreur soft-delete lots cascade:", lotDeleteError);
+      } else {
+        lotsSoftDeleted = count ?? lots.length;
+      }
+    }
+
     // ✅ SOTA 2026: Soft-delete au lieu de hard-delete
     // Marquer comme supprimé plutôt que supprimer définitivement
     const { data: softDeletedProperty, error: softDeleteError } = await serviceClient
       .from("properties")
       .update({
         etat: "archived",
-        deleted_at: new Date().toISOString(),
+        deleted_at: now,
         deleted_by: profile.id
       })
       .eq("id", propertyId)
@@ -846,7 +931,7 @@ export async function DELETE(
     // Si soft-delete échoue (colonne manquante), faire un hard-delete
     if (softDeleteError) {
       console.warn("[DELETE Property] Soft-delete échoué, fallback hard-delete:", softDeleteError.message);
-      
+
       const { error: deleteError } = await serviceClient
         .from("properties")
         .delete()
@@ -880,8 +965,11 @@ export async function DELETE(
     return NextResponse.json({
       success: true,
       mode: "soft_delete",
-      message: "Propriété archivée. Les locataires ont été notifiés.",
-      tenantsNotified: allLeases?.length || 0
+      message: property.type === "immeuble"
+        ? `Immeuble archivé avec ${lotsSoftDeleted} lot${lotsSoftDeleted > 1 ? "s" : ""}. Les locataires ont été notifiés.`
+        : "Propriété archivée. Les locataires ont été notifiés.",
+      tenantsNotified: allLeases?.length || 0,
+      ...(lotsSoftDeleted > 0 ? { lotsSoftDeleted } : {}),
     });
   } catch (error: unknown) {
     return handleApiError(error);

--- a/lib/properties/guards.ts
+++ b/lib/properties/guards.ts
@@ -95,6 +95,13 @@ export async function canCreateProperty(
 // 2. GUARD SUPPRESSION — Verification des liaisons
 // ============================================
 
+export interface DeleteGuardLotInfo {
+  id: string;
+  adresse: string | null;
+  hasActiveLease: boolean;
+  activeLeases: number;
+}
+
 export interface DeleteGuardResult {
   canDelete: boolean;
   canArchive: boolean;
@@ -107,7 +114,15 @@ export interface DeleteGuardResult {
     tickets: number;
     photos: number;
   };
+  /**
+   * Lots de l'immeuble (uniquement renseigné si la property est `type='immeuble'`).
+   * Les lots cascadent en soft-delete avec l'immeuble parent.
+   */
+  lots?: DeleteGuardLotInfo[];
 }
+
+const ACTIVE_LEASE_STATUSES = ['active', 'pending_signature', 'partially_signed', 'fully_signed'];
+const TERMINATED_LEASE_STATUSES = ['terminated', 'expired', 'cancelled'];
 
 /**
  * Verifie si un bien peut etre supprime ou archive.
@@ -116,6 +131,11 @@ export interface DeleteGuardResult {
  *  - Bail actif/en signature → BLOQUEUR (ni suppression ni archivage)
  *  - Baux termines, documents, tickets → WARNING (archivage OK, pas suppression definitive)
  *  - Aucune liaison → Suppression definitive OK
+ *
+ * Cas IMMEUBLE (type='immeuble') :
+ *  - Les lots enfants (properties.parent_property_id = immeuble.id) sont également contrôlés
+ *  - Un bail actif sur un lot bloque la suppression de l'immeuble
+ *  - La suppression cascade en soft-delete sur tous les lots
  */
 export async function canDeleteProperty(
   supabase: SupabaseClient,
@@ -125,10 +145,10 @@ export async function canDeleteProperty(
   const blockers: string[] = [];
   const warnings: string[] = [];
 
-  // Verifier ownership
+  // Verifier ownership + récupérer le type pour brancher la logique cascade
   const { data: property } = await supabase
     .from('properties')
-    .select('id, owner_id')
+    .select('id, owner_id, type')
     .eq('id', propertyId)
     .eq('owner_id', ownerId)
     .single();
@@ -164,11 +184,9 @@ export async function canDeleteProperty(
   ]);
 
   const allLeases = leasesResult.data ?? [];
-  const activeStatuses = ['active', 'pending_signature', 'partially_signed', 'fully_signed'];
-  const terminatedStatuses = ['terminated', 'expired', 'cancelled'];
 
-  const activeLeases = allLeases.filter((l: { statut: string }) => activeStatuses.includes(l.statut)).length;
-  const terminatedLeases = allLeases.filter((l: { statut: string }) => terminatedStatuses.includes(l.statut)).length;
+  let activeLeases = allLeases.filter((l: { statut: string }) => ACTIVE_LEASE_STATUSES.includes(l.statut)).length;
+  let terminatedLeases = allLeases.filter((l: { statut: string }) => TERMINATED_LEASE_STATUSES.includes(l.statut)).length;
 
   const linkedData = {
     activeLeases,
@@ -178,11 +196,95 @@ export async function canDeleteProperty(
     photos: photosResult.count ?? 0,
   };
 
-  // BLOQUEURS — empechent toute suppression/archivage
+  // BLOQUEURS — empechent toute suppression/archivage (sur la property elle-même)
   if (activeLeases > 0) {
     blockers.push(
       `Ce bien a ${activeLeases} bail${activeLeases > 1 ? 'x' : ''} actif${activeLeases > 1 ? 's' : ''} ou en cours de signature. Terminez-le${activeLeases > 1 ? 's' : ''} d'abord.`,
     );
+  }
+
+  // ============================================
+  // CASCADE IMMEUBLE — Vérifier les lots enfants
+  // ============================================
+  let lotsInfo: DeleteGuardLotInfo[] | undefined;
+
+  if (property.type === 'immeuble') {
+    // Récupérer tous les lots actifs (non soft-deleted) de l'immeuble
+    const { data: lots } = await supabase
+      .from('properties')
+      .select('id, adresse_complete, type, parent_property_id')
+      .eq('parent_property_id', propertyId)
+      .is('deleted_at', null);
+
+    const lotList = lots ?? [];
+    lotsInfo = [];
+
+    if (lotList.length > 0) {
+      // Récupérer en une seule requête tous les baux des lots
+      const lotIds = lotList.map((l: { id: string }) => l.id);
+      const { data: lotsLeases } = await supabase
+        .from('leases')
+        .select('id, statut, property_id')
+        .in('property_id', lotIds);
+
+      const allLotLeases = lotsLeases ?? [];
+
+      // Compter les liaisons agrégées (documents + tickets + photos) des lots
+      const [lotsDocsResult, lotsTicketsResult, lotsPhotosResult] = await Promise.all([
+        supabase
+          .from('documents')
+          .select('id', { count: 'exact', head: true })
+          .in('property_id', lotIds),
+        supabase
+          .from('work_orders')
+          .select('id', { count: 'exact', head: true })
+          .in('property_id', lotIds),
+        supabase
+          .from('photos')
+          .select('id', { count: 'exact', head: true })
+          .in('property_id', lotIds),
+      ]);
+
+      // Vérifier chaque lot individuellement et construire lotsInfo
+      for (const lot of lotList) {
+        const lotLeasesAll = allLotLeases.filter(
+          (l: { property_id: string }) => l.property_id === lot.id,
+        );
+        const lotActiveLeases = lotLeasesAll.filter(
+          (l: { statut: string }) => ACTIVE_LEASE_STATUSES.includes(l.statut),
+        ).length;
+        const lotTerminatedLeases = lotLeasesAll.filter(
+          (l: { statut: string }) => TERMINATED_LEASE_STATUSES.includes(l.statut),
+        ).length;
+
+        lotsInfo.push({
+          id: lot.id,
+          adresse: lot.adresse_complete ?? null,
+          hasActiveLease: lotActiveLeases > 0,
+          activeLeases: lotActiveLeases,
+        });
+
+        if (lotActiveLeases > 0) {
+          const label = lot.adresse_complete || lot.id;
+          blockers.push(
+            `Le lot "${label}" a ${lotActiveLeases} bail${lotActiveLeases > 1 ? 'x' : ''} actif${lotActiveLeases > 1 ? 's' : ''}. Résiliez-le${lotActiveLeases > 1 ? 's' : ''} d'abord.`,
+          );
+        }
+
+        // Agréger les compteurs pour les warnings
+        activeLeases += lotActiveLeases;
+        terminatedLeases += lotTerminatedLeases;
+      }
+
+      // Mettre à jour linkedData avec les totaux agrégés (immeuble + lots)
+      linkedData.activeLeases = activeLeases;
+      linkedData.terminatedLeases = terminatedLeases;
+      linkedData.documents += lotsDocsResult.count ?? 0;
+      linkedData.tickets += lotsTicketsResult.count ?? 0;
+      linkedData.photos += lotsPhotosResult.count ?? 0;
+
+      warnings.push(`${lotList.length} lot${lotList.length > 1 ? 's' : ''} ${lotList.length > 1 ? 'seront' : 'sera'} également supprimé${lotList.length > 1 ? 's' : ''}`);
+    }
   }
 
   // WARNINGS — permettent l'archivage mais pas la suppression definitive
@@ -202,6 +304,7 @@ export async function canDeleteProperty(
     blockers,
     warnings,
     linkedData,
+    ...(lotsInfo !== undefined ? { lots: lotsInfo } : {}),
   };
 }
 


### PR DESCRIPTION
- canDeleteProperty() now detects `type='immeuble'` and checks all child
  lots (via parent_property_id) for active leases before allowing deletion.
  Blockers are generated per-lot with contextual messages.
  linkedData aggregates counts from both the immeuble and all its lots.
  New `lots` field in DeleteGuardResult provides per-lot info.

- DELETE handler cascades soft-delete (deleted_at + deleted_by) to all
  child lots before archiving the parent immeuble. Tenant notifications
  now cover leases on lots as well as the parent property.

- New GET /api/properties/[id]/can-delete route exposes the guard as a
  pre-flight check endpoint returning blockers, warnings, linkedData,
  and per-lot details for UI consumption.

https://claude.ai/code/session_013VjwEcs7Am8GsEVovxMZmq