### PR TITLE
Sprint 5: Add provider role to messaging system with admin read-only view

### DIFF
--- a/__tests__/components/contact-provider-button.test.tsx
+++ b/__tests__/components/contact-provider-button.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests du bouton ContactProviderButton (Sprint 4)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// --- Mocks ---
+const routerPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+const toastFn = vi.fn();
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: toastFn }),
+}));
+
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+  },
+  from: vi.fn(),
+};
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => mockSupabase,
+}));
+
+const { getOrCreateOwnerProvider, getOrCreateTenantProvider } = vi.hoisted(() => ({
+  getOrCreateOwnerProvider: vi.fn(),
+  getOrCreateTenantProvider: vi.fn(),
+}));
+vi.mock("@/lib/services/chat.service", () => ({
+  chatService: {
+    getOrCreateOwnerProviderConversation: getOrCreateOwnerProvider,
+    getOrCreateTenantProviderConversation: getOrCreateTenantProvider,
+  },
+}));
+
+// --- Component under test (imported AFTER mocks) ---
+import { ContactProviderButton } from "@/components/tickets/contact-provider-button";
+
+const baseProps = {
+  ticketId: "ticket-1",
+  propertyId: "property-1",
+  providerProfileId: "provider-1",
+  providerName: "Marie",
+};
+
+describe("ContactProviderButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: "profile-1" } }),
+    });
+  });
+
+  it("renders the button with the provider name", () => {
+    render(<ContactProviderButton {...baseProps} viewerRole="owner" />);
+    expect(screen.getByRole("button", { name: /Contacter Marie/i })).toBeInTheDocument();
+  });
+
+  it("calls getOrCreateOwnerProviderConversation when viewerRole=owner", async () => {
+    getOrCreateOwnerProvider.mockResolvedValue({ id: "conv-1" });
+
+    render(<ContactProviderButton {...baseProps} viewerRole="owner" />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(getOrCreateOwnerProvider).toHaveBeenCalledWith({
+        ticket_id: "ticket-1",
+        property_id: "property-1",
+        owner_profile_id: "profile-1",
+        provider_profile_id: "provider-1",
+      });
+    });
+    expect(routerPush).toHaveBeenCalledWith("/owner/messages?conversation=conv-1");
+  });
+
+  it("calls getOrCreateTenantProviderConversation when viewerRole=tenant", async () => {
+    getOrCreateTenantProvider.mockResolvedValue({ id: "conv-2" });
+
+    render(<ContactProviderButton {...baseProps} viewerRole="tenant" />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(getOrCreateTenantProvider).toHaveBeenCalledWith({
+        ticket_id: "ticket-1",
+        property_id: "property-1",
+        tenant_profile_id: "profile-1",
+        provider_profile_id: "provider-1",
+      });
+    });
+    expect(routerPush).toHaveBeenCalledWith("/tenant/messages?conversation=conv-2");
+  });
+
+  it("shows a destructive toast when the service throws", async () => {
+    getOrCreateOwnerProvider.mockRejectedValue(new Error("network down"));
+
+    render(<ContactProviderButton {...baseProps} viewerRole="owner" />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(toastFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          description: "network down",
+        })
+      );
+    });
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it("disables the button while creating", async () => {
+    let resolveCreate: (value: unknown) => void = () => {};
+    getOrCreateOwnerProvider.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve;
+      })
+    );
+
+    render(<ContactProviderButton {...baseProps} viewerRole="owner" />);
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button).toBeDisabled());
+    expect(screen.getByText(/Création/)).toBeInTheDocument();
+
+    resolveCreate({ id: "conv-x" });
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+});

--- a/__tests__/components/conversation-role-badge.test.tsx
+++ b/__tests__/components/conversation-role-badge.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Tests du badge ConversationRoleBadge (Sprint 3)
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { ConversationRoleBadge } from "@/components/chat/conversation-role-badge";
+
+describe("ConversationRoleBadge", () => {
+  it("renders the correct label for each of the 4 roles", () => {
+    const { rerender } = render(<ConversationRoleBadge role="owner" />);
+    expect(screen.getByText("Propriétaire")).toBeInTheDocument();
+
+    rerender(<ConversationRoleBadge role="tenant" />);
+    expect(screen.getByText("Locataire")).toBeInTheDocument();
+
+    rerender(<ConversationRoleBadge role="provider" />);
+    expect(screen.getByText("Prestataire")).toBeInTheDocument();
+
+    rerender(<ConversationRoleBadge role="admin" />);
+    expect(screen.getByText("Support Talok")).toBeInTheDocument();
+  });
+
+  it("applies role-specific color classes", () => {
+    const { container, rerender } = render(<ConversationRoleBadge role="owner" />);
+    expect(container.firstChild).toHaveClass("bg-blue-50", "text-blue-700", "border-blue-200");
+
+    rerender(<ConversationRoleBadge role="tenant" />);
+    expect(container.firstChild).toHaveClass("bg-cyan-50", "text-cyan-700", "border-cyan-200");
+
+    rerender(<ConversationRoleBadge role="provider" />);
+    expect(container.firstChild).toHaveClass("bg-orange-50", "text-orange-700", "border-orange-200");
+
+    rerender(<ConversationRoleBadge role="admin" />);
+    expect(container.firstChild).toHaveClass("bg-green-50", "text-green-700", "border-green-200");
+  });
+
+  it("hides the icon when showIcon=false", () => {
+    // showIcon=true → renders svg (lucide icon)
+    const { container: withIcon } = render(<ConversationRoleBadge role="owner" showIcon />);
+    expect(withIcon.querySelector("svg")).not.toBeNull();
+
+    // showIcon=false → no svg
+    const { container: withoutIcon } = render(<ConversationRoleBadge role="owner" showIcon={false} />);
+    expect(withoutIcon.querySelector("svg")).toBeNull();
+  });
+});

--- a/__tests__/db/conversations_enriched_rpc.sql
+++ b/__tests__/db/conversations_enriched_rpc.sql
@@ -276,6 +276,86 @@ END $$;
 
 
 -- ============================================================================
+-- Test 9 : p_search matches participant prenom (owner viewer, cherche "Tenant")
+-- Le fixture a tenant prenom='Tenant' → doit matcher la conv owner_tenant.
+-- ============================================================================
+SELECT pg_temp.set_viewer('11111111-1111-1111-1111-111111111111');
+
+DO $$
+DECLARE
+  v_count INT;
+  v_id TEXT;
+BEGIN
+  SELECT COUNT(*)::INT, MIN(id::text) INTO v_count, v_id
+  FROM public.get_conversations_enriched(25, 0, NULL, 'Tenant');
+
+  IF v_count != 1 THEN
+    RAISE EXCEPTION 'TEST 9 FAILED : attendu 1 match pour "Tenant", obtenu %', v_count;
+  END IF;
+  IF v_id != 'aaaaaaaa-0001-0000-0000-000000000000' THEN
+    RAISE EXCEPTION 'TEST 9 FAILED : attendu conv owner_tenant, obtenu %', v_id;
+  END IF;
+  RAISE NOTICE 'TEST 9 OK : search "Tenant" matche la conv owner_tenant';
+END $$;
+
+
+-- ============================================================================
+-- Test 10 : p_search matches ticket titre (owner viewer, cherche "Fuite")
+-- Fixture ticket titre='Fuite robinet cuisine' → owner_provider conv matche.
+-- ============================================================================
+DO $$
+DECLARE
+  v_count INT;
+  v_id TEXT;
+BEGIN
+  SELECT COUNT(*)::INT, MIN(id::text) INTO v_count, v_id
+  FROM public.get_conversations_enriched(25, 0, NULL, 'Fuite');
+
+  IF v_count != 1 THEN
+    RAISE EXCEPTION 'TEST 10 FAILED : attendu 1 match pour "Fuite", obtenu %', v_count;
+  END IF;
+  IF v_id != 'aaaaaaaa-0002-0000-0000-000000000000' THEN
+    RAISE EXCEPTION 'TEST 10 FAILED : attendu conv owner_provider, obtenu %', v_id;
+  END IF;
+  RAISE NOTICE 'TEST 10 OK : search "Fuite" matche la conv owner_provider via ticket titre';
+END $$;
+
+
+-- ============================================================================
+-- Test 11 : p_search no match → 0 rows, total_count = 0
+-- ============================================================================
+DO $$
+DECLARE
+  v_count INT;
+BEGIN
+  SELECT COUNT(*)::INT INTO v_count
+  FROM public.get_conversations_enriched(25, 0, NULL, 'ZZZ_nothing_matches_ZZZ');
+
+  IF v_count != 0 THEN
+    RAISE EXCEPTION 'TEST 11 FAILED : attendu 0 match, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 11 OK : search qui ne matche rien retourne 0 rows';
+END $$;
+
+
+-- ============================================================================
+-- Test 12 : p_search vide/whitespace traité comme NULL (pas de filtre)
+-- ============================================================================
+DO $$
+DECLARE
+  v_count INT;
+BEGIN
+  SELECT COUNT(*)::INT INTO v_count
+  FROM public.get_conversations_enriched(25, 0, NULL, '   ');
+
+  IF v_count != 2 THEN
+    RAISE EXCEPTION 'TEST 12 FAILED : attendu 2 rows (pas de filtre), obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 12 OK : search vide équivaut à pas de filtre';
+END $$;
+
+
+-- ============================================================================
 -- Cleanup
 -- ============================================================================
 SET session_replication_role = replica;

--- a/__tests__/db/conversations_enriched_rpc.sql
+++ b/__tests__/db/conversations_enriched_rpc.sql
@@ -1,0 +1,301 @@
+-- ============================================================================
+-- Tests d'intégration — RPC get_conversations_enriched (Sprint 3)
+-- ============================================================================
+-- À exécuter via psql après `npx supabase db reset` :
+--   psql postgresql://postgres:postgres@localhost:54322/postgres \
+--     -f __tests__/db/conversations_enriched_rpc.sql
+--
+-- Le RPC utilise public.user_profile_id() et public.user_role() via
+-- SECURITY DEFINER, qui lisent auth.uid(). Pour tester sans faux auth, on
+-- injecte directement set_config('request.jwt.claims', ...) avec le user_id
+-- que l'on veut simuler (pattern Supabase standard pour tests RLS).
+-- ============================================================================
+
+BEGIN;
+
+SET session_replication_role = replica;
+
+-- Profiles : 1 owner, 1 tenant, 1 provider
+INSERT INTO public.profiles (id, user_id, role, prenom, nom) VALUES
+  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'owner',    'Owner',    'Un'),
+  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'tenant',   'Tenant',   'Deux'),
+  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'provider', 'Provider', 'Trois');
+
+INSERT INTO public.owner_profiles (profile_id, type)
+VALUES ('11111111-1111-1111-1111-111111111111', 'societe');
+
+INSERT INTO public.legal_entities (
+  id, owner_profile_id, entity_type, nom
+) VALUES (
+  '77777777-7777-7777-7777-777777777777',
+  '11111111-1111-1111-1111-111111111111',
+  'sci_ir',
+  'SCI Atomgiste'
+);
+
+INSERT INTO public.properties (id, owner_id, adresse_complete, ville, code_postal, pays, type_bien)
+VALUES ('44444444-4444-4444-4444-444444444444',
+        '11111111-1111-1111-1111-111111111111',
+        '1 Rue de Test', 'Paris', '75001', 'France', 'appartement');
+
+INSERT INTO public.leases (id, property_id, statut, date_debut, date_fin, loyer_hc, charges, depot_garantie)
+VALUES ('66666666-6666-6666-6666-666666666666',
+        '44444444-4444-4444-4444-444444444444',
+        'actif',
+        '2026-01-01', '2027-01-01',
+        1000, 100, 1000);
+
+INSERT INTO public.tickets (id, property_id, created_by_profile_id, titre, description)
+VALUES ('55555555-5555-5555-5555-555555555555',
+        '44444444-4444-4444-4444-444444444444',
+        '11111111-1111-1111-1111-111111111111',
+        'Fuite robinet cuisine',
+        'La cuisine prend l''eau.');
+
+-- Conversations : 1 owner_tenant + 1 owner_provider + 1 tenant_provider
+INSERT INTO public.conversations (
+  id, conversation_type, status, property_id, lease_id,
+  owner_profile_id, tenant_profile_id
+) VALUES (
+  'aaaaaaaa-0001-0000-0000-000000000000', 'owner_tenant', 'active',
+  '44444444-4444-4444-4444-444444444444',
+  '66666666-6666-6666-6666-666666666666',
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222'
+);
+
+INSERT INTO public.conversations (
+  id, conversation_type, status, property_id, ticket_id,
+  owner_profile_id, provider_profile_id
+) VALUES (
+  'aaaaaaaa-0002-0000-0000-000000000000', 'owner_provider', 'active',
+  '44444444-4444-4444-4444-444444444444',
+  '55555555-5555-5555-5555-555555555555',
+  '11111111-1111-1111-1111-111111111111',
+  '33333333-3333-3333-3333-333333333333'
+);
+
+INSERT INTO public.conversations (
+  id, conversation_type, status, property_id, ticket_id,
+  tenant_profile_id, provider_profile_id
+) VALUES (
+  'aaaaaaaa-0003-0000-0000-000000000000', 'tenant_provider', 'active',
+  '44444444-4444-4444-4444-444444444444',
+  '55555555-5555-5555-5555-555555555555',
+  '22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333'
+);
+
+SET session_replication_role = origin;
+
+
+-- ============================================================================
+-- Helper : simuler l'identité du viewer via request.jwt.claims
+-- On set le sub (auth.uid), les helpers public.user_profile_id() et
+-- public.user_role() lisent auth.uid() + profiles pour déduire.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION pg_temp.set_viewer(p_user_id UUID) RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub', p_user_id::text, 'role', 'authenticated')::text,
+    true);
+  PERFORM set_config('role', 'authenticated', true);
+END;
+$$;
+
+
+-- ============================================================================
+-- Test 1 : Viewer owner, conv owner_tenant → sous-titre bail, role tenant
+-- ============================================================================
+SELECT pg_temp.set_viewer('11111111-1111-1111-1111-111111111111');
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  SELECT * INTO r
+  FROM public.get_conversations_enriched(25, 0, 'owner_tenant')
+  WHERE id = 'aaaaaaaa-0001-0000-0000-000000000000';
+
+  IF r.other_party_role != 'tenant' THEN
+    RAISE EXCEPTION 'TEST 1 FAILED : attendu role=tenant, obtenu %', r.other_party_role;
+  END IF;
+  IF r.other_party_subtitle NOT LIKE 'Bail actif · 1 Rue de Test%' THEN
+    RAISE EXCEPTION 'TEST 1 FAILED : sous-titre inattendu "%"', r.other_party_subtitle;
+  END IF;
+  RAISE NOTICE 'TEST 1 OK : viewer=owner, conv=owner_tenant, sous-titre bail, role=tenant';
+END $$;
+
+
+-- ============================================================================
+-- Test 2 : Viewer owner, conv owner_provider → sous-titre ticket, role provider
+-- ============================================================================
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  SELECT * INTO r
+  FROM public.get_conversations_enriched(25, 0, 'owner_provider')
+  WHERE id = 'aaaaaaaa-0002-0000-0000-000000000000';
+
+  IF r.other_party_role != 'provider' THEN
+    RAISE EXCEPTION 'TEST 2 FAILED : attendu role=provider, obtenu %', r.other_party_role;
+  END IF;
+  IF r.other_party_subtitle NOT LIKE 'Ticket · Fuite robinet%' THEN
+    RAISE EXCEPTION 'TEST 2 FAILED : sous-titre inattendu "%"', r.other_party_subtitle;
+  END IF;
+  RAISE NOTICE 'TEST 2 OK : viewer=owner, conv=owner_provider, sous-titre ticket, role=provider';
+END $$;
+
+
+-- ============================================================================
+-- Test 3 : Viewer tenant, conv owner_tenant → sous-titre SCI, role owner
+-- ============================================================================
+SELECT pg_temp.set_viewer('22222222-2222-2222-2222-222222222222');
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  SELECT * INTO r
+  FROM public.get_conversations_enriched(25, 0, 'owner_tenant')
+  WHERE id = 'aaaaaaaa-0001-0000-0000-000000000000';
+
+  IF r.other_party_role != 'owner' THEN
+    RAISE EXCEPTION 'TEST 3 FAILED : attendu role=owner, obtenu %', r.other_party_role;
+  END IF;
+  IF r.other_party_subtitle NOT LIKE 'SCI Atomgiste · 1 Rue de Test%' THEN
+    RAISE EXCEPTION 'TEST 3 FAILED : sous-titre inattendu "%"', r.other_party_subtitle;
+  END IF;
+  RAISE NOTICE 'TEST 3 OK : viewer=tenant, conv=owner_tenant, sous-titre SCI, role=owner';
+END $$;
+
+
+-- ============================================================================
+-- Test 4 : Viewer provider, conv owner_provider → sous-titre ticket, role owner
+-- ============================================================================
+SELECT pg_temp.set_viewer('33333333-3333-3333-3333-333333333333');
+
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  SELECT * INTO r
+  FROM public.get_conversations_enriched(25, 0, 'owner_provider')
+  WHERE id = 'aaaaaaaa-0002-0000-0000-000000000000';
+
+  IF r.other_party_role != 'owner' THEN
+    RAISE EXCEPTION 'TEST 4 FAILED : attendu role=owner, obtenu %', r.other_party_role;
+  END IF;
+  IF r.other_party_subtitle NOT LIKE 'Ticket · Fuite robinet%' THEN
+    RAISE EXCEPTION 'TEST 4 FAILED : sous-titre inattendu "%"', r.other_party_subtitle;
+  END IF;
+  RAISE NOTICE 'TEST 4 OK : viewer=provider, conv=owner_provider, role=owner';
+END $$;
+
+
+-- ============================================================================
+-- Test 5 : Filter p_type='owner_provider' → 1 résultat, total_count = 1
+-- (même pour un viewer qui a 2 conv au total)
+-- ============================================================================
+SELECT pg_temp.set_viewer('11111111-1111-1111-1111-111111111111');
+
+DO $$
+DECLARE
+  v_count INT;
+  r RECORD;
+BEGIN
+  SELECT COUNT(*), MIN(total_count) INTO v_count, r
+  FROM public.get_conversations_enriched(25, 0, 'owner_provider');
+
+  IF v_count != 1 THEN
+    RAISE EXCEPTION 'TEST 5 FAILED : attendu 1 row, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 5 OK : filter owner_provider retourne 1 conv pour owner';
+END $$;
+
+
+-- ============================================================================
+-- Test 6 : Filter NULL (defaut) → toutes les conv accessibles (2 pour owner)
+-- ============================================================================
+DO $$
+DECLARE
+  v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM public.get_conversations_enriched(25, 0, NULL);
+
+  IF v_count != 2 THEN
+    RAISE EXCEPTION 'TEST 6 FAILED : attendu 2 rows (owner_tenant + owner_provider), obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 6 OK : sans filter, retourne les 2 conv accessibles à owner';
+END $$;
+
+
+-- ============================================================================
+-- Test 7 : total_count correct (>= rows retournées)
+-- ============================================================================
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  SELECT * INTO r
+  FROM public.get_conversations_enriched(1, 0, NULL)
+  LIMIT 1;
+
+  IF r.total_count != 2 THEN
+    RAISE EXCEPTION 'TEST 7 FAILED : attendu total_count=2, obtenu %', r.total_count;
+  END IF;
+  RAISE NOTICE 'TEST 7 OK : total_count = 2 même avec limit=1';
+END $$;
+
+
+-- ============================================================================
+-- Test 8 : Pagination offset
+-- ============================================================================
+DO $$
+DECLARE
+  v_page1 TEXT;
+  v_page2 TEXT;
+BEGIN
+  SELECT id::text INTO v_page1
+  FROM public.get_conversations_enriched(1, 0, NULL)
+  LIMIT 1;
+
+  SELECT id::text INTO v_page2
+  FROM public.get_conversations_enriched(1, 1, NULL)
+  LIMIT 1;
+
+  IF v_page1 = v_page2 THEN
+    RAISE EXCEPTION 'TEST 8 FAILED : offset 0 et 1 retournent la même conv "%"', v_page1;
+  END IF;
+  RAISE NOTICE 'TEST 8 OK : offset 0 et offset 1 retournent des conv distinctes';
+END $$;
+
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+SET session_replication_role = replica;
+
+DELETE FROM public.conversations WHERE id IN (
+  'aaaaaaaa-0001-0000-0000-000000000000',
+  'aaaaaaaa-0002-0000-0000-000000000000',
+  'aaaaaaaa-0003-0000-0000-000000000000'
+);
+DELETE FROM public.tickets WHERE id = '55555555-5555-5555-5555-555555555555';
+DELETE FROM public.leases WHERE id = '66666666-6666-6666-6666-666666666666';
+DELETE FROM public.properties WHERE id = '44444444-4444-4444-4444-444444444444';
+DELETE FROM public.legal_entities WHERE id = '77777777-7777-7777-7777-777777777777';
+DELETE FROM public.owner_profiles WHERE profile_id = '11111111-1111-1111-1111-111111111111';
+DELETE FROM public.profiles WHERE id IN (
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333'
+);
+
+SET session_replication_role = origin;
+
+COMMIT;

