### PR TITLE
fix(messages): owner messages bugs + charges-regul RLS drift closer

### DIFF
--- a/.claude/skills/talok-charges-regularization/SKILL.md
+++ b/.claude/skills/talok-charges-regularization/SKILL.md
@@ -524,6 +524,10 @@ Système de rappels à brancher sur le cron existant :
 
 ## 9. Gaps actuels & roadmap
 
+### Re-audit Sprint P0 — 2026-04-19
+
+Audit complet des 4 P0 du sprint initial : **tous résolus en prod**. Aucune nouvelle migration applicative nécessaire. Seule action : migration `20260418150000_fix_charges_contested_rls.sql` committée pour formaliser la dérive git ↔ prod (la policy avait été appliquée via SQL Editor le 18/04 sans être versionnée). Tests `apply-engine.test.ts` confirmés exhaustifs (19/19 passent, couvrent les 5 scénarios B/C/D/E + toutes les validations). Le sprint "4 migrations à créer" décrit dans le prompt initial est obsolète — tout existe déjà sous un schéma plus robuste (cf. rapport Phase 0 du 19/04).
+
 ### Gaps critiques (P0)
 
 1. ✅ **RÉSOLU Sprint 0.a (17/04/2026)** — `regularization_invoice_id` ajouté sur `lease_charge_regularizations` (migration `20260417090000_charges_reg_invoice_link.sql`, appliquée prod 18/04).

--- a/.claude/skills/talok-documents-sota/SKILL.md
+++ b/.claude/skills/talok-documents-sota/SKILL.md
@@ -3,9 +3,11 @@ name: talok-documents-sota
 description: >
   Architecture SOTA complète de la gestion des documents Talok.
   Utilise ce skill pour tout travail sur les documents : upload, consultation,
-  génération automatique, quittances, GED, permissions, bugs, nouveaux comptes.
+  génération automatique, quittances, GED, permissions, bugs, nouveaux comptes,
+  affichage de noms de fichiers (cleanAttachmentName / truncateMiddle / clean-filename).
   Déclenche dès que la tâche touche à documents, upload, storage, quittance,
-  bail PDF, EDL PDF, CNI, coffre-fort, bibliothèque, GED, pièces jointes.
+  bail PDF, EDL PDF, CNI, coffre-fort, bibliothèque, GED, pièces jointes,
+  attachment, filename, nom de fichier, bubble attachment.
 ---
 
 # Talok — Gestion des documents SOTA
@@ -410,3 +412,47 @@ Le flux justificatif traverse les deux skills :
 | `useGedUpload`, hooks React documents | Pas de hooks React compta (server-side only) |
 
 **Règle :** ne JAMAIS dupliquer la logique OCR/analyse dans ce skill. Importer depuis `@/lib/accounting`.
