### PR TITLE
Auto-trigger accounting OCR on document upload & work order entries

### DIFF
--- a/.claude/skills/talok-accounting/SKILL.md
+++ b/.claude/skills/talok-accounting/SKILL.md
@@ -147,6 +147,36 @@ Validation montants : `validateOCRAmounts(extracted)` — cohérence HT + TVA = 
 **Important :** Le document physique est géré par `talok-documents-sota` (upload, storage, bucket).
 L'analyse OCR/IA et la liaison comptable sont gérées ICI via `document_analyses`.
 
+### 8.1 Auto-trigger à l'upload
+
+Depuis QW3, l'OCR comptable est **déclenché automatiquement** à l'upload pour les 6 types de pièces comptables :
+
+| `documents.type` | Déclenche OCR auto ? |
+|------------------|:---:|
+| `facture` | ✅ |
+| `devis` | ✅ |
+| `avis_imposition` | ✅ |
+| `taxe_fonciere` | ✅ |
+| `assurance_pno` | ✅ |
+| `appel_fonds` | ✅ |
+
+**Point d'entrée :** `app/api/documents/upload/route.ts` appelle `triggerAccountingOcr()` (`lib/accounting/auto-ocr.ts`) en fire-and-forget après l'insert `documents`.
+
+**Comportement quota :**
+- Plan `gratuit` ou indéfini → skip + `metadata.ocr_skipped_reason = 'plan_not_eligible'`
+- Plan `confort` quota 30/mois atteint → skip + `metadata.ocr_skipped_reason = 'quota_exceeded'`
+- Plans `pro` / `enterprise_*` → illimité, jamais skippé
+
+**Garde-fous :**
+- Re-check existence du document (race avec delete)
+- Skip si `entity_id` du document ≠ entity attendu
+- Skip si une analyse existe déjà pour ce document
+- Jamais `throw` — toutes les erreurs sont loggées
+
+**L'OCR auto n'auto-valide PAS l'écriture.** L'extraction atterrit dans `document_analyses.extracted_data` avec `processing_status='completed'`. La création de l'écriture reste déclenchée manuellement par l'utilisateur via `POST /api/accounting/documents/[id]/validate` (revue humaine obligatoire).
+
+**Extension de la liste :** pour ajouter un type au trigger auto, éditer `OCR_ACCOUNTING_DOCUMENT_TYPES` dans `lib/accounting/auto-ocr.ts` et documenter ici.
+
 ---
 
 ## 9. Feature gating comptabilité

--- a/app/api/documents/upload/route.ts
+++ b/app/api/documents/upload/route.ts
@@ -10,6 +10,10 @@ import { DOCUMENT_TYPES, ALLOWED_MIME_TYPES } from "@/lib/documents/constants";
 import { withSecurity } from "@/lib/api/with-security";
 import { withSubscriptionLimit, createSubscriptionErrorResponse } from "@/lib/middleware/subscription-check";
 import { tesseractOCRService } from "@/lib/ocr/tesseract.service";