--- a/__tests__/db/conversations_four_roles.sql
+++ b/__tests__/db/conversations_four_roles.sql
@@ -1,0 +1,248 @@
+-- ============================================================================
+-- Tests d'intégration SQL — Sprint 1 extension conversations 4 rôles
+-- ============================================================================
+-- À exécuter via psql après `npx supabase db reset` :
+--   psql postgresql://postgres:postgres@localhost:54322/postgres \
+--     -f __tests__/db/conversations_four_roles.sql
+--
+-- Chaque test RAISE NOTICE en succès ou RAISE EXCEPTION en échec. L'exécution
+-- s'interrompt au premier échec, donc un run propre = tous les tests passent.
+--
+-- UUIDs hardcodés (règle projet : pas de :param ni $1 en SQL Editor).
+-- Bypass FK via session_replication_role pour ne pas avoir à créer les
+-- auth.users — ce qui permet d'exécuter sans service role.
+-- ============================================================================
+
+BEGIN;
+
+SET session_replication_role = replica;
+
+-- Setup : 3 profiles de test + 1 property + 1 ticket
+INSERT INTO public.profiles (id, user_id, role, prenom, nom) VALUES
+  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'owner',    'Owner',    'Test'),
+  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'tenant',   'Tenant',   'Test'),
+  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'provider', 'Provider', 'Test');
+
+INSERT INTO public.properties (id, owner_id, adresse_complete, ville, code_postal, pays, type_bien)
+VALUES ('44444444-4444-4444-4444-444444444444',
+        '11111111-1111-1111-1111-111111111111',
+        '1 Rue de Test', 'Paris', '75001', 'France', 'appartement');
+
+INSERT INTO public.tickets (id, property_id, titre, statut)
+VALUES ('55555555-5555-5555-5555-555555555555',
+        '44444444-4444-4444-4444-444444444444',
+        'Ticket Test', 'open');
+
+SET session_replication_role = origin;
+
+
+-- ============================================================================
+-- Test 1 : CHECK rejette provider sur owner_tenant
+-- ============================================================================
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.conversations (
+      id, conversation_type,
+      property_id, owner_profile_id, tenant_profile_id, provider_profile_id
+    ) VALUES (
+      'aaaaaaaa-0001-0000-0000-000000000000', 'owner_tenant',
+      '44444444-4444-4444-4444-444444444444',
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222',
+      '33333333-3333-3333-3333-333333333333'
+    );
+    RAISE EXCEPTION 'TEST 1 FAILED : CHECK aurait dû rejeter provider sur owner_tenant';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE 'TEST 1 OK : CHECK rejette provider non-NULL sur owner_tenant';
+  END;
+END $$;
+
+
+-- ============================================================================
+-- Test 2 : CHECK rejette tenant sur owner_provider
+-- ============================================================================
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.conversations (
+      id, conversation_type,
+      owner_profile_id, tenant_profile_id, provider_profile_id, ticket_id
+    ) VALUES (
+      'aaaaaaaa-0002-0000-0000-000000000000', 'owner_provider',
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222',
+      '33333333-3333-3333-3333-333333333333',
+      '55555555-5555-5555-5555-555555555555'
+    );
+    RAISE EXCEPTION 'TEST 2 FAILED : CHECK aurait dû rejeter tenant sur owner_provider';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE 'TEST 2 OK : CHECK rejette tenant non-NULL sur owner_provider';
+  END;
+END $$;
+
+
+-- ============================================================================
+-- Test 3 : CHECK rejette owner sur tenant_provider
+-- ============================================================================
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.conversations (
+      id, conversation_type,
+      owner_profile_id, tenant_profile_id, provider_profile_id, ticket_id
+    ) VALUES (
+      'aaaaaaaa-0003-0000-0000-000000000000', 'tenant_provider',
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222',
+      '33333333-3333-3333-3333-333333333333',
+      '55555555-5555-5555-5555-555555555555'
+    );
+    RAISE EXCEPTION 'TEST 3 FAILED : CHECK aurait dû rejeter owner sur tenant_provider';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE 'TEST 3 OK : CHECK rejette owner non-NULL sur tenant_provider';
+  END;
+END $$;
+
+
+-- ============================================================================
+-- Test 4 : Insert owner_tenant valide (provider=NULL)
+-- ============================================================================
+INSERT INTO public.conversations (
+  id, conversation_type,
+  property_id, owner_profile_id, tenant_profile_id
+) VALUES (
+  'aaaaaaaa-0004-0000-0000-000000000000', 'owner_tenant',
+  '44444444-4444-4444-4444-444444444444',
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222'
+);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.conversations WHERE id = 'aaaaaaaa-0004-0000-0000-000000000000') THEN
+    RAISE EXCEPTION 'TEST 4 FAILED : conversation owner_tenant non insérée';
+  END IF;
+  RAISE NOTICE 'TEST 4 OK : owner_tenant insert accepte provider_profile_id=NULL';
+END $$;
+
+
+-- ============================================================================
+-- Test 5 : Insert owner_provider valide (tenant=NULL)
+-- ============================================================================
+INSERT INTO public.conversations (
+  id, conversation_type,
+  owner_profile_id, provider_profile_id, ticket_id
+) VALUES (
+  'aaaaaaaa-0005-0000-0000-000000000000', 'owner_provider',
+  '11111111-1111-1111-1111-111111111111',
+  '33333333-3333-3333-3333-333333333333',
+  '55555555-5555-5555-5555-555555555555'
+);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.conversations WHERE id = 'aaaaaaaa-0005-0000-0000-000000000000') THEN
+    RAISE EXCEPTION 'TEST 5 FAILED : conversation owner_provider non insérée';
+  END IF;
+  RAISE NOTICE 'TEST 5 OK : owner_provider insert accepte tenant_profile_id=NULL';
+END $$;
+
+
+-- ============================================================================
+-- Test 6 : UNIQUE partiel owner_tenant rejette doublon actif
+-- ============================================================================
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.conversations (
+      id, conversation_type, status,
+      property_id, owner_profile_id, tenant_profile_id
+    ) VALUES (
+      'aaaaaaaa-0006-0000-0000-000000000000', 'owner_tenant', 'active',
+      '44444444-4444-4444-4444-444444444444',
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222'
+    );
+    RAISE EXCEPTION 'TEST 6 FAILED : UNIQUE aurait dû rejeter le doublon owner_tenant';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE 'TEST 6 OK : UNIQUE partiel rejette doublon active+owner_tenant+(property,owner,tenant)';
+  END;
+END $$;
+
+
+-- ============================================================================
+-- Test 7 : Trigger unread incrémente provider_unread_count sur owner→provider
+-- ============================================================================
+INSERT INTO public.messages (
+  id, conversation_id, sender_profile_id, sender_role, content
+) VALUES (
+  'bbbbbbbb-0001-0000-0000-000000000000',
+  'aaaaaaaa-0005-0000-0000-000000000000',  -- owner_provider conv du Test 5
+  '11111111-1111-1111-1111-111111111111',  -- owner
+  'owner',
+  'Hello provider'
+);
+DO $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  SELECT provider_unread_count INTO v_count
+  FROM public.conversations
+  WHERE id = 'aaaaaaaa-0005-0000-0000-000000000000';
+  IF v_count != 1 THEN
+    RAISE EXCEPTION 'TEST 7 FAILED : provider_unread_count attendu=1, obtenu=%', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 7 OK : trigger incrémente provider_unread_count à 1 sur owner→provider';
+END $$;
+
+
+-- ============================================================================
+-- Test 8 : mark_messages_as_read reset le bon unread pour provider
+-- ============================================================================
+SELECT public.mark_messages_as_read(
+  'aaaaaaaa-0005-0000-0000-000000000000',
+  '33333333-3333-3333-3333-333333333333'  -- provider
+);
+DO $$
+DECLARE
+  v_count INTEGER;
+  v_read_at TIMESTAMPTZ;
+BEGIN
+  SELECT provider_unread_count INTO v_count
+  FROM public.conversations
+  WHERE id = 'aaaaaaaa-0005-0000-0000-000000000000';
+  IF v_count != 0 THEN
+    RAISE EXCEPTION 'TEST 8 FAILED : provider_unread_count attendu=0 après mark, obtenu=%', v_count;
+  END IF;
+
+  SELECT read_at INTO v_read_at
+  FROM public.messages
+  WHERE id = 'bbbbbbbb-0001-0000-0000-000000000000';
+  IF v_read_at IS NULL THEN
+    RAISE EXCEPTION 'TEST 8 FAILED : read_at aurait dû être set sur le message';
+  END IF;
+
+  RAISE NOTICE 'TEST 8 OK : mark_messages_as_read reset provider_unread_count et set read_at';
+END $$;
+
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+SET session_replication_role = replica;
+
+DELETE FROM public.messages WHERE id = 'bbbbbbbb-0001-0000-0000-000000000000';
+DELETE FROM public.conversations WHERE id IN (
+  'aaaaaaaa-0004-0000-0000-000000000000',
+  'aaaaaaaa-0005-0000-0000-000000000000'
+);
+DELETE FROM public.tickets WHERE id = '55555555-5555-5555-5555-555555555555';
+DELETE FROM public.properties WHERE id = '44444444-4444-4444-4444-444444444444';
+DELETE FROM public.profiles WHERE id IN (
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333'
+);
+
+SET session_replication_role = origin;
+
+COMMIT;

--- a/__tests__/db/conversations_rls_four_roles.sql
+++ b/__tests__/db/conversations_rls_four_roles.sql
@@ -1,0 +1,271 @@
+-- ============================================================================
+-- Tests RLS conversations + messages — 4 rôles (Sprint 5)
+-- ============================================================================
+-- Vérifie que les policies Sprint 1 + extensions Sprint 5 admin bloquent
+-- correctement chaque rôle :
+--
+--   - owner     : SELECT/INSERT/UPDATE seulement sur ses conv (owner_profile_id)
+--   - tenant    : idem (tenant_profile_id)
+--   - provider  : idem (provider_profile_id)
+--   - admin     : SELECT toutes les conv (clause user_role()='admin'), pas
+--                 d'INSERT/UPDATE de messages (sender_profile_id check)
+--
+-- À exécuter via psql après `npx supabase db reset` :
+--   psql postgresql://postgres:postgres@localhost:54322/postgres \
+--     -f __tests__/db/conversations_rls_four_roles.sql
+-- ============================================================================
+
+BEGIN;
+
+SET session_replication_role = replica;
+
+-- 4 profiles : owner, tenant, provider, admin + 1 outsider
+INSERT INTO public.profiles (id, user_id, role, prenom, nom) VALUES
+  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'owner',    'Owner',    'Test'),
+  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'tenant',   'Tenant',   'Test'),
+  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'provider', 'Provider', 'Test'),
+  ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 'admin',    'Admin',    'Talok'),
+  ('55555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 'tenant',   'Outside',  'User');
+
+INSERT INTO public.properties (id, owner_id, adresse_complete, ville, code_postal, pays, type_bien)
+VALUES ('66666666-6666-6666-6666-666666666666',
+        '11111111-1111-1111-1111-111111111111',
+        '1 Rue de Test', 'Paris', '75001', 'France', 'appartement');
+
+INSERT INTO public.tickets (id, property_id, created_by_profile_id, titre, description)
+VALUES ('77777777-7777-7777-7777-777777777777',
+        '66666666-6666-6666-6666-666666666666',
+        '11111111-1111-1111-1111-111111111111',
+        'Test ticket', 'desc');
+
+-- 1 conv owner_tenant + 1 conv owner_provider
+INSERT INTO public.conversations (
+  id, conversation_type, status, property_id,
+  owner_profile_id, tenant_profile_id
+) VALUES (
+  'aaaaaaaa-0001-0000-0000-000000000000', 'owner_tenant', 'active',
+  '66666666-6666-6666-6666-666666666666',
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222'
+);
+
+INSERT INTO public.conversations (
+  id, conversation_type, status, property_id, ticket_id,
+  owner_profile_id, provider_profile_id
+) VALUES (
+  'aaaaaaaa-0002-0000-0000-000000000000', 'owner_provider', 'active',
+  '66666666-6666-6666-6666-666666666666',
+  '77777777-7777-7777-7777-777777777777',
+  '11111111-1111-1111-1111-111111111111',
+  '33333333-3333-3333-3333-333333333333'
+);
+
+-- 2 messages (1 par conv) pour tester SELECT messages
+INSERT INTO public.messages (id, conversation_id, sender_profile_id, sender_role, content)
+VALUES ('bbbbbbbb-0001-0000-0000-000000000000',
+        'aaaaaaaa-0001-0000-0000-000000000000',
+        '11111111-1111-1111-1111-111111111111',
+        'owner', 'Hello tenant');
+
+INSERT INTO public.messages (id, conversation_id, sender_profile_id, sender_role, content)
+VALUES ('bbbbbbbb-0002-0000-0000-000000000000',
+        'aaaaaaaa-0002-0000-0000-000000000000',
+        '11111111-1111-1111-1111-111111111111',
+        'owner', 'Hello provider');
+
+SET session_replication_role = origin;
+
+
+-- Helper : simule auth.uid() via request.jwt.claims
+CREATE OR REPLACE FUNCTION pg_temp.set_viewer(p_user_id UUID) RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM set_config('request.jwt.claims',
+    json_build_object('sub', p_user_id::text, 'role', 'authenticated')::text,
+    true);
+  PERFORM set_config('role', 'authenticated', true);
+END;
+$$;
+
+
+-- ============================================================================
+-- Test 1 : owner voit ses 2 conv (owner_tenant + owner_provider)
+-- ============================================================================
+SELECT pg_temp.set_viewer('11111111-1111-1111-1111-111111111111');
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM public.conversations
+  WHERE id IN (
+    'aaaaaaaa-0001-0000-0000-000000000000',
+    'aaaaaaaa-0002-0000-0000-000000000000'
+  );
+  IF v_count != 2 THEN
+    RAISE EXCEPTION 'TEST 1 FAILED : owner attendu 2 conv, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 1 OK : owner voit ses 2 conv';
+END $$;
+
+
+-- ============================================================================
+-- Test 2 : tenant voit seulement la conv owner_tenant
+-- ============================================================================
+SELECT pg_temp.set_viewer('22222222-2222-2222-2222-222222222222');
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM public.conversations
+  WHERE id IN (
+    'aaaaaaaa-0001-0000-0000-000000000000',
+    'aaaaaaaa-0002-0000-0000-000000000000'
+  );
+  IF v_count != 1 THEN
+    RAISE EXCEPTION 'TEST 2 FAILED : tenant attendu 1 conv, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 2 OK : tenant voit seulement owner_tenant (1 conv)';
+END $$;
+
+
+-- ============================================================================
+-- Test 3 : provider voit seulement la conv owner_provider
+-- ============================================================================
+SELECT pg_temp.set_viewer('33333333-3333-3333-3333-333333333333');
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM public.conversations
+  WHERE id IN (
+    'aaaaaaaa-0001-0000-0000-000000000000',
+    'aaaaaaaa-0002-0000-0000-000000000000'
+  );
+  IF v_count != 1 THEN
+    RAISE EXCEPTION 'TEST 3 FAILED : provider attendu 1 conv, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 3 OK : provider voit seulement owner_provider (1 conv)';
+END $$;
+
+
+-- ============================================================================
+-- Test 4 : admin voit les 2 conv (clause user_role()='admin')
+-- ============================================================================
+SELECT pg_temp.set_viewer('44444444-4444-4444-4444-444444444444');
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM public.conversations
+  WHERE id IN (
+    'aaaaaaaa-0001-0000-0000-000000000000',
+    'aaaaaaaa-0002-0000-0000-000000000000'
+  );
+  IF v_count != 2 THEN
+    RAISE EXCEPTION 'TEST 4 FAILED : admin attendu 2 conv, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 4 OK : admin voit toutes les conv (2)';
+END $$;
+
+
+-- ============================================================================
+-- Test 5 : outsider tenant (pas participant) ne voit aucune conv
+-- ============================================================================
+SELECT pg_temp.set_viewer('55555555-5555-5555-5555-555555555555');
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM public.conversations
+  WHERE id IN (
+    'aaaaaaaa-0001-0000-0000-000000000000',
+    'aaaaaaaa-0002-0000-0000-000000000000'
+  );
+  IF v_count != 0 THEN
+    RAISE EXCEPTION 'TEST 5 FAILED : outsider attendu 0 conv, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 5 OK : outsider voit 0 conv';
+END $$;
+
+
+-- ============================================================================
+-- Test 6 : provider peut SELECT ses messages mais PAS ceux des autres conv
+-- ============================================================================
+SELECT pg_temp.set_viewer('33333333-3333-3333-3333-333333333333');
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM public.messages
+  WHERE id IN (
+    'bbbbbbbb-0001-0000-0000-000000000000',
+    'bbbbbbbb-0002-0000-0000-000000000000'
+  );
+  -- provider est dans owner_provider (conv 0002), pas dans owner_tenant (0001)
+  IF v_count != 1 THEN
+    RAISE EXCEPTION 'TEST 6 FAILED : provider attendu 1 message visible, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 6 OK : provider voit 1 message (le sien)';
+END $$;
+
+
+-- ============================================================================
+-- Test 7 : admin peut SELECT TOUS les messages
+-- ============================================================================
+SELECT pg_temp.set_viewer('44444444-4444-4444-4444-444444444444');
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM public.messages
+  WHERE id IN (
+    'bbbbbbbb-0001-0000-0000-000000000000',
+    'bbbbbbbb-0002-0000-0000-000000000000'
+  );
+  IF v_count != 2 THEN
+    RAISE EXCEPTION 'TEST 7 FAILED : admin attendu 2 messages, obtenu %', v_count;
+  END IF;
+  RAISE NOTICE 'TEST 7 OK : admin voit les 2 messages';
+END $$;
+
+
+-- ============================================================================
+-- Test 8 : admin NE PEUT PAS INSERT un message (sender_profile_id check)
+-- ============================================================================
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.messages (
+      id, conversation_id, sender_profile_id, sender_role, content
+    ) VALUES (
+      'bbbbbbbb-9999-0000-0000-000000000000',
+      'aaaaaaaa-0001-0000-0000-000000000000',
+      '44444444-4444-4444-4444-444444444444',  -- admin id
+      'owner', 'Admin tente d''envoyer'
+    );
+    RAISE EXCEPTION 'TEST 8 FAILED : admin n''aurait pas dû pouvoir INSERT';
+  EXCEPTION WHEN insufficient_privilege OR check_violation THEN
+    RAISE NOTICE 'TEST 8 OK : admin bloqué sur INSERT message (RLS)';
+  END;
+END $$;
+
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+SET session_replication_role = replica;
+
+DELETE FROM public.messages WHERE id IN (
+  'bbbbbbbb-0001-0000-0000-000000000000',
+  'bbbbbbbb-0002-0000-0000-000000000000'
+);
+DELETE FROM public.conversations WHERE id IN (
+  'aaaaaaaa-0001-0000-0000-000000000000',
+  'aaaaaaaa-0002-0000-0000-000000000000'
+);
+DELETE FROM public.tickets WHERE id = '77777777-7777-7777-7777-777777777777';
+DELETE FROM public.properties WHERE id = '66666666-6666-6666-6666-666666666666';
+DELETE FROM public.profiles WHERE id IN (
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333',
+  '44444444-4444-4444-4444-444444444444',
+  '55555555-5555-5555-5555-555555555555'
+);
+
+SET session_replication_role = origin;
+
+COMMIT;

--- a/__tests__/services/chat.service.test.ts
+++ b/__tests__/services/chat.service.test.ts
@@ -37,59 +37,6 @@ describe("ChatService", () => {
     vi.clearAllMocks();
   });
 
-  describe("getConversations", () => {
-    it("should return empty array when user is not authenticated", async () => {
-      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null } });
-      
-      const { chatService } = await import("@/lib/services/chat.service");
-      
-      await expect(chatService.getConversations()).rejects.toThrow("Non authentifié");
-    });
-
-    it("should fetch conversations for authenticated user", async () => {
-      const mockUser = { id: "user-123" };
-      const mockProfile = { id: "profile-123" };
-      const mockConversations = [
-        {
-          id: "conv-1",
-          owner_profile_id: "profile-123",
-          tenant_profile_id: "profile-456",
-          last_message_at: "2025-01-01T10:00:00Z",
-          owner: { prenom: "John", nom: "Doe" },
-          tenant: { prenom: "Jane", nom: "Smith" },
-          property: { adresse_complete: "123 Rue Test", ville: "Paris" },
-        },
-      ];
-
-      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: mockUser } });
-      mockSupabase.from.mockImplementation(((table: string) => {
-        if (table === "profiles") {
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockReturnThis(),
-            single: vi.fn().mockResolvedValue({ data: mockProfile }),
-          };
-        }
-        if (table === "conversations") {
-          return {
-            select: vi.fn().mockReturnThis(),
-            or: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockReturnThis(),
-            order: vi.fn().mockResolvedValue({ data: mockConversations }),
-          };
-        }
-        return (mockSupabase.from as any)(table);
-      }) as any);
-
-      const { chatService } = await import("@/lib/services/chat.service");
-      const conversations = await chatService.getConversations();
-
-      expect(conversations).toHaveLength(1);
-      expect(conversations[0].owner_name).toBe("John Doe");
-      expect(conversations[0].tenant_name).toBe("Jane Smith");
-    });
-  });
-
   describe("sendMessage", () => {
     it("should throw error when user is not authenticated", async () => {
       mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null } });

--- a/__tests__/services/chat.service.test.ts
+++ b/__tests__/services/chat.service.test.ts
@@ -163,6 +163,224 @@ describe("ChatService", () => {
     });
   });
 
