### PR TITLE
fix(tenant): hydration mismatch + NEXT_NOT_FOUND EDL regressions

### DIFF
--- a/app/tenant/documents/page.tsx
+++ b/app/tenant/documents/page.tsx
@@ -239,9 +239,13 @@ export default function TenantDocumentsPage() {
 
   // Fetch EDL data from the `edl` table — Documents Essentiels needs this because
   // EDLs are stored in a separate table and may not exist in the `documents` table.
-  // Use isLoading to prevent hydration mismatch: SSR renders with empty edlList,
-  // and we must not use cached React Query data during initial client render.
-  const { data: edlList = [], isLoading: edlListLoading } = useTenantInspections();
+  const { data: edlList = [] } = useTenantInspections();
+
+  // Hydration guard: SSR renders with no EDL data, but React Query may return
+  // cached data synchronously on the client's first render, causing a mismatch.
+  // Only use edlList AFTER mount (useEffect fires after hydration is complete).
+  const [edlMounted, setEdlMounted] = useState(false);
+  useEffect(() => setEdlMounted(true), []);
 
   const pendingActions = useTenantPendingActions({
     dashboard,
@@ -304,9 +308,10 @@ export default function TenantDocumentsPage() {
     // Fallback: if no EDL found in documents table, use the edl table data.
     // EDLs are stored in a separate `edl` table and may not have a matching
     // row in `documents`. We synthesize a virtual document for the card.
-    // Guard: only use edlList AFTER loading completes to prevent hydration
-    // mismatch (SSR has no data, client may have cached React Query data).
-    if (!edlEntree && !edlListLoading && edlList.length > 0) {
+    // Guard: only use edlList AFTER mount to prevent hydration mismatch.
+    // SSR has no EDL data; React Query may have cached data on first client
+    // render. useEffect sets edlMounted=true after hydration completes.
+    if (!edlEntree && edlMounted && edlList.length > 0) {
       // Pick the most relevant EDL: prefer signed entree, then any entree, then any EDL
       const signedEntree = edlList.find(e => e.type === "entree" && e.isSigned);
       const anyEntree = edlList.find(e => e.type === "entree");
@@ -330,7 +335,7 @@ export default function TenantDocumentsPage() {
     }
 
     return { bail, quittance, edl: edlEntree, assurance };
-  }, [documents, edlList, edlListLoading, BAIL_TYPES, QUITTANCE_TYPES, EDL_TYPES, ASSURANCE_TYPES]);
+  }, [documents, edlList, edlMounted, BAIL_TYPES, QUITTANCE_TYPES, EDL_TYPES, ASSURANCE_TYPES]);
 
   // ── Filtrage et tri des documents ──
   const filteredDocuments = useMemo(() => {

--- a/app/tenant/documents/page.tsx
+++ b/app/tenant/documents/page.tsx
@@ -239,7 +239,9 @@ export default function TenantDocumentsPage() {
 
   // Fetch EDL data from the `edl` table — Documents Essentiels needs this because
   // EDLs are stored in a separate table and may not exist in the `documents` table.
-  const { data: edlList = [] } = useTenantInspections();
+  // Use isLoading to prevent hydration mismatch: SSR renders with empty edlList,
+  // and we must not use cached React Query data during initial client render.
+  const { data: edlList = [], isLoading: edlListLoading } = useTenantInspections();
 
   const pendingActions = useTenantPendingActions({
     dashboard,
@@ -302,7 +304,9 @@ export default function TenantDocumentsPage() {
     // Fallback: if no EDL found in documents table, use the edl table data.
     // EDLs are stored in a separate `edl` table and may not have a matching
     // row in `documents`. We synthesize a virtual document for the card.
-    if (!edlEntree && edlList.length > 0) {
+    // Guard: only use edlList AFTER loading completes to prevent hydration
+    // mismatch (SSR has no data, client may have cached React Query data).
+    if (!edlEntree && !edlListLoading && edlList.length > 0) {
       // Pick the most relevant EDL: prefer signed entree, then any entree, then any EDL
       const signedEntree = edlList.find(e => e.type === "entree" && e.isSigned);
       const anyEntree = edlList.find(e => e.type === "entree");
@@ -326,7 +330,7 @@ export default function TenantDocumentsPage() {
     }
 
     return { bail, quittance, edl: edlEntree, assurance };
-  }, [documents, edlList, BAIL_TYPES, QUITTANCE_TYPES, EDL_TYPES, ASSURANCE_TYPES]);
+  }, [documents, edlList, edlListLoading, BAIL_TYPES, QUITTANCE_TYPES, EDL_TYPES, ASSURANCE_TYPES]);
 
   // ── Filtrage et tri des documents ──
   const filteredDocuments = useMemo(() => {

--- a/app/tenant/inspections/[id]/page.tsx
+++ b/app/tenant/inspections/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 export const runtime = "nodejs";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
-import { redirect, notFound } from "next/navigation";
+import { redirect } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 import TenantEDLDetailClient from "./TenantEDLDetailClient";
 
@@ -16,41 +16,43 @@ export async function generateMetadata({ params }: { params: { id: string } }) {
 }
 
 async function fetchTenantEDL(edlId: string, profileId: string) {
-  const supabase = await createClient();
-  const serviceClient = getServiceClient(); // Pour bypass RLS sur certaines requêtes
+  const serviceClient = getServiceClient();
 
-  // Récupérer le user_id du profil pour la recherche
-  const { data: profileData } = await supabase
+  // Récupérer le user_id du profil — via serviceClient pour éviter les
+  // blocages RLS sur profiles qui rendraient userId=undefined et casseraient
+  // tous les essais de lookup de signature ci-dessous.
+  const { data: profileData } = await serviceClient
     .from("profiles")
     .select("user_id")
     .eq("id", profileId)
     .single();
-  
+
   const userId = profileData?.user_id;
 
   // Vérifier que le locataire est bien signataire de cet EDL
-  // Recherche par signer_profile_id OU signer_user_id
+  // Toutes les requêtes passent par serviceClient pour éviter les recursions
+  // RLS (42P17) — l'auth est déjà vérifiée par le layout parent.
   let mySignature = null;
-  
+
   // Essai 1: par signer_profile_id
-  const { data: sigByProfile } = await supabase
+  const { data: sigByProfile } = await serviceClient
     .from("edl_signatures")
     .select("*")
     .eq("edl_id", edlId)
     .eq("signer_profile_id", profileId)
     .maybeSingle();
-  
+
   if (sigByProfile) {
     mySignature = sigByProfile;
   } else if (userId) {
     // Essai 2: par signer_user_id
-    const { data: sigByUser } = await supabase
+    const { data: sigByUser } = await serviceClient
       .from("edl_signatures")
       .select("*")
       .eq("edl_id", edlId)
       .eq("signer_user_id", userId)
       .maybeSingle();
-    
+
     if (sigByUser) {
       mySignature = sigByUser;
     }
@@ -58,16 +60,14 @@ async function fetchTenantEDL(edlId: string, profileId: string) {
 
   // Essai 3: Vérifier si le locataire est signataire du bail associé à l'EDL
   if (!mySignature) {
-    // Récupérer l'EDL pour avoir le lease_id
-    const { data: edlForLease } = await supabase
+    const { data: edlForLease } = await serviceClient
       .from("edl")
       .select("lease_id")
       .eq("id", edlId)
       .single();
 
     if (edlForLease?.lease_id) {
-      // Vérifier si le locataire est signataire du bail
-      const { data: leaseSigner } = await supabase
+      const { data: leaseSigner } = await serviceClient
         .from("lease_signers")
         .select("*")
         .eq("lease_id", edlForLease.lease_id)
@@ -81,31 +81,14 @@ async function fetchTenantEDL(edlId: string, profileId: string) {
     }
   }
 
-  // Essai 4: Bypass RLS — Rechercher dans edl_signatures via serviceClient
-  // Couvre le cas où la signature via token n'a pas correctement rattaché le profil
-  if (!mySignature) {
-    const orFilters = [`signer_profile_id.eq.${profileId}`];
-    if (userId) orFilters.push(`signer_user_id.eq.${userId}`);
-
-    const { data: sigByService } = await serviceClient
-      .from("edl_signatures")
-      .select("*")
-      .eq("edl_id", edlId)
-      .or(orFilters.join(","))
-      .maybeSingle();
-
-    if (sigByService) {
-      mySignature = sigByService;
-    }
-  }
-
   if (!mySignature) {
     console.error("[fetchTenantEDL] Not a signer - access denied");
     return null;
   }
 
-  // Récupérer l'EDL complet
-  const { data: edl, error } = await supabase
+  // Récupérer l'EDL complet — via serviceClient pour éviter les recursions
+  // RLS sur les joins edl→leases→properties
+  const { data: edl, error } = await serviceClient
     .from("edl")
     .select(
       `
@@ -173,12 +156,12 @@ async function fetchTenantEDL(edlId: string, profileId: string) {
     (edl as any).lease.property = finalProperty;
   }
 
-  // Récupérer les items, médias et signatures
+  // Récupérer les items, médias et signatures — via serviceClient
   const [{ data: edl_items }, { data: edl_media }, { data: signaturesRaw }] =
     await Promise.all([
-      supabase.from("edl_items").select("*").eq("edl_id", edlId),
-      supabase.from("edl_media").select("*").eq("edl_id", edlId),
-      supabase
+      serviceClient.from("edl_items").select("*").eq("edl_id", edlId),
+      serviceClient.from("edl_media").select("*").eq("edl_id", edlId),
+      serviceClient
         .from("edl_signatures")
         .select("*, profile:signer_profile_id(*)")
         .eq("edl_id", edlId),
@@ -355,7 +338,7 @@ async function DetailContent({
   const data = await fetchTenantEDL(edlId, profileId);
 
   if (!data) {
-    notFound();
+    redirect("/tenant/inspections");
   }
 
   return <TenantEDLDetailClient data={data} profileId={profileId} />;


### PR DESCRIPTION
## Summary

- **Hydration mismatch (#425, #422) sur `/tenant/documents`** : `useTenantInspections()` retournait des données React Query cachées dès le premier rendu client, alors que le SSR rendait avec `edlList=[]`. Fix : pattern `useState`+`useEffect` hasMounted qui garantit `edlMounted=false` pendant l'hydration (useEffect fire APRÈS).

- **NEXT_NOT_FOUND sur `/tenant/inspections/[id]`** : `fetchTenantEDL()` utilisait `createClient()` (user-scoped, RLS) pour les queries profile/signatures/EDL. Si les RLS bloquaient, `userId` devenait undefined → tous les essais de lookup échouaient → `notFound()`. Fix : toutes les queries data passent par `serviceClient()` (auth vérifiée par le layout). `notFound()` remplacé par `redirect("/tenant/inspections")`.

## Test plan

- [ ] `/tenant/documents` : pas d'erreur #425/#422 dans la console
- [ ] `/tenant/documents` : carte EDL dans Documents Essentiels affiche le bon statut après chargement
- [ ] `/tenant/inspections/{id}` : la page détail charge sans NEXT_NOT_FOUND
- [ ] `/tenant/inspections` : boutons Voir/Télécharger fonctionnels sur EDL signés

https://claude.ai/code/session_01FHAWevVXa8HfVTX4jh1JZX