+import {
+  shouldTriggerAccountingOcr,
+  triggerAccountingOcr,
+} from "@/lib/accounting/auto-ocr";
 import { getDisplayName } from "@/lib/documents/format-name";
 
 /**
@@ -331,6 +335,28 @@ export const POST = withSecurity(async function POST(request: Request) {
         // L'OCR est non-bloquant : si ça échoue, le document est quand même uploadé
         console.error("[POST /api/documents/upload] OCR processing failed (non-blocking):", ocrError);
       }
+    }
+
+    // OCR automatique comptable (GPT-4o-mini) pour les pièces comptables.
+    // Fire-and-forget : ne pas await, ne pas bloquer la réponse upload.
+    // Skippe silencieusement si l'owner n'est pas éligible au plan OCR ou
+    // si le quota mensuel est dépassé (flag posé dans metadata).
+    if (
+      document &&
+      shouldTriggerAccountingOcr(type) &&
+      resolvedEntityId &&
+      resolvedOwnerId
+    ) {
+      void triggerAccountingOcr(serviceClient as any, {
+        documentId: (document as any).id,
+        ownerProfileId: resolvedOwnerId,
+        entityId: resolvedEntityId,
+      }).catch((err) => {
+        console.error(
+          "[POST /api/documents/upload] accounting auto-ocr fire-and-forget failed:",
+          err
+        );
+      });
     }
 
     return NextResponse.json({ document }, { status: 201 });

--- a/features/providers/services/work-orders-extended.service.ts
+++ b/features/providers/services/work-orders-extended.service.ts
@@ -387,6 +387,86 @@ export async function completeIntervention(
   return data as WorkOrderExtended;
 }
 
+/**
+ * Resolve the legal_entity_id for a work order.
+ * Prefer wo.entity_id, fall back to wo.property.legal_entity_id.
+ */
+async function resolveWorkOrderEntityId(
+  supabase: SupabaseClient,
+  wo: WorkOrderExtended,
+): Promise<string | null> {
+  if (wo.entity_id) return wo.entity_id;
+  if (!wo.property_id) return null;
+  const { data } = await supabase
+    .from('properties')
+    .select('legal_entity_id')
+    .eq('id', wo.property_id)
+    .maybeSingle();
+  return (data as { legal_entity_id?: string } | null)?.legal_entity_id ?? null;
+}
+
+/**
+ * Post an auto-entry for a work order (supplier_invoice or supplier_payment).
+ * Fire-and-forget: logs errors but never throws. Best effort.
+ * Updates work_orders.accounting_entry_id on success (supplier_invoice only).
+ */
+async function postWorkOrderAutoEntry(
+  supabase: SupabaseClient,
+  params: {
+    workOrder: WorkOrderExtended;
+    event: 'supplier_invoice' | 'supplier_payment';
+    amountCents: number;
+    date: string;
+    label: string;
+    reference?: string;
+    userId: string;
+    persistEntryIdOnWorkOrder?: boolean;
+  },
+): Promise<void> {
+  try {
+    const entityId = await resolveWorkOrderEntityId(supabase, params.workOrder);
+    if (!entityId) {
+      console.warn(
+        '[work-orders] Skipping auto-entry: no entity_id resolvable for work order',
+        params.workOrder.id,
+      );
+      return;
+    }
+
+    const { createAutoEntry } = await import('@/lib/accounting/engine');
+    const { getOrCreateCurrentExercise } = await import('@/lib/accounting/auto-exercise');
+
+    const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+    if (!exercise) {
+      console.warn('[work-orders] Skipping auto-entry: no exercise for entity', entityId);
+      return;
+    }
+
+    const entry = await createAutoEntry(supabase, params.event, {
+      entityId,
+      exerciseId: exercise.id,
+      userId: params.userId,
+      amountCents: params.amountCents,
+      label: params.label,
+      date: params.date,
+      reference: params.reference,
+    });
+
+    if (params.persistEntryIdOnWorkOrder && entry?.id) {
+      await supabase
+        .from('work_orders')
+        .update({ accounting_entry_id: entry.id })
+        .eq('id', params.workOrder.id);
+    }
+  } catch (err) {
+    console.error(
+      `[work-orders] createAutoEntry(${params.event}) failed (non-blocking):`,
+      err instanceof Error ? err.message : err,
+    );
+    // Never throw — work order status change is already committed
+  }
+}
+
 /** Provider submits an invoice */
 export async function submitInvoice(
   supabase: SupabaseClient,
@@ -408,7 +488,22 @@ export async function submitInvoice(
     .single();
 
   if (error) throw error;
-  return data as WorkOrderExtended;
+
+  // Accounting auto-entry (fire-and-forget, non-blocking)
+  // Debit 615100 (Entretien) / Credit 401000 (Fournisseurs)
+  const updatedWo = data as WorkOrderExtended;
+  void postWorkOrderAutoEntry(supabase, {
+    workOrder: updatedWo,
+    event: 'supplier_invoice',
+    amountCents: input.invoice_amount_cents,
+    date: new Date().toISOString().split('T')[0],
+    label: `Facture prestataire - ${updatedWo.title ?? 'Work order'}`,
+    reference: workOrderId,
+    userId: updatedWo.owner_id ?? 'system',
+    persistEntryIdOnWorkOrder: true,
+  });
+
+  return updatedWo;
 }
 
 /** Owner marks the work order as paid */

--- a/features/providers/services/work-orders-extended.service.ts
+++ b/features/providers/services/work-orders-extended.service.ts
@@ -527,7 +527,24 @@ export async function markAsPaid(
     .single();
 
   if (error) throw error;
-  return data as WorkOrderExtended;
+
+  // Accounting auto-entry (fire-and-forget, non-blocking)
+  // Debit 401000 (Fournisseurs) / Credit 512100 (Banque)
+  const updatedWo = data as WorkOrderExtended;
+  const paymentAmountCents = updatedWo.invoice_amount_cents ?? 0;
+  if (paymentAmountCents > 0) {
+    void postWorkOrderAutoEntry(supabase, {
+      workOrder: updatedWo,
+      event: 'supplier_payment',
+      amountCents: paymentAmountCents,
+      date: new Date().toISOString().split('T')[0],
+      label: `Paiement prestataire - ${updatedWo.title ?? 'Work order'}`,
+      reference: workOrderId,
+      userId: updatedWo.owner_id ?? 'system',
+    });
+  }
+
+  return updatedWo;
 }
 
 /** Cancel a work order */

--- a/lib/accounting/auto-ocr.ts
+++ b/lib/accounting/auto-ocr.ts
@@ -1,0 +1,229 @@
+/**
+ * Accounting Auto-OCR trigger
+ *
+ * Fire-and-forget helper that launches the GPT-4o-mini OCR pipeline
+ * (ocr-analyze-document edge function) for accounting documents uploaded
+ * by users whose plan includes OCR quota.
+ *
+ * Callers must NOT await this — it is meant to be scheduled after the
+ * document insert and before returning the HTTP response to the client.
+ *
+ * Design decisions (QW3):
+ * - Skips silently on quota exhaustion, flags metadata.ocr_skipped_reason.
+ * - Skips silently on missing entity or plan not eligible.
+ * - Re-verifies document existence to guard against race with delete.
+ * - Does NOT auto-validate — the /validate route remains human-reviewed.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Document types that trigger accounting OCR auto-analysis on upload. */
+export const OCR_ACCOUNTING_DOCUMENT_TYPES = [
+  'facture',
+  'devis',
+  'avis_imposition',
+  'taxe_fonciere',
+  'assurance_pno',
+  'appel_fonds',
+] as const;
+
+export type OcrAccountingDocumentType =
+  (typeof OCR_ACCOUNTING_DOCUMENT_TYPES)[number];
+
+export function shouldTriggerAccountingOcr(
+  type: string | null | undefined,
+): type is OcrAccountingDocumentType {
+  if (!type) return false;
+  return (OCR_ACCOUNTING_DOCUMENT_TYPES as readonly string[]).includes(type);
+}
+
+/**
+ * Monthly OCR quota per plan slug.
+ * Mirrors the quota declared in app/api/accounting/documents/analyze/route.ts.
+ */
+const OCR_QUOTAS: Record<string, number> = {
+  confort: 30,
+  pro: Infinity,
+  enterprise_s: Infinity,
+  enterprise_m: Infinity,
+  enterprise_l: Infinity,
+  enterprise_xl: Infinity,
+};
+
+type OcrSkipReason = 'quota_exceeded' | 'plan_not_eligible';
+
+export interface TriggerAccountingOcrParams {
+  documentId: string;
+  /** Profile id of the plan holder (= property owner). Used for quota/plan lookup. */
+  ownerProfileId: string;
+  entityId: string;
+}
+
+async function flagOcrSkipped(
+  supabase: SupabaseClient,
+  documentId: string,
+  existingMetadata: unknown,
+  reason: OcrSkipReason,
+  planSlug: string,
+): Promise<void> {
+  try {
+    const metadata = {
+      ...((existingMetadata as Record<string, unknown> | null) ?? {}),
+      ocr_skipped_reason: reason,
+      ocr_skipped_plan: planSlug,
+      ocr_skipped_at: new Date().toISOString(),
+    };
+    await supabase.from('documents').update({ metadata }).eq('id', documentId);
+  } catch (err) {
+    console.error('[auto-ocr] flagOcrSkipped failed', err);
+  }
+}
+
+/**
+ * Trigger GPT-4o-mini OCR for an accounting document.
+ * Never throws — all errors are logged. Intended for fire-and-forget use.
+ */
+export async function triggerAccountingOcr(
+  supabase: SupabaseClient,
+  params: TriggerAccountingOcrParams,
+): Promise<void> {
+  try {
+    // 1. Re-verify document existence + entity match (guard against race with delete)
+    const { data: document } = await supabase
+      .from('documents')
+      .select('id, entity_id, metadata')
+      .eq('id', params.documentId)
+      .maybeSingle();
+
+    if (!document) {
+      console.warn(
+        '[auto-ocr] Document not found — skipping',
+        params.documentId,
+      );
+      return;
+    }
+    const doc = document as {
+      id: string;
+      entity_id: string | null;
+      metadata: unknown;
+    };
+    if (doc.entity_id !== params.entityId) {
+      console.warn(
+        '[auto-ocr] Entity mismatch — skipping',
+        params.documentId,
+      );
+      return;
+    }
+
+    // 2. Skip if an analysis already exists (race with other triggers)
+    const { data: existing } = await supabase
+      .from('document_analyses')
+      .select('id')
+      .eq('document_id', params.documentId)
+      .limit(1);
+    if (existing && existing.length > 0) {
+      return;
+    }
+
+    // 3. Resolve plan + quota
+    const { getSubscriptionByProfileId } = await import(
+      '@/lib/subscriptions/subscription-service'
+    );
+    const subscription = await getSubscriptionByProfileId(
+      params.ownerProfileId,
+    );
+    const planSlug = subscription?.plan_slug ?? 'gratuit';
+    const maxOcr = OCR_QUOTAS[planSlug] ?? 0;
+
+    if (maxOcr === 0) {
+      await flagOcrSkipped(
+        supabase,
+        params.documentId,
+        doc.metadata,
+        'plan_not_eligible',
+        planSlug,
+      );
+      return;
+    }
+
+    if (maxOcr !== Infinity) {
+      const monthStart = new Date(
+        new Date().getFullYear(),
+        new Date().getMonth(),
+        1,
+      ).toISOString();
+      const { count } = await supabase
+        .from('document_analyses')
+        .select('id', { count: 'exact', head: true })
+        .eq('entity_id', params.entityId)
+        .gte('created_at', monthStart);
+      if ((count ?? 0) >= maxOcr) {
+        await flagOcrSkipped(
+          supabase,
+          params.documentId,
+          doc.metadata,
+          'quota_exceeded',
+          planSlug,
+        );
+        return;
+      }
+    }
+
+    // 4. Resolve territory (for TVA rate validation in edge function)
+    const { data: entity } = await supabase
+      .from('legal_entities')
+      .select('territory')
+      .eq('id', params.entityId)
+      .maybeSingle();
+    const territory =
+      (entity as { territory?: string } | null)?.territory ?? 'metropole';
+
+    // 5. Insert analysis record (pending)
+    const { data: analysis, error: insertErr } = await supabase
+      .from('document_analyses')
+      .insert({
+        document_id: params.documentId,
+        entity_id: params.entityId,
+        processing_status: 'pending',
+        extracted_data: {},
+      })
+      .select('id')
+      .single();
+
+    if (insertErr || !analysis) {
+      console.error(
+        '[auto-ocr] document_analyses insert failed',
+        insertErr,
+      );
+      return;
+    }
+
+    const analysisId = (analysis as { id: string }).id;
+
+    // 6. Invoke edge function — still inside fire-and-forget promise
+    const { error: fnErr } = await supabase.functions.invoke(
+      'ocr-analyze-document',
+      {
+        body: {
+          documentId: params.documentId,
+          entityId: params.entityId,
+          territory,
+          analysisId,
+        },
+      },
+    );
+
+    if (fnErr) {
+      console.error('[auto-ocr] edge function invoke failed', fnErr);
+      await supabase
+        .from('document_analyses')
+        .update({ processing_status: 'failed' })
+        .eq('id', analysisId);
+    }
+  } catch (err) {
+    console.error(
+      '[auto-ocr] unexpected error (non-blocking)',
+      err instanceof Error ? err.message : err,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements automatic OCR processing for accounting documents on upload and adds fire-and-forget accounting entry creation for work order lifecycle events (invoice submission and payment).

## Key Changes

### Accounting Auto-OCR on Upload
- **New module** `lib/accounting/auto-ocr.ts`: Fire-and-forget helper that triggers GPT-4o-mini OCR pipeline for 6 accounting document types (facture, devis, avis_imposition, taxe_fonciere, assurance_pno, appel_fonds)
- **Quota enforcement**: Respects plan-based OCR limits (confort: 30/month, pro/enterprise: unlimited, gratuit: 0)
- **Graceful degradation**: Silently skips on quota exhaustion or ineligible plans, flagging `metadata.ocr_skipped_reason`
- **Race condition guards**: Re-verifies document existence and entity match before processing
- **Integration point** `app/api/documents/upload/route.ts`: Calls `triggerAccountingOcr()` in fire-and-forget after document insert
- **Important**: Auto-OCR does NOT auto-validate entries—extraction lands in `document_analyses` with `processing_status='pending'`. Manual validation via `/api/accounting/documents/[id]/validate` remains required.

### Work Order Accounting Auto-Entries
- **New helper** `postWorkOrderAutoEntry()` in `features/providers/services/work-orders-extended.service.ts`: Fire-and-forget accounting entry creation for supplier invoices and payments
- **Entity resolution**: Prefers `work_orders.entity_id`, falls back to `properties.legal_entity_id`
- **Integration points**:
  - `submitInvoice()`: Creates supplier_invoice entry (615100 debit / 401000 credit), persists `accounting_entry_id` on work order
  - `markAsPaid()`: Creates supplier_payment entry (401000 debit / 512100 credit)
- **Non-blocking**: All errors logged but never thrown; work order status changes already committed

### Documentation
- Updated `SKILL.md` with auto-trigger behavior, quota rules, and extension guidance

## Implementation Details

- Both features use fire-and-forget patterns (`void` promises) to avoid blocking HTTP responses
- Comprehensive error logging with `[auto-ocr]` and `[work-orders]` prefixes for observability
- Quota counting uses monthly window (1st of month to current date)
- Auto-entries use `createAutoEntry()` from accounting engine with current exercise resolution

https://claude.ai/code/session_01Hn8s3cQA69Tzkscy7b1M6V