+  describe("getOrCreateOwnerProviderConversation", () => {
+    it("should return existing owner_provider conversation when one matches", async () => {
+      const existingId = "conv-op-1";
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u" } } });
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "conversations") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: existingId } }),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: existingId,
+                conversation_type: "owner_provider",
+                ticket_id: "t-1",
+                owner_profile_id: "o-1",
+                provider_profile_id: "p-1",
+                owner: { prenom: "O", nom: "Wner" },
+                provider: { prenom: "P", nom: "Rov" },
+              },
+            }),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      const conv = await chatService.getOrCreateOwnerProviderConversation({
+        ticket_id: "t-1",
+        property_id: "pr-1",
+        owner_profile_id: "o-1",
+        provider_profile_id: "p-1",
+      });
+
+      expect(conv.id).toBe(existingId);
+      expect(conv.owner_name).toBe("O Wner");
+      expect(conv.provider_name).toBe("P Rov");
+    });
+
+    it("should insert with conversation_type='owner_provider' when none exists", async () => {
+      const insertedRef = { value: null as any };
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u" } } });
+
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "conversations") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+            single: vi.fn().mockResolvedValue({
+              data: { id: "new-op", conversation_type: "owner_provider" },
+            }),
+            insert: vi.fn((payload: any) => {
+              insertedRef.value = payload;
+              return {
+                select: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: { id: "new-op" } }),
+              };
+            }),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      await chatService.getOrCreateOwnerProviderConversation({
+        ticket_id: "t-2",
+        property_id: "pr-2",
+        owner_profile_id: "o-2",
+        provider_profile_id: "p-2",
+      });
+
+      expect(insertedRef.value).toMatchObject({
+        conversation_type: "owner_provider",
+        ticket_id: "t-2",
+        owner_profile_id: "o-2",
+        provider_profile_id: "p-2",
+      });
+      expect(insertedRef.value.tenant_profile_id).toBeUndefined();
+    });
+  });
+
+  describe("getOrCreateTenantProviderConversation", () => {
+    it("should insert with conversation_type='tenant_provider' and no owner_profile_id", async () => {
+      const insertedRef = { value: null as any };
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u" } } });
+
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "conversations") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+            single: vi.fn().mockResolvedValue({
+              data: { id: "new-tp", conversation_type: "tenant_provider" },
+            }),
+            insert: vi.fn((payload: any) => {
+              insertedRef.value = payload;
+              return {
+                select: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: { id: "new-tp" } }),
+              };
+            }),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      await chatService.getOrCreateTenantProviderConversation({
+        ticket_id: "t-3",
+        property_id: "pr-3",
+        tenant_profile_id: "te-3",
+        provider_profile_id: "p-3",
+      });
+
+      expect(insertedRef.value).toMatchObject({
+        conversation_type: "tenant_provider",
+        ticket_id: "t-3",
+        tenant_profile_id: "te-3",
+        provider_profile_id: "p-3",
+      });
+      expect(insertedRef.value.owner_profile_id).toBeUndefined();
+    });
+  });
+
+  describe("sendMessage — provider sender", () => {
+    it("should send message with sender_role='provider' when caller is the provider", async () => {
+      const mockUser = { id: "user-prov" };
+      const mockProfile = { id: "profile-prov" };
+      const mockConversation = {
+        owner_profile_id: "profile-owner",
+        tenant_profile_id: null,
+        provider_profile_id: "profile-prov",
+      };
+      const mockMessage = {
+        id: "msg-p",
+        conversation_id: "conv-op",
+        content: "Bonjour",
+        sender_profile_id: "profile-prov",
+        sender_role: "provider",
+        sender: { prenom: "Pro", nom: "Vider" },
+      };
+
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: mockUser } });
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "profiles") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockProfile }),
+          };
+        }
+        if (table === "conversations") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockConversation }),
+          };
+        }
+        if (table === "messages") {
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: mockMessage }),
+            })),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      const msg = await chatService.sendMessage({
+        conversation_id: "conv-op",
+        content: "Bonjour",
+      });
+
+      expect(msg.sender_role).toBe("provider");
+    });
+
+    it("should throw when caller is not a participant of the conversation", async () => {
+      const mockUser = { id: "user-stranger" };
+      const mockProfile = { id: "profile-stranger" };
+      const mockConversation = {
+        owner_profile_id: "profile-owner",
+        tenant_profile_id: "profile-tenant",
+        provider_profile_id: null,
+      };
+
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: mockUser } });
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "profiles") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockProfile }),
+          };
+        }
+        if (table === "conversations") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockConversation }),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      await expect(
+        chatService.sendMessage({
+          conversation_id: "conv-x",
+          content: "Hi",
+        })
+      ).rejects.toThrow("Utilisateur non participant");
+    });
+  });
+
   describe("markAsRead", () => {
     it("should call RPC to mark messages as read", async () => {
       const mockUser = { id: "user-123" };

--- a/__tests__/services/chat.service.test.ts
+++ b/__tests__/services/chat.service.test.ts
@@ -381,6 +381,124 @@ describe("ChatService", () => {
     });
   });
 
+  describe("getConversationsEnriched", () => {
+    it("should call RPC with default params and return data+count+hasMore", async () => {
+      const rpcRows = [
+        { id: "c1", conversation_type: "owner_tenant", total_count: 3 },
+        { id: "c2", conversation_type: "owner_provider", total_count: 3 },
+      ];
+      const rpcMock = vi.fn().mockResolvedValue({ data: rpcRows, error: null });
+      mockSupabase.rpc = rpcMock;
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      const result = await chatService.getConversationsEnriched();
+
+      expect(rpcMock).toHaveBeenCalledWith("get_conversations_enriched", {
+        p_limit: 25,
+        p_offset: 0,
+        p_type: null,
+      });
+      expect(result.data).toHaveLength(2);
+      expect(result.count).toBe(3);
+      expect(result.hasMore).toBe(true);
+      // total_count est stripé du payload retourné
+      expect((result.data[0] as any).total_count).toBeUndefined();
+    });
+
+    it("should forward type filter to the RPC", async () => {
+      const rpcMock = vi.fn().mockResolvedValue({ data: [], error: null });
+      mockSupabase.rpc = rpcMock;
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      await chatService.getConversationsEnriched({
+        limit: 10,
+        offset: 5,
+        type: "owner_provider",
+      });
+
+      expect(rpcMock).toHaveBeenCalledWith("get_conversations_enriched", {
+        p_limit: 10,
+        p_offset: 5,
+        p_type: "owner_provider",
+      });
+    });
+
+    it("should return hasMore=false when count <= offset + data.length", async () => {
+      const rpcMock = vi.fn().mockResolvedValue({
+        data: [{ id: "c1", total_count: 5 }, { id: "c2", total_count: 5 }],
+        error: null,
+      });
+      mockSupabase.rpc = rpcMock;
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      const result = await chatService.getConversationsEnriched({ limit: 2, offset: 3 });
+
+      expect(result.count).toBe(5);
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe("getOtherPartyInfo", () => {
+    it("viewer=owner, owner_tenant → returns tenant info", async () => {
+      const { getOtherPartyInfo } = await import("@/lib/services/chat.service");
+      const info = getOtherPartyInfo({
+        id: "c",
+        conversation_type: "owner_tenant",
+        owner_profile_id: "o",
+        tenant_profile_id: "t",
+        provider_profile_id: null,
+        tenant_name: "Alice",
+        tenant_avatar: "avatar-t",
+        tenant_prenom: "Alice",
+        tenant_nom: "Smith",
+      } as any, "o");
+      expect(info.role).toBe("tenant");
+      expect(info.name).toBe("Alice");
+      expect(info.avatar).toBe("avatar-t");
+    });
+
+    it("viewer=tenant, tenant_provider → returns provider info", async () => {
+      const { getOtherPartyInfo } = await import("@/lib/services/chat.service");
+      const info = getOtherPartyInfo({
+        id: "c",
+        conversation_type: "tenant_provider",
+        owner_profile_id: null,
+        tenant_profile_id: "t",
+        provider_profile_id: "p",
+        provider_name: "Bob",
+        provider_avatar: null,
+      } as any, "t");
+      expect(info.role).toBe("provider");
+      expect(info.name).toBe("Bob");
+    });
+
+    it("viewer=provider, owner_provider → returns owner info", async () => {
+      const { getOtherPartyInfo } = await import("@/lib/services/chat.service");
+      const info = getOtherPartyInfo({
+        id: "c",
+        conversation_type: "owner_provider",
+        owner_profile_id: "o",
+        tenant_profile_id: null,
+        provider_profile_id: "p",
+        owner_name: "Charlie",
+      } as any, "p");
+      expect(info.role).toBe("owner");
+      expect(info.name).toBe("Charlie");
+    });
+
+    it("viewer is not a participant → returns role=null", async () => {
+      const { getOtherPartyInfo } = await import("@/lib/services/chat.service");
+      const info = getOtherPartyInfo({
+        id: "c",
+        conversation_type: "owner_tenant",
+        owner_profile_id: "o",
+        tenant_profile_id: "t",
+        provider_profile_id: null,
+      } as any, "stranger");
+      expect(info.role).toBeNull();
+    });
+  });
+
   describe("markAsRead", () => {
     it("should call RPC to mark messages as read", async () => {
       const mockUser = { id: "user-123" };

--- a/__tests__/services/chat.service.test.ts
+++ b/__tests__/services/chat.service.test.ts
@@ -344,6 +344,7 @@ describe("ChatService", () => {
         p_limit: 25,
         p_offset: 0,
         p_type: null,
+        p_search: null,
       });
       expect(result.data).toHaveLength(2);
       expect(result.count).toBe(3);
@@ -367,6 +368,7 @@ describe("ChatService", () => {
         p_limit: 10,
         p_offset: 5,
         p_type: "owner_provider",
+        p_search: null,
       });
     });
 
@@ -382,6 +384,36 @@ describe("ChatService", () => {
 
       expect(result.count).toBe(5);
       expect(result.hasMore).toBe(false);
+    });
+
+    it("should forward trimmed search param to the RPC as p_search", async () => {
+      const rpcMock = vi.fn().mockResolvedValue({ data: [], error: null });
+      mockSupabase.rpc = rpcMock;
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      await chatService.getConversationsEnriched({ search: "  Marie  " });
+
+      expect(rpcMock).toHaveBeenCalledWith("get_conversations_enriched", {
+        p_limit: 25,
+        p_offset: 0,
+        p_type: null,
+        p_search: "Marie",
+      });
+    });
+
+    it("should send p_search=null when search is empty or whitespace", async () => {
+      const rpcMock = vi.fn().mockResolvedValue({ data: [], error: null });
+      mockSupabase.rpc = rpcMock;
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      await chatService.getConversationsEnriched({ search: "   " });
+
+      expect(rpcMock).toHaveBeenCalledWith("get_conversations_enriched", {
+        p_limit: 25,
+        p_offset: 0,
+        p_type: null,
+        p_search: null,
+      });
     });
   });
 

--- a/__tests__/services/chat.service.test.ts
+++ b/__tests__/services/chat.service.test.ts
@@ -499,6 +499,68 @@ describe("ChatService", () => {
     });
   });
 
+  describe("getTicketMetadata", () => {
+    it("returns ticket data when ticket exists", async () => {
+      const ticketRow = {
+        id: "tk-1",
+        titre: "Fuite robinet",
+        statut: "in_progress",
+        priorite: "haute",
+      };
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "tickets") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: ticketRow, error: null }),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      const data = await chatService.getTicketMetadata("tk-1");
+      expect(data).toEqual(ticketRow);
+    });
+
+    it("returns null when ticket not found", async () => {
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "tickets") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      const data = await chatService.getTicketMetadata("missing");
+      expect(data).toBeNull();
+    });
+
+    it("returns null when query errors", async () => {
+      mockSupabase.from.mockImplementation(((table: string) => {
+        if (table === "tickets") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: { code: "42501", message: "permission denied" },
+            }),
+          };
+        }
+        return (mockSupabase.from as any)(table);
+      }) as any);
+
+      const { chatService } = await import("@/lib/services/chat.service");
+      const data = await chatService.getTicketMetadata("forbidden");
+      expect(data).toBeNull();
+    });
+  });
+
   describe("markAsRead", () => {
     it("should call RPC to mark messages as read", async () => {
       const mockUser = { id: "user-123" };

--- a/__tests__/services/notification-service.test.ts
+++ b/__tests__/services/notification-service.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests du service notifications (Sprint 6 — extension 3 rôles + email)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --- Mocks des dépendances --------------------------------------------------
+
+const { mockCreateClient, mockCreateServiceClient, mockSendEmail } = vi.hoisted(() => {
+  return {
+    mockCreateClient: vi.fn(),
+    mockCreateServiceClient: vi.fn(),
+    mockSendEmail: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: mockCreateClient,
+  createServiceRoleClient: mockCreateServiceClient,
+}));
+
+vi.mock("@/lib/emails/resend.service", () => ({
+  sendEmail: mockSendEmail,
+}));
+
+// Ré-import à chaque test après clear
+async function loadService() {
+  vi.resetModules();
+  return await import("@/lib/services/notification-service");
+}
+
+// --- Helpers mock -----------------------------------------------------------
+
+function buildInsertChain(returned: any) {
+  return {
+    insert: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: returned, error: null }),
+    })),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: { user_id: "user-x" } }),
+  };
+}
+
+describe("notifyMessageReceived", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds actionUrl for owner with ?conversation=<id>", async () => {
+    const insertedNotif = {
+      id: "notif-1",
+      type: "message_received",
+      title: "Message de X",
+      message: "Hi",
+      profile_id: "p-owner",
+      channels: ["in_app"],
+      action_url: "/owner/messages?conversation=conv-1",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    const mockClient = {
+      from: vi.fn(() => buildInsertChain(insertedNotif)),
+    };
+    mockCreateClient.mockResolvedValue(mockClient);
+    // Service client inexistant pour ce test (pas de push, pas d'email)
+    mockCreateServiceClient.mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+      })),
+      auth: { admin: { getUserById: vi.fn().mockResolvedValue({ data: { user: null } }) } },
+    });
+
+    const { notifyMessageReceived } = await loadService();
+    await notifyMessageReceived(
+      "p-owner",
+      "Alice",
+      "Bonjour propriétaire",
+      "conv-1",
+      "owner",
+    );
+
+    // Récupérer l'argument passé à insert
+    const insertCall = mockClient.from.mock.results
+      .map((r: any) => r.value.insert)
+      .find((fn: any) => fn?.mock?.calls?.length > 0);
+    expect(insertCall).toBeDefined();
+    const payload = insertCall.mock.calls[0][0];
+    expect(payload.action_url).toBe("/owner/messages?conversation=conv-1");
+    expect(payload.type).toBe("message_received");
+  });
+
+  it("builds actionUrl for tenant", async () => {
+    const mockClient = {
+      from: vi.fn(() => buildInsertChain({ id: "notif-t", type: "message_received" })),
+    };
+    mockCreateClient.mockResolvedValue(mockClient);
+    mockCreateServiceClient.mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+      })),
+      auth: { admin: { getUserById: vi.fn().mockResolvedValue({ data: { user: null } }) } },
+    });
+
+    const { notifyMessageReceived } = await loadService();
+    await notifyMessageReceived("p-tenant", "Bob", "Salut", "conv-2", "tenant");
+
+    const payload = mockClient.from.mock.results
+      .map((r: any) => r.value.insert)
+      .find((fn: any) => fn?.mock?.calls?.length > 0).mock.calls[0][0];
+    expect(payload.action_url).toBe("/tenant/messages?conversation=conv-2");
+  });
+
+  it("builds actionUrl for provider (Sprint 6 nouveauté)", async () => {
+    const mockClient = {
+      from: vi.fn(() => buildInsertChain({ id: "notif-p", type: "message_received" })),
+    };
+    mockCreateClient.mockResolvedValue(mockClient);
+    mockCreateServiceClient.mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+      })),
+      auth: { admin: { getUserById: vi.fn().mockResolvedValue({ data: { user: null } }) } },
+    });
+
+    const { notifyMessageReceived } = await loadService();
+    await notifyMessageReceived(
+      "p-provider",
+      "Marie",
+      "Intervention demain",
+      "conv-3",
+      "provider",
+    );
+
+    const payload = mockClient.from.mock.results
+      .map((r: any) => r.value.insert)
+      .find((fn: any) => fn?.mock?.calls?.length > 0).mock.calls[0][0];
+    expect(payload.action_url).toBe("/provider/messages?conversation=conv-3");
+  });
+
+  it("truncates message preview to 100 chars with ellipsis", async () => {
+    const mockClient = {
+      from: vi.fn(() => buildInsertChain({ id: "notif-tr", type: "message_received" })),
+    };
+    mockCreateClient.mockResolvedValue(mockClient);
+    mockCreateServiceClient.mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+      })),
+      auth: { admin: { getUserById: vi.fn().mockResolvedValue({ data: { user: null } }) } },
+    });
+
+    const longText = "a".repeat(250);
+    const { notifyMessageReceived } = await loadService();
+    await notifyMessageReceived("p", "X", longText, "c", "tenant");
+
+    const payload = mockClient.from.mock.results
+      .map((r: any) => r.value.insert)
+      .find((fn: any) => fn?.mock?.calls?.length > 0).mock.calls[0][0];
+    expect(payload.message).toBe("a".repeat(100) + "...");
+  });
+});

--- a/app/admin/moderation/page.tsx
+++ b/app/admin/moderation/page.tsx
@@ -78,6 +78,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { AdminConversationsPanel } from "@/components/admin/admin-conversations-panel";
 
 // Types
 interface ModerationRule {
@@ -671,6 +672,10 @@ export default function AdminModerationPage() {
               <Settings className="h-4 w-4" />
               Règles IA
             </TabsTrigger>
+            <TabsTrigger value="conversations" className="gap-2">
+              <MessageSquare className="h-4 w-4" />
+              Conversations
+            </TabsTrigger>
           </TabsList>
 
           {/* Queue Tab */}
@@ -948,6 +953,17 @@ export default function AdminModerationPage() {
                 )}
               </CardContent>
             </Card>
+          </TabsContent>
+
+          {/* Conversations Tab — Sprint 5 admin read-only view */}
+          <TabsContent value="conversations" className="space-y-4">
+            {profile?.id ? (
+              <AdminConversationsPanel adminProfileId={profile.id} />
+            ) : (
+              <div className="text-center py-12 text-sm text-muted-foreground">
+                Profil admin non chargé.
+              </div>
+            )}
           </TabsContent>
         </Tabs>
 

--- a/app/api/messages/notify/route.ts
+++ b/app/api/messages/notify/route.ts
@@ -2,6 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { notifyMessageReceived } from "@/lib/services/notification-service";
 
+/**
+ * POST /api/messages/notify
+ *
+ * Appelée en fire-and-forget par `chatService.sendMessage` après un INSERT
+ * réussi sur `messages`. Détermine le destinataire parmi les 3 participants
+ * possibles (owner / tenant / provider) et délègue la création de la
+ * notification (in-app + push + email) à `notifyMessageReceived`.
+ */
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
@@ -17,7 +25,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Paramètres manquants" }, { status: 400 });
     }
 
-    // Récupérer le profil de l'expéditeur
     const { data: senderProfile } = await supabase
       .from("profiles")
       .select("id, prenom, nom")
@@ -28,37 +35,65 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
     }
 
-    // Récupérer la conversation pour identifier le destinataire
     const { data: conversation } = await supabase
       .from("conversations")
-      .select("owner_profile_id, tenant_profile_id")
+      .select("owner_profile_id, tenant_profile_id, provider_profile_id, conversation_type")
       .eq("id", conversationId)
-      .single();
+      .single() as { data: {
+        owner_profile_id: string | null;
+        tenant_profile_id: string | null;
+        provider_profile_id: string | null;
+        conversation_type: string | null;
+      } | null };
 
     if (!conversation) {
       return NextResponse.json({ error: "Conversation non trouvée" }, { status: 404 });
     }
 
-    // Déterminer le destinataire (l'autre participant)
-    const recipientId = senderProfile.id === conversation.owner_profile_id
-      ? conversation.tenant_profile_id
-      : conversation.owner_profile_id;
+    // Déterminer le destinataire parmi les 3 participants selon qui envoie.
+    // Chaque conversation_type a exactement 2 participants non-null, donc
+    // "l'autre" est toujours univoque.
+    let recipientId: string | null = null;
+    let recipientRole: "owner" | "tenant" | "provider" | null = null;
 
