### PR TITLE
Add cascading fetch strategy with anti-bot service fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,3 +204,16 @@ PASSWORD_RESET_COOKIE_SECRET=remplacez-par-un-secret-unique-d-au-moins-32-caract
 # GRDF_CLIENT_ID=your-grdf-client-id
 # GRDF_CLIENT_SECRET=your-grdf-client-secret
 # GRDF_REDIRECT_URI=https://your-domain.com/api/oauth/grdf/callback
+
+# ==============================================================================
+# IMPORT D'ANNONCES - Services anti-bot (optionnels)
+# ==============================================================================
+# Sans ces clés, /api/scrape utilise un fetch direct qui se fait bloquer par
+# LeBonCoin / SeLoger / BienIci (DataDome). Avec une clé, la cascade essaie
+# d'abord ScrapingBee puis Browserless avant le fetch direct.
+#
+# ScrapingBee : https://www.scrapingbee.com (~30€/mois pour 150k crédits)
+# SCRAPINGBEE_API_KEY=
+#
+# Browserless v2 : https://www.browserless.io (~50€/mois)
+# BROWSERLESS_API_KEY=

--- a/app/api/properties/init/route.ts
+++ b/app/api/properties/init/route.ts
@@ -103,6 +103,30 @@ export async function POST(request: Request) {
 
     const { type, adresse, cp, ville } = validation.data;
 
+    // 3b. Reuse: si un draft du même type sans adresse existe déjà pour ce owner,
+    // le retourner (idempotence du wizard, évite l'accumulation de drafts fantômes
+    // qui se bloqueraient mutuellement via le trigger anti-doublon)
+    const { data: existingDraft } = await serviceClient
+      .from("properties")
+      .select("id")
+      .eq("owner_id", profile.id)
+      .eq("type", type)
+      .eq("etat", "draft")
+      .or("adresse_complete.is.null,adresse_complete.eq.")
+      .is("deleted_at", null)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (existingDraft) {
+      return NextResponse.json({
+        success: true,
+        propertyId: existingDraft.id,
+        status: "draft",
+        reused: true,
+      });
+    }
+
     // 4. Générer un code unique pour la propriété
     let uniqueCode: string;
     let attempts = 0;

--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -1046,6 +1046,160 @@ function mergeData(sources: Partial<ExtractedData>[]): ExtractedData {
 }
 
 // ============================================
+// FETCH EN CASCADE (ScrapingBee -> Browserless -> direct)
+// ============================================
+
+const DIRECT_FETCH_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  "Accept":
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+  "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+  "Cache-Control": "no-cache",
+  "Pragma": "no-cache",
+};
+
+const FETCH_TIMEOUT_MS = 12000;
+const MAX_HTML_BYTES = 5 * 1024 * 1024;
+
+// Sites qui activent le bypass anti-bot premium côté ScrapingBee/Browserless
+const PROTECTED_SITES = new Set(["leboncoin", "seloger", "bienici", "logic-immo", "figaro"]);
+
+type FetchOk = { kind: "ok"; html: string; via: string };
+type FetchBlocked = { kind: "blocked"; attempts: string[] };
+type FetchNotFound = { kind: "not_found"; attempts: string[] };
+type FetchError = { kind: "error"; attempts: string[] };
+type FetchOutcome = FetchOk | FetchBlocked | FetchNotFound | FetchError;
+
+function looksBlocked(html: string): boolean {
+  if (!html || html.length < 1000) return true;
+  const lower = html.slice(0, 8000).toLowerCase();
+  return (
+    lower.includes("datadome") ||
+    lower.includes("are you a human") ||
+    lower.includes("g-recaptcha") ||
+    (lower.includes("cloudflare") && lower.includes("challenge")) ||
+    (lower.includes("captcha") && !lower.includes("nocaptcha"))
+  );
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit = {}): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function readHtml(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_HTML_BYTES) {
+    throw new Error("Page trop volumineuse (>5MB)");
+  }
+  return response.text();
+}
+
+async function fetchViaScrapingBee(url: string, isProtected: boolean): Promise<Response> {
+  const apiKey = process.env.SCRAPINGBEE_API_KEY!;
+  const params = new URLSearchParams({
+    api_key: apiKey,
+    url,
+    render_js: "true",
+    country_code: "fr",
+  });
+  if (isProtected) {
+    params.set("premium_proxy", "true");
+    params.set("stealth_proxy", "true");
+  }
+  return fetchWithTimeout(`https://app.scrapingbee.com/api/v1/?${params.toString()}`);
+}
+
+async function fetchViaBrowserless(url: string, isProtected: boolean): Promise<Response> {
+  const token = process.env.BROWSERLESS_API_KEY!;
+  const endpoint = `https://production-sfo.browserless.io/content?token=${encodeURIComponent(token)}`;
+  return fetchWithTimeout(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      url,
+      gotoOptions: { waitUntil: "networkidle2", timeout: FETCH_TIMEOUT_MS - 1000 },
+      ...(isProtected ? { stealth: true, humanLike: true } : {}),
+    }),
+  });
+}
+
+async function fetchDirect(url: string): Promise<Response> {
+  return fetchWithTimeout(url, { headers: DIRECT_FETCH_HEADERS });
+}
+
+async function tryProvider(
+  label: string,
+  fetcher: () => Promise<Response>,
+  attempts: string[]
+): Promise<{ html: string; via: string } | { status: number } | null> {
+  try {
+    const response = await fetcher();
+    if (response.status === 404) {
+      attempts.push(`${label}:404`);
+      return { status: 404 };
+    }
+    if (!response.ok) {
+      attempts.push(`${label}:${response.status}`);
+      return null;
+    }
+    const html = await readHtml(response);
+    if (looksBlocked(html)) {
+      attempts.push(`${label}:blocked-html`);
+      return null;
+    }
+    attempts.push(`${label}:ok`);
+    return { html, via: label };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    attempts.push(`${label}:err(${msg.slice(0, 40)})`);
+    return null;
+  }
+}
+
+async function fetchPageHtmlWithFallback(url: string, site: string): Promise<FetchOutcome> {
+  const attempts: string[] = [];
+  const isProtected = PROTECTED_SITES.has(site);
+  let saw404 = false;
+
+  const providers: Array<{ label: string; enabled: boolean; run: () => Promise<Response> }> = [
+    {
+      label: "scrapingbee",
+      enabled: !!process.env.SCRAPINGBEE_API_KEY,
+      run: () => fetchViaScrapingBee(url, isProtected),
+    },
+    {
+      label: "browserless",
+      enabled: !!process.env.BROWSERLESS_API_KEY,
+      run: () => fetchViaBrowserless(url, isProtected),
+    },
+    { label: "direct", enabled: true, run: () => fetchDirect(url) },
+  ];
+
+  for (const p of providers) {
+    if (!p.enabled) continue;
+    const result = await tryProvider(p.label, p.run, attempts);
+    if (result && "html" in result) {
+      console.info(`[Scrape] OK via ${result.via} (attempts: ${attempts.join(", ")})`);
+      return { kind: "ok", html: result.html, via: result.via };
+    }
+    if (result && "status" in result && result.status === 404) {
+      saw404 = true;
+    }
+  }
+
+  console.warn(`[Scrape] All providers failed for ${site} (${attempts.join(", ")})`);
+  if (saw404) return { kind: "not_found", attempts };
+  return { kind: "blocked", attempts };
+}
+
+// ============================================
 // ENDPOINT PRINCIPAL
 // ============================================
 