+
+---
+
+## 14. Affichage des noms de fichiers (convention canonique)
+
+Les filenames stockés en Supabase Storage contiennent systématiquement du bruit technique :
+- Préfixe user ID : `u4725513253_`
+- UUID v4 injecté par l'upload : `_943f417c-e62d-4224-aa56-836a1563f969_`
+- Suffixe d'index : `_1.png`
+- Underscores à la place des espaces
+
+**Ne jamais afficher un filename brut dans l'UI.** Utiliser systématiquement :
+
+```ts
+import { cleanAttachmentName, truncateMiddle } from "@/lib/utils/clean-filename";
+
+const display = truncateMiddle(cleanAttachmentName(rawFilename), 40);
+```
+
+Résultat attendu :
+- Input  : `u4725513253_Appartement_T3_-_chambre_principale_realistic_mas_943f417c-e62d-4224-aa56-836a1563f969_1.png`
+- Output : `Appartement T3 - chambre principale realistic mas.png`
+
+**Contextes d'application :**
+- Bubbles d'attachement dans `/owner/messages` et `/tenant/messages`
+- Liste documents dans la GED (`/owner/documents`, `/tenant/documents`)
+- Aperçus de pièces jointes dans les tickets
+- Export PDF qui liste des documents source
+
+**Truncate middle :** préserve début + extension, ellipsis au centre. Permet de garder
+`.pdf`/`.jpg` visible (critère UX : l'utilisateur doit toujours voir le type de fichier).
+
+**Ne pas réimplémenter** de nettoyage local dans les composants : passer systématiquement
+par ces deux utils.
+
+Source canonique : `lib/utils/clean-filename.ts`.
+Tests : `__tests__/lib/clean-filename.test.ts` (cas u{id}/UUID/suffixe _N, truncate middle).
+
+### Anti-patterns à refuser en code review
+
+- `attachment.filename` (ou `document.original_filename`) affiché directement dans du JSX
+- Regex ad-hoc de nettoyage dans un composant (`.replace(/u\d+_/, '')`, etc.)
+- Troncature brutale `.slice(0, 30) + '...'` qui masque l'extension
+- Ré-implémentation locale de `cleanAttachmentName` / `truncateMiddle` sous un autre nom

--- a/__tests__/lib/clean-filename.test.ts
+++ b/__tests__/lib/clean-filename.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { cleanAttachmentName, truncateMiddle } from "@/lib/utils/clean-filename";
+
+describe("cleanAttachmentName", () => {
+  it("removes user ID prefix, embedded UUID, trailing _N suffix and converts underscores to spaces", () => {
+    const input =
+      "u4725513253_Appartement_T3_-_chambre_principale_realistic_mas_943f417c-e62d-4224-aa56-836a1563f969_1.png";
+    expect(cleanAttachmentName(input)).toBe(
+      "Appartement T3 - chambre principale realistic mas.png"
+    );
+  });
+
+  it("keeps a simple filename untouched (apart from underscore replacement)", () => {
+    expect(cleanAttachmentName("document.pdf")).toBe("document.pdf");
+    expect(cleanAttachmentName("my_file.pdf")).toBe("my file.pdf");
+  });
+
+  it("handles a filename without extension", () => {
+    expect(cleanAttachmentName("u123_my_document")).toBe("my document");
+  });
+
+  it("cleans multiple UUID-like segments", () => {
+    const input =
+      "u42_report_12345678-1234-1234-1234-123456789abc_final.docx";
+    expect(cleanAttachmentName(input)).toBe("report final.docx");
+  });
+});
+
+describe("truncateMiddle", () => {
+  it("leaves short names unchanged", () => {
+    expect(truncateMiddle("short.png")).toBe("short.png");
+  });
+
+  it("truncates long names preserving extension and showing an ellipsis", () => {
+    const long =
+      "a-very-long-file-name-that-is-well-above-the-limit-really.png";
+    const out = truncateMiddle(long, 30);
+    expect(out.length).toBeLessThanOrEqual(30);
+    expect(out.endsWith(".png")).toBe(true);
+    expect(out).toContain("…");
+  });
+});

--- a/components/chat/chat-window.tsx
+++ b/components/chat/chat-window.tsx
@@ -33,6 +33,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { chatService, type Message, type Conversation } from "@/lib/services/chat.service";
+import { getInitials } from "@/lib/design-system/utils";
+import { cleanAttachmentName, truncateMiddle } from "@/lib/utils/clean-filename";
 import { formatDistanceToNow } from "date-fns";
 import { fr } from "date-fns/locale";
 
@@ -46,12 +48,13 @@ function MessageImage({ src, alt, fileName, isMe }: {
   const [hasError, setHasError] = useState(false);
 
   if (hasError) {
+    const cleaned = fileName ? truncateMiddle(cleanAttachmentName(fileName)) : "Image non disponible";
     return (
       <div className={`flex items-center gap-2 text-sm ${
         isMe ? "text-primary-foreground/80" : "text-muted-foreground"
       }`}>
         <Paperclip className="h-4 w-4 flex-shrink-0" />
-        <span>{fileName || "Image non disponible"}</span>
+        <span title={fileName ?? undefined}>{cleaned}</span>
       </div>
     );
   }
@@ -92,6 +95,8 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
   const isOwner = currentProfileId === conversation.owner_profile_id;
   const otherName = isOwner ? conversation.tenant_name : conversation.owner_name;
   const otherAvatar = isOwner ? conversation.tenant_avatar : conversation.owner_avatar;
+  const otherPrenom = isOwner ? conversation.tenant_prenom : conversation.owner_prenom;
+  const otherNom = isOwner ? conversation.tenant_nom : conversation.owner_nom;
 
   // Charger les messages
   useEffect(() => {
@@ -385,7 +390,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
           <Avatar className="h-10 w-10">
             {otherAvatar && <AvatarImage src={otherAvatar} alt={otherName || "Interlocuteur"} />}
             <AvatarFallback>
-              {otherName?.split(" ").map(n => n[0]).join("").toUpperCase() || "?"}
+              {getInitials(otherPrenom, otherNom)}
             </AvatarFallback>
           </Avatar>
           <div className="flex-1 min-w-0">
@@ -567,12 +572,17 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
                                         href={message.attachment_url}
                                         target="_blank"
                                         rel="noopener noreferrer"
+                                        title={message.attachment_name ?? undefined}
                                         className={`flex items-center gap-2 text-sm ${
                                           isMe ? "text-primary-foreground/80" : "text-muted-foreground"
                                         } hover:underline`}
                                       >
-                                        <File className="h-4 w-4" />
-                                        {message.attachment_name || "Fichier"}
+                                        <File className="h-4 w-4 flex-shrink-0" />
+                                        <span className="truncate">
+                                          {message.attachment_name
+                                            ? truncateMiddle(cleanAttachmentName(message.attachment_name))
+                                            : "Fichier"}
+                                        </span>
                                       </a>
                                     )}
                                   </div>

--- a/components/chat/conversations-list.tsx
+++ b/components/chat/conversations-list.tsx
@@ -17,6 +17,7 @@ import {
   Ticket
 } from "lucide-react";
 import { chatService, type Conversation } from "@/lib/services/chat.service";
+import { getInitials } from "@/lib/design-system/utils";
 import { formatDistanceToNow } from "date-fns";
 import { fr } from "date-fns/locale";
 
@@ -109,6 +110,13 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
   const getOtherAvatar = (conv: Conversation) => {
     const isOwner = currentProfileId === conv.owner_profile_id;
     return isOwner ? conv.tenant_avatar : conv.owner_avatar;
+  };
+
+  const getOtherInitials = (conv: Conversation) => {
+    const isOwner = currentProfileId === conv.owner_profile_id;
+    const prenom = isOwner ? conv.tenant_prenom : conv.owner_prenom;
+    const nom = isOwner ? conv.tenant_nom : conv.owner_nom;
+    return getInitials(prenom, nom);
   };
 
   const formatLastMessage = (dateString?: string | null) => {
@@ -219,12 +227,7 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
                           <AvatarImage src={getOtherAvatar(conversation)!} alt={getOtherName(conversation) || "Interlocuteur"} />
                         )}
                         <AvatarFallback className="bg-gradient-to-br from-primary/20 to-primary/10">
-                          {getOtherName(conversation)
-                            ?.split(" ")
-                            .map((n) => n[0])
-                            .join("")
-                            .toUpperCase()
-                            .slice(0, 2) || "?"}
+                          {getOtherInitials(conversation)}
                         </AvatarFallback>
                       </Avatar>
 

--- a/components/messages/MessagesPageContent.tsx
+++ b/components/messages/MessagesPageContent.tsx
@@ -141,7 +141,7 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
                     tenantProfileId: signer.profile_id,
                     tenantName: p ? `${p.prenom || ""} ${p.nom || ""}`.trim() : "Locataire",
                     propertyId: lease.property_id,
-                    propertyAddress: `${prop.adresse_complete || ""}, ${prop.ville || ""}`.trim(),
+                    propertyAddress: prop.adresse_complete || "",
                     leaseId: lease.id,
                   });
                 }

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -1,6 +1,23 @@
 /**
  * Service de Chat en temps réel
  * Gère les conversations et messages entre propriétaires et locataires
+ *
+ * IMPORTANT — Exécution côté navigateur uniquement.
+ * Ce service est importé par des composants `"use client"` (MessagesPageContent,
+ * ConversationsList, ChatWindow). Le client Supabase utilisé ici est donc
+ * OBLIGATOIREMENT le client browser (createClient de @/lib/supabase/client),
+ * user-scoped via cookies, soumis à RLS.
+ *
+ * Ne PAS importer `getServiceClient()` ici : la service role key ne doit
+ * JAMAIS atterrir dans le bundle navigateur (exposerait un bypass total des
+ * RLS à tout visiteur). Pour les opérations nécessitant un bypass RLS
+ * contrôlé, passer par une route API (ex. /api/messages/*).
+ *
+ * Risque 42P17 (recursion sur profiles) : éliminé côté DB par la migration
+ * `20260213000000_fix_profiles_rls_recursion_v2.sql` — les policies actives
+ * utilisent des helpers SECURITY DEFINER (`get_my_profile_id()`, `is_admin()`)
+ * qui bypassent la récursion. Les queries profiles depuis le browser client
+ * sont donc sûres.
  */
 
 import { createClient } from "@/lib/supabase/client";