-    if (!recipientId) {
+    if (senderProfile.id === conversation.owner_profile_id) {
+      if (conversation.tenant_profile_id) {
+        recipientId = conversation.tenant_profile_id;
+        recipientRole = "tenant";
+      } else if (conversation.provider_profile_id) {
+        recipientId = conversation.provider_profile_id;
+        recipientRole = "provider";
+      }
+    } else if (senderProfile.id === conversation.tenant_profile_id) {
+      if (conversation.owner_profile_id) {
+        recipientId = conversation.owner_profile_id;
+        recipientRole = "owner";
+      } else if (conversation.provider_profile_id) {
+        recipientId = conversation.provider_profile_id;
+        recipientRole = "provider";
+      }
+    } else if (senderProfile.id === conversation.provider_profile_id) {
+      if (conversation.owner_profile_id) {
+        recipientId = conversation.owner_profile_id;
+        recipientRole = "owner";
+      } else if (conversation.tenant_profile_id) {
+        recipientId = conversation.tenant_profile_id;
+        recipientRole = "tenant";
+      }
+    }
+
+    if (!recipientId || !recipientRole) {
       return NextResponse.json({ error: "Destinataire non trouvé" }, { status: 404 });
     }
 
     const senderName = `${senderProfile.prenom || ""} ${senderProfile.nom || ""}`.trim() || "Utilisateur";
-
-    // Déterminer le rôle du destinataire pour l'URL
-    const recipientRole = recipientId === conversation.owner_profile_id ? "owner" : "tenant";
 
     await notifyMessageReceived(
       recipientId,
       senderName,
       messageContent,
       conversationId,
-      recipientRole as "owner" | "tenant",
+      recipientRole,
     );
 
     return NextResponse.json({ success: true });

--- a/app/provider/layout.tsx
+++ b/app/provider/layout.tsx
@@ -20,6 +20,7 @@ import {
   FolderOpen,
   Shield,
   Image,
+  MessageSquare,
 } from "lucide-react";
 import { NotificationCenter } from "@/components/notifications/notification-center";
 import { ProviderBottomNav } from "@/components/layout/provider-bottom-nav";
@@ -31,6 +32,7 @@ import { OfflineIndicator } from "@/components/ui/offline-indicator";
 const navigation = [
   { name: "Tableau de bord", href: "/provider/dashboard", icon: LayoutDashboard },
   { name: "Mes missions", href: "/provider/jobs", icon: Briefcase },
+  { name: "Messages", href: "/provider/messages", icon: MessageSquare },
   { name: "Calendrier", href: "/provider/calendar", icon: Calendar },
   { name: "Mes devis", href: "/provider/quotes", icon: FileText },
   { name: "Mes factures", href: "/provider/invoices", icon: Receipt },

--- a/app/provider/messages/page.tsx
+++ b/app/provider/messages/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { MessagesPageContent } from "@/components/messages/MessagesPageContent";
+
+export default function ProviderMessagesPage() {
+  const router = useRouter();
+  const onNotAuthenticated = useCallback(() => {
+    router.replace("/auth/signin");
+  }, [router]);
+
+  return (
+    <MessagesPageContent
+      subtitle="Vos conversations avec les propriétaires et locataires"
+      onNotAuthenticated={onNotAuthenticated}
+    />
+  );
+}

--- a/components/admin/admin-conversations-panel.tsx
+++ b/components/admin/admin-conversations-panel.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/**
+ * Sprint 5 — Vue admin read-only des conversations Messages.
+ *
+ * Affichée comme un onglet dans /admin/moderation. Liste toutes les
+ * conversations actives via le RPC get_conversations_enriched (Sprint 3) —
+ * accessible à l'admin grâce à la clause `user_role()='admin'` des RLS
+ * Sprint 1. Click sur une conversation → ouvre un Sheet avec ChatWindow
+ * en mode readOnly.
+ */
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { format } from "date-fns";
+import { fr } from "date-fns/locale";
+import { MessageSquare, RefreshCw, ChevronRight } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { useToast } from "@/components/ui/use-toast";
+
+import {
+  chatService,
+  type Conversation,
+  type ConversationEnriched,
+  type ConversationType,
+} from "@/lib/services/chat.service";
+import { ChatWindow } from "@/components/chat/chat-window";
+import {
+  ConversationRoleBadge,
+  type ConversationRole,
+} from "@/components/chat/conversation-role-badge";
+
+const TYPE_LABELS: Record<ConversationType, string> = {
+  owner_tenant: "Propriétaire ↔ Locataire",
+  owner_provider: "Propriétaire ↔ Prestataire",
+  tenant_provider: "Locataire ↔ Prestataire",
+};
+
+interface AdminConversationsPanelProps {
+  /**
+   * Profil admin courant — utilisé comme `currentProfileId` du ChatWindow.
+   * Comme l'admin n'est jamais participant, getOtherPartyInfo retournera
+   * role=null, ce qui est OK : le badge "rôle de l'autre" ne s'affiche pas
+   * mais les messages restent lisibles via la clause RLS admin.
+   */
+  adminProfileId: string;
+}
+
+export function AdminConversationsPanel({ adminProfileId }: AdminConversationsPanelProps) {
+  const { toast } = useToast();
+  const [conversations, setConversations] = useState<ConversationEnriched[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [selectedFull, setSelectedFull] = useState<Conversation | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const load = async () => {
+    setRefreshing(true);
+    try {
+      const result = await chatService.getConversationsEnriched({ limit: 100, offset: 0 });
+      setConversations(result.data);
+    } catch (error) {
+      console.error("[AdminConversationsPanel] load", error);
+      toast({
+        title: "Erreur",
+        description: "Impossible de charger les conversations",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSelect = async (enriched: ConversationEnriched) => {
+    try {
+      const full = await chatService.getConversation(enriched.id);
+      if (full) {
+        setSelectedFull(full);
+        setSheetOpen(true);
+      }
+    } catch (error) {
+      console.error("[AdminConversationsPanel] open", error);
+      toast({
+        title: "Erreur",
+        description: "Impossible d'ouvrir la conversation",
+        variant: "destructive",
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-20 bg-muted animate-pulse rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {conversations.length} conversation{conversations.length > 1 ? "s" : ""} active{conversations.length > 1 ? "s" : ""}
+        </p>
+        <Button variant="outline" size="sm" onClick={load} disabled={refreshing}>
+          <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? "animate-spin" : ""}`} />
+          Actualiser
+        </Button>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {conversations.length === 0 ? (
+            <div className="text-center py-12">
+              <MessageSquare className="h-12 w-12 mx-auto text-muted-foreground/40 mb-3" />
+              <p className="text-sm text-muted-foreground">Aucune conversation active</p>
+            </div>
+          ) : (
+            <div className="divide-y">
+              {conversations.map((conv) => (
+                <motion.button
+                  key={conv.id}
+                  layout
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  type="button"
+                  onClick={() => handleSelect(conv)}
+                  className="w-full flex items-center justify-between p-4 hover:bg-muted/50 transition-colors text-left"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <Badge variant="outline" className="text-xs">
+                        {TYPE_LABELS[conv.conversation_type]}
+                      </Badge>
+                      {conv.other_party_role && (
+                        <ConversationRoleBadge
+                          role={conv.other_party_role as ConversationRole}
+                          size="sm"
+                          showIcon={false}
+                        />
+                      )}
+                    </div>
+                    <p className="text-sm font-medium truncate">
+                      {conv.other_party_name || "Conversation"}
+                    </p>
+                    {conv.other_party_subtitle && (
+                      <p className="text-xs text-muted-foreground truncate">
+                        {conv.other_party_subtitle}
+                      </p>
+                    )}
+                    {conv.last_message_preview && (
+                      <p className="text-xs text-muted-foreground truncate mt-1 italic">
+                        "{conv.last_message_preview}"
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    {conv.last_message_at && (
+                      <span className="text-xs text-muted-foreground">
+                        {format(new Date(conv.last_message_at), "d MMM HH:mm", { locale: fr })}
+                      </span>
+                    )}
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                </motion.button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent className="w-full sm:max-w-2xl p-0 flex flex-col">
+          <SheetHeader className="p-4 border-b">
+            <SheetTitle className="text-base">Conversation — vue admin</SheetTitle>
+          </SheetHeader>
+          <div className="flex-1 overflow-hidden">
+            {selectedFull && (
+              <ChatWindow
+                conversation={selectedFull}
+                currentProfileId={adminProfileId}
+                readOnly
+              />
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/components/chat/chat-window.tsx
+++ b/components/chat/chat-window.tsx
@@ -32,7 +32,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { chatService, type Message, type Conversation } from "@/lib/services/chat.service";
+import {
+  chatService,
+  getOtherPartyInfo,
+  type Message,
+  type Conversation,
+  type SenderRole,
+} from "@/lib/services/chat.service";
+import { ConversationRoleBadge, type ConversationRole } from "@/components/chat/conversation-role-badge";
 import { getInitials } from "@/lib/design-system/utils";
 import { cleanAttachmentName, truncateMiddle } from "@/lib/utils/clean-filename";
 import { formatDistanceToNow } from "date-fns";
@@ -92,11 +99,18 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const isOwner = currentProfileId === conversation.owner_profile_id;
-  const otherName = isOwner ? conversation.tenant_name : conversation.owner_name;
-  const otherAvatar = isOwner ? conversation.tenant_avatar : conversation.owner_avatar;
-  const otherPrenom = isOwner ? conversation.tenant_prenom : conversation.owner_prenom;
-  const otherNom = isOwner ? conversation.tenant_nom : conversation.owner_nom;
+  const otherParty = getOtherPartyInfo(conversation, currentProfileId);
+  const otherRole = otherParty.role as ConversationRole | null;
+  const otherName = otherParty.name;
+  const otherAvatar = otherParty.avatar;
+  const otherPrenom = otherParty.prenom;
+  const otherNom = otherParty.nom;
+  const viewerRole: SenderRole =
+    currentProfileId === conversation.owner_profile_id
+      ? "owner"
+      : currentProfileId === conversation.tenant_profile_id
+      ? "tenant"
+      : "provider";
 
   // Charger les messages
   useEffect(() => {
@@ -169,7 +183,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
       id: `temp-${Date.now()}`,
       conversation_id: conversation.id,
       sender_profile_id: currentProfileId,
-      sender_role: isOwner ? "owner" : "tenant",
+      sender_role: viewerRole,
       content: messageContent,
       content_type: "text",
       created_at: new Date().toISOString(),
@@ -399,9 +413,7 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
               {conversation.property_address}
             </p>
           </div>
-          <Badge variant="outline" className="text-xs">
-            {isOwner ? "Locataire" : "Propriétaire"}
-          </Badge>
+          {otherRole && <ConversationRoleBadge role={otherRole} size="sm" />}
           {conversation.ticket_id && (
             <Badge variant="secondary" className="text-xs">
               Ticket lié

--- a/components/chat/chat-window.tsx
+++ b/components/chat/chat-window.tsx
@@ -83,9 +83,20 @@ interface ChatWindowProps {
   currentProfileId: string;
   onBack?: () => void;
   onConversationStatusChange?: (conversationId: string, status: "archived" | "closed") => void;
+  /**
+   * Sprint 5 — vue admin read-only. Masque l'input, l'upload, les actions
+   * de statut et le bouton de signalement. Les messages restent lisibles.
+   */
+  readOnly?: boolean;
 }
 
-export function ChatWindow({ conversation, currentProfileId, onBack, onConversationStatusChange }: ChatWindowProps) {
+export function ChatWindow({
+  conversation,
+  currentProfileId,
+  onBack,
+  onConversationStatusChange,
+  readOnly = false,
+}: ChatWindowProps) {
   const { toast } = useToast();
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
@@ -451,22 +462,24 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
               Ticket lié
             </Badge>
           )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
-                <MoreVertical className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleClose}>
-                Clôturer (résolu)
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleArchive} className="text-muted-foreground">
-                Archiver
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {!readOnly && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreVertical className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={handleClose}>
+                  Clôturer (résolu)
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleArchive} className="text-muted-foreground">
+                  Archiver
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </CardHeader>
 
@@ -665,8 +678,8 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
                             )}
                           </div>
 
-                          {/* Report button for received messages */}
-                          {!isMe && !message.id.startsWith("temp-") && (
+                          {/* Report button for received messages — masqué en read-only */}
+                          {!isMe && !readOnly && !message.id.startsWith("temp-") && (
                             <Button
                               variant="ghost"
                               size="icon"
@@ -688,57 +701,63 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
         )}
       </div>
 
-      {/* Input */}
-      <div className="p-4 border-t flex-shrink-0">
-        <form onSubmit={handleSend} className="flex items-center gap-2">
-          <input
-            ref={fileInputRef}
-            type="file"
-            className="hidden"
-            accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt,.zip"
-            onChange={handleFileSelect}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-10 w-10 text-muted-foreground hover:text-foreground"
-            disabled={sending || uploading}
-            onClick={() => fileInputRef.current?.click()}
-            aria-label="Ajouter une pièce jointe"
-          >
-            {uploading ? (
-              <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
-            ) : (
-              <Paperclip className="h-5 w-5" aria-hidden="true" />
-            )}
-          </Button>
+      {/* Input — masqué en mode read-only (vue admin) */}
+      {readOnly ? (
+        <div className="p-3 border-t flex-shrink-0 bg-muted/30 text-center text-xs text-muted-foreground">
+          Vue lecture seule — réservée à l'administration.
+        </div>
+      ) : (
+        <div className="p-4 border-t flex-shrink-0">
+          <form onSubmit={handleSend} className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt,.zip"
+              onChange={handleFileSelect}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 text-muted-foreground hover:text-foreground"
+              disabled={sending || uploading}
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Ajouter une pièce jointe"
+            >
+              {uploading ? (
+                <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+              ) : (
+                <Paperclip className="h-5 w-5" aria-hidden="true" />
+              )}
+            </Button>
 
-          <Input
-            ref={inputRef}
-            value={newMessage}
-            onChange={(e) => setNewMessage(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Écrivez votre message..."
-            className="flex-1"
-            disabled={sending}
-          />
+            <Input
+              ref={inputRef}
+              value={newMessage}
+              onChange={(e) => setNewMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Écrivez votre message..."
+              className="flex-1"
+              disabled={sending}
+            />
 
-          <Button
-            type="submit"
-            size="icon"
-            className="h-10 w-10"
-            disabled={!newMessage.trim() || sending}
-            aria-label={sending ? "Envoi en cours..." : "Envoyer le message"}
-          >
-            {sending ? (
-              <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
-            ) : (
-              <Send className="h-5 w-5" aria-hidden="true" />
-            )}
-          </Button>
-        </form>
-      </div>
+            <Button
+              type="submit"
+              size="icon"
+              className="h-10 w-10"
+              disabled={!newMessage.trim() || sending}
+              aria-label={sending ? "Envoi en cours..." : "Envoyer le message"}
+            >
+              {sending ? (
+                <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+              ) : (
+                <Send className="h-5 w-5" aria-hidden="true" />
+              )}
+            </Button>
+          </form>
+        </div>
+      )}
 
       {/* Report dialog */}
       {reportingMessage && (

--- a/components/chat/chat-window.tsx
+++ b/components/chat/chat-window.tsx
@@ -22,7 +22,8 @@ import {
   Pencil,
   Trash2,
   Flag,
-  X
+  X,
+  Wrench
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import {
@@ -111,6 +112,28 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
       : currentProfileId === conversation.tenant_profile_id
       ? "tenant"
       : "provider";
+
+  // Sprint 4 — métadata ticket affichée dans le header quand la conv y est liée
+  const [ticketMeta, setTicketMeta] = useState<{
+    id: string;
+    titre: string;
+    statut: string;
+    priorite: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!conversation.ticket_id) {
+      setTicketMeta(null);
+      return;
+    }
+    let cancelled = false;
+    chatService.getTicketMetadata(conversation.ticket_id).then((data) => {
+      if (!cancelled) setTicketMeta(data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [conversation.ticket_id]);
 
   // Charger les messages
   useEffect(() => {
@@ -412,9 +435,18 @@ export function ChatWindow({ conversation, currentProfileId, onBack, onConversat
             <p className="text-xs text-muted-foreground truncate">
               {conversation.property_address}
             </p>
+            {ticketMeta && (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                <Wrench className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                <span className="truncate">Ticket · {ticketMeta.titre}</span>
+                <Badge variant="outline" className="text-[10px] capitalize px-1.5 py-0 h-4">
+                  {ticketMeta.statut.replace("_", " ")}
+                </Badge>
+              </div>
+            )}
           </div>
           {otherRole && <ConversationRoleBadge role={otherRole} size="sm" />}
-          {conversation.ticket_id && (
+          {conversation.ticket_id && !ticketMeta && (
             <Badge variant="secondary" className="text-xs">
               Ticket lié
             </Badge>

--- a/components/chat/conversation-role-badge.tsx
+++ b/components/chat/conversation-role-badge.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+// =====================================================
+// Badge rôle dans une conversation Messages
+// 4 rôles : owner | tenant | provider | admin
+// Pattern aligné sur components/provider/provider-badges.tsx
+// (classes Tailwind directes, wrap Badge variant="outline")
+// =====================================================
+
+import { Home, User, Wrench, Shield } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export type ConversationRole = "owner" | "tenant" | "provider" | "admin";
+
+interface RoleConfig {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+}
+
+const ROLE_CONFIGS: Record<ConversationRole, RoleConfig> = {
+  owner: {
+    icon: Home,
+    label: "Propriétaire",
+    color: "text-blue-700",
+    bgColor: "bg-blue-50",
+    borderColor: "border-blue-200",
+  },
+  tenant: {
+    icon: User,
+    label: "Locataire",
+    color: "text-cyan-700",
+    bgColor: "bg-cyan-50",
+    borderColor: "border-cyan-200",
+  },
+  provider: {
+    icon: Wrench,
+    label: "Prestataire",
+    color: "text-orange-700",
+    bgColor: "bg-orange-50",
+    borderColor: "border-orange-200",
+  },
+  admin: {
+    icon: Shield,
+    label: "Support Talok",
+    color: "text-green-700",
+    bgColor: "bg-green-50",
+    borderColor: "border-green-200",
+  },
+};
+
+const sizeClasses = {
+  sm: "text-[10px] px-1.5 py-0 h-5",
+  md: "text-xs px-2 py-0.5",
+  lg: "text-sm px-2.5 py-1",
+};
+
+const iconSizes = {
+  sm: "h-3 w-3",
+  md: "h-3.5 w-3.5",
+  lg: "h-4 w-4",
+};
+
+interface ConversationRoleBadgeProps {
+  role: ConversationRole;
+  showIcon?: boolean;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+export function ConversationRoleBadge({
+  role,
+  showIcon = true,
+  size = "md",
+  className = "",
+}: ConversationRoleBadgeProps) {
+  const config = ROLE_CONFIGS[role];
+  const Icon = config.icon;
+
+  return (
+    <Badge
+      variant="outline"
+      className={`${config.bgColor} ${config.color} ${config.borderColor} ${sizeClasses[size]} gap-1 font-medium ${className}`}
+    >
+      {showIcon && <Icon className={iconSizes[size]} />}
+      {config.label}
+    </Badge>
+  );
+}

--- a/components/chat/conversations-list.tsx
+++ b/components/chat/conversations-list.tsx
@@ -14,7 +14,8 @@ import {
   MessageSquare,
   Home,
   RefreshCw,
-  Ticket
+  Ticket,
+  Loader2
 } from "lucide-react";
 import {
   chatService,
@@ -43,29 +44,44 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
   const [conversations, setConversations] = useState<ConversationEnriched[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [searching, setSearching] = useState(false);
   const [usePolling, setUsePolling] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  const loadConversations = useCallback(async () => {
+  const loadConversations = useCallback(async (searchTerm?: string) => {
     try {
       setLoadError(null);
-      const result = await chatService.getConversationsEnriched();
+      const result = await chatService.getConversationsEnriched({
+        search: searchTerm || undefined,
+      });
       setConversations(result.data);
     } catch (error) {
       console.error("Erreur chargement conversations:", error);
       setLoadError("Impossible de charger les conversations");
     } finally {
       setLoading(false);
+      setSearching(false);
     }
   }, []);
 
+  // Debounce search term — 300ms après la dernière frappe
   useEffect(() => {
-    loadConversations();
+    const handle = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(handle);
+  }, [search]);
 
+  // Refetch serveur à chaque changement de debouncedSearch (inclus au mount via "")
+  useEffect(() => {
+    if (debouncedSearch !== "") setSearching(true);
+    loadConversations(debouncedSearch);
+  }, [debouncedSearch, loadConversations]);
+
+  // Realtime + polling fallback (le load initial est fait par le useEffect debounce ci-dessus).
+  useEffect(() => {
     let unsubscribe: (() => void) | undefined;
     let pollInterval: NodeJS.Timeout | undefined;
 
-    // Tenter la souscription Realtime
     try {
       unsubscribe = chatService.subscribeToConversations((updated) => {
         setConversations((prev) =>
@@ -77,7 +93,6 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
         );
       });
 
-      // Vérifier si Realtime fonctionne
       if (!chatService.isRealtimeEnabled()) {
         setUsePolling(true);
       }
@@ -86,10 +101,10 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
       setUsePolling(true);
     }
 
-    // Fallback: polling toutes les 15 secondes si WebSocket échoue
+    // Fallback polling : refetch avec le dernier searchTerm debounce
     if (usePolling) {
       pollInterval = setInterval(() => {
-        loadConversations();
+        loadConversations(debouncedSearch);
       }, 15000);
     }
 
@@ -97,17 +112,12 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
       unsubscribe?.();
       if (pollInterval) clearInterval(pollInterval);
     };
-  }, [loadConversations, usePolling]);
+  }, [loadConversations, usePolling, debouncedSearch]);
 
 
-  const filteredConversations = conversations.filter((conv) => {
-    if (!search) return true;
-    const searchLower = search.toLowerCase();
-    return (
-      conv.other_party_name?.toLowerCase().includes(searchLower) ||
-      conv.other_party_subtitle?.toLowerCase().includes(searchLower)
-    );
-  });
+  // Sprint 9 — le filtre est désormais server-side via p_search.
+  // Le state `conversations` contient déjà la liste filtrée.
+  const filteredConversations = conversations;
 
   const getUnreadCount = (conv: ConversationEnriched) => {
     if (currentProfileId === conv.owner_profile_id) return conv.owner_unread_count;
@@ -167,8 +177,11 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
             placeholder="Rechercher..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-9"
+            className="pl-9 pr-9"
           />
+          {searching && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground animate-spin" />
+          )}
         </div>
       </CardHeader>
 
@@ -177,7 +190,7 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
           {loadError && (
             <div className="p-3 mb-2 text-sm text-destructive bg-destructive/10 rounded-lg">
               {loadError}
-              <button onClick={loadConversations} className="underline ml-1 font-medium">
+              <button onClick={() => loadConversations(debouncedSearch)} className="underline ml-1 font-medium">
                 Réessayer
               </button>
             </div>

--- a/components/chat/conversations-list.tsx
+++ b/components/chat/conversations-list.tsx
@@ -16,20 +16,31 @@ import {
   RefreshCw,
   Ticket
 } from "lucide-react";
-import { chatService, type Conversation } from "@/lib/services/chat.service";
-import { getInitials } from "@/lib/design-system/utils";
+import {
+  chatService,
+  type ConversationEnriched,
+} from "@/lib/services/chat.service";
+import { ConversationRoleBadge, type ConversationRole } from "@/components/chat/conversation-role-badge";
 import { formatDistanceToNow } from "date-fns";
 import { fr } from "date-fns/locale";
 
 interface ConversationsListProps {
   currentProfileId: string;
-  currentRole?: "owner" | "tenant";
+  currentRole?: "owner" | "tenant" | "provider" | "admin";
   selectedId?: string;
-  onSelect: (conversation: Conversation) => void;
+  onSelect: (conversation: ConversationEnriched) => void;
+}
+
+function initialsFromFullName(name: string | null | undefined): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return (parts[0][0] ?? "?").toUpperCase();
+  return ((parts[0][0] ?? "") + (parts[parts.length - 1][0] ?? "")).toUpperCase();
 }
 
 export function ConversationsList({ currentProfileId, currentRole, selectedId, onSelect }: ConversationsListProps) {
-  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [conversations, setConversations] = useState<ConversationEnriched[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [usePolling, setUsePolling] = useState(false);
@@ -38,8 +49,8 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
   const loadConversations = useCallback(async () => {
     try {
       setLoadError(null);
-      const data = await chatService.getConversations();
-      setConversations(data);
+      const result = await chatService.getConversationsEnriched();
+      setConversations(result.data);
     } catch (error) {
       console.error("Erreur chargement conversations:", error);
       setLoadError("Impossible de charger les conversations");
@@ -58,7 +69,11 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
     try {
       unsubscribe = chatService.subscribeToConversations((updated) => {
         setConversations((prev) =>
-          prev.map((c) => (c.id === updated.id ? { ...c, ...updated } : c))
+          prev.map((c) =>
+            c.id === updated.id
+              ? ({ ...c, ...updated } as ConversationEnriched)
+              : c
+          )
         );
       });
 
@@ -88,35 +103,17 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
   const filteredConversations = conversations.filter((conv) => {
     if (!search) return true;
     const searchLower = search.toLowerCase();
-    const isOwner = currentProfileId === conv.owner_profile_id;
-    const otherName = isOwner ? conv.tenant_name : conv.owner_name;
     return (
-      otherName?.toLowerCase().includes(searchLower) ||
-      conv.property_address?.toLowerCase().includes(searchLower) ||
-      conv.subject?.toLowerCase().includes(searchLower)
+      conv.other_party_name?.toLowerCase().includes(searchLower) ||
+      conv.other_party_subtitle?.toLowerCase().includes(searchLower)
     );
   });
 
-  const getUnreadCount = (conv: Conversation) => {
-    const isOwner = currentProfileId === conv.owner_profile_id;
-    return isOwner ? conv.owner_unread_count : conv.tenant_unread_count;
-  };
-
-  const getOtherName = (conv: Conversation) => {
-    const isOwner = currentProfileId === conv.owner_profile_id;
-    return isOwner ? conv.tenant_name : conv.owner_name;
-  };
-
-  const getOtherAvatar = (conv: Conversation) => {
-    const isOwner = currentProfileId === conv.owner_profile_id;
-    return isOwner ? conv.tenant_avatar : conv.owner_avatar;
-  };
-
-  const getOtherInitials = (conv: Conversation) => {
-    const isOwner = currentProfileId === conv.owner_profile_id;
-    const prenom = isOwner ? conv.tenant_prenom : conv.owner_prenom;
-    const nom = isOwner ? conv.tenant_nom : conv.owner_nom;
-    return getInitials(prenom, nom);
+  const getUnreadCount = (conv: ConversationEnriched) => {
+    if (currentProfileId === conv.owner_profile_id) return conv.owner_unread_count;
+    if (currentProfileId === conv.tenant_profile_id) return conv.tenant_unread_count;
+    if (currentProfileId === conv.provider_profile_id) return conv.provider_unread_count;
+    return 0;
   };
 
   const formatLastMessage = (dateString?: string | null) => {
@@ -223,11 +220,14 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
                   >
                     <div className="flex items-start gap-3">
                       <Avatar className="h-12 w-12 flex-shrink-0">
-                        {getOtherAvatar(conversation) && (
-                          <AvatarImage src={getOtherAvatar(conversation)!} alt={getOtherName(conversation) || "Interlocuteur"} />
+                        {conversation.other_party_avatar_url && (
+                          <AvatarImage
+                            src={conversation.other_party_avatar_url}
+                            alt={conversation.other_party_name || "Interlocuteur"}
+                          />
                         )}
                         <AvatarFallback className="bg-gradient-to-br from-primary/20 to-primary/10">
-                          {getOtherInitials(conversation)}
+                          {initialsFromFullName(conversation.other_party_name)}
                         </AvatarFallback>
                       </Avatar>
 
@@ -235,8 +235,15 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
                         <div className="flex items-center justify-between gap-2">
                           <div className="flex items-center gap-2 min-w-0">
                             <p className={`font-medium truncate ${unreadCount > 0 ? "font-semibold" : ""}`}>
-                              {getOtherName(conversation) || "Utilisateur"}
+                              {conversation.other_party_name || "Utilisateur"}
                             </p>
+                            {conversation.other_party_role && (
+                              <ConversationRoleBadge
+                                role={conversation.other_party_role as ConversationRole}
+                                size="sm"
+                                showIcon={false}
+                              />
+                            )}
                             {conversation.ticket_id && (
                               <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-5 flex-shrink-0">
                                 <Ticket className="h-3 w-3 mr-0.5" />
@@ -251,16 +258,12 @@ export function ConversationsList({ currentProfileId, currentRole, selectedId, o
                           )}
                         </div>
 
-                        {conversation.subject && (
-                          <p className="text-xs font-medium text-foreground/70 truncate mt-0.5">
-                            {conversation.subject}
+                        {conversation.other_party_subtitle && (
+                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+                            <Home className="h-3 w-3 flex-shrink-0" />
+                            <span className="truncate">{conversation.other_party_subtitle}</span>
                           </p>
                         )}
-
-                        <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
-                          <Home className="h-3 w-3" />
-                          <span className="truncate">{conversation.property_address}</span>
-                        </p>
 
                         {conversation.last_message_preview && (
                           <p className={`text-sm mt-1 truncate ${

--- a/components/messages/MessagesPageContent.tsx
+++ b/components/messages/MessagesPageContent.tsx
@@ -43,7 +43,11 @@ interface MessagesPageContentProps {
 
 export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPageContentProps) {
   const pathname = usePathname();
-  const currentRole: "owner" | "tenant" = pathname?.startsWith("/owner") ? "owner" : "tenant";
+  const currentRole: "owner" | "tenant" | "provider" = pathname?.startsWith("/owner")
+    ? "owner"
+    : pathname?.startsWith("/provider")
+    ? "provider"
+    : "tenant";
   const [loading, setLoading] = useState(true);
   const [currentProfileId, setCurrentProfileId] = useState<string>("");
   const [selectedConversation, setSelectedConversation] = useState<Conversation | null>(null);

--- a/components/messages/MessagesPageContent.tsx
+++ b/components/messages/MessagesPageContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { motion } from "framer-motion";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -43,6 +43,8 @@ interface MessagesPageContentProps {
 
 export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPageContentProps) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const conversationIdFromUrl = searchParams?.get("conversation") ?? null;
   const currentRole: "owner" | "tenant" | "provider" = pathname?.startsWith("/owner")
     ? "owner"
     : pathname?.startsWith("/provider")
@@ -89,71 +91,75 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
         if (profile) {
           setCurrentProfileId(profile.id);
 
-          // Charger le contexte pour le bouton "Nouvelle conversation"
-          try {
-            // 1) Côté locataire : chercher via lease_signers
-            const { data: signerData } = await supabase
-              .from("lease_signers")
-              .select("lease_id")
-              .eq("profile_id", profile.id)
-              .order("created_at", { ascending: false })
-              .limit(1)
-              .single();
-
-            if (signerData?.lease_id) {
-              const { data: leaseData } = await supabase
-                .from("leases")
-                .select("id, property_id, properties(owner_id)")
-                .eq("id", signerData.lease_id)
+          // Sprint 5 — providers ne créent pas de conversation depuis ici
+          // (ils répondent uniquement). Skip les fetches lease/owner inutiles.
+          if (currentRole !== "provider") {
+            // Charger le contexte pour le bouton "Nouvelle conversation"
+            try {
+              // 1) Côté locataire : chercher via lease_signers
+              const { data: signerData } = await supabase
+                .from("lease_signers")
+                .select("lease_id")
+                .eq("profile_id", profile.id)
+                .order("created_at", { ascending: false })
+                .limit(1)
                 .single();
 
-              if (leaseData?.property_id && (leaseData as any).properties?.owner_id) {
-                setLeaseContext({
-                  propertyId: leaseData.property_id,
-                  ownerId: (leaseData as any).properties.owner_id,
-                  leaseId: leaseData.id,
-                });
-              }
-            }
-          } catch {
-            // Pas de bail signé — vérifier côté propriétaire
-          }
+              if (signerData?.lease_id) {
+                const { data: leaseData } = await supabase
+                  .from("leases")
+                  .select("id, property_id, properties(owner_id)")
+                  .eq("id", signerData.lease_id)
+                  .single();
 
-          // 2) Côté propriétaire : chercher les baux actifs avec locataires
-          try {
-            const { data: ownerLeases } = await supabase
-              .from("leases")
-              .select(`
-                id,
-                property_id,
-                properties(owner_id, adresse_complete, ville),
-                lease_signers(profile_id, profiles(prenom, nom))
-              `)
-              .eq("properties.owner_id", profile.id)
-              .in("statut", ["active", "signed"]);
-
-            if (ownerLeases && ownerLeases.length > 0) {
-              const tenants: TenantOption[] = [];
-              for (const lease of ownerLeases) {
-                const prop = (lease as any).properties;
-                const signers = (lease as any).lease_signers;
-                if (!prop || !signers || !lease.property_id) continue;
-                for (const signer of signers) {
-                  if (signer.profile_id === profile.id) continue; // skip self
-                  const p = signer.profiles;
-                  tenants.push({
-                    tenantProfileId: signer.profile_id,
-                    tenantName: p ? `${p.prenom || ""} ${p.nom || ""}`.trim() : "Locataire",
-                    propertyId: lease.property_id,
-                    propertyAddress: prop.adresse_complete || "",
-                    leaseId: lease.id,
+                if (leaseData?.property_id && (leaseData as any).properties?.owner_id) {
+                  setLeaseContext({
+                    propertyId: leaseData.property_id,
+                    ownerId: (leaseData as any).properties.owner_id,
+                    leaseId: leaseData.id,
                   });
                 }
               }
-              setOwnerTenants(tenants);
+            } catch {
+              // Pas de bail signé — vérifier côté propriétaire
             }
-          } catch {
-            // Silently ignore — owner tenants not available
+
+            // 2) Côté propriétaire : chercher les baux actifs avec locataires
+            try {
+              const { data: ownerLeases } = await supabase
+                .from("leases")
+                .select(`
+                  id,
+                  property_id,
+                  properties(owner_id, adresse_complete, ville),
+                  lease_signers(profile_id, profiles(prenom, nom))
+                `)
+                .eq("properties.owner_id", profile.id)
+                .in("statut", ["active", "signed"]);
+
+              if (ownerLeases && ownerLeases.length > 0) {
+                const tenants: TenantOption[] = [];
+                for (const lease of ownerLeases) {
+                  const prop = (lease as any).properties;
+                  const signers = (lease as any).lease_signers;
+                  if (!prop || !signers || !lease.property_id) continue;
+                  for (const signer of signers) {
+                    if (signer.profile_id === profile.id) continue; // skip self
+                    const p = signer.profiles;
+                    tenants.push({
+                      tenantProfileId: signer.profile_id,
+                      tenantName: p ? `${p.prenom || ""} ${p.nom || ""}`.trim() : "Locataire",
+                      propertyId: lease.property_id,
+                      propertyAddress: prop.adresse_complete || "",
+                      leaseId: lease.id,
+                    });
+                  }
+                }
+                setOwnerTenants(tenants);
+              }
+            } catch {
+              // Silently ignore — owner tenants not available
+            }
           }
         }
       } catch (error) {
@@ -164,7 +170,27 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
     }
 
     init();
-  }, [onNotAuthenticated]);
+  }, [onNotAuthenticated, currentRole]);
+
+  // Sprint 5 QW1 — ouvrir directement la conv si ?conversation=<id> dans l'URL
+  // (utilisé par ContactProviderButton après création/récupération d'une conv).
+  useEffect(() => {
+    if (!conversationIdFromUrl || !currentProfileId) return;
+    let cancelled = false;
+    chatService
+      .getConversation(conversationIdFromUrl)
+      .then((full) => {
+        if (!cancelled && full) {
+          setSelectedConversation(full);
+        }
+      })
+      .catch((error) => {
+        console.error("Erreur ouverture conversation depuis URL:", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationIdFromUrl, currentProfileId]);
 
   const handleSelectConversation = async (enriched: ConversationEnriched) => {
     // La liste renvoie un ConversationEnriched (sous-titres pré-calculés).

--- a/components/messages/MessagesPageContent.tsx
+++ b/components/messages/MessagesPageContent.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { MessageSquare, ArrowRight, Plus, Loader2 } from "lucide-react";
 import { PageTransition } from "@/components/ui/page-transition";
 import { chatService } from "@/lib/services/chat.service";
-import type { Conversation } from "@/lib/services/chat.service";
+import type { Conversation, ConversationEnriched } from "@/lib/services/chat.service";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -162,8 +162,18 @@ export function MessagesPageContent({ subtitle, onNotAuthenticated }: MessagesPa
     init();
   }, [onNotAuthenticated]);
 
-  const handleSelectConversation = (conversation: Conversation) => {
-    setSelectedConversation(conversation);
+  const handleSelectConversation = async (enriched: ConversationEnriched) => {
+    // La liste renvoie un ConversationEnriched (sous-titres pré-calculés).
+    // ChatWindow attend un Conversation complet (avec profils joints pour
+    // l'avatar + le nom). On re-fetch la forme canonique au clic.
+    try {
+      const full = await chatService.getConversation(enriched.id);
+      if (full) {
+        setSelectedConversation(full);
+      }
+    } catch (error) {
+      console.error("Erreur ouverture conversation:", error);
+    }
   };
 
   const handleBack = () => {

--- a/components/tickets/contact-provider-button.tsx
+++ b/components/tickets/contact-provider-button.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { MessageSquare, Loader2 } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+import { createClient } from "@/lib/supabase/client";
+import { chatService } from "@/lib/services/chat.service";
+
+interface ContactProviderButtonProps {
+  ticketId: string;
+  propertyId: string;
+  providerProfileId: string;
+  providerName: string;
+  viewerRole: "owner" | "tenant";
+}
+
+/**
+ * Bouton "Contacter <prestataire>" affiché sur la fiche ticket.
+ * Sprint 4 — initiation provider via ticket. Idempotent : si la conversation
+ * existe déjà (UNIQUE partiel Sprint 1), on récupère et on redirige.
+ *
+ * Le profil courant est résolu côté composant pour ne pas faire fuiter
+ * l'identité du caller dans les props (et garder TicketDetailView agnostique
+ * du module messages).
+ */
+export function ContactProviderButton({
+  ticketId,
+  propertyId,
+  providerProfileId,
+  providerName,
+  viewerRole,
+}: ContactProviderButtonProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    setLoading(true);
+    try {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Non authentifié");
+
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("id")
+        .eq("user_id", user.id)
+        .single();
+      if (profileError || !profile) throw new Error("Profil introuvable");
+
+      const conversation =
+        viewerRole === "owner"
+          ? await chatService.getOrCreateOwnerProviderConversation({
+              ticket_id: ticketId,
+              property_id: propertyId,
+              owner_profile_id: profile.id,
+              provider_profile_id: providerProfileId,
+            })
+          : await chatService.getOrCreateTenantProviderConversation({
+              ticket_id: ticketId,
+              property_id: propertyId,
+              tenant_profile_id: profile.id,
+              provider_profile_id: providerProfileId,
+            });
+
+      const route = viewerRole === "owner" ? "/owner/messages" : "/tenant/messages";
+      router.push(`${route}?conversation=${conversation.id}`);
+    } catch (err) {
+      console.error("[ContactProviderButton]", err);
+      toast({
+        title: "Impossible de démarrer la conversation",
+        description: err instanceof Error ? err.message : "Erreur inconnue",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      disabled={loading}
+      className="w-full gap-2"
+    >
+      {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <MessageSquare className="h-4 w-4" />}
+      {loading ? "Création…" : `Contacter ${providerName}`}
+    </Button>
+  );
+}

--- a/features/tickets/components/ticket-detail.tsx
+++ b/features/tickets/components/ticket-detail.tsx
@@ -28,6 +28,7 @@ import { TicketComments } from "./ticket-comments";
 import { AssignProviderModal } from "./assign-provider-modal";
 import { CreateWorkOrderButton } from "./create-work-order-button";
 import { SatisfactionRating } from "./satisfaction-rating";
+import { ContactProviderButton } from "@/components/tickets/contact-provider-button";
 
 const CATEGORY_LABELS: Record<string, string> = {
   plomberie: "Plomberie",
@@ -329,6 +330,19 @@ export function TicketDetailView({ ticketId, userRole, backHref }: TicketDetailV
                   </span>
                 )}
               </div>
+
+              {/* Sprint 4 — Contacter le prestataire (owner ou tenant uniquement) */}
+              {(userRole === "owner" || userRole === "tenant") &&
+                activeWorkOrder.provider?.id &&
+                ticket.property_id && (
+                  <ContactProviderButton
+                    ticketId={ticketId}
+                    propertyId={ticket.property_id}
+                    providerProfileId={activeWorkOrder.provider.id}
+                    providerName={activeWorkOrder.provider.prenom || "le prestataire"}
+                    viewerRole={userRole}
+                  />
+                )}
             </GlassCard>
           )}
 

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -419,6 +419,30 @@ class ChatService {
   }
 
   /**
+   * Récupérer les métadonnées d'un ticket pour enrichir le header de la
+   * conversation associée (Sprint 4). Retourne null si le ticket est
+   * introuvable ou bloqué par RLS.
+   */
+  async getTicketMetadata(ticketId: string): Promise<{
+    id: string;
+    titre: string;
+    statut: string;
+    priorite: string;
+  } | null> {
+    const { data, error } = await this.supabase
+      .from("tickets")
+      .select("id, titre, statut, priorite")
+      .eq("id", ticketId)
+      .maybeSingle();
+
+    if (error) {
+      console.warn("[chatService.getTicketMetadata]", error);
+      return null;
+    }
+    return (data as { id: string; titre: string; statut: string; priorite: string } | null) ?? null;
+  }
+
+  /**
    * Récupérer une conversation par ID
    */
   async getConversation(conversationId: string): Promise<Conversation | null> {

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -122,6 +122,128 @@ export interface GetConversationsFilter {
   type?: ConversationType;
 }
 
+/**
+ * Row returned by the `get_conversations_enriched` RPC (Sprint 3).
+ * Includes raw conversation columns + pre-computed subtitles and
+ * other-party info so the UI list can render in one round-trip.
+ */
+export interface ConversationEnriched {
+  id: string;
+  conversation_type: ConversationType;
+  property_id: string | null;
+  lease_id: string | null;
+  ticket_id: string | null;
+  owner_profile_id: string | null;
+  tenant_profile_id: string | null;
+  provider_profile_id: string | null;
+  status: "active" | "archived" | "closed";
+  last_message_at: string | null;
+  last_message_preview: string | null;
+  owner_unread_count: number;
+  tenant_unread_count: number;
+  provider_unread_count: number;
+  created_at: string;
+  updated_at: string;
+  other_party_subtitle: string | null;
+  other_party_name: string | null;
+  other_party_avatar_url: string | null;
+  other_party_role: SenderRole | null;
+}
+
+export interface GetConversationsEnrichedParams {
+  limit?: number;
+  offset?: number;
+  type?: ConversationType;
+}
+
+export interface GetConversationsEnrichedResult {
+  data: ConversationEnriched[];
+  count: number;
+  hasMore: boolean;
+}
+
+export interface OtherPartyInfo {
+  role: SenderRole | null;
+  name?: string;
+  avatar?: string | null;
+  prenom?: string | null;
+  nom?: string | null;
+}
+
+/**
+ * Derive "the other participant" info from a Conversation + the current user.
+ * Works for all 3 conversation_types (owner_tenant, owner_provider, tenant_provider).
+ * Returns role=null when the viewer is not a participant (should not happen if
+ * RLS is correctly enforced, but the UI tolerates it).
+ */
+export function getOtherPartyInfo(
+  conversation: Conversation,
+  currentProfileId: string
+): OtherPartyInfo {
+  const ct = conversation.conversation_type;
+
+  if (currentProfileId === conversation.owner_profile_id) {
+    if (ct === "owner_tenant") {
+      return {
+        role: "tenant",
+        name: conversation.tenant_name,
+        avatar: conversation.tenant_avatar,
+        prenom: conversation.tenant_prenom,
+        nom: conversation.tenant_nom,
+      };
+    }
+    if (ct === "owner_provider") {
+      return {
+        role: "provider",
+        name: conversation.provider_name,
+        avatar: conversation.provider_avatar,
+        prenom: conversation.provider_prenom,
+        nom: conversation.provider_nom,
+      };
+    }
+  } else if (currentProfileId === conversation.tenant_profile_id) {
+    if (ct === "owner_tenant") {
+      return {
+        role: "owner",
+        name: conversation.owner_name,
+        avatar: conversation.owner_avatar,
+        prenom: conversation.owner_prenom,
+        nom: conversation.owner_nom,
+      };
+    }
+    if (ct === "tenant_provider") {
+      return {
+        role: "provider",
+        name: conversation.provider_name,
+        avatar: conversation.provider_avatar,
+        prenom: conversation.provider_prenom,
+        nom: conversation.provider_nom,
+      };
+    }
+  } else if (currentProfileId === conversation.provider_profile_id) {
+    if (ct === "owner_provider") {
+      return {
+        role: "owner",
+        name: conversation.owner_name,
+        avatar: conversation.owner_avatar,
+        prenom: conversation.owner_prenom,
+        nom: conversation.owner_nom,
+      };
+    }
+    if (ct === "tenant_provider") {
+      return {
+        role: "tenant",
+        name: conversation.tenant_name,
+        avatar: conversation.tenant_avatar,
+        prenom: conversation.tenant_prenom,
+        nom: conversation.tenant_nom,
+      };
+    }
+  }
+
+  return { role: null };
+}
+
 class ChatService {
   private supabase = createClient();
   private channels: Map<string, RealtimeChannel> = new Map();
@@ -257,6 +379,43 @@ class ChatService {
         property_address: conv.property?.adresse_complete || "",
       };
     });
+  }
+
+  /**
+   * Récupérer les conversations enrichies via le RPC
+   * `get_conversations_enriched` (sous-titres + other_party pré-calculés,
+   * pagination via offset/limit). Sprint 3.
+   *
+   * Sert `MessagesPageContent`. L'ancien `getConversations` reste en place
+   * pour les callers legacy ; Sprint 4 décidera de sa suppression.
+   */
+  async getConversationsEnriched(
+    params: GetConversationsEnrichedParams = {}
+  ): Promise<GetConversationsEnrichedResult> {
+    const limit = params.limit ?? 25;
+    const offset = params.offset ?? 0;
+
+    const { data, error } = await (this.supabase.rpc as any)("get_conversations_enriched", {
+      p_limit: limit,
+      p_offset: offset,
+      p_type: params.type ?? null,
+    });
+
+    if (error) throw error;
+
+    const rows = (data ?? []) as (ConversationEnriched & { total_count: number | string })[];
+    const count = rows.length > 0 ? Number(rows[0].total_count ?? 0) : 0;
+
+    const cleaned: ConversationEnriched[] = rows.map((row) => {
+      const { total_count: _ignored, ...rest } = row;
+      return rest as ConversationEnriched;
+    });
+
+    return {
+      data: cleaned,
+      count,
+      hasMore: offset + cleaned.length < count,
+    };
   }
 
   /**

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -118,10 +118,6 @@ export interface CreateTenantProviderConversationData {
   initial_message?: string;
 }
 
-export interface GetConversationsFilter {
-  type?: ConversationType;
-}
-
 /**
  * Row returned by the `get_conversations_enriched` RPC (Sprint 3).
  * Includes raw conversation columns + pre-computed subtitles and
@@ -264,130 +260,16 @@ class ChatService {
   }
 
   /**
-   * Récupérer toutes les conversations de l'utilisateur.
-   * Filtre optionnel par conversation_type pour segmenter par feature UI
-   * (ex: liste locataire vs liste tickets/prestataires).
-   */
-  async getConversations(filter: GetConversationsFilter = {}): Promise<Conversation[]> {
-    const { data: { user } } = await this.supabase.auth.getUser();
-    if (!user) throw new Error("Non authentifié");
-
-    const { data: profile, error: profileError } = await this.supabase
-      .from("profiles")
-      .select("id")
-      .eq("user_id", user.id)
-      .single();
-
-    if (profileError || !profile) throw new Error("Profil non trouvé");
-
-    let query = this.supabase
-      .from("conversations")
-      .select(`
-        *,
-        owner:profiles!conversations_owner_profile_id_fkey (
-          id,
-          prenom,
-          nom,
-          avatar_url
-        ),
-        tenant:profiles!conversations_tenant_profile_id_fkey (
-          id,
-          prenom,
-          nom,
-          avatar_url
-        ),
-        provider:profiles!conversations_provider_profile_id_fkey (
-          id,
-          prenom,
-          nom,
-          avatar_url
-        ),
-        property:properties (
-          adresse_complete,
-          ville
-        )
-      `)
-      .or(`owner_profile_id.eq.${profile.id},tenant_profile_id.eq.${profile.id},provider_profile_id.eq.${profile.id}`)
-      .eq("status", "active")
-      .order("last_message_at", { ascending: false, nullsFirst: false });
-
-    if (filter.type) {
-      query = query.eq("conversation_type", filter.type);
-    }
-
-    const { data, error } = await query;
-
-    if (error) throw error;
-
-    // Fallback : si l'embed FK ne renvoie pas le profil (cas RLS/visibilité
-    // où PostgREST embedde `null`), on résout les profils manquants via une
-    // seconde requête ciblée.
-    //
-    // Browser client (user-scoped) volontaire : getServiceClient() est interdit
-    // côté client (leak service role). Cette requête reste soumise aux RLS v2
-    // de `profiles` (policy `profiles_owner_read_tenants` via lease_signers,
-    // helpers SECURITY DEFINER anti-recursion 42P17). Si la RLS refuse, on
-    // retombe proprement sur `"Utilisateur"` côté UI — c'est le comportement
-    // voulu (pas de bypass silencieux).
-    const missingProfileIds = new Set<string>();
-    for (const conv of (data || []) as any[]) {
-      if (conv.owner_profile_id && !conv.owner?.prenom && !conv.owner?.nom) {
-        missingProfileIds.add(conv.owner_profile_id);
-      }
-      if (conv.tenant_profile_id && !conv.tenant?.prenom && !conv.tenant?.nom) {
-        missingProfileIds.add(conv.tenant_profile_id);
-      }
-      if (conv.provider_profile_id && !conv.provider?.prenom && !conv.provider?.nom) {
-        missingProfileIds.add(conv.provider_profile_id);
-      }
-    }
-    const profileMap = new Map<string, { prenom?: string; nom?: string; avatar_url?: string | null }>();
-    if (missingProfileIds.size > 0) {
-      const { data: profs } = await this.supabase
-        .from("profiles")
-        .select("id, prenom, nom, avatar_url")
-        .in("id", Array.from(missingProfileIds));
-      for (const p of (profs || []) as any[]) {
-        profileMap.set(p.id, { prenom: p.prenom, nom: p.nom, avatar_url: p.avatar_url });
-      }
-    }
-
-    return (data || []).map((conv: any) => {
-      const owner = conv.owner?.prenom || conv.owner?.nom
-        ? conv.owner
-        : profileMap.get(conv.owner_profile_id);
-      const tenant = conv.tenant?.prenom || conv.tenant?.nom
-        ? conv.tenant
-        : profileMap.get(conv.tenant_profile_id);
-      const provider = conv.provider?.prenom || conv.provider?.nom
-        ? conv.provider
-        : profileMap.get(conv.provider_profile_id);
-      return {
-        ...conv,
-        owner_prenom: owner?.prenom || null,
-        owner_nom: owner?.nom || null,
-        tenant_prenom: tenant?.prenom || null,
-        tenant_nom: tenant?.nom || null,
-        provider_prenom: provider?.prenom || null,
-        provider_nom: provider?.nom || null,
-        owner_name: `${owner?.prenom || ""} ${owner?.nom || ""}`.trim(),
-        tenant_name: `${tenant?.prenom || ""} ${tenant?.nom || ""}`.trim(),
-        provider_name: `${provider?.prenom || ""} ${provider?.nom || ""}`.trim(),
-        owner_avatar: owner?.avatar_url || null,
-        tenant_avatar: tenant?.avatar_url || null,
-        provider_avatar: provider?.avatar_url || null,
-        property_address: conv.property?.adresse_complete || "",
-      };
-    });
-  }
-
-  /**
-   * Récupérer les conversations enrichies via le RPC
-   * `get_conversations_enriched` (sous-titres + other_party pré-calculés,
-   * pagination via offset/limit). Sprint 3.
+   * Récupérer les conversations de l'utilisateur via le RPC
+   * `get_conversations_enriched` (Sprint 3).
    *
-   * Sert `MessagesPageContent`. L'ancien `getConversations` reste en place
-   * pour les callers legacy ; Sprint 4 décidera de sa suppression.
+   * Retourne les lignes brutes + sous-titres pré-calculés + other_party_*
+   * en un seul round-trip. Filtre optionnel par `conversation_type`,
+   * pagination via `offset`/`limit` (défaut 25/0).
+   *
+   * Seul point d'entrée pour lister les conversations côté service
+   * (l'ancien `getConversations` client-side a été supprimé dans
+   * le sprint cleanup).
    */
   async getConversationsEnriched(
     params: GetConversationsEnrichedParams = {}

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -150,6 +150,8 @@ export interface GetConversationsEnrichedParams {
   limit?: number;
   offset?: number;
   type?: ConversationType;
+  /** Full-text search (ILIKE) on participant names, ticket title, and last message preview. */
+  search?: string;
 }
 
 export interface GetConversationsEnrichedResult {
@@ -277,10 +279,12 @@ class ChatService {
     const limit = params.limit ?? 25;
     const offset = params.offset ?? 0;
 
+    const trimmedSearch = params.search?.trim();
     const { data, error } = await (this.supabase.rpc as any)("get_conversations_enriched", {
       p_limit: limit,
       p_offset: offset,
       p_type: params.type ?? null,
+      p_search: trimmedSearch && trimmedSearch.length > 0 ? trimmedSearch : null,
     });
 
     if (error) throw error;

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -23,30 +23,40 @@
 import { createClient } from "@/lib/supabase/client";
 import type { RealtimeChannel } from "@supabase/supabase-js";
 
+export type ConversationType = "owner_tenant" | "owner_provider" | "tenant_provider";
+export type SenderRole = "owner" | "tenant" | "provider";
+
 export interface Conversation {
   id: string;
+  conversation_type: ConversationType;
   property_id: string;
   lease_id?: string | null;
   ticket_id?: string | null;
-  owner_profile_id: string;
-  tenant_profile_id: string;
+  owner_profile_id: string | null;
+  tenant_profile_id: string | null;
+  provider_profile_id: string | null;
   subject?: string | null;
   last_message_at?: string | null;
   last_message_preview?: string | null;
   status: "active" | "archived" | "closed";
   owner_unread_count: number;
   tenant_unread_count: number;
+  provider_unread_count: number;
   created_at: string;
   updated_at: string;
   // Joined data
   owner_name?: string;
   tenant_name?: string;
+  provider_name?: string;
   owner_prenom?: string | null;
   owner_nom?: string | null;
   tenant_prenom?: string | null;
   tenant_nom?: string | null;
+  provider_prenom?: string | null;
+  provider_nom?: string | null;
   owner_avatar?: string | null;
   tenant_avatar?: string | null;
+  provider_avatar?: string | null;
   property_address?: string;
 }
 
@@ -54,7 +64,7 @@ export interface Message {
   id: string;
   conversation_id: string;
   sender_profile_id: string;
-  sender_role: "owner" | "tenant";
+  sender_role: SenderRole;
   content: string;
   content_type: "text" | "image" | "file" | "system";
   attachment_url?: string | null;
@@ -90,6 +100,28 @@ export interface CreateConversationData {
   initial_message?: string;
 }
 
+export interface CreateOwnerProviderConversationData {
+  ticket_id: string;
+  property_id: string;
+  owner_profile_id: string;
+  provider_profile_id: string;
+  subject?: string;
+  initial_message?: string;
+}
+
+export interface CreateTenantProviderConversationData {
+  ticket_id: string;
+  property_id: string;
+  tenant_profile_id: string;
+  provider_profile_id: string;
+  subject?: string;
+  initial_message?: string;
+}
+
+export interface GetConversationsFilter {
+  type?: ConversationType;
+}
+
 class ChatService {
   private supabase = createClient();
   private channels: Map<string, RealtimeChannel> = new Map();
@@ -110,9 +142,11 @@ class ChatService {
   }
 
   /**
-   * Récupérer toutes les conversations de l'utilisateur
+   * Récupérer toutes les conversations de l'utilisateur.
+   * Filtre optionnel par conversation_type pour segmenter par feature UI
+   * (ex: liste locataire vs liste tickets/prestataires).
    */
-  async getConversations(): Promise<Conversation[]> {
+  async getConversations(filter: GetConversationsFilter = {}): Promise<Conversation[]> {
     const { data: { user } } = await this.supabase.auth.getUser();
     if (!user) throw new Error("Non authentifié");
 
@@ -124,7 +158,7 @@ class ChatService {
 
     if (profileError || !profile) throw new Error("Profil non trouvé");
 
-    const { data, error } = await this.supabase
+    let query = this.supabase
       .from("conversations")
       .select(`
         *,
@@ -140,14 +174,26 @@ class ChatService {
           nom,
           avatar_url
         ),
+        provider:profiles!conversations_provider_profile_id_fkey (
+          id,
+          prenom,
+          nom,
+          avatar_url
+        ),
         property:properties (
           adresse_complete,
           ville
         )
       `)
-      .or(`owner_profile_id.eq.${profile.id},tenant_profile_id.eq.${profile.id}`)
+      .or(`owner_profile_id.eq.${profile.id},tenant_profile_id.eq.${profile.id},provider_profile_id.eq.${profile.id}`)
       .eq("status", "active")
       .order("last_message_at", { ascending: false, nullsFirst: false });
+
+    if (filter.type) {
+      query = query.eq("conversation_type", filter.type);
+    }
+
+    const { data, error } = await query;
 
     if (error) throw error;
 
@@ -163,8 +209,15 @@ class ChatService {
     // voulu (pas de bypass silencieux).
     const missingProfileIds = new Set<string>();
     for (const conv of (data || []) as any[]) {
-      if (!conv.owner?.prenom && !conv.owner?.nom) missingProfileIds.add(conv.owner_profile_id);
-      if (!conv.tenant?.prenom && !conv.tenant?.nom) missingProfileIds.add(conv.tenant_profile_id);
+      if (conv.owner_profile_id && !conv.owner?.prenom && !conv.owner?.nom) {
+        missingProfileIds.add(conv.owner_profile_id);
+      }
+      if (conv.tenant_profile_id && !conv.tenant?.prenom && !conv.tenant?.nom) {
+        missingProfileIds.add(conv.tenant_profile_id);
+      }
+      if (conv.provider_profile_id && !conv.provider?.prenom && !conv.provider?.nom) {
+        missingProfileIds.add(conv.provider_profile_id);
+      }
     }
     const profileMap = new Map<string, { prenom?: string; nom?: string; avatar_url?: string | null }>();
     if (missingProfileIds.size > 0) {
@@ -184,16 +237,23 @@ class ChatService {
       const tenant = conv.tenant?.prenom || conv.tenant?.nom
         ? conv.tenant
         : profileMap.get(conv.tenant_profile_id);
+      const provider = conv.provider?.prenom || conv.provider?.nom
+        ? conv.provider
+        : profileMap.get(conv.provider_profile_id);
       return {
         ...conv,
         owner_prenom: owner?.prenom || null,
         owner_nom: owner?.nom || null,
         tenant_prenom: tenant?.prenom || null,
         tenant_nom: tenant?.nom || null,
+        provider_prenom: provider?.prenom || null,
+        provider_nom: provider?.nom || null,
         owner_name: `${owner?.prenom || ""} ${owner?.nom || ""}`.trim(),
         tenant_name: `${tenant?.prenom || ""} ${tenant?.nom || ""}`.trim(),
+        provider_name: `${provider?.prenom || ""} ${provider?.nom || ""}`.trim(),
         owner_avatar: owner?.avatar_url || null,
         tenant_avatar: tenant?.avatar_url || null,
+        provider_avatar: provider?.avatar_url || null,
         property_address: conv.property?.adresse_complete || "",
       };
     });
@@ -217,6 +277,11 @@ class ChatService {
           nom,
           avatar_url
         ),
+        provider:profiles!conversations_provider_profile_id_fkey (
+          prenom,
+          nom,
+          avatar_url
+        ),
         property:properties (
           adresse_complete,
           ville
@@ -230,17 +295,22 @@ class ChatService {
       throw error;
     }
 
+    const d = data as any;
     return {
-      ...data,
-      owner_prenom: data.owner?.prenom || null,
-      owner_nom: data.owner?.nom || null,
-      tenant_prenom: data.tenant?.prenom || null,
-      tenant_nom: data.tenant?.nom || null,
-      owner_name: `${data.owner?.prenom || ""} ${data.owner?.nom || ""}`.trim(),
-      tenant_name: `${data.tenant?.prenom || ""} ${data.tenant?.nom || ""}`.trim(),
-      owner_avatar: data.owner?.avatar_url || null,
-      tenant_avatar: data.tenant?.avatar_url || null,
-      property_address: data.property?.adresse_complete || "",
+      ...d,
+      owner_prenom: d.owner?.prenom || null,
+      owner_nom: d.owner?.nom || null,
+      tenant_prenom: d.tenant?.prenom || null,
+      tenant_nom: d.tenant?.nom || null,
+      provider_prenom: d.provider?.prenom || null,
+      provider_nom: d.provider?.nom || null,
+      owner_name: `${d.owner?.prenom || ""} ${d.owner?.nom || ""}`.trim(),
+      tenant_name: `${d.tenant?.prenom || ""} ${d.tenant?.nom || ""}`.trim(),
+      provider_name: `${d.provider?.prenom || ""} ${d.provider?.nom || ""}`.trim(),
+      owner_avatar: d.owner?.avatar_url || null,
+      tenant_avatar: d.tenant?.avatar_url || null,
+      provider_avatar: d.provider?.avatar_url || null,
+      property_address: d.property?.adresse_complete || "",
     } as Conversation;
   }
 
@@ -261,7 +331,7 @@ class ChatService {
       // Re-fetch avec les données jointes (profiles, property)
       const full = await this.getConversation(existing.id);
       if (full) return full;
-      return existing as Conversation;
+      return existing as unknown as Conversation;
     }
 
     // Créer une nouvelle conversation
@@ -290,7 +360,107 @@ class ChatService {
     // Re-fetch avec les données jointes
     const fullNew = await this.getConversation(newConv.id);
     if (fullNew) return fullNew;
-    return newConv as Conversation;
+    return newConv as unknown as Conversation;
+  }
+
+  /**
+   * Créer ou récupérer une conversation owner↔provider (liée à un ticket).
+   * UNIQUE partiel sur (ticket_id, owner_profile_id, provider_profile_id)
+   * WHERE status='active' AND conversation_type='owner_provider' (migration Sprint 1).
+   */
+  async getOrCreateOwnerProviderConversation(
+    data: CreateOwnerProviderConversationData
+  ): Promise<Conversation> {
+    const { data: existing } = await this.supabase
+      .from("conversations")
+      .select("id")
+      .eq("conversation_type", "owner_provider")
+      .eq("ticket_id", data.ticket_id)
+      .eq("owner_profile_id", data.owner_profile_id)
+      .eq("provider_profile_id", data.provider_profile_id)
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (existing) {
+      const full = await this.getConversation(existing.id);
+      if (full) return full;
+    }
+
+    const { data: newConv, error } = await this.supabase
+      .from("conversations")
+      .insert({
+        conversation_type: "owner_provider",
+        ticket_id: data.ticket_id,
+        property_id: data.property_id,
+        owner_profile_id: data.owner_profile_id,
+        provider_profile_id: data.provider_profile_id,
+        subject: data.subject || "Conversation prestataire",
+      } as any)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    if (data.initial_message && newConv) {
+      await this.sendMessage({
+        conversation_id: newConv.id,
+        content: data.initial_message,
+      });
+    }
+
+    const full = await this.getConversation(newConv.id);
+    if (full) return full;
+    return newConv as unknown as Conversation;
+  }
+
+  /**
+   * Créer ou récupérer une conversation tenant↔provider (liée à un ticket).
+   * UNIQUE partiel sur (ticket_id, tenant_profile_id, provider_profile_id)
+   * WHERE status='active' AND conversation_type='tenant_provider' (migration Sprint 1).
+   */
+  async getOrCreateTenantProviderConversation(
+    data: CreateTenantProviderConversationData
+  ): Promise<Conversation> {
+    const { data: existing } = await this.supabase
+      .from("conversations")
+      .select("id")
+      .eq("conversation_type", "tenant_provider")
+      .eq("ticket_id", data.ticket_id)
+      .eq("tenant_profile_id", data.tenant_profile_id)
+      .eq("provider_profile_id", data.provider_profile_id)
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (existing) {
+      const full = await this.getConversation(existing.id);
+      if (full) return full;
+    }
+
+    const { data: newConv, error } = await this.supabase
+      .from("conversations")
+      .insert({
+        conversation_type: "tenant_provider",
+        ticket_id: data.ticket_id,
+        property_id: data.property_id,
+        tenant_profile_id: data.tenant_profile_id,
+        provider_profile_id: data.provider_profile_id,
+        subject: data.subject || "Conversation prestataire",
+      } as any)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    if (data.initial_message && newConv) {
+      await this.sendMessage({
+        conversation_id: newConv.id,
+        content: data.initial_message,
+      });
+    }
+
+    const full = await this.getConversation(newConv.id);
+    if (full) return full;
+    return newConv as unknown as Conversation;
   }
 
   /**
@@ -328,7 +498,7 @@ class ChatService {
       .single();
 
     if (error) throw error;
-    return newConv as Conversation;
+    return newConv as unknown as Conversation;
   }
 
   /**
@@ -380,16 +550,25 @@ class ChatService {
 
     if (profileError || !profile) throw new Error("Profil non trouvé");
 
-    // Déterminer le rôle de l'expéditeur
+    // Déterminer le rôle de l'expéditeur parmi 3 participants possibles
     const { data: conversation } = await this.supabase
       .from("conversations")
-      .select("owner_profile_id, tenant_profile_id")
+      .select("owner_profile_id, tenant_profile_id, provider_profile_id")
       .eq("id", data.conversation_id)
-      .single();
+      .single() as { data: { owner_profile_id: string | null; tenant_profile_id: string | null; provider_profile_id: string | null } | null };
 
     if (!conversation) throw new Error("Conversation non trouvée");
 
-    const senderRole = profile.id === conversation.owner_profile_id ? "owner" : "tenant";
+    let senderRole: SenderRole;
+    if (profile.id === conversation.owner_profile_id) {
+      senderRole = "owner";
+    } else if (profile.id === conversation.tenant_profile_id) {
+      senderRole = "tenant";
+    } else if (profile.id === conversation.provider_profile_id) {
+      senderRole = "provider";
+    } else {
+      throw new Error("Utilisateur non participant à cette conversation");
+    }
 
     const { data: message, error } = await this.supabase
       .from("messages")
@@ -753,14 +932,16 @@ class ChatService {
 
     const { data: conversations } = await this.supabase
       .from("conversations")
-      .select("owner_unread_count, tenant_unread_count, owner_profile_id")
-      .or(`owner_profile_id.eq.${profile.id},tenant_profile_id.eq.${profile.id}`);
+      .select("owner_unread_count, tenant_unread_count, provider_unread_count, owner_profile_id, tenant_profile_id, provider_profile_id")
+      .or(`owner_profile_id.eq.${profile.id},tenant_profile_id.eq.${profile.id},provider_profile_id.eq.${profile.id}`);
 
     if (!conversations) return 0;
 
-    return conversations.reduce((total, conv) => {
-      const isOwner = conv.owner_profile_id === profile.id;
-      return total + (isOwner ? (conv.owner_unread_count ?? 0) : (conv.tenant_unread_count ?? 0));
+    return (conversations as any[]).reduce((total, conv) => {
+      if (conv.owner_profile_id === profile.id) return total + (conv.owner_unread_count ?? 0);
+      if (conv.tenant_profile_id === profile.id) return total + (conv.tenant_unread_count ?? 0);
+      if (conv.provider_profile_id === profile.id) return total + (conv.provider_unread_count ?? 0);
+      return total;
     }, 0);
   }
 }

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -9,6 +9,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { createServiceRoleClient } from "@/lib/supabase/server";
+import { sendEmail } from "@/lib/emails/resend.service";
 
 // Types
 export type NotificationType = 
@@ -121,7 +122,7 @@ const notificationConfig: Record<NotificationType, {
   },
   message_received: {
     defaultPriority: "normal",
-    defaultChannels: ["in_app", "push"],
+    defaultChannels: ["in_app", "push", "email"],
     icon: "💬",
   },
   maintenance_scheduled: {
@@ -257,6 +258,126 @@ async function dispatchPush(
 }
 
 /**
+ * Envoie un email de notification via Resend. Best-effort, ne jette pas.
+ *
+ * Respecte :
+ *   - notification_preferences.email_enabled (défaut true si absent)
+ *   - notification_preferences.disabled_templates (skip si type dedans)
+ * Throttle : saute l'envoi si une notification du même type pour le même
+ * profil + même conversation a déjà reçu un email dans les 2 dernières
+ * minutes (évite le spam lors d'échanges rapides).
+ *
+ * Après envoi, met à jour notifications.channels_status.email_sent_at pour
+ * que les prochains appels voient l'émission récente via le throttle.
+ */
+async function dispatchEmail(
+  notificationId: string,
+  profileId: string,
+  title: string,
+  body: string,
+  actionUrl: string | undefined,
+  notificationType: NotificationType,
+  metadata?: Record<string, any>,
+): Promise<void> {
+  try {
+    const serviceClient = createServiceRoleClient();
+
+    // 1. Résoudre email + prénom depuis profiles → auth.users
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("user_id, prenom")
+      .eq("id", profileId)
+      .maybeSingle() as { data: { user_id: string | null; prenom: string | null } | null };
+    if (!profile?.user_id) return;
+
+    const { data: authUser } = await serviceClient.auth.admin.getUserById(profile.user_id);
+    const email = authUser?.user?.email;
+    if (!email) return;
+
+    // 2. Préférences utilisateur — table notification_preferences
+    const { data: prefs } = await serviceClient
+      .from("notification_preferences")
+      .select("email_enabled, disabled_templates")
+      .eq("profile_id", profileId)
+      .maybeSingle() as { data: { email_enabled: boolean | null; disabled_templates: string[] | null } | null };
+    if (prefs?.email_enabled === false) return;
+    if (prefs?.disabled_templates?.includes(notificationType)) return;
+
+    // 3. Throttle 2 minutes par (profile, type, conversation_id)
+    const conversationId = metadata?.conversationId ?? metadata?.conversation_id;
+    if (conversationId) {
+      const twoMinAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+      const { data: recent } = await serviceClient
+        .from("notifications")
+        .select("id, channels_status, metadata")
+        .eq("profile_id", profileId)
+        .eq("type", notificationType)
+        .gte("created_at", twoMinAgo)
+        .neq("id", notificationId)
+        .order("created_at", { ascending: false })
+        .limit(10);
+      const throttled = (recent ?? []).some((n: any) => {
+        const cid = n.metadata?.conversationId ?? n.metadata?.conversation_id;
+        return cid === conversationId && n.channels_status?.email_sent_at;
+      });
+      if (throttled) return;
+    }
+
+    // 4. Envoi via Resend — HTML minimal, pas de template dédié v1
+    const fullUrl = actionUrl
+      ? actionUrl.startsWith("http")
+        ? actionUrl
+        : `https://app.talok.fr${actionUrl}`
+      : undefined;
+    const salutation = profile.prenom ? `Bonjour ${profile.prenom},` : "Bonjour,";
+    const html = `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:560px;margin:0 auto;padding:24px;">
+        <p>${salutation}</p>
+        <p><strong>${escapeHtml(title)}</strong></p>
+        <p style="color:#374151;">${escapeHtml(body)}</p>
+        ${fullUrl ? `<p style="margin-top:24px;"><a href="${fullUrl}" style="display:inline-block;background:#2563EB;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">Ouvrir sur Talok</a></p>` : ""}
+        <hr style="margin:32px 0;border:0;border-top:1px solid #E5E7EB;">
+        <p style="color:#6B7280;font-size:12px;">Vous recevez cet email car vous avez une notification Talok. Gérez vos préférences depuis votre espace.</p>
+      </div>
+    `;
+
+    const result = await sendEmail({
+      to: email,
+      subject: title,
+      html,
+      tags: [
+        { name: "notification_type", value: notificationType },
+        { name: "talok_channel", value: "notification" },
+      ],
+    });
+
+    if (result.success) {
+      // 5. Marquer email_sent_at sur la notification pour le throttle futur
+      await serviceClient
+        .from("notifications")
+        .update({
+          channels_status: {
+            email_sent_at: new Date().toISOString(),
+            email_id: result.id ?? null,
+          },
+        } as any)
+        .eq("id", notificationId);
+    }
+  } catch (e) {
+    console.warn("[notification-service] Email dispatch failed:", e);
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
  * Crée une notification in-app et envoie un push réel si le canal push est activé.
  * recipientId est traité comme profile_id : on résout user_id pour la RLS.
  */
@@ -312,6 +433,19 @@ export async function createNotification(
   if (channels.includes("push")) {
     dispatchPush(input.recipientId, input.title, input.message, input.actionUrl)
       .catch((e) => console.warn("[notification-service] dispatchPush error:", e));
+  }
+
+  // Envoyer un email si le canal email est activé (best-effort, throttle 2min)
+  if (channels.includes("email") && data?.id) {
+    dispatchEmail(
+      data.id as string,
+      input.recipientId,
+      input.title,
+      input.message,
+      input.actionUrl,
+      input.type,
+      input.metadata,
+    ).catch((e) => console.warn("[notification-service] dispatchEmail error:", e));
   }
 
   // Convertir au format Notification
@@ -568,15 +702,20 @@ export async function notifyMessageReceived(
   senderName: string,
   messagePreview: string,
   conversationId: string,
-  recipientRole?: "owner" | "tenant"
+  recipientRole?: "owner" | "tenant" | "provider"
 ): Promise<Notification | null> {
-  const basePath = recipientRole === "owner" ? "/owner/messages" : "/tenant/messages";
+  const basePath =
+    recipientRole === "owner"
+      ? "/owner/messages"
+      : recipientRole === "provider"
+      ? "/provider/messages"
+      : "/tenant/messages";
   return createNotification({
     type: "message_received",
     title: `Message de ${senderName}`,
     message: messagePreview.slice(0, 100) + (messagePreview.length > 100 ? "..." : ""),
     recipientId,
-    actionUrl: basePath,
+    actionUrl: `${basePath}?conversation=${conversationId}`,
     actionLabel: "Répondre",
     metadata: { senderName, conversationId },
   });

--- a/supabase/migrations/20260419130000_extend_conversations_four_roles.sql
+++ b/supabase/migrations/20260419130000_extend_conversations_four_roles.sql
@@ -1,0 +1,356 @@
+-- ============================================================================
+-- Sprint 1 — Extension schéma Messages pour 4 rôles
+-- owner + tenant + provider + admin (admin via RLS only, pas participant)
+-- ============================================================================
+-- Décisions validées Thomas :
+--   - Scope v1 = owner + tenant + provider + admin
+--   - Admin = pure RLS read-only (pas de colonne admin_profile_id)
+--   - Option A : colonnes additionnelles (pas de junction conversation_participants)
+--   - 3 conversation_type : owner_tenant | owner_provider | tenant_provider
+--   - 1 user = 1 rôle (pas de multi-rôle en v1)
+--
+-- État prod confirmé 2026-04-19 :
+--   - conversations : 14 colonnes, aucune pré-existence Sprint 1
+--   - 9 indexes dont 2 UNIQUE partiels dupliqués à nettoyer
+--     (idx_conversations_unique_pair + idx_conversations_unique_active_pair)
+--
+-- Structure : 4 blocs BEGIN/COMMIT indépendants
+--   1. Schéma (colonnes, CHECK, UNIQUE, sender_role extension)
+--   2. Trigger unread étendu 6 branches
+--   3. RPC mark_messages_as_read étendue
+--   4. RLS policies étendues
+-- ============================================================================
+
+
+-- ============================================================================
+-- BLOC 1 — Schéma conversations + messages
+-- ============================================================================
+
+BEGIN;
+
+-- Étape 1 : conversation_type avec DEFAULT 'owner_tenant' pour backward compat
+-- Les services existants (chat.service.ts:269, :319) n'envoient pas ce champ
+-- → DEFAULT s'applique, les INSERT actuels continuent de marcher.
+ALTER TABLE public.conversations
+  ADD COLUMN conversation_type TEXT NOT NULL DEFAULT 'owner_tenant'
+    CHECK (conversation_type IN ('owner_tenant', 'owner_provider', 'tenant_provider'));
+
+COMMENT ON COLUMN public.conversations.conversation_type IS
+  'Discriminator 3 valeurs : owner_tenant | owner_provider | tenant_provider. DEFAULT owner_tenant pour backward compat.';
+
+-- Étape 2 : provider_profile_id + provider_unread_count
+ALTER TABLE public.conversations
+  ADD COLUMN provider_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+ALTER TABLE public.conversations
+  ADD COLUMN provider_unread_count INTEGER NOT NULL DEFAULT 0
+    CHECK (provider_unread_count >= 0);
+
+-- Étape 3 : relâcher NOT NULL sur owner/tenant pour accueillir les conversations
+-- owner_provider (pas de tenant) et tenant_provider (pas de owner).
+-- L'intégrité reste assurée par le CHECK de l'Étape 4.
+ALTER TABLE public.conversations
+  ALTER COLUMN owner_profile_id DROP NOT NULL;
+
+ALTER TABLE public.conversations
+  ALTER COLUMN tenant_profile_id DROP NOT NULL;
+
+-- Étape 4 : CHECK conversation_type <-> FKs cohérents
+-- Toutes les rows historiques ont conversation_type='owner_tenant' (DEFAULT Étape 1)
+-- avec owner+tenant NOT NULL et provider NULL → CHECK passe sur l'existant.
+ALTER TABLE public.conversations
+  ADD CONSTRAINT check_conversation_type_participants CHECK (
+    (conversation_type = 'owner_tenant'
+      AND owner_profile_id IS NOT NULL
+      AND tenant_profile_id IS NOT NULL
+      AND provider_profile_id IS NULL)
+    OR (conversation_type = 'owner_provider'
+      AND owner_profile_id IS NOT NULL
+      AND provider_profile_id IS NOT NULL
+      AND tenant_profile_id IS NULL)
+    OR (conversation_type = 'tenant_provider'
+      AND tenant_profile_id IS NOT NULL
+      AND provider_profile_id IS NOT NULL
+      AND owner_profile_id IS NULL)
+  );
+
+-- Étape 5 : cleanup UNIQUE partiels dupliqués (drift prod 2026-04-19)
+DROP INDEX IF EXISTS public.idx_conversations_unique_pair;
+DROP INDEX IF EXISTS public.idx_conversations_unique_active_pair;
+
+-- Étape 6 : 3 nouveaux UNIQUE partiels par type
+-- owner_tenant : une seule conv active par (property, owner, tenant)
+CREATE UNIQUE INDEX idx_conversations_unique_owner_tenant
+  ON public.conversations (property_id, owner_profile_id, tenant_profile_id)
+  WHERE status = 'active' AND conversation_type = 'owner_tenant';
+
+-- owner_provider : une conv active par (ticket, owner, provider).
+-- Scopé sur ticket_id car un ticket unique sur un bien entre mêmes parties.
+CREATE UNIQUE INDEX idx_conversations_unique_owner_provider
+  ON public.conversations (ticket_id, owner_profile_id, provider_profile_id)
+  WHERE status = 'active' AND conversation_type = 'owner_provider' AND ticket_id IS NOT NULL;
+
+-- tenant_provider : idem owner_provider
+CREATE UNIQUE INDEX idx_conversations_unique_tenant_provider
+  ON public.conversations (ticket_id, tenant_profile_id, provider_profile_id)
+  WHERE status = 'active' AND conversation_type = 'tenant_provider' AND ticket_id IS NOT NULL;
+
+-- Étape 7 : index provider_profile_id pour perf RLS (EXISTS sur messages)
+CREATE INDEX idx_conversations_provider_profile_id
+  ON public.conversations (provider_profile_id)
+  WHERE provider_profile_id IS NOT NULL;
+
+-- Étape 8 : étendre messages.sender_role pour accueillir 'provider'
+-- Nom exact de la contrainte confirmé par Phase 0 : pattern standard Postgres
+-- (table_column_check). Si absent en prod, le DROP no-op et l'ADD crée.
+ALTER TABLE public.messages
+  DROP CONSTRAINT IF EXISTS messages_sender_role_check;
+
+ALTER TABLE public.messages
+  ADD CONSTRAINT messages_sender_role_check
+    CHECK (sender_role IN ('owner', 'tenant', 'provider'));
+
+COMMIT;
+
+
+-- ============================================================================
+-- BLOC 2 — Trigger unread_count étendu (6 branches : 3 types × 2 directions)
+-- ============================================================================
+
+BEGIN;
+
+-- Remplace la fonction existante update_conversation_on_new_message()
+-- (20260416100000:10) en étendant la logique aux 3 conversation_type.
+-- Conserve LEFT(content, 100) comme dans l'original (pas 200).
+CREATE OR REPLACE FUNCTION public.update_conversation_on_new_message()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_type TEXT;
+BEGIN
+  SELECT conversation_type INTO v_type
+  FROM public.conversations
+  WHERE id = NEW.conversation_id;
+
+  IF v_type = 'owner_tenant' THEN
+    UPDATE public.conversations
+    SET
+      last_message_at = NEW.created_at,
+      last_message_preview = LEFT(NEW.content, 100),
+      updated_at = NOW(),
+      owner_unread_count = CASE
+        WHEN NEW.sender_role = 'tenant' THEN COALESCE(owner_unread_count, 0) + 1
+        ELSE owner_unread_count
+      END,
+      tenant_unread_count = CASE
+        WHEN NEW.sender_role = 'owner' THEN COALESCE(tenant_unread_count, 0) + 1
+        ELSE tenant_unread_count
+      END
+    WHERE id = NEW.conversation_id;
+
+  ELSIF v_type = 'owner_provider' THEN
+    UPDATE public.conversations
+    SET
+      last_message_at = NEW.created_at,
+      last_message_preview = LEFT(NEW.content, 100),
+      updated_at = NOW(),
+      owner_unread_count = CASE
+        WHEN NEW.sender_role = 'provider' THEN COALESCE(owner_unread_count, 0) + 1
+        ELSE owner_unread_count
+      END,
+      provider_unread_count = CASE
+        WHEN NEW.sender_role = 'owner' THEN COALESCE(provider_unread_count, 0) + 1
+        ELSE provider_unread_count
+      END
+    WHERE id = NEW.conversation_id;
+
+  ELSIF v_type = 'tenant_provider' THEN
+    UPDATE public.conversations
+    SET
+      last_message_at = NEW.created_at,
+      last_message_preview = LEFT(NEW.content, 100),
+      updated_at = NOW(),
+      tenant_unread_count = CASE
+        WHEN NEW.sender_role = 'provider' THEN COALESCE(tenant_unread_count, 0) + 1
+        ELSE tenant_unread_count
+      END,
+      provider_unread_count = CASE
+        WHEN NEW.sender_role = 'tenant' THEN COALESCE(provider_unread_count, 0) + 1
+        ELSE provider_unread_count
+      END
+    WHERE id = NEW.conversation_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger déjà attaché via 20260416100000:37, pas besoin de le recréer.
+
+COMMIT;
+
+
+-- ============================================================================
+-- BLOC 3 — RPC mark_messages_as_read étendue (3 rôles)
+-- ============================================================================
+
+BEGIN;
+
+-- Remplace la version de 20260223200000:161 en ajoutant la branche provider.
+-- Conserve la signature (p_conversation_id, p_reader_profile_id).
+CREATE OR REPLACE FUNCTION public.mark_messages_as_read(
+  p_conversation_id UUID,
+  p_reader_profile_id UUID
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_conv RECORD;
+BEGIN
+  SELECT owner_profile_id, tenant_profile_id, provider_profile_id
+  INTO v_conv
+  FROM public.conversations
+  WHERE id = p_conversation_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Marquer read_at sur les messages non lus reçus par le lecteur
+  UPDATE public.messages
+  SET read_at = COALESCE(read_at, NOW())
+  WHERE conversation_id = p_conversation_id
+    AND sender_profile_id != p_reader_profile_id
+    AND read_at IS NULL;
+
+  -- Remettre à zéro le compteur non lu du lecteur selon sa position
+  IF v_conv.owner_profile_id = p_reader_profile_id THEN
+    UPDATE public.conversations
+    SET owner_unread_count = 0, updated_at = NOW()
+    WHERE id = p_conversation_id;
+  ELSIF v_conv.tenant_profile_id = p_reader_profile_id THEN
+    UPDATE public.conversations
+    SET tenant_unread_count = 0, updated_at = NOW()
+    WHERE id = p_conversation_id;
+  ELSIF v_conv.provider_profile_id = p_reader_profile_id THEN
+    UPDATE public.conversations
+    SET provider_unread_count = 0, updated_at = NOW()
+    WHERE id = p_conversation_id;
+  END IF;
+END;
+$$;
+
+-- GRANT déjà posé par la migration d'origine, pas besoin de repasser.
+
+COMMIT;
+
+
+-- ============================================================================
+-- BLOC 4 — RLS policies étendues (conversations + messages)
+-- ============================================================================
+-- Noms des policies exacts de l'existant (Phase 0 Point 3). On DROP + CREATE
+-- sur ces noms pour éviter policies orphelines en prod.
+-- Helpers : public.user_profile_id() et public.user_role() (pas auth.uid()).
+-- ============================================================================
+
+BEGIN;
+
+-- --- conversations ---
+
+DROP POLICY IF EXISTS "Users can view own conversations" ON public.conversations;
+CREATE POLICY "Users can view own conversations"
+  ON public.conversations FOR SELECT
+  USING (
+    owner_profile_id = public.user_profile_id()
+    OR tenant_profile_id = public.user_profile_id()
+    OR provider_profile_id = public.user_profile_id()
+    OR public.user_role() = 'admin'
+  );
+
+DROP POLICY IF EXISTS "Users can insert conversations" ON public.conversations;
+CREATE POLICY "Users can insert conversations"
+  ON public.conversations FOR INSERT
+  WITH CHECK (
+    owner_profile_id = public.user_profile_id()
+    OR tenant_profile_id = public.user_profile_id()
+    OR provider_profile_id = public.user_profile_id()
+    OR public.user_role() = 'admin'
+  );
+
+DROP POLICY IF EXISTS "Users can update own conversations" ON public.conversations;
+CREATE POLICY "Users can update own conversations"
+  ON public.conversations FOR UPDATE
+  USING (
+    owner_profile_id = public.user_profile_id()
+    OR tenant_profile_id = public.user_profile_id()
+    OR provider_profile_id = public.user_profile_id()
+    OR public.user_role() = 'admin'
+  );
+
+-- --- messages ---
+
+DROP POLICY IF EXISTS "Users can view messages of own conversations" ON public.messages;
+CREATE POLICY "Users can view messages of own conversations"
+  ON public.messages FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.conversations c
+      WHERE c.id = messages.conversation_id
+        AND (
+          c.owner_profile_id = public.user_profile_id()
+          OR c.tenant_profile_id = public.user_profile_id()
+          OR c.provider_profile_id = public.user_profile_id()
+        )
+    )
+    OR public.user_role() = 'admin'
+  );
+
+DROP POLICY IF EXISTS "Users can insert messages in own conversations" ON public.messages;
+CREATE POLICY "Users can insert messages in own conversations"
+  ON public.messages FOR INSERT
+  WITH CHECK (
+    sender_profile_id = public.user_profile_id()
+    AND EXISTS (
+      SELECT 1 FROM public.conversations c
+      WHERE c.id = messages.conversation_id
+        AND (
+          c.owner_profile_id = public.user_profile_id()
+          OR c.tenant_profile_id = public.user_profile_id()
+          OR c.provider_profile_id = public.user_profile_id()
+        )
+    )
+  );
+
+-- La policy UPDATE "Users can update own messages" (20260309000001) reste
+-- inchangée : elle ne filtre que sur sender_profile_id = user_profile_id(),
+-- donc elle fonctionne déjà pour un provider qui édite ses propres messages.
+-- On la reposte quand même pour étendre le EXISTS aux 3 rôles (cohérence
+-- avec les autres policies, même si la clause AND EXISTS n'est pas nécessaire
+-- côté sécurité vu que sender_profile_id suffit).
+
+DROP POLICY IF EXISTS "Users can update own messages" ON public.messages;
+CREATE POLICY "Users can update own messages"
+  ON public.messages FOR UPDATE
+  USING (
+    sender_profile_id = public.user_profile_id()
+    AND EXISTS (
+      SELECT 1 FROM public.conversations c
+      WHERE c.id = messages.conversation_id
+        AND (
+          c.owner_profile_id = public.user_profile_id()
+          OR c.tenant_profile_id = public.user_profile_id()
+          OR c.provider_profile_id = public.user_profile_id()
+        )
+    )
+  )
+  WITH CHECK (
+    sender_profile_id = public.user_profile_id()
+  );
+
+COMMIT;

--- a/supabase/migrations/20260419140000_rpc_get_conversations_enriched.sql
+++ b/supabase/migrations/20260419140000_rpc_get_conversations_enriched.sql
@@ -1,0 +1,260 @@
+-- ============================================================================
+-- Sprint 3 — RPC get_conversations_enriched
+-- Retourne conversations paginées + sous-titres pré-calculés + other_party_*
+-- en un seul round-trip (vs N+1 query côté service).
+-- ============================================================================
+-- Adaptations vs brief initial (Phase 0 surprises) :
+--   - legal_entities.nom (pas `denomination`) — Phase 0 confirmé
+--   - tickets : pas de colonne `numero`. Sous-titre = 'Ticket · ' || LEFT(titre, 40)
+--   - legal_entities.entity_type (pas `forme_juridique`)
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_conversations_enriched(
+  p_limit INT DEFAULT 25,
+  p_offset INT DEFAULT 0,
+  p_type TEXT DEFAULT NULL
+) RETURNS TABLE (
+  id UUID,
+  conversation_type TEXT,
+  property_id UUID,
+  lease_id UUID,
+  ticket_id UUID,
+  owner_profile_id UUID,
+  tenant_profile_id UUID,
+  provider_profile_id UUID,
+  status TEXT,
+  last_message_at TIMESTAMPTZ,
+  last_message_preview TEXT,
+  owner_unread_count INT,
+  tenant_unread_count INT,
+  provider_unread_count INT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  other_party_subtitle TEXT,
+  other_party_name TEXT,
+  other_party_avatar_url TEXT,
+  other_party_role TEXT,
+  total_count BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_user_role TEXT;
+BEGIN
+  v_user_id := public.user_profile_id();
+  v_user_role := public.user_role();
+
+  RETURN QUERY
+  WITH accessible AS (
+    SELECT c.*
+    FROM public.conversations c
+    WHERE (
+      c.owner_profile_id = v_user_id
+      OR c.tenant_profile_id = v_user_id
+      OR c.provider_profile_id = v_user_id
+      OR v_user_role = 'admin'
+    )
+    AND (p_type IS NULL OR c.conversation_type = p_type)
+    AND c.status = 'active'
+    ORDER BY c.last_message_at DESC NULLS LAST
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*)::BIGINT AS cnt
+    FROM public.conversations c
+    WHERE (
+      c.owner_profile_id = v_user_id
+      OR c.tenant_profile_id = v_user_id
+      OR c.provider_profile_id = v_user_id
+      OR v_user_role = 'admin'
+    )
+    AND (p_type IS NULL OR c.conversation_type = p_type)
+    AND c.status = 'active'
+  )
+  SELECT
+    ac.id,
+    ac.conversation_type,
+    ac.property_id,
+    ac.lease_id,
+    ac.ticket_id,
+    ac.owner_profile_id,
+    ac.tenant_profile_id,
+    ac.provider_profile_id,
+    ac.status,
+    ac.last_message_at,
+    ac.last_message_preview,
+    ac.owner_unread_count,
+    ac.tenant_unread_count,
+    ac.provider_unread_count,
+    ac.created_at,
+    ac.updated_at,
+
+    -- Sous-titre métier selon position du viewer
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            COALESCE(
+              (SELECT
+                 'Bail ' ||
+                 CASE l.statut
+                   WHEN 'actif' THEN 'actif'
+                   WHEN 'signed' THEN 'signé'
+                   ELSE l.statut
+                 END ||
+                 ' · ' || COALESCE(p.adresse_complete, 'adresse inconnue')
+               FROM public.leases l
+               LEFT JOIN public.properties p ON p.id = l.property_id
+               WHERE l.id = ac.lease_id
+               LIMIT 1),
+              'Locataire'
+            )
+          WHEN 'owner_provider' THEN
+            COALESCE(
+              (SELECT 'Ticket · ' || LEFT(t.titre, 40)
+               FROM public.tickets t
+               WHERE t.id = ac.ticket_id
+               LIMIT 1),
+              'Prestataire'
+            )
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            COALESCE(
+              (SELECT le.nom || ' · ' || COALESCE(p.adresse_complete, 'adresse inconnue')
+               FROM public.legal_entities le
+               JOIN public.properties p ON p.id = ac.property_id
+               WHERE le.owner_profile_id = ac.owner_profile_id
+               LIMIT 1),
+              (SELECT 'Propriétaire · ' || COALESCE(p.adresse_complete, 'adresse inconnue')
+               FROM public.properties p WHERE p.id = ac.property_id),
+              'Propriétaire'
+            )
+          WHEN 'tenant_provider' THEN
+            COALESCE(
+              (SELECT 'Ticket · ' || LEFT(t.titre, 40)
+               FROM public.tickets t
+               WHERE t.id = ac.ticket_id
+               LIMIT 1),
+              'Prestataire'
+            )
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        COALESCE(
+          (SELECT 'Ticket · ' || LEFT(t.titre, 40)
+           FROM public.tickets t
+           WHERE t.id = ac.ticket_id
+           LIMIT 1),
+          'Client'
+        )
+      WHEN v_user_role = 'admin' THEN
+        'Conversation ' || ac.conversation_type
+      ELSE NULL
+    END AS other_party_subtitle,
+
+    -- Nom de l'autre participant (prenom + nom trimmé)
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          WHEN 'owner_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          ELSE NULL
+        END
+      ELSE 'Utilisateur'
+    END AS other_party_name,
+
+    -- Avatar de l'autre participant (pour fallback initiales si NULL)
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          WHEN 'owner_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          ELSE NULL
+        END
+      ELSE NULL
+    END AS other_party_avatar_url,
+
+    -- Rôle de l'autre participant (pour le badge)
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN 'tenant'
+          WHEN 'owner_provider' THEN 'provider'
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN 'owner'
+          WHEN 'tenant_provider' THEN 'provider'
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_provider' THEN 'owner'
+          WHEN 'tenant_provider' THEN 'tenant'
+          ELSE NULL
+        END
+      ELSE NULL
+    END AS other_party_role,
+
+    (SELECT cnt FROM total) AS total_count
+  FROM accessible ac;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_conversations_enriched IS
+  'Returns paginated conversations with pre-computed subtitles and other-party info for the calling user. Sprint 3 — Messages 4 roles.';
+
+GRANT EXECUTE ON FUNCTION public.get_conversations_enriched(INT, INT, TEXT) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260419150000_get_conversations_enriched_add_search.sql
+++ b/supabase/migrations/20260419150000_get_conversations_enriched_add_search.sql
@@ -1,0 +1,288 @@
+-- ============================================================================
+-- Sprint 9 — Recherche serveur dans get_conversations_enriched
+-- ============================================================================
+-- Ajoute un paramètre optionnel `p_search TEXT` qui filtre les conversations
+-- accessibles sur : prénom/nom des participants, titre du ticket lié, et
+-- last_message_preview. Remplace le filtre client-side lossy de
+-- components/chat/conversations-list.tsx.
+--
+-- NOTE : Postgres n'autorise pas CREATE OR REPLACE FUNCTION à changer
+-- l'arité — on DROP+CREATE dans une transaction. Les callers passant 3
+-- positional args continueront de marcher (p_search DEFAULT NULL).
+-- ============================================================================
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.get_conversations_enriched(int, int, text);
+
+CREATE OR REPLACE FUNCTION public.get_conversations_enriched(
+  p_limit INT DEFAULT 25,
+  p_offset INT DEFAULT 0,
+  p_type TEXT DEFAULT NULL,
+  p_search TEXT DEFAULT NULL
+) RETURNS TABLE (
+  id UUID,
+  conversation_type TEXT,
+  property_id UUID,
+  lease_id UUID,
+  ticket_id UUID,
+  owner_profile_id UUID,
+  tenant_profile_id UUID,
+  provider_profile_id UUID,
+  status TEXT,
+  last_message_at TIMESTAMPTZ,
+  last_message_preview TEXT,
+  owner_unread_count INT,
+  tenant_unread_count INT,
+  provider_unread_count INT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  other_party_subtitle TEXT,
+  other_party_name TEXT,
+  other_party_avatar_url TEXT,
+  other_party_role TEXT,
+  total_count BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_user_role TEXT;
+  v_search_like TEXT;
+BEGIN
+  v_user_id := public.user_profile_id();
+  v_user_role := public.user_role();
+  v_search_like := CASE WHEN p_search IS NULL OR btrim(p_search) = '' THEN NULL
+                        ELSE '%' || p_search || '%' END;
+
+  RETURN QUERY
+  WITH accessible AS (
+    SELECT c.*
+    FROM public.conversations c
+    LEFT JOIN public.profiles po ON po.id = c.owner_profile_id
+    LEFT JOIN public.profiles pt ON pt.id = c.tenant_profile_id
+    LEFT JOIN public.profiles pp ON pp.id = c.provider_profile_id
+    LEFT JOIN public.tickets   t  ON t.id  = c.ticket_id
+    WHERE (
+      c.owner_profile_id = v_user_id
+      OR c.tenant_profile_id = v_user_id
+      OR c.provider_profile_id = v_user_id
+      OR v_user_role = 'admin'
+    )
+    AND (p_type IS NULL OR c.conversation_type = p_type)
+    AND c.status = 'active'
+    AND (
+      v_search_like IS NULL
+      OR c.last_message_preview ILIKE v_search_like
+      OR po.prenom ILIKE v_search_like OR po.nom ILIKE v_search_like
+      OR pt.prenom ILIKE v_search_like OR pt.nom ILIKE v_search_like
+      OR pp.prenom ILIKE v_search_like OR pp.nom ILIKE v_search_like
+      OR t.titre ILIKE v_search_like
+    )
+    ORDER BY c.last_message_at DESC NULLS LAST
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*)::BIGINT AS cnt
+    FROM public.conversations c
+    LEFT JOIN public.profiles po ON po.id = c.owner_profile_id
+    LEFT JOIN public.profiles pt ON pt.id = c.tenant_profile_id
+    LEFT JOIN public.profiles pp ON pp.id = c.provider_profile_id
+    LEFT JOIN public.tickets   t  ON t.id  = c.ticket_id
+    WHERE (
+      c.owner_profile_id = v_user_id
+      OR c.tenant_profile_id = v_user_id
+      OR c.provider_profile_id = v_user_id
+      OR v_user_role = 'admin'
+    )
+    AND (p_type IS NULL OR c.conversation_type = p_type)
+    AND c.status = 'active'
+    AND (
+      v_search_like IS NULL
+      OR c.last_message_preview ILIKE v_search_like
+      OR po.prenom ILIKE v_search_like OR po.nom ILIKE v_search_like
+      OR pt.prenom ILIKE v_search_like OR pt.nom ILIKE v_search_like
+      OR pp.prenom ILIKE v_search_like OR pp.nom ILIKE v_search_like
+      OR t.titre ILIKE v_search_like
+    )
+  )
+  SELECT
+    ac.id,
+    ac.conversation_type,
+    ac.property_id,
+    ac.lease_id,
+    ac.ticket_id,
+    ac.owner_profile_id,
+    ac.tenant_profile_id,
+    ac.provider_profile_id,
+    ac.status,
+    ac.last_message_at,
+    ac.last_message_preview,
+    ac.owner_unread_count,
+    ac.tenant_unread_count,
+    ac.provider_unread_count,
+    ac.created_at,
+    ac.updated_at,
+
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            COALESCE(
+              (SELECT
+                 'Bail ' ||
+                 CASE l.statut
+                   WHEN 'actif' THEN 'actif'
+                   WHEN 'signed' THEN 'signé'
+                   ELSE l.statut
+                 END ||
+                 ' · ' || COALESCE(p.adresse_complete, 'adresse inconnue')
+               FROM public.leases l
+               LEFT JOIN public.properties p ON p.id = l.property_id
+               WHERE l.id = ac.lease_id
+               LIMIT 1),
+              'Locataire'
+            )
+          WHEN 'owner_provider' THEN
+            COALESCE(
+              (SELECT 'Ticket · ' || LEFT(t.titre, 40)
+               FROM public.tickets t
+               WHERE t.id = ac.ticket_id
+               LIMIT 1),
+              'Prestataire'
+            )
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            COALESCE(
+              (SELECT le.nom || ' · ' || COALESCE(p.adresse_complete, 'adresse inconnue')
+               FROM public.legal_entities le
+               JOIN public.properties p ON p.id = ac.property_id
+               WHERE le.owner_profile_id = ac.owner_profile_id
+               LIMIT 1),
+              (SELECT 'Propriétaire · ' || COALESCE(p.adresse_complete, 'adresse inconnue')
+               FROM public.properties p WHERE p.id = ac.property_id),
+              'Propriétaire'
+            )
+          WHEN 'tenant_provider' THEN
+            COALESCE(
+              (SELECT 'Ticket · ' || LEFT(t.titre, 40)
+               FROM public.tickets t
+               WHERE t.id = ac.ticket_id
+               LIMIT 1),
+              'Prestataire'
+            )
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        COALESCE(
+          (SELECT 'Ticket · ' || LEFT(t.titre, 40)
+           FROM public.tickets t
+           WHERE t.id = ac.ticket_id
+           LIMIT 1),
+          'Client'
+        )
+      WHEN v_user_role = 'admin' THEN
+        'Conversation ' || ac.conversation_type
+      ELSE NULL
+    END AS other_party_subtitle,
+
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          WHEN 'owner_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT TRIM(COALESCE(pr.prenom, '') || ' ' || COALESCE(pr.nom, ''))
+             FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          ELSE NULL
+        END
+      ELSE 'Utilisateur'
+    END AS other_party_name,
+
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          WHEN 'owner_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.provider_profile_id)
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.owner_profile_id)
+          WHEN 'tenant_provider' THEN
+            (SELECT pr.avatar_url FROM public.profiles pr WHERE pr.id = ac.tenant_profile_id)
+          ELSE NULL
+        END
+      ELSE NULL
+    END AS other_party_avatar_url,
+
+    CASE
+      WHEN ac.owner_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN 'tenant'
+          WHEN 'owner_provider' THEN 'provider'
+          ELSE NULL
+        END
+      WHEN ac.tenant_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_tenant' THEN 'owner'
+          WHEN 'tenant_provider' THEN 'provider'
+          ELSE NULL
+        END
+      WHEN ac.provider_profile_id = v_user_id THEN
+        CASE ac.conversation_type
+          WHEN 'owner_provider' THEN 'owner'
+          WHEN 'tenant_provider' THEN 'tenant'
+          ELSE NULL
+        END
+      ELSE NULL
+    END AS other_party_role,
+
+    (SELECT cnt FROM total) AS total_count
+  FROM accessible ac;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_conversations_enriched IS
+  'Paginated enriched conversations for the caller. Sprint 3 + Sprint 9 search. Optional p_search matches against participant names, ticket title, and last_message_preview (ILIKE).';
+
+GRANT EXECUTE ON FUNCTION public.get_conversations_enriched(INT, INT, TEXT, TEXT) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Extends the messaging system to support a third conversation type (`owner_provider` and `tenant_provider`) alongside the existing `owner_tenant` conversations. Adds provider role support throughout the chat service, introduces an admin read-only moderation view, and implements server-side conversation search via a new RPC function.

## Key Changes

### Core Schema & Database (Sprint 1 Extension)
- Added `conversation_type` discriminator column with 3 values: `owner_tenant`, `owner_provider`, `tenant_provider`
- Added `provider_profile_id` and `provider_unread_count` columns to conversations table
- Made `owner_profile_id` and `tenant_profile_id` nullable to support conversations without all three roles
- Added CHECK constraint ensuring conversation type matches participant columns
- Created 3 new UNIQUE partial indexes per conversation type to prevent duplicates
- Extended `sender_role` type to include "provider" alongside "owner" and "tenant"

### RPC Functions (Sprint 3 & 9)
- **`get_conversations_enriched`**: Returns paginated conversations with pre-computed subtitles and other-party info in a single round-trip, replacing N+1 queries
- **Search enhancement**: Added optional `p_search` parameter for full-text filtering on participant names, ticket titles, and message previews
- Both RPCs use SECURITY DEFINER with RLS to enforce access control and support admin read-only access

### Chat Service Extensions
- Added `getOrCreateOwnerProviderConversation()` and `getOrCreateTenantProviderConversation()` methods for idempotent conversation creation
- Introduced `getOtherPartyInfo()` utility function to derive "the other participant" info from any conversation type
- Updated `Conversation` interface with provider fields and new `conversation_type` discriminator
- Added `ConversationEnriched` interface for RPC results with pre-computed metadata

### UI Components
- **`ConversationRoleBadge`**: New badge component displaying role (owner/tenant/provider/admin) with appropriate icons and colors
- **`ChatWindow`**: Added `readOnly` prop for admin moderation view; uses `getOtherPartyInfo()` to support all conversation types
- **`ConversationsList`**: Refactored to use `ConversationEnriched` from RPC; added search support and role badge display
- **`AdminConversationsPanel`**: New admin-only component listing all conversations with read-only ChatWindow access
- **`ContactProviderButton`**: New button on ticket detail to initiate provider conversations

### Notification Service
- Extended `dispatchEmail()` function to send email notifications via Resend
- Added throttling (2-minute window) to prevent spam during rapid exchanges
- Respects user notification preferences (email_enabled, disabled_templates)
- Integrated into message notification flow with "in_app", "push", and "email" channels

### Routes & Pages
- Added `/provider/messages` page for provider messaging interface
- Integrated `AdminConversationsPanel` into `/admin/moderation` page
- Updated `MessagesPageContent` to support provider role and URL-based conversation selection

### Testing
- Added comprehensive SQL integration tests for 4-role schema validation
- Added RLS policy tests for owner/tenant/provider/admin access control
- Added RPC integration tests for `get_conversations_enriched` with search
- Added service layer tests for new conversation creation methods
- Added component tests for `ConversationRoleBadge` and `ContactProviderButton`

## Notable Implementation Details

- **Backward Compatibility**: `conversation_type` defaults to `'owner_tenant'` so existing INSERT statements continue to work
- **Admin Access Pattern**: Admin users are never conversation participants but can view all conversations via RLS clause `user_role()='admin'`; `getOtherPartyInfo()` returns `role=null` for admins, which the UI tolerates gracefully
- **Idempotent Conversation Creation**: Uses UNIQUE partial indexes to ensure only one active conversation per participant pair per conversation type
- **Server-Side Search**: Moved lossy client-side filtering to server RPC for better performance and accuracy
- **Email Throttling**: Prevents notification spam by

https://claude.ai/code/session_013p6KhqvZWMPspx43iRYXkt