### PR TITLE
claude/fix-message-bubbles-IAu96

### DIFF
--- a/components/chat/chat-window.tsx
+++ b/components/chat/chat-window.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Send,
@@ -37,6 +36,37 @@ import { chatService, type Message, type Conversation } from "@/lib/services/cha
 import { formatDistanceToNow } from "date-fns";
 import { fr } from "date-fns/locale";
 
+/** Image avec fallback en cas d'erreur de chargement */
+function MessageImage({ src, alt, fileName, isMe }: {
+  src: string;
+  alt: string;
+  fileName?: string | null;
+  isMe: boolean;
+}) {
+  const [hasError, setHasError] = useState(false);
+
+  if (hasError) {
+    return (
+      <div className={`flex items-center gap-2 text-sm ${
+        isMe ? "text-primary-foreground/80" : "text-muted-foreground"
+      }`}>
+        <Paperclip className="h-4 w-4 flex-shrink-0" />
+        <span>{fileName || "Image non disponible"}</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className="max-w-[280px] max-h-[280px] rounded-lg object-cover cursor-pointer"
+      onError={() => setHasError(true)}
+      loading="lazy"
+    />
+  );
+}
+
 interface ChatWindowProps {
   conversation: Conversation;
   currentProfileId: string;
@@ -61,6 +91,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
 
   const isOwner = currentProfileId === conversation.owner_profile_id;
   const otherName = isOwner ? conversation.tenant_name : conversation.owner_name;
+  const otherAvatar = isOwner ? conversation.tenant_avatar : conversation.owner_avatar;
 
   // Charger les messages
   useEffect(() => {
@@ -352,6 +383,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
             </Button>
           )}
           <Avatar className="h-10 w-10">
+            {otherAvatar && <AvatarImage src={otherAvatar} alt={otherName || "Interlocuteur"} />}
             <AvatarFallback>
               {otherName?.split(" ").map(n => n[0]).join("").toUpperCase() || "?"}
             </AvatarFallback>
@@ -363,7 +395,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
             </p>
           </div>
           <Badge variant="outline" className="text-xs">
-            {isOwner ? "Propriétaire" : "Locataire"}
+            {isOwner ? "Locataire" : "Propriétaire"}
           </Badge>
           {conversation.ticket_id && (
             <Badge variant="secondary" className="text-xs">
@@ -390,7 +422,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
       </CardHeader>
 
       {/* Messages */}
-      <ScrollArea ref={scrollRef} className="flex-1 p-4">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4">
         {loading ? (
           <div className="space-y-4">
             {[1, 2, 3].map((i) => (
@@ -515,19 +547,20 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
                               </div>
                             ) : (
                               <>
-                                {message.content_type === "text" && (
+                                {message.content_type === "text" && !message.attachment_url && (
                                   <p className="text-sm whitespace-pre-wrap break-words">
                                     {message.content}
                                   </p>
                                 )}
 
                                 {message.attachment_url && (
-                                  <div className="mt-2">
-                                    {message.content_type === "image" ? (
-                                      <img
+                                  <div className={message.content_type !== "text" ? "mt-0" : "mt-2"}>
+                                    {message.content_type === "image" || message.attachment_type?.startsWith("image/") ? (
+                                      <MessageImage
                                         src={message.attachment_url}
                                         alt={message.attachment_name || "Image"}
-                                        className="max-w-full rounded-lg"
+                                        fileName={message.attachment_name}
+                                        isMe={isMe}
                                       />
                                     ) : (
                                       <a
@@ -599,7 +632,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
             ))}
           </div>
         )}
-      </ScrollArea>
+      </div>
 
       {/* Input */}
       <div className="p-4 border-t flex-shrink-0">

--- a/components/chat/conversations-list.tsx
+++ b/components/chat/conversations-list.tsx
@@ -22,22 +22,26 @@ import { fr } from "date-fns/locale";
 
 interface ConversationsListProps {
   currentProfileId: string;
+  currentRole?: "owner" | "tenant";
   selectedId?: string;
   onSelect: (conversation: Conversation) => void;
 }
 
-export function ConversationsList({ currentProfileId, selectedId, onSelect }: ConversationsListProps) {
+export function ConversationsList({ currentProfileId, currentRole, selectedId, onSelect }: ConversationsListProps) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [usePolling, setUsePolling] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const loadConversations = useCallback(async () => {
     try {
+      setLoadError(null);
       const data = await chatService.getConversations();
       setConversations(data);
     } catch (error) {
       console.error("Erreur chargement conversations:", error);
+      setLoadError("Impossible de charger les conversations");
     } finally {
       setLoading(false);
     }
@@ -102,6 +106,11 @@ export function ConversationsList({ currentProfileId, selectedId, onSelect }: Co
     return isOwner ? conv.tenant_name : conv.owner_name;
   };
 
+  const getOtherAvatar = (conv: Conversation) => {
+    const isOwner = currentProfileId === conv.owner_profile_id;
+    return isOwner ? conv.tenant_avatar : conv.owner_avatar;
+  };
+
   const formatLastMessage = (dateString?: string | null) => {
     if (!dateString) return "";
     return formatDistanceToNow(new Date(dateString), { 
@@ -160,7 +169,15 @@ export function ConversationsList({ currentProfileId, selectedId, onSelect }: Co
 
       <ScrollArea className="flex-1">
         <CardContent className="p-2">
-          {filteredConversations.length === 0 ? (
+          {loadError && (
+            <div className="p-3 mb-2 text-sm text-destructive bg-destructive/10 rounded-lg">
+              {loadError}
+              <button onClick={loadConversations} className="underline ml-1 font-medium">
+                Réessayer
+              </button>
+            </div>
+          )}
+          {filteredConversations.length === 0 && !loadError ? (
             <div className="text-center py-12 px-4">
               <div className="bg-muted/50 rounded-full p-4 inline-block mb-4">
                 <MessageSquare className="h-10 w-10 text-muted-foreground/40" />
@@ -171,7 +188,9 @@ export function ConversationsList({ currentProfileId, selectedId, onSelect }: Co
               <p className="text-sm text-muted-foreground max-w-xs mx-auto">
                 {search
                   ? "Essayez un autre terme de recherche."
-                  : "Votre propriétaire n'a pas encore envoyé de message. Utilisez le bouton ci-dessus pour initier la conversation."}
+                  : currentRole === "owner"
+                    ? "Créez une conversation avec un locataire via le bouton ci-dessus."
+                    : "Votre propriétaire n'a pas encore envoyé de message. Utilisez le bouton ci-dessus pour initier la conversation."}
               </p>
             </div>
           ) : (
@@ -196,6 +215,9 @@ export function ConversationsList({ currentProfileId, selectedId, onSelect }: Co
                   >
                     <div className="flex items-start gap-3">
                       <Avatar className="h-12 w-12 flex-shrink-0">
+                        {getOtherAvatar(conversation) && (
+                          <AvatarImage src={getOtherAvatar(conversation)!} alt={getOtherName(conversation) || "Interlocuteur"} />
+                        )}
                         <AvatarFallback className="bg-gradient-to-br from-primary/20 to-primary/10">
                           {getOtherName(conversation)
                             ?.split(" ")

--- a/components/messages/MessagesPageContent.tsx
+++ b/components/messages/MessagesPageContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { motion } from "framer-motion";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -41,6 +42,8 @@ interface MessagesPageContentProps {
 }
 
 export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPageContentProps) {
+  const pathname = usePathname();
+  const currentRole: "owner" | "tenant" = pathname?.startsWith("/owner") ? "owner" : "tenant";
   const [loading, setLoading] = useState(true);
   const [currentProfileId, setCurrentProfileId] = useState<string>("");
   const [selectedConversation, setSelectedConversation] = useState<Conversation | null>(null);
@@ -317,6 +320,7 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
               </div>
               <ConversationsList
                 currentProfileId={currentProfileId}
+                currentRole={currentRole}
                 selectedId={undefined}
                 onSelect={handleSelectConversation}
               />
@@ -415,6 +419,7 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
           <div className="h-full">
             <ConversationsList
               currentProfileId={currentProfileId}
+              currentRole={currentRole}
               selectedId={selectedConversation?.id}
               onSelect={handleSelectConversation}
             />

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -24,6 +24,8 @@ export interface Conversation {
   // Joined data
   owner_name?: string;
   tenant_name?: string;
+  owner_avatar?: string | null;
+  tenant_avatar?: string | null;
   property_address?: string;
 }
 
@@ -130,6 +132,8 @@ class ChatService {
       ...conv,
       owner_name: `${conv.owner?.prenom || ""} ${conv.owner?.nom || ""}`.trim(),
       tenant_name: `${conv.tenant?.prenom || ""} ${conv.tenant?.nom || ""}`.trim(),
+      owner_avatar: conv.owner?.avatar_url || null,
+      tenant_avatar: conv.tenant?.avatar_url || null,
       property_address: conv.property ? `${conv.property.adresse_complete}, ${conv.property.ville}` : "",
     }));
   }
@@ -169,6 +173,8 @@ class ChatService {
       ...data,
       owner_name: `${data.owner?.prenom || ""} ${data.owner?.nom || ""}`.trim(),
       tenant_name: `${data.tenant?.prenom || ""} ${data.tenant?.nom || ""}`.trim(),
+      owner_avatar: data.owner?.avatar_url || null,
+      tenant_avatar: data.tenant?.avatar_url || null,
       property_address: data.property ? `${data.property.adresse_complete}, ${data.property.ville}` : "",
     } as Conversation;
   }
@@ -187,6 +193,9 @@ class ChatService {
       .single();
 
     if (existing) {
+      // Re-fetch avec les données jointes (profiles, property)
+      const full = await this.getConversation(existing.id);
+      if (full) return full;
       return existing as Conversation;
     }
 
@@ -207,20 +216,15 @@ class ChatService {
 
     // Envoyer le message initial si fourni
     if (data.initial_message && newConv) {
-      const { data: profile } = await this.supabase
-        .from("profiles")
-        .select("id")
-        .eq("user_id", (await this.supabase.auth.getUser()).data.user?.id ?? "")
-        .single();
-
-      const senderRole = profile?.id === data.owner_profile_id ? "owner" : "tenant";
-
       await this.sendMessage({
         conversation_id: newConv.id,
         content: data.initial_message,
       });
     }
 
+    // Re-fetch avec les données jointes
+    const fullNew = await this.getConversation(newConv.id);
+    if (fullNew) return fullNew;
     return newConv as Conversation;
   }
 
@@ -630,7 +634,7 @@ class ChatService {
     size: number;
   }> {
     const fileName = `chat/${conversationId}/${Date.now()}_${file.name}`;
-    
+
     const { data, error } = await this.supabase.storage
       .from("documents")
       .upload(fileName, file, {
@@ -640,16 +644,31 @@ class ChatService {
 
     if (error) throw error;
 
-    const { data: urlData } = this.supabase.storage
+    // Tenter une URL signée (bucket privé) avec fallback sur URL publique
+    const { data: signedData } = await this.supabase.storage
       .from("documents")
-      .getPublicUrl(data.path);
+      .createSignedUrl(data.path, 60 * 60 * 24 * 7); // 7 jours
+
+    const url = signedData?.signedUrl
+      || this.supabase.storage.from("documents").getPublicUrl(data.path).data.publicUrl;
 
     return {
-      url: urlData.publicUrl,
+      url,
       name: file.name,
       type: file.type,
       size: file.size,
     };
+  }
+
+  /**
+   * Générer une URL signée pour un attachment existant
+   */
+  async getSignedAttachmentUrl(storagePath: string): Promise<string | null> {
+    const { data, error } = await this.supabase.storage
+      .from("documents")
+      .createSignedUrl(storagePath, 3600); // 1h
+    if (error || !data?.signedUrl) return null;
+    return data.signedUrl;
   }
 
   /**

--- a/supabase/migrations/20260416100000_fix_messages_conversation_trigger.sql
+++ b/supabase/migrations/20260416100000_fix_messages_conversation_trigger.sql
@@ -1,0 +1,69 @@
+-- Migration: Fix Messages Module
+-- 1. Trigger AFTER INSERT ON messages → update conversations metadata
+-- 2. Backfill existing conversations with last_message data
+-- 3. Unique index to prevent duplicate conversations (race condition)
+
+-- ============================================
+-- 1. TRIGGER: update conversation on new message
+-- ============================================
+
+CREATE OR REPLACE FUNCTION public.update_conversation_on_new_message()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE conversations
+  SET
+    last_message_at = NEW.created_at,
+    last_message_preview = LEFT(NEW.content, 100),
+    updated_at = NOW(),
+    owner_unread_count = CASE
+      WHEN NEW.sender_role = 'tenant' THEN COALESCE(owner_unread_count, 0) + 1
+      ELSE owner_unread_count
+    END,
+    tenant_unread_count = CASE
+      WHEN NEW.sender_role = 'owner' THEN COALESCE(tenant_unread_count, 0) + 1
+      ELSE tenant_unread_count
+    END
+  WHERE id = NEW.conversation_id;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_update_conversation_on_message ON messages;
+
+CREATE TRIGGER trg_update_conversation_on_message
+  AFTER INSERT ON messages
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_conversation_on_new_message();
+
+-- ============================================
+-- 2. BACKFILL: populate last_message_at/preview for existing conversations
+-- ============================================
+
+UPDATE conversations c
+SET
+  last_message_at = sub.max_created,
+  last_message_preview = sub.last_content,
+  updated_at = NOW()
+FROM (
+  SELECT DISTINCT ON (m.conversation_id)
+    m.conversation_id,
+    m.created_at AS max_created,
+    LEFT(m.content, 100) AS last_content
+  FROM messages m
+  WHERE m.deleted_at IS NULL
+  ORDER BY m.conversation_id, m.created_at DESC
+) sub
+WHERE c.id = sub.conversation_id
+  AND c.last_message_at IS NULL;
+
+-- ============================================
+-- 3. UNIQUE INDEX: prevent duplicate active conversations
+-- ============================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_unique_active_pair
+  ON conversations (property_id, owner_profile_id, tenant_profile_id)
+  WHERE status = 'active';


### PR DESCRIPTION
1. SQL trigger: create AFTER INSERT ON messages trigger to update
   conversations.last_message_at, last_message_preview, and
   *_unread_count (was never incremented). Includes backfill for
   existing conversations and UNIQUE index to prevent duplicates.

2. Header: getOrCreateConversation now re-fetches with profile/property
   joins so the interlocutor name + avatar display correctly. Badge now
   shows the interlocutor's role (not the current user's).

3. Sidebar: add currentRole prop to ConversationsList so empty state
   text is role-aware ("Créez une conversation avec un locataire" for
   owners vs "Votre propriétaire..." for tenants). Add visible error
   state instead of silent console.error.

4. Images: uploadAttachment uses createSignedUrl with public fallback.
   Add MessageImage component with onError fallback showing filename.
   Fix rendering so image attachments display even if content_type
   was stored as "text".

5. Avatars: map owner_avatar/tenant_avatar in getConversations and
   getConversation. Display AvatarImage in sidebar items and chat
   header.

6. ScrollArea: replace Radix ScrollArea (broken ref forwarding) with
   native scrollable div so auto-scroll works.

https://claude.ai/code/session_011Dch2PAHRTxKAsYQJU4Dmb