@@ -134,8 +151,16 @@ class ChatService {
 
     if (error) throw error;
 
-    // Fallback : si l'embed FK ne renvoie pas le profil (RLS/visibilité),
-    // on résout les profils manquants via une seconde requête ciblée.
+    // Fallback : si l'embed FK ne renvoie pas le profil (cas RLS/visibilité
+    // où PostgREST embedde `null`), on résout les profils manquants via une
+    // seconde requête ciblée.
+    //
+    // Browser client (user-scoped) volontaire : getServiceClient() est interdit
+    // côté client (leak service role). Cette requête reste soumise aux RLS v2
+    // de `profiles` (policy `profiles_owner_read_tenants` via lease_signers,
+    // helpers SECURITY DEFINER anti-recursion 42P17). Si la RLS refuse, on
+    // retombe proprement sur `"Utilisateur"` côté UI — c'est le comportement
+    // voulu (pas de bypass silencieux).
     const missingProfileIds = new Set<string>();
     for (const conv of (data || []) as any[]) {
       if (!conv.owner?.prenom && !conv.owner?.nom) missingProfileIds.add(conv.owner_profile_id);

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -24,6 +24,10 @@ export interface Conversation {
   // Joined data
   owner_name?: string;
   tenant_name?: string;
+  owner_prenom?: string | null;
+  owner_nom?: string | null;
+  tenant_prenom?: string | null;
+  tenant_nom?: string | null;
   owner_avatar?: string | null;
   tenant_avatar?: string | null;
   property_address?: string;
@@ -108,11 +112,13 @@ class ChatService {
       .select(`
         *,
         owner:profiles!conversations_owner_profile_id_fkey (
+          id,
           prenom,
           nom,
           avatar_url
         ),
         tenant:profiles!conversations_tenant_profile_id_fkey (
+          id,
           prenom,
           nom,
           avatar_url
@@ -128,14 +134,44 @@ class ChatService {
 
     if (error) throw error;
 
-    return (data || []).map((conv: any) => ({
-      ...conv,
-      owner_name: `${conv.owner?.prenom || ""} ${conv.owner?.nom || ""}`.trim(),
-      tenant_name: `${conv.tenant?.prenom || ""} ${conv.tenant?.nom || ""}`.trim(),
-      owner_avatar: conv.owner?.avatar_url || null,
-      tenant_avatar: conv.tenant?.avatar_url || null,
-      property_address: conv.property ? `${conv.property.adresse_complete}, ${conv.property.ville}` : "",
-    }));
+    // Fallback : si l'embed FK ne renvoie pas le profil (RLS/visibilité),
+    // on résout les profils manquants via une seconde requête ciblée.
+    const missingProfileIds = new Set<string>();
+    for (const conv of (data || []) as any[]) {
+      if (!conv.owner?.prenom && !conv.owner?.nom) missingProfileIds.add(conv.owner_profile_id);
+      if (!conv.tenant?.prenom && !conv.tenant?.nom) missingProfileIds.add(conv.tenant_profile_id);
+    }
+    const profileMap = new Map<string, { prenom?: string; nom?: string; avatar_url?: string | null }>();
+    if (missingProfileIds.size > 0) {
+      const { data: profs } = await this.supabase
+        .from("profiles")
+        .select("id, prenom, nom, avatar_url")
+        .in("id", Array.from(missingProfileIds));
+      for (const p of (profs || []) as any[]) {
+        profileMap.set(p.id, { prenom: p.prenom, nom: p.nom, avatar_url: p.avatar_url });
+      }
+    }
+
+    return (data || []).map((conv: any) => {
+      const owner = conv.owner?.prenom || conv.owner?.nom
+        ? conv.owner
+        : profileMap.get(conv.owner_profile_id);
+      const tenant = conv.tenant?.prenom || conv.tenant?.nom
+        ? conv.tenant
+        : profileMap.get(conv.tenant_profile_id);
+      return {
+        ...conv,
+        owner_prenom: owner?.prenom || null,
+        owner_nom: owner?.nom || null,
+        tenant_prenom: tenant?.prenom || null,
+        tenant_nom: tenant?.nom || null,
+        owner_name: `${owner?.prenom || ""} ${owner?.nom || ""}`.trim(),
+        tenant_name: `${tenant?.prenom || ""} ${tenant?.nom || ""}`.trim(),
+        owner_avatar: owner?.avatar_url || null,
+        tenant_avatar: tenant?.avatar_url || null,
+        property_address: conv.property?.adresse_complete || "",
+      };
+    });
   }
 
   /**
@@ -171,11 +207,15 @@ class ChatService {
 
     return {
       ...data,
+      owner_prenom: data.owner?.prenom || null,
+      owner_nom: data.owner?.nom || null,
+      tenant_prenom: data.tenant?.prenom || null,
+      tenant_nom: data.tenant?.nom || null,
       owner_name: `${data.owner?.prenom || ""} ${data.owner?.nom || ""}`.trim(),
       tenant_name: `${data.tenant?.prenom || ""} ${data.tenant?.nom || ""}`.trim(),
       owner_avatar: data.owner?.avatar_url || null,
       tenant_avatar: data.tenant?.avatar_url || null,
-      property_address: data.property ? `${data.property.adresse_complete}, ${data.property.ville}` : "",
+      property_address: data.property?.adresse_complete || "",
     } as Conversation;
   }
 

--- a/lib/utils/clean-filename.ts
+++ b/lib/utils/clean-filename.ts
@@ -1,0 +1,16 @@
+export function cleanAttachmentName(raw: string): string {
+  let name = raw.replace(/^u\d+_/, "");
+  name = name.replace(/_?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_?/gi, "_");
+  name = name.replace(/_\d+(\.[a-z0-9]+)$/i, "$1");
+  const ext = name.match(/\.[a-z0-9]+$/i)?.[0] ?? "";
+  const base = name.replace(/\.[a-z0-9]+$/i, "").replace(/_/g, " ").trim();
+  return base + ext;
+}
+
+export function truncateMiddle(name: string, max = 40): string {
+  if (name.length <= max) return name;
+  const ext = name.match(/\.[a-z0-9]+$/i)?.[0] ?? "";
+  const base = name.replace(/\.[a-z0-9]+$/i, "");
+  const keep = Math.floor((max - ext.length - 1) / 2);
+  return base.slice(0, keep) + "…" + base.slice(-keep) + ext;
+}

--- a/supabase/migrations/20260418150000_fix_charges_contested_rls.sql
+++ b/supabase/migrations/20260418150000_fix_charges_contested_rls.sql
@@ -1,0 +1,54 @@
+-- =====================================================
+-- MIGRATION: Gap P0 #4 — Policy tenant contested (version finale appliquée prod)
+-- Date: 2026-04-18
+-- Sprint: 0.c (Fondations DB — Régularisation des charges)
+--
+-- Supersede 20260417090300_fix_tenant_contest_rls.sql (jamais tourné en prod).
+-- Celle-ci a été appliquée directement via SQL Editor Supabase le 2026-04-18
+-- mais n'avait pas été committée en tant que migration versionnée — ce fichier
+-- corrige la dérive git ↔ prod en formalisant l'état réel.
+--
+-- Différence vs. 20260417090300 (strict sent → contested uniquement) :
+--   USING      identique  (status='sent' AND membre du bail)
+--   WITH CHECK assoupli   status IN ('sent', 'contested') — permet les UPDATE
+--              idempotents sent → sent (ex. tenant met à jour son
+--              `contest_reason` avant de basculer en contested) et
+--              sent → contested (transition normale).
+--
+-- Garde-fous inchangés :
+--   - owner reste seul à pouvoir passer en 'settled', 'acknowledged', etc.
+--     (policy `lease_charge_reg_owner_access` couvre tous les cas)
+--   - tenant ne peut pas modifier status vers autre chose que sent/contested
+--   - appartenance au bail vérifiée des deux côtés
+--
+-- Idempotent : DROP POLICY IF EXISTS avant CREATE POLICY. Peut être ré-appliquée
+-- sans effet secondaire sur la prod qui la possède déjà.
+-- =====================================================
+
+DROP POLICY IF EXISTS "lease_charge_reg_tenant_contest" ON lease_charge_regularizations;
+
+CREATE POLICY "lease_charge_reg_tenant_contest" ON lease_charge_regularizations
+  FOR UPDATE TO authenticated
+  USING (
+    status = 'sent'
+    AND lease_id IN (
+      SELECT l.id FROM leases l
+      JOIN lease_signers ls ON ls.lease_id = l.id
+      JOIN profiles pr ON pr.id = ls.profile_id
+      WHERE pr.user_id = auth.uid()
+        AND ls.role IN ('locataire_principal', 'colocataire')
+    )
+  )
+  WITH CHECK (
+    status IN ('sent', 'contested')
+    AND lease_id IN (
+      SELECT l.id FROM leases l
+      JOIN lease_signers ls ON ls.lease_id = l.id
+      JOIN profiles pr ON pr.id = ls.profile_id
+      WHERE pr.user_id = auth.uid()
+        AND ls.role IN ('locataire_principal', 'colocataire')
+    )
+  );
+
+COMMENT ON POLICY "lease_charge_reg_tenant_contest" ON lease_charge_regularizations IS
+  'Locataire : UPDATE autorisé depuis status=sent vers status IN (sent, contested). Version finale Sprint 0.c — supersede 20260417090300. Gap P0 #4 du skill talok-charges-regularization.';


### PR DESCRIPTION
## Summary

Three topics landed together on the same branch (independent, low-risk):

### 1. `/owner/messages` — 3 visible bugs
- **Other-party name/initials** in conversations list: `chat.service.ts` now exposes `owner_prenom/nom` and `tenant_prenom/nom` separately and falls back to a targeted `profiles` query when the embedded FK returns nothing under RLS. List and header both use `getInitials(prenom, nom)` now.
- **Attachment filenames**: new `lib/utils/clean-filename.ts` with `cleanAttachmentName` (strips `u{id}_`, UUID v4, `_N` suffix, underscores → spaces) and `truncateMiddle` (preserves extension). Applied to the chat bubble for files and to the image-error fallback.
- **Duplicated address** in conversation header: `property_address` now returns `adresse_complete` only (removed the `, ville` concat — the full address already contains the city).

### 2. `chat.service.ts` hardening
- Top-of-file + inline comments documenting that this service runs **client-side only** (imported by `"use client"` components), so `getServiceClient()` cannot be used (would leak the service role key to the browser). The profile fallback stays under RLS v2 — the 42P17 recursion risk is eliminated by `20260213…_fix_profiles_rls_recursion_v2` (SECURITY DEFINER helpers). Unreadable profiles deliberately fall back to `"Utilisateur"`, no silent RLS bypass.
- `talok-documents-sota` skill: added §14 "Affichage des noms de fichiers" documenting the canonical `cleanAttachmentName` + `truncateMiddle` convention + anti-patterns for code review.

### 3. `charges-regul` — git/prod drift closer
Phase 0 audit of the "Sprint P0 charges-regul" prompt concluded that the 4 prescribed gaps are **already resolved in prod** under a more robust architecture than the theoretical spec:
- P0-1 `regularization_invoice_id` FK → `20260417090000` + `apply/route.ts:287` ✅
- P0-2 auto accounting entry on settle → `lib/charges/apply-engine.ts` (3-line balanced planner) + `apply/route.ts:228` (synchronous `createEntry` + `validateEntry`) ✅
- P0-3 PCG seed → `20260417090400` + `chart_of_accounts` per entity, 6-digit codes (`419100`, `614100`, `654000`, `708000`) ✅
- P0-4 tenant-contested RLS → `20260417090300` + drift closer in this PR ✅

The only tangible action was closing one drift: `supabase/migrations/20260418150000_fix_charges_contested_rls.sql`. The policy was applied directly via SQL Editor on 2026-04-18 during Sprint 0.c but never committed as a migration file. This supersedes `20260417090300` with a slightly looser `WITH CHECK (status IN ('sent','contested'))` to allow idempotent tenant updates on `contest_reason`. Idempotent (`DROP POLICY IF EXISTS`), safe to re-apply on prod.

Skill `talok-charges-regularization` gets a 2026-04-19 re-audit stamp under §9.

## Test plan

- [x] `npx tsc --noEmit` clean on all touched files (pre-existing errors in other test files are unrelated).
- [x] `npx vitest run __tests__/lib/clean-filename.test.ts __tests__/services/chat.service.test.ts tests/unit/charges/apply-engine.test.ts` → **30/30 passed** (6 + 5 + 19).
- [ ] Manual: open `/owner/messages` on an account with at least one active conversation, verify the other party's name + `MV`-style initials appear in the list and the address is not duplicated in the header.
- [ ] Manual: send an image attachment to a conversation; verify the rendered filename is the cleaned version (no `u…_UUID_1.png`).
- [ ] Manual on prod DB after deploy: confirm the tenant-contest policy permits the existing `/api/charges/regularization/[id]/contest` route to run (it already does — migration is just closing git drift, not changing behaviour).

https://claude.ai/code/session_01Qkitjty88PrE3YxuCLU7Cc