@@ -1102,50 +1256,30 @@ export async function POST(request: Request) {
     // Détecter le site source
     const site = detectSourceSite(url);
 
-    // 6. Fetch avec timeout (10 secondes)
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    // 6. Fetch avec cascade ScrapingBee -> Browserless -> direct
+    const fetchResult = await fetchPageHtmlWithFallback(url, site);
 
-    let response: Response;
-    try {
-      response = await fetch(url, {
-        signal: controller.signal,
-        headers: {
-          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-          "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
-          "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
-          "Cache-Control": "no-cache",
-          "Pragma": "no-cache",
+    if (fetchResult.kind === "blocked") {
+      return NextResponse.json(
+        {
+          error: "Ce site bloque les imports automatiques. Copiez les infos manuellement, ou essayez une annonce PAP / agence.",
+          code: "SCRAPE_BLOCKED",
+          attempts: fetchResult.attempts,
         },
-      });
-    } finally {
-      clearTimeout(timeoutId);
+        { status: 502 }
+      );
+    }
+    if (fetchResult.kind === "not_found") {
+      return NextResponse.json(
+        { error: "L'annonce n'a pas été trouvée. Vérifiez l'URL.", code: "SCRAPE_NOT_FOUND" },
+        { status: 404 }
+      );
+    }
+    if (fetchResult.kind === "error") {
+      throw new ApiError(502, `Aucune méthode de scrape n'a fonctionné (${fetchResult.attempts.join(" | ")})`);
     }
 
-    if (!response.ok) {
-      const statusCode = response.status;
-      if (statusCode === 403 || statusCode === 429) {
-        return NextResponse.json(
-          { error: "Le site a bloqué la requête. Réessayez plus tard ou remplissez manuellement.", code: "SCRAPE_BLOCKED" },
-          { status: 502 }
-        );
-      }
-      if (statusCode === 404) {
-        return NextResponse.json(
-          { error: "L'annonce n'a pas été trouvée. Vérifiez l'URL.", code: "SCRAPE_NOT_FOUND" },
-          { status: 404 }
-        );
-      }
-      throw new ApiError(502, `Le site a répondu avec une erreur (${statusCode})`);
-    }
-
-    // 7. Vérifier la taille de la réponse (max 5MB)
-    const contentLength = response.headers.get("content-length");
-    if (contentLength && parseInt(contentLength) > 5 * 1024 * 1024) {
-      throw new Error("La page est trop volumineuse (max 5MB)");
-    }
-
-    const html = await response.text();
+    const html = fetchResult.html;
     const $ = cheerio.load(html);
     
     // Texte brut pour analyse

--- a/features/properties/components/v3/immersive/steps/ImportStep.tsx
+++ b/features/properties/components/v3/immersive/steps/ImportStep.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Sparkles, Link as LinkIcon, ArrowRight, Building, Loader2 } from "lucide-react";
+import { Sparkles, Link as LinkIcon, ArrowRight, Building, Loader2, Info } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -65,8 +65,8 @@ export function ImportStep({ onImport, onSkip, isAnalyzing }: ImportStepProps) {
                 </div>
 
                 <form onSubmit={handleSubmit} className="mt-auto space-y-3">
-                    <Input 
-                        placeholder="https://www.leboncoin.fr/..." 
+                    <Input
+                        placeholder="https://www.pap.fr/..."
                         className="bg-background border-indigo-200 dark:border-indigo-700 focus-visible:ring-indigo-500"
                         value={url}
                         onChange={(e) => setUrl(e.target.value)}
@@ -122,8 +122,17 @@ export function ImportStep({ onImport, onSkip, isAnalyzing }: ImportStepProps) {
         </motion.div>
       </div>
       
-      <div className="text-center text-xs text-muted-foreground">
-         Compatible avec la plupart des sites immobiliers majeurs.
+      <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50/60 dark:bg-amber-950/20 p-3 text-xs text-amber-900 dark:text-amber-200 flex gap-2">
+         <Info className="w-4 h-4 mt-0.5 flex-shrink-0" />
+         <div className="space-y-1">
+            <p className="font-medium">Compatibilité de l'import automatique</p>
+            <p>
+               <span className="font-semibold">Fonctionne bien :</span> PAP, Orpi, Century21, Laforêt, Guy Hoquet, sites d'agences indépendantes.
+            </p>
+            <p>
+               <span className="font-semibold">Souvent bloqué :</span> LeBonCoin, SeLoger, BienIci, Logic-Immo (protection anti-bot). Préférez la création manuelle pour ces sites.
+            </p>
+         </div>
       </div>
     </div>
   );

--- a/features/properties/components/v3/property-wizard-v3.tsx
+++ b/features/properties/components/v3/property-wizard-v3.tsx
@@ -216,9 +216,15 @@ export function PropertyWizardV3({ propertyId, initialData, onSuccess, onCancel 
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ url }),
         });
-        const { data, error } = await response.json();
-        
-        if (error) throw new Error(error);
+        const payload = await response.json();
+        const { data, error, code } = payload || {};
+
+        if (!response.ok || error) {
+            const err = new Error(error || "Erreur d'import");
+            (err as any).code = code;
+            (err as any).status = response.status;
+            throw err;
+        }
         
         // Pré-remplir le store avec les données scrapées
         // ⚠️ Ne JAMAIS utiliser le titre comme adresse !
@@ -378,9 +384,21 @@ export function PropertyWizardV3({ propertyId, initialData, onSuccess, onCancel 
         }
     } catch (err) {
         console.error(err);
+        const errCode = (err as any)?.code as string | undefined;
+        const errMsg = err instanceof Error ? err.message : "Impossible de récupérer les infos";
+
+        let description = errMsg;
+        if (errCode === "SCRAPE_BLOCKED") {
+            description = "Ce site bloque les imports automatiques (LeBonCoin, SeLoger…). Créez le bien manuellement, c'est plus rapide.";
+        } else if (errCode === "SCRAPE_NOT_FOUND") {
+            description = "L'annonce n'a pas été trouvée. Vérifiez l'URL ou remplissez manuellement.";
+        } else if (errCode === "SCRAPE_TIMEOUT") {
+            description = "Le site met trop de temps à répondre. Réessayez ou remplissez manuellement.";
+        }
+
         toast({
-            title: "Erreur d'import",
-            description: "Impossible de récupérer les infos. Veuillez remplir manuellement.",
+            title: "Import indisponible",
+            description,
             variant: "destructive",
         });
         // En cas d'erreur, on laisse l'utilisateur continuer manuellement

--- a/supabase/migrations/20260419160000_fix_prevent_duplicate_property_skip_empty.sql
+++ b/supabase/migrations/20260419160000_fix_prevent_duplicate_property_skip_empty.sql
@@ -1,0 +1,65 @@
+-- ----------------------------------------------------------------------------
+-- Fix: prevent_duplicate_property() bloquait la création de drafts via
+-- /api/properties/init quand un draft fantôme à adresse vide existait déjà
+-- pour le même owner. Le trigger considérait deux INSERTs avec
+-- adresse_complete='' et code_postal='' comme un doublon.
+--
+-- Changements:
+--  1. Skip la vérification si NEW n'a pas encore d'adresse réelle (drafts init)
+--  2. Skip pour les wrappers d'immeuble (jamais en doublon avec un lot)
+--  3. Exclure les rows existantes en etat='draft' (n'empêchent pas une nouvelle
+--     création si l'utilisateur veut recommencer)
+--  4. Exclure les rows existantes type='immeuble' (un wrapper d'immeuble n'est
+--     pas un doublon d'un bien individuel à la même adresse)
+--  5. Cleanup en fin de migration des drafts fantômes accumulés > 24h
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION prevent_duplicate_property()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_existing_id UUID;
+BEGIN
+  -- Skip si NEW n'a pas encore d'adresse réelle (cas des drafts init)
+  IF NEW.adresse_complete IS NULL
+     OR TRIM(NEW.adresse_complete) = ''
+     OR NEW.code_postal IS NULL
+     OR TRIM(NEW.code_postal) = '' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Skip pour les wrappers d'immeuble (jamais en doublon avec un lot)
+  IF NEW.type = 'immeuble' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT id INTO v_existing_id
+  FROM properties
+  WHERE owner_id = NEW.owner_id
+    AND LOWER(TRIM(adresse_complete)) = LOWER(TRIM(NEW.adresse_complete))
+    AND code_postal = NEW.code_postal
+    AND deleted_at IS NULL
+    AND COALESCE(etat, 'published') <> 'draft'
+    AND type <> 'immeuble'
+    AND id != COALESCE(NEW.id, '00000000-0000-0000-0000-000000000000'::UUID)
+  LIMIT 1;
+
+  IF v_existing_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Propriété en doublon détectée (id: %). Même adresse et code postal pour ce propriétaire.', v_existing_id
+      USING HINT = 'Vérifiez si cette propriété existe déjà avant d''en créer une nouvelle.',
+            ERRCODE = 'unique_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger reste identique (BEFORE INSERT) — on ne re-crée que la fonction.
+
+-- ----------------------------------------------------------------------------
+-- Cleanup: supprimer les drafts fantômes à adresse vide créés il y a > 24h
+-- pour éviter l'accumulation pour les utilisateurs déjà bloqués.
+-- ----------------------------------------------------------------------------
+DELETE FROM properties
+WHERE etat = 'draft'
+  AND (adresse_complete IS NULL OR TRIM(adresse_complete) = '')
+  AND created_at < NOW() - INTERVAL '24 hours';


### PR DESCRIPTION
## Summary
Implements a robust cascading fetch strategy for web scraping that attempts multiple providers in sequence (ScrapingBee → Browserless → direct fetch) to handle anti-bot protections on real estate sites. Also fixes a database trigger issue preventing draft property creation and improves user feedback for import failures.

## Key Changes

### Scraping Infrastructure (`app/api/scrape/route.ts`)
- **New cascading fetch system** with three providers:
  - ScrapingBee (premium proxy + stealth mode for protected sites)
  - Browserless (headless browser with stealth/humanLike options)
  - Direct fetch (fallback with realistic User-Agent headers)
- **Protected sites detection**: Identifies sites like LeBonCoin, SeLoger, BienIci that require premium anti-bot bypass
- **Intelligent blocking detection**: `looksBlocked()` function identifies common anti-bot patterns (DataDome, Cloudflare challenges, reCAPTCHA)
- **Structured outcome types**: Returns `FetchOk | FetchBlocked | FetchNotFound | FetchError` with detailed attempt logs
- **Timeout & size limits**: 12-second timeout per request, 5MB max response size
- **Replaces old simple fetch** with comprehensive error handling and provider fallback logic

### Database Migration (`supabase/migrations/20260419160000_fix_prevent_duplicate_property_skip_empty.sql`)
- **Fixes `prevent_duplicate_property()` trigger** that was blocking draft creation:
  - Skips duplicate check for properties without real addresses (empty drafts)
  - Excludes existing drafts from duplicate detection (allows user to restart)
  - Excludes building wrappers (`type='immeuble'`) from duplicate logic
  - Prevents false positives when initializing new properties
- **Cleanup**: Removes phantom drafts older than 24 hours to prevent accumulation

### Property Initialization (`app/api/properties/init/route.ts`)
- **Draft reuse logic**: Returns existing empty draft if one exists for the same owner/type
- **Idempotence**: Prevents accumulation of phantom drafts when wizard is restarted
- **Reduces database bloat** from repeated draft creation attempts

### Error Handling & UX
- **Enhanced error responses** in `property-wizard-v3.tsx`:
  - Parses error codes (`SCRAPE_BLOCKED`, `SCRAPE_NOT_FOUND`, `SCRAPE_TIMEOUT`)
  - Provides site-specific guidance in toast messages
  - Distinguishes between blocked sites vs. not found vs. timeout
- **Updated import UI** (`ImportStep.tsx`):
  - Changed placeholder from LeBonCoin to PAP (better success rate)
  - Added informational banner showing which sites work well vs. are often blocked
  - Guides users toward manual creation for protected sites

### Configuration
- **Updated `.env.example`** with optional anti-bot service keys:
  - `SCRAPINGBEE_API_KEY` (ScrapingBee)
  - `BROWSERLESS_API_KEY` (Browserless v2)
  - Explains fallback behavior when keys are absent

## Implementation Details
- Cascade only proceeds to next provider if current one fails (timeout, HTTP error, or blocked HTML detected)
- All attempts are logged for debugging: `scrapingbee:ok`, `browserless:blocked-html`, `direct:err(timeout)`, etc.
- Protected sites automatically enable premium features (premium_proxy, stealth_proxy, humanLike) when available
- Direct fetch includes realistic browser headers to minimize blocking on unprotected sites
- Database trigger now safely allows draft creation without false duplicate errors

https://claude.ai/code/session_01AQLXPFuMgN7i6byxSgrwNL