### PR TITLE
claude/fix-edl-tenant-sync-QXZrn

### DIFF
--- a/app/tenant/documents/page.tsx
+++ b/app/tenant/documents/page.tsx
@@ -49,6 +49,7 @@ import {
   FileSignature,
   Receipt,
   FileCheck,
+  ChevronRight,
 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DocumentGroups } from "@/components/documents/document-groups";
@@ -68,6 +69,7 @@ import { groupDocuments } from "@/lib/documents/group-documents";
 import { GroupedDocumentCard } from "@/features/documents/components/grouped-document-card";
 import Link from "next/link";
 import { useTenantPendingActions } from "@/lib/hooks/use-tenant-pending-actions";
+import { useTenantInspections } from "@/lib/hooks/queries/use-tenant-inspections";
 
 // ──────────────────────────────────────────────
 // Helpers
@@ -235,6 +237,10 @@ export default function TenantDocumentsPage() {
 
   const pendingEDLs = useMemo(() => dashboard?.pending_edls || [], [dashboard]);
 
+  // Fetch EDL data from the `edl` table — Documents Essentiels needs this because
+  // EDLs are stored in a separate table and may not exist in the `documents` table.
+  const { data: edlList = [] } = useTenantInspections();
+
   const pendingActions = useTenantPendingActions({
     dashboard,
     hasSignedLease,
@@ -293,8 +299,34 @@ export default function TenantDocumentsPage() {
       if (bail && quittance && edlEntree && assurance) break;
     }
 
+    // Fallback: if no EDL found in documents table, use the edl table data.
+    // EDLs are stored in a separate `edl` table and may not have a matching
+    // row in `documents`. We synthesize a virtual document for the card.
+    if (!edlEntree && edlList.length > 0) {
+      // Pick the most relevant EDL: prefer signed entree, then any entree, then any EDL
+      const signedEntree = edlList.find(e => e.type === "entree" && e.isSigned);
+      const anyEntree = edlList.find(e => e.type === "entree");
+      const bestEdl = signedEntree || anyEntree || edlList[0];
+      if (bestEdl) {
+        edlEntree = {
+          id: bestEdl.id,
+          type: bestEdl.type === "entree" ? "EDL_entree" : "EDL_sortie",
+          title: `État des lieux ${bestEdl.type === "entree" ? "d'entrée" : "de sortie"}`,
+          storage_path: null,
+          created_at: bestEdl.scheduled_at || bestEdl.created_at,
+          property_id: bestEdl.property?.id || null,
+          metadata: {},
+          // Flag for the card to know this is from the edl table
+          _fromEdlTable: true,
+          _edlId: bestEdl.id,
+          _edlStatus: bestEdl.status,
+          _edlIsSigned: bestEdl.isSigned,
+        };
+      }
+    }
+
     return { bail, quittance, edl: edlEntree, assurance };
-  }, [documents, BAIL_TYPES, QUITTANCE_TYPES, EDL_TYPES, ASSURANCE_TYPES]);
+  }, [documents, edlList, BAIL_TYPES, QUITTANCE_TYPES, EDL_TYPES, ASSURANCE_TYPES]);
 
   // ── Filtrage et tri des documents ──
   const filteredDocuments = useMemo(() => {
@@ -607,15 +639,35 @@ export default function TenantDocumentsPage() {
 
                 {/* EDL d'entrée */}
                 {keyDocuments.edl ? (
-                  <DocumentCard
-                    doc={keyDocuments.edl}
-                    resolvedType={detectType(keyDocuments.edl)}
-                    displayTitle={getDocumentDisplayName(keyDocuments.edl)}
-                    onPreview={handlePreview}
-                    onDownload={handleDownload}
-                    compact
-                    isNew={isRecent(keyDocuments.edl)}
-                  />
+                  keyDocuments.edl._fromEdlTable ? (
+                    // EDL from the `edl` table — link to detail page
+                    <Link href={`/tenant/inspections/${keyDocuments.edl._edlId}`}>
+                      <GlassCard className="flex items-center gap-4 p-4 border border-emerald-200 bg-emerald-50/30 hover:shadow-lg transition-all duration-200 cursor-pointer h-full">
+                        <div className="p-2.5 rounded-xl bg-emerald-100 shrink-0">
+                          <FileCheck className="h-5 w-5 text-emerald-600" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-foreground truncate">{keyDocuments.edl.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {keyDocuments.edl._edlIsSigned ? "Signé" : keyDocuments.edl._edlStatus === "in_progress" ? "En cours" : keyDocuments.edl._edlStatus}
+                            {" — "}
+                            {formatSafeDate(keyDocuments.edl.created_at)}
+                          </p>
+                        </div>
+                        <ChevronRight className="h-4 w-4 text-emerald-600 shrink-0" />
+                      </GlassCard>
+                    </Link>
+                  ) : (
+                    <DocumentCard
+                      doc={keyDocuments.edl}
+                      resolvedType={detectType(keyDocuments.edl)}
+                      displayTitle={getDocumentDisplayName(keyDocuments.edl)}
+                      onPreview={handlePreview}
+                      onDownload={handleDownload}
+                      compact
+                      isNew={isRecent(keyDocuments.edl)}
+                    />
+                  )
                 ) : (
                   <GlassCard className="flex items-center gap-4 p-4 border-dashed border-2 border-border bg-muted/30">
                     <div className="p-2.5 rounded-xl bg-muted shrink-0">

--- a/app/tenant/inspections/page.tsx
+++ b/app/tenant/inspections/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,7 +11,9 @@ import {
   AlertCircle,
   Loader2,
   FileText,
-  Info
+  Info,
+  Eye,
+  Download,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDateShort } from "@/lib/helpers/format";
@@ -24,6 +27,41 @@ import { useTenantInspections } from "@/lib/hooks/queries/use-tenant-inspections
 
 export default function TenantInspectionsPage() {
   const { data: edlList = [], isLoading, error, refetch } = useTenantInspections();
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const handleDownloadPDF = useCallback(async (edlId: string, edlType: string) => {
+    setDownloadingId(edlId);
+    try {
+      const response = await fetch("/api/edl/pdf", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ edlId }),
+      });
+      if (!response.ok) throw new Error("Erreur génération document");
+      const { html: pdfHtml, fileName } = await response.json();
+      const html2pdf = (await import("html2pdf.js")).default;
+      const element = document.createElement("div");
+      element.innerHTML = pdfHtml;
+      element.style.position = "absolute";
+      element.style.left = "-9999px";
+      document.body.appendChild(element);
+      await html2pdf()
+        .set({
+          margin: 10,
+          filename: fileName || `edl_${edlType}_${edlId.slice(0, 8)}.pdf`,
+          image: { type: "jpeg", quality: 0.95 },
+          html2canvas: { scale: 2, useCORS: true },
+          jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+        })
+        .from(element)
+        .save();
+      document.body.removeChild(element);
+    } catch {
+      // Silent fail — user sees the button reset
+    } finally {
+      setDownloadingId(null);
+    }
+  }, []);
 
   const pendingCount = edlList.filter(e => e.needsMySignature).length;
 
@@ -143,20 +181,49 @@ export default function TenantInspectionsPage() {
                         </div>
                       </div>
 
-                      <div className="flex items-center gap-3">
-                        <Button 
+                      <div className="flex items-center gap-2 flex-wrap">
+                        {edl.status === "signed" && (
+                          <>
+                            <Button
+                              asChild
+                              variant="outline"
+                              size="sm"
+                              className="h-9 px-3 rounded-xl border-border hover:bg-indigo-50 hover:text-indigo-600"
+                            >
+                              <Link href={`/tenant/inspections/${edl.id}`}>
+                                <Eye className="h-4 w-4 mr-1.5" />
+                                Voir
+                              </Link>
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-9 px-3 rounded-xl border-border hover:bg-emerald-50 hover:text-emerald-600"
+                              onClick={() => handleDownloadPDF(edl.id, edl.type)}
+                              disabled={downloadingId === edl.id}
+                            >
+                              {downloadingId === edl.id ? (
+                                <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                              ) : (
+                                <Download className="h-4 w-4 mr-1.5" />
+                              )}
+                              {downloadingId === edl.id ? "PDF…" : "Télécharger"}
+                            </Button>
+                          </>
+                        )}
+                        <Button
                           asChild
                           variant={edl.needsMySignature ? "default" : "outline"}
                           className={cn(
-                            "h-11 px-6 font-bold shadow-lg transition-all rounded-xl",
-                            edl.needsMySignature 
-                              ? "bg-amber-500 hover:bg-amber-600 shadow-amber-100" 
+                            "h-9 px-4 font-bold shadow-sm transition-all rounded-xl",
+                            edl.needsMySignature
+                              ? "bg-amber-500 hover:bg-amber-600 shadow-amber-100"
                               : "border-border hover:bg-indigo-50 hover:text-indigo-600"
                           )}
                         >
                           <Link href={edl.needsMySignature ? `/signature-edl/${edl.invitation_token}` : `/tenant/inspections/${edl.id}`}>
                             {edl.needsMySignature ? "Signer l'EDL" : "Consulter"}
-                            <ChevronRight className="ml-2 h-4 w-4" />
+                            <ChevronRight className="ml-1.5 h-4 w-4" />
                           </Link>
                         </Button>
                       </div>

--- a/supabase/migrations/20260416100000_fix_tickets_rls_recursion.sql
+++ b/supabase/migrations/20260416100000_fix_tickets_rls_recursion.sql
@@ -1,0 +1,165 @@
+-- =====================================================
+-- Migration: Fix tickets RLS infinite recursion (42P17)
+-- Date: 2026-04-16
+--
+-- CONTEXT:
+-- The "Users can view tickets of accessible properties" SELECT policy
+-- on `tickets` (20260215200002_fix_rls_tenant_access_beyond_active.sql)
+-- uses inline EXISTS subqueries that cause circular RLS evaluation:
+--
+--   EXISTS (
+--     SELECT 1 FROM leases l
+--     JOIN lease_signers ls ON ls.lease_id = l.id
+--     WHERE l.property_id = tickets.property_id
+--       AND ls.profile_id = user_profile_id()
+--       AND l.statut IN ('active', 'notice_given')
+--   )
+--
+-- Reading `leases` triggers leases SELECT RLS → which checks
+-- `properties` RLS → which uses tenant_accessible_property_ids() →
+-- reads `leases` again → Postgres detects the cycle at plan time:
+--
+--   ERROR: 42P17 infinite recursion detected in policy for
+--          relation "tickets"
+--
+-- This breaks useTenantRealtime (500 on tickets query) and any
+-- tenant-side ticket access.
+--
+-- FIX:
+-- Replace the inline EXISTS on leases/lease_signers with a
+-- SECURITY DEFINER helper function that bypasses RLS. Same pattern
+-- used by tenant_accessible_property_ids() and
+-- owner_accessible_work_order_ids().
+--
+-- Also fix the INSERT policy which has the same inline pattern.
+--
+-- Safe to re-run (CREATE OR REPLACE FUNCTION + DROP POLICY IF EXISTS).
+-- =====================================================
+
+-- =====================================================
+-- 1. SECURITY DEFINER helper: ticket ids the current authenticated
+--    user can read as a tenant (via lease_signers on the same property)
+-- =====================================================
+CREATE OR REPLACE FUNCTION public.tenant_accessible_ticket_ids()
+RETURNS SETOF UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT DISTINCT t.id
+  FROM public.tickets t
+  JOIN public.leases l ON l.property_id = t.property_id
+  JOIN public.lease_signers ls ON ls.lease_id = l.id
+  WHERE ls.profile_id = public.user_profile_id()
+    AND l.statut IN ('active', 'notice_given');
+$$;
+
+COMMENT ON FUNCTION public.tenant_accessible_ticket_ids IS
+  'Returns ticket ids that the currently authenticated user can access '
+  'as a tenant signer on an active or notice_given lease for the same '
+  'property. SECURITY DEFINER to bypass RLS on leases and lease_signers '
+  'and avoid the infinite recursion caused by the inline EXISTS subquery '
+  'in the tickets SELECT policy.';
+
+-- =====================================================
+-- 2. SECURITY DEFINER helper: property ids the current user can
+--    create tickets for as a tenant
+-- =====================================================
+CREATE OR REPLACE FUNCTION public.tenant_ticketable_property_ids()
+RETURNS SETOF UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT DISTINCT l.property_id
+  FROM public.leases l
+  JOIN public.lease_signers ls ON ls.lease_id = l.id
+  WHERE ls.profile_id = public.user_profile_id()
+    AND l.statut IN ('active', 'notice_given');
+$$;
+
+COMMENT ON FUNCTION public.tenant_ticketable_property_ids IS
+  'Returns property ids where the current user is a tenant with an '
+  'active or notice_given lease. Used for the tickets INSERT policy '
+  'to avoid RLS recursion.';
+
+-- =====================================================
+-- 3. Rewrite SELECT policy — no more inline leases/profiles subqueries
+-- =====================================================
+DROP POLICY IF EXISTS "Users can view tickets of accessible properties" ON tickets;
+DROP POLICY IF EXISTS "tickets_select_policy" ON tickets;
+
+CREATE POLICY "Users can view tickets of accessible properties"
+  ON tickets
+  FOR SELECT
+  USING (
+    -- Creator of the ticket
+    tickets.created_by_profile_id = public.user_profile_id()
+    OR
+    -- Owner of the property (direct check, no sub-select on properties)
+    EXISTS (
+      SELECT 1 FROM properties p
+      WHERE p.id = tickets.property_id
+        AND p.owner_id = public.user_profile_id()
+    )
+    OR
+    -- Tenant with active/notice_given lease (SECURITY DEFINER helper)
+    tickets.id IN (SELECT public.tenant_accessible_ticket_ids())
+    OR
+    -- Provider assigned via work_order
+    EXISTS (
+      SELECT 1 FROM work_orders wo
+      WHERE wo.ticket_id = tickets.id
+        AND wo.provider_id = public.user_profile_id()
+    )
+    OR
+    -- Admin (direct check on auth.uid(), no sub-select on profiles)
+    public.user_profile_id() IN (
+      SELECT p.id FROM profiles p WHERE p.id = public.user_profile_id() AND p.role = 'admin'
+    )
+  );
+
+COMMENT ON POLICY "Users can view tickets of accessible properties" ON tickets IS
+  'Unified SELECT policy for tickets. Uses tenant_accessible_ticket_ids() '
+  'SECURITY DEFINER helper to avoid the infinite recursion through '
+  'leases → properties → leases policies.';
+
+-- =====================================================
+-- 4. Rewrite INSERT policy — same recursion fix
+-- =====================================================
+DROP POLICY IF EXISTS "Users can create tickets for accessible properties" ON tickets;
+DROP POLICY IF EXISTS "tickets_insert_policy" ON tickets;
+
+CREATE POLICY "Users can create tickets for accessible properties"
+  ON tickets
+  FOR INSERT
+  WITH CHECK (
+    -- Owner of the property
+    EXISTS (
+      SELECT 1 FROM properties p
+      WHERE p.id = tickets.property_id
+        AND p.owner_id = public.user_profile_id()
+    )
+    OR
+    -- Tenant with active/notice_given lease (SECURITY DEFINER helper)
+    tickets.property_id IN (SELECT public.tenant_ticketable_property_ids())
+    OR
+    -- Admin
+    public.user_profile_id() IN (
+      SELECT p.id FROM profiles p WHERE p.id = public.user_profile_id() AND p.role = 'admin'
+    )
+  );
+
+COMMENT ON POLICY "Users can create tickets for accessible properties" ON tickets IS
+  'INSERT policy for tickets. Uses tenant_ticketable_property_ids() '
+  'SECURITY DEFINER helper to avoid the infinite recursion.';
+
+-- =====================================================
+-- Log
+-- =====================================================
+DO $$
+BEGIN
+  RAISE NOTICE '[MIGRATION] Fix tickets RLS recursion — replaced inline leases/lease_signers EXISTS with SECURITY DEFINER helpers';
+END $$;


### PR DESCRIPTION
Bug 1 — Documents Essentiels showed "Pas encore réalisé" for EDL even when
signed, because the component only searched the `documents` table while EDLs
live in the separate `edl` table. Now falls back to useTenantInspections() data
to synthesize a virtual document card with proper status and link.

Bug 2 — Tenant inspections list page had no View/Download buttons. Added "Voir"
and "Télécharger" CTAs on signed EDL cards using the existing /api/edl/pdf
endpoint with client-side html2pdf.js conversion.

Bug 3 — RLS infinite recursion on `tickets` (42P17) caused by inline
EXISTS(SELECT FROM leases JOIN lease_signers) in the SELECT/INSERT policies,
which triggered leases→properties→leases cycle. Fixed with SECURITY DEFINER
helpers `tenant_accessible_ticket_ids()` and `tenant_ticketable_property_ids()`,
following the same pattern as tenant_accessible_property_ids().

https://claude.ai/code/session_01FHAWevVXa8HfVTX4jh1JZX