### PR TITLE
Add EDL signature notifications and email templates

### DIFF
--- a/app/api/edl/[id]/invite/route.ts
+++ b/app/api/edl/[id]/invite/route.ts
@@ -275,6 +275,42 @@ export async function POST(
     }
 
     // ===============================
+    // 5a. ENVOYER L'EMAIL TRANSACTIONNEL (Resend — template dédié EDL)
+    // ===============================
+    try {
+      // Récupérer le nom complet du propriétaire pour le template
+      const ownerId = (edl as any).property?.owner_id as string | undefined;
+      let ownerName = "Votre propriétaire";
+      if (ownerId) {
+        const { data: ownerProfile } = await serviceClient
+          .from("profiles")
+          .select("prenom, nom")
+          .eq("id", ownerId)
+          .maybeSingle() as { data: { prenom: string | null; nom: string | null } | null };
+        if (ownerProfile) {
+          const full = `${ownerProfile.prenom || ""} ${ownerProfile.nom || ""}`.trim();
+          if (full) ownerName = full;
+        }
+      }
+
+      const edlType = ((edl as any).type === "sortie" ? "sortie" : "entree") as "entree" | "sortie";
+      const propertyAddress = (edl as any).property?.adresse_complete || "votre logement";
+
+      const { sendEDLSignatureRequest } = await import("@/lib/emails/resend.service");
+      sendEDLSignatureRequest({
+        signerEmail: targetEmail,
+        signerName: targetName || targetEmail.split("@")[0],
+        ownerName,
+        propertyAddress,
+        edlId,
+        edlType,
+        signatureToken: invitationToken,
+      }).catch((e) => console.warn(`[EDL Invite ${edlId}] Email Resend échoué:`, String(e)));
+    } catch (e) {
+      console.warn(`[EDL Invite ${edlId}] Email dispatch error:`, String(e));
+    }
+
+    // ===============================
     // 5b. NOTIFICATION IN-APP DIRECTE
     // ===============================
     if (targetProfileId || targetUserId) {

--- a/app/api/edl/[id]/sign/route.ts
+++ b/app/api/edl/[id]/sign/route.ts
@@ -634,6 +634,77 @@ export async function POST(
       },
     } as any);
 
+    // ===============================
+    // NOTIFICATIONS — contrepartie + double signature
+    // ===============================
+    try {
+      const { notifyEDLSignedByCounterparty, notifyEDLFullySigned } =
+        await import("@/lib/services/notification-service");
+
+      const { data: edlContext } = await serviceClient
+        .from("edl")
+        .select(`
+          type,
+          lease_id,
+          property:properties(adresse_complete, owner_id),
+          leases(
+            property_id,
+            lease_signers(role, profile_id)
+          )
+        `)
+        .eq("id", edlId)
+        .maybeSingle();
+
+      const propertyAddress =
+        (edlContext as any)?.property?.adresse_complete ||
+        "votre logement";
+      const edlType = ((edlContext as any)?.type || "entree") as "entree" | "sortie";
+      const ownerProfileId = (edlContext as any)?.property?.owner_id as string | undefined;
+      const tenantProfileId = (edlContext as any)?.leases?.lease_signers?.find(
+        (s: any) => ["locataire_principal", "tenant", "locataire"].includes(s.role)
+      )?.profile_id as string | undefined;
+
+      const fullySigned = !!(hasOwner && hasTenant);
+
+      if (fullySigned) {
+        // Les deux parties sont signées — notifier les deux
+        if (ownerProfileId) {
+          await notifyEDLFullySigned(
+            ownerProfileId,
+            edlId,
+            edlType,
+            propertyAddress,
+            "owner",
+          );
+        }
+        if (tenantProfileId) {
+          await notifyEDLFullySigned(
+            tenantProfileId,
+            edlId,
+            edlType,
+            propertyAddress,
+            "tenant",
+          );
+        }
+      } else {
+        // Une seule partie a signé — notifier la contrepartie
+        const counterpartyId = isOwner ? tenantProfileId : ownerProfileId;
+        const counterpartyRole: "owner" | "tenant" = isOwner ? "tenant" : "owner";
+        if (counterpartyId) {
+          await notifyEDLSignedByCounterparty(
+            counterpartyId,
+            edlId,
+            edlType,
+            propertyAddress,
+            signerRole,
+            counterpartyRole,
+          );
+        }
+      }
+    } catch (notifErr) {
+      console.warn("[sign-edl] Notification non-bloquante échouée:", String(notifErr));
+    }
+
     // FIX AUDIT 2026-02-16: Invalider le cache pour que l'UI reflète la signature
     revalidatePath("/owner/inspections");
     revalidatePath(`/owner/inspections/${edlId}`);

--- a/app/api/edl/[id]/sign/route.ts
+++ b/app/api/edl/[id]/sign/route.ts
@@ -635,11 +635,15 @@ export async function POST(
     } as any);
 
     // ===============================
-    // NOTIFICATIONS — contrepartie + double signature
+    // NOTIFICATIONS + EMAILS — contrepartie + double signature
     // ===============================
     try {
       const { notifyEDLSignedByCounterparty, notifyEDLFullySigned } =
         await import("@/lib/services/notification-service");
+      const {
+        sendEDLCounterpartySignedNotification,
+        sendEDLFullySignedNotification,
+      } = await import("@/lib/emails/resend.service");
 
       const { data: edlContext } = await serviceClient
         .from("edl")
@@ -664,30 +668,60 @@ export async function POST(
         (s: any) => ["locataire_principal", "tenant", "locataire"].includes(s.role)
       )?.profile_id as string | undefined;
 
+      // Résolution email + nom par profile_id (via auth.users pour l'email)
+      const resolveRecipient = async (profileId: string | undefined) => {
+        if (!profileId) return null;
+        const { data: p } = await serviceClient
+          .from("profiles")
+          .select("user_id, prenom, nom, email")
+          .eq("id", profileId)
+          .maybeSingle() as { data: { user_id: string | null; prenom: string | null; nom: string | null; email: string | null } | null };
+        if (!p) return null;
+        let email = p.email;
+        if (!email && p.user_id) {
+          const { data: authUser } = await serviceClient.auth.admin.getUserById(p.user_id);
+          email = authUser?.user?.email ?? null;
+        }
+        if (!email) return null;
+        const name = `${p.prenom || ""} ${p.nom || ""}`.trim() || email.split("@")[0];
+        return { email, name };
+      };
+
+      const signerFullName = `${profile.prenom || ""} ${profile.nom || ""}`.trim() || user.email || "Signataire";
       const fullySigned = !!(hasOwner && hasTenant);
 
       if (fullySigned) {
-        // Les deux parties sont signées — notifier les deux
+        // Les deux parties sont signées — notifier les deux (in-app + email dédié)
         if (ownerProfileId) {
-          await notifyEDLFullySigned(
-            ownerProfileId,
-            edlId,
-            edlType,
-            propertyAddress,
-            "owner",
-          );
+          await notifyEDLFullySigned(ownerProfileId, edlId, edlType, propertyAddress, "owner");
+          const r = await resolveRecipient(ownerProfileId);
+          if (r) {
+            sendEDLFullySignedNotification({
+              recipientEmail: r.email,
+              recipientName: r.name,
+              recipientRole: "owner",
+              propertyAddress,
+              edlId,
+              edlType,
+            }).catch((e) => console.warn("[sign-edl] Email owner fully signed:", String(e)));
+          }
         }
         if (tenantProfileId) {
-          await notifyEDLFullySigned(
-            tenantProfileId,
-            edlId,
-            edlType,
-            propertyAddress,
-            "tenant",
-          );
+          await notifyEDLFullySigned(tenantProfileId, edlId, edlType, propertyAddress, "tenant");
+          const r = await resolveRecipient(tenantProfileId);
+          if (r) {
+            sendEDLFullySignedNotification({
+              recipientEmail: r.email,
+              recipientName: r.name,
+              recipientRole: "tenant",
+              propertyAddress,
+              edlId,
+              edlType,
+            }).catch((e) => console.warn("[sign-edl] Email tenant fully signed:", String(e)));
+          }
         }
       } else {
-        // Une seule partie a signé — notifier la contrepartie
+        // Une seule partie a signé — notifier la contrepartie (in-app + email dédié)
         const counterpartyId = isOwner ? tenantProfileId : ownerProfileId;
         const counterpartyRole: "owner" | "tenant" = isOwner ? "tenant" : "owner";
         if (counterpartyId) {
@@ -699,6 +733,19 @@ export async function POST(
             signerRole,
             counterpartyRole,
           );
+          const r = await resolveRecipient(counterpartyId);
+          if (r) {
+            sendEDLCounterpartySignedNotification({
+              recipientEmail: r.email,
+              recipientName: r.name,
+              signerName: signerFullName,
+              signerRole,
+              recipientRole: counterpartyRole,
+              propertyAddress,
+              edlId,
+              edlType,
+            }).catch((e) => console.warn("[sign-edl] Email counterparty signed:", String(e)));
+          }
         }
       }
     } catch (notifErr) {

--- a/app/owner/inspections/InspectionsClient.tsx
+++ b/app/owner/inspections/InspectionsClient.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Plus, ClipboardList, Search, CheckCircle2, Clock, Eye, Pencil, FileText, Printer, Trash2, Loader2, AlertTriangle, RefreshCw } from "lucide-react";
+import { Plus, ClipboardList, Search, CheckCircle2, Clock, Eye, Pencil, FileText, Printer, Trash2, Loader2, AlertTriangle, RefreshCw, FileSignature, Hourglass } from "lucide-react";
 import { CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -49,6 +49,9 @@ interface Inspection {
   property_city: string;
   tenant_name: string;
   signatures_count: number;
+  owner_signed: boolean;
+  tenant_signed: boolean;
+  tenant_invited_at: string | null;
   created_at: string;
 }
 
@@ -185,20 +188,68 @@ export function InspectionsClient({ inspections }: Props) {
           draft: { label: "Brouillon", type: "neutral", animate: false },
         };
         const config = statusMap[edl.status] || statusMap.draft;
+
+        // Sous-badge d'attente pour les EDL "completed" (double signature requise)
+        const pendingLabel =
+          edl.status === "completed" && !edl.owner_signed
+            ? "À signer"
+            : edl.status === "completed" && edl.owner_signed && !edl.tenant_signed
+              ? "En attente locataire"
+              : edl.status === "completed" && !edl.owner_signed && edl.tenant_signed
+                ? "À signer"
+                : null;
+
         return (
-          <StatusBadge
-            status={config.label}
-            type={config.type}
-            animate={config.animate}
-          />
+          <div className="flex flex-col items-start gap-1">
+            <StatusBadge
+              status={config.label}
+              type={config.type}
+              animate={config.animate}
+            />
+            {pendingLabel && (
+              <span
+                className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ${
+                  pendingLabel === "À signer"
+                    ? "border-blue-200 bg-blue-50 text-blue-700"
+                    : "border-amber-200 bg-amber-50 text-amber-700"
+                }`}
+              >
+                {pendingLabel === "À signer" ? (
+                  <FileSignature className="h-3 w-3" />
+                ) : (
+                  <Hourglass className="h-3 w-3" />
+                )}
+                {pendingLabel}
+              </span>
+            )}
+          </div>
         );
       },
     },
     {
       header: "Actions",
       className: "text-right",
-      cell: (edl: Inspection) => (
+      cell: (edl: Inspection) => {
+        const canOwnerSign =
+          !edl.owner_signed &&
+          ["completed", "in_progress"].includes(edl.status);
+
+        return (
         <div className="flex justify-end gap-2">
+          {canOwnerSign && (
+            <Button
+              size="sm"
+              asChild
+              className="bg-blue-600 hover:bg-blue-700 text-white shadow-sm h-8 gap-1.5 px-2.5"
+              title="Signer l'état des lieux"
+            >
+              <Link href={`/owner/inspections/${edl.id}?sign=1`}>
+                <FileSignature className="h-4 w-4" />
+                <span className="text-xs font-medium">Signer</span>
+              </Link>
+            </Button>
+          )}
+
           <Button size="sm" variant="outline" asChild className="hover:bg-blue-50 hover:border-blue-300 h-8 gap-1.5 px-2.5 text-blue-600 border-blue-200" title="Voir l'état des lieux">
             <Link href={`/owner/inspections/${edl.id}`}>
               <Eye className="h-4 w-4" />
@@ -232,7 +283,8 @@ export function InspectionsClient({ inspections }: Props) {
             </Button>
           )}
         </div>
-      ),
+        );
+      },
     },
   ];
 

--- a/app/owner/inspections/[id]/InspectionDetailClient.tsx
+++ b/app/owner/inspections/[id]/InspectionDetailClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import {
@@ -169,8 +169,9 @@ const itemVariants = {
 
 export function InspectionDetailClient({ data }: Props) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { toast } = useToast();
-  
+
   // États
   const [isSending, setIsSending] = useState(false);
   const [isSigning, setIsSigning] = useState(false);
@@ -523,6 +524,16 @@ export function InspectionDetailClient({ data }: Props) {
   const ownerSigned = !!(ownerSignature?.signed_at && (ownerSignature?.signature_image_path || ownerSignature?.signature_image));
   const tenantSigned = !!(tenantSignature?.signed_at && (tenantSignature?.signature_image_path || tenantSignature?.signature_image));
   const actualSignaturesCount = (edl.edl_signatures || []).filter((s: any) => (s.signature_image_path || s.signature_image) && s.signed_at).length;
+
+  // Auto-ouverture du dialog de signature via ?sign=1 (depuis la liste EDL)
+  useEffect(() => {
+    if (searchParams?.get("sign") === "1" && !ownerSigned && edl.status !== "signed") {
+      setIsSignModalOpen(true);
+      // Nettoyer l'URL pour que l'utilisateur puisse fermer/rouvrir librement
+      router.replace(`/owner/inspections/${edl.id}`, { scroll: false });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="min-h-screen bg-muted/50 flex flex-col">

--- a/app/owner/inspections/page.tsx
+++ b/app/owner/inspections/page.tsx
@@ -42,15 +42,33 @@ async function fetchInspections(profileId: string) {
     return [];
   }
 
-  return (data || []).map((edl: any) => ({
-    ...edl,
-    property_address: edl.leases?.properties?.adresse_complete || "",
-    property_city: edl.leases?.properties?.ville || "",
-    tenant_name: edl.leases?.lease_signers?.find((s: any) => s.role === "locataire_principal")?.profiles
-      ? `${edl.leases.lease_signers.find((s: any) => s.role === "locataire_principal").profiles.prenom || ""} ${edl.leases.lease_signers.find((s: any) => s.role === "locataire_principal").profiles.nom || ""}`.trim()
-      : "Locataire",
-    signatures_count: edl.edl_signatures?.length || 0,
-  }));
+  return (data || []).map((edl: any) => {
+    const sigs = edl.edl_signatures || [];
+    const ownerSigned = sigs.some((s: any) =>
+      ["owner", "proprietaire", "bailleur"].includes(s.signer_role) &&
+      s.signed_at && s.signature_image_path
+    );
+    const tenantSigned = sigs.some((s: any) =>
+      ["tenant", "locataire", "locataire_principal"].includes(s.signer_role) &&
+      s.signed_at && s.signature_image_path
+    );
+    const tenantInvitedAt = sigs.find((s: any) =>
+      ["tenant", "locataire", "locataire_principal"].includes(s.signer_role)
+    )?.invitation_sent_at || null;
+
+    return {
+      ...edl,
+      property_address: edl.leases?.properties?.adresse_complete || "",
+      property_city: edl.leases?.properties?.ville || "",
+      tenant_name: edl.leases?.lease_signers?.find((s: any) => s.role === "locataire_principal")?.profiles
+        ? `${edl.leases.lease_signers.find((s: any) => s.role === "locataire_principal").profiles.prenom || ""} ${edl.leases.lease_signers.find((s: any) => s.role === "locataire_principal").profiles.nom || ""}`.trim()
+        : "Locataire",
+      signatures_count: sigs.length,
+      owner_signed: ownerSigned,
+      tenant_signed: tenantSigned,
+      tenant_invited_at: tenantInvitedAt,
+    };
+  });
 }
 
 function InspectionsSkeleton() {

--- a/lib/emails/resend.service.ts
+++ b/lib/emails/resend.service.ts
@@ -929,6 +929,117 @@ export async function sendOwnerPaymentAlert(data: {
   });
 }
 
+/**
+ * Envoie au locataire une invitation à signer un état des lieux
+ */
+export async function sendEDLSignatureRequest(data: {
+  signerEmail: string;
+  signerName: string;
+  ownerName: string;
+  propertyAddress: string;
+  edlId: string;
+  edlType: "entree" | "sortie";
+  signatureToken: string;
+}): Promise<EmailResult> {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
+  const template = emailTemplates.edlSignatureRequest({
+    signerName: data.signerName,
+    ownerName: data.ownerName,
+    propertyAddress: data.propertyAddress,
+    edlType: data.edlType,
+    signatureUrl: `${appUrl}/signature-edl/${data.signatureToken}`,
+  });
+
+  return sendEmail({
+    to: data.signerEmail,
+    subject: template.subject,
+    html: template.html,
+    idempotencyKey: `edl-signature-request/${data.edlId}/${data.signatureToken}`,
+    tags: [
+      { name: 'type', value: 'edl_signature_request' },
+      { name: 'edl_id', value: data.edlId },
+      { name: 'edl_type', value: data.edlType },
+    ],
+  });
+}
+
+/**
+ * Notifie la contrepartie qu'une partie a signé l'EDL
+ */
+export async function sendEDLCounterpartySignedNotification(data: {
+  recipientEmail: string;
+  recipientName: string;
+  signerName: string;
+  signerRole: "owner" | "tenant";
+  recipientRole: "owner" | "tenant";
+  propertyAddress: string;
+  edlId: string;
+  edlType: "entree" | "sortie";
+  tokenUrl?: string;
+}): Promise<EmailResult> {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
+  const signatureUrl =
+    data.recipientRole === "owner"
+      ? `${appUrl}/owner/inspections/${data.edlId}?sign=1`
+      : data.tokenUrl || `${appUrl}/tenant/inspections/${data.edlId}`;
+  const template = emailTemplates.edlCounterpartySigned({
+    recipientName: data.recipientName,
+    signerName: data.signerName,
+    signerRoleLabel: data.signerRole === "owner" ? "Le propriétaire" : "Le locataire",
+    propertyAddress: data.propertyAddress,
+    edlType: data.edlType,
+    signatureUrl,
+  });
+
+  return sendEmail({
+    to: data.recipientEmail,
+    subject: template.subject,
+    html: template.html,
+    idempotencyKey: `edl-counterparty-signed/${data.edlId}/${data.signerRole}`,
+    tags: [
+      { name: 'type', value: 'edl_counterparty_signed' },
+      { name: 'edl_id', value: data.edlId },
+      { name: 'signer_role', value: data.signerRole },
+    ],
+  });
+}
+
+/**
+ * Notifie une partie que l'EDL est entièrement signé
+ */
+export async function sendEDLFullySignedNotification(data: {
+  recipientEmail: string;
+  recipientName: string;
+  recipientRole: "owner" | "tenant";
+  propertyAddress: string;
+  edlId: string;
+  edlType: "entree" | "sortie";
+}): Promise<EmailResult> {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
+  const edlUrl =
+    data.recipientRole === "owner"
+      ? `${appUrl}/owner/inspections/${data.edlId}`
+      : `${appUrl}/tenant/inspections/${data.edlId}`;
+  const template = emailTemplates.edlFullySigned({
+    recipientName: data.recipientName,
+    propertyAddress: data.propertyAddress,
+    edlType: data.edlType,
+    edlUrl,
+  });
+
+  return sendEmail({
+    to: data.recipientEmail,
+    subject: template.subject,
+    html: template.html,
+    idempotencyKey: `edl-fully-signed/${data.edlId}/${data.recipientRole}`,
+    tags: [
+      { name: 'type', value: 'edl_fully_signed' },
+      { name: 'edl_id', value: data.edlId },
+      { name: 'recipient_role', value: data.recipientRole },
+    ],
+  });
+}
+
 // Export du service
 export const emailService = {
   send: sendEmail,
@@ -939,6 +1050,9 @@ export const emailService = {
   sendTicketUpdateNotification,
   sendSignatureRequest,
   sendLeaseSignedNotification,
+  sendEDLSignatureRequest,
+  sendEDLCounterpartySignedNotification,
+  sendEDLFullySignedNotification,
   sendPropertyInvitation,
   sendWelcomeEmail,
   sendPasswordResetEmail,

--- a/lib/emails/templates.ts
+++ b/lib/emails/templates.ts
@@ -2344,5 +2344,114 @@ export const emailTemplates = {
       `, `Impaye J+${data.daysLate} — ${data.tenantName} — ${data.amount.toLocaleString('fr-FR')} \u20AC`),
     };
   },
+
+  /**
+   * Invitation locataire à signer un état des lieux
+   */
+  edlSignatureRequest: (data: {
+    signerName: string;
+    ownerName: string;
+    propertyAddress: string;
+    edlType: "entree" | "sortie";
+    signatureUrl: string;
+  }) => {
+    const kind = data.edlType === "entree" ? "d'entrée" : "de sortie";
+    return {
+      subject: `État des lieux ${kind} à signer — ${data.propertyAddress}`,
+      html: baseLayout(`
+        <div class="content">
+          <div style="text-align: center; margin-bottom: 24px;">
+            <span class="badge badge-info">ACTION REQUISE</span>
+          </div>
+
+          <h1>État des lieux ${kind} à signer</h1>
+          <p>Bonjour ${escapeHtml(data.signerName)},</p>
+          <p>${escapeHtml(data.ownerName)} vous invite à signer l'état des lieux ${kind} pour le logement suivant :</p>
+
+          <div class="highlight-box">
+            <p style="font-weight: 600; color: ${COLORS.gray[900]}; margin-bottom: 8px;">${escapeHtml(data.propertyAddress)}</p>
+            <p style="color: ${COLORS.gray[500]}; font-size: 14px; margin: 0;">Type : État des lieux ${kind}</p>
+          </div>
+
+          <p>Prévoyez quelques minutes pour vérifier le document et signer. Une pièce d'identité valide (CNI) est nécessaire.</p>
+
+          <div style="text-align: center;">
+            <a href="${data.signatureUrl}" class="button">Signer l'état des lieux</a>
+          </div>
+
+          <p style="font-size: 14px; color: ${COLORS.gray[500]};">
+            Ce lien est valable 7 jours. Contactez ${escapeHtml(data.ownerName)} si vous avez une question.
+          </p>
+        </div>
+      `, `Signez l'état des lieux ${kind} pour ${escapeHtml(data.propertyAddress)}`),
+    };
+  },
+
+  /**
+   * Notification : une partie a signé l'EDL, la contrepartie doit signer
+   */
+  edlCounterpartySigned: (data: {
+    recipientName: string;
+    signerName: string;
+    signerRoleLabel: string;
+    propertyAddress: string;
+    edlType: "entree" | "sortie";
+    signatureUrl: string;
+  }) => {
+    const kind = data.edlType === "entree" ? "d'entrée" : "de sortie";
+    return {
+      subject: `${data.signerRoleLabel} a signé — EDL ${kind} ${data.propertyAddress}`,
+      html: baseLayout(`
+        <div class="content">
+          <div style="text-align: center; margin-bottom: 24px;">
+            <span class="badge badge-info">SIGNATURE REÇUE</span>
+          </div>
+
+          <h1>${escapeHtml(data.signerRoleLabel)} a signé l'état des lieux</h1>
+          <p>Bonjour ${escapeHtml(data.recipientName)},</p>
+          <p><strong>${escapeHtml(data.signerName)}</strong> (${escapeHtml(data.signerRoleLabel)}) vient de signer l'état des lieux ${kind} pour <strong>${escapeHtml(data.propertyAddress)}</strong>.</p>
+          <p>Il ne reste plus que votre signature pour finaliser le document.</p>
+
+          <div style="text-align: center;">
+            <a href="${data.signatureUrl}" class="button">Signer à mon tour</a>
+          </div>
+        </div>
+      `, `Il reste votre signature sur l'EDL ${kind} ${escapeHtml(data.propertyAddress)}`),
+    };
+  },
+
+  /**
+   * Notification : EDL entièrement signé par les deux parties
+   */
+  edlFullySigned: (data: {
+    recipientName: string;
+    propertyAddress: string;
+    edlType: "entree" | "sortie";
+    edlUrl: string;
+  }) => {
+    const kind = data.edlType === "entree" ? "d'entrée" : "de sortie";
+    return {
+      subject: `État des lieux ${kind} signé — ${data.propertyAddress}`,
+      html: baseLayout(`
+        <div class="content">
+          <div style="text-align: center; margin-bottom: 24px;">
+            <span class="badge badge-success">EDL FINALISÉ</span>
+          </div>
+
+          <h1>État des lieux ${kind} signé par toutes les parties</h1>
+          <p>Bonjour ${escapeHtml(data.recipientName)},</p>
+          <p>L'état des lieux ${kind} pour <strong>${escapeHtml(data.propertyAddress)}</strong> est maintenant entièrement signé. Le PDF scellé est disponible dans votre espace Talok.</p>
+
+          <div class="highlight-box" style="border-left-color: ${COLORS.success};">
+            <p style="font-weight: 600; color: ${COLORS.success}; font-size: 18px; margin: 0;">✓ EDL finalisé avec succès</p>
+          </div>
+
+          <div style="text-align: center;">
+            <a href="${data.edlUrl}" class="button button-success">Voir le PDF signé</a>
+          </div>
+        </div>
+      `, `L'EDL ${kind} pour ${escapeHtml(data.propertyAddress)} est entièrement signé`),
+    };
+  },
 };
 

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -138,19 +138,22 @@ const notificationConfig: Record<NotificationType, {
     defaultChannels: ["in_app", "email"],
     icon: "📈",
   },
+  // L'email pour ces 3 types est géré par les helpers sendEDL*Notification
+  // dédiés (templates spécifiques + idempotencyKey). On garde in_app + push
+  // ici pour éviter un email générique dupliqué.
   edl_ready_to_sign: {
     defaultPriority: "high",
-    defaultChannels: ["in_app", "email", "push"],
+    defaultChannels: ["in_app", "push"],
     icon: "✍️",
   },
   edl_signed_by_counterparty: {
     defaultPriority: "normal",
-    defaultChannels: ["in_app", "email"],
+    defaultChannels: ["in_app", "push"],
     icon: "✍️",
   },
   edl_fully_signed: {
     defaultPriority: "normal",
-    defaultChannels: ["in_app", "email"],
+    defaultChannels: ["in_app"],
     icon: "✅",
   },
   system: {

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -12,7 +12,7 @@ import { createServiceRoleClient } from "@/lib/supabase/server";
 import { sendEmail } from "@/lib/emails/resend.service";
 
 // Types
-export type NotificationType = 
+export type NotificationType =
   | "payment_received"
   | "payment_due"
   | "payment_late"
@@ -26,6 +26,9 @@ export type NotificationType =
   | "message_received"
   | "maintenance_scheduled"
   | "rent_revision"
+  | "edl_ready_to_sign"
+  | "edl_signed_by_counterparty"
+  | "edl_fully_signed"
   | "system"
   | "custom";
 
@@ -134,6 +137,21 @@ const notificationConfig: Record<NotificationType, {
     defaultPriority: "high",
     defaultChannels: ["in_app", "email"],
     icon: "📈",
+  },
+  edl_ready_to_sign: {
+    defaultPriority: "high",
+    defaultChannels: ["in_app", "email", "push"],
+    icon: "✍️",
+  },
+  edl_signed_by_counterparty: {
+    defaultPriority: "normal",
+    defaultChannels: ["in_app", "email"],
+    icon: "✍️",
+  },
+  edl_fully_signed: {
+    defaultPriority: "normal",
+    defaultChannels: ["in_app", "email"],
+    icon: "✅",
   },
   system: {
     defaultPriority: "low",
@@ -721,6 +739,87 @@ export async function notifyMessageReceived(
   });
 }
 
+/**
+ * Notifie qu'un EDL est prêt à être signé (status "completed")
+ */
+export async function notifyEDLReadyToSign(
+  recipientId: string,
+  edlId: string,
+  edlType: "entree" | "sortie",
+  propertyAddress: string,
+  recipientRole: "owner" | "tenant",
+  tokenUrl?: string,
+): Promise<Notification | null> {
+  const kind = edlType === "entree" ? "d'entrée" : "de sortie";
+  const actionUrl =
+    recipientRole === "owner"
+      ? `/owner/inspections/${edlId}?sign=1`
+      : tokenUrl || `/tenant/inspections/${edlId}`;
+  return createNotification({
+    type: "edl_ready_to_sign",
+    title: "État des lieux prêt à être signé",
+    message: `L'EDL ${kind} pour ${propertyAddress} est prêt. Veuillez le signer.`,
+    recipientId,
+    actionUrl,
+    actionLabel: "Signer",
+    metadata: { edlId, edlType, propertyAddress, recipientRole },
+  });
+}
+
+/**
+ * Notifie qu'une partie a signé l'EDL — l'autre doit encore signer.
+ */
+export async function notifyEDLSignedByCounterparty(
+  recipientId: string,
+  edlId: string,
+  edlType: "entree" | "sortie",
+  propertyAddress: string,
+  signerRole: "owner" | "tenant",
+  recipientRole: "owner" | "tenant",
+): Promise<Notification | null> {
+  const who = signerRole === "owner" ? "Le propriétaire" : "Le locataire";
+  const kind = edlType === "entree" ? "d'entrée" : "de sortie";
+  const actionUrl =
+    recipientRole === "owner"
+      ? `/owner/inspections/${edlId}?sign=1`
+      : `/tenant/inspections/${edlId}`;
+  return createNotification({
+    type: "edl_signed_by_counterparty",
+    title: `${who} a signé l'état des lieux`,
+    message: `${who} a signé l'EDL ${kind} pour ${propertyAddress}. Il reste votre signature.`,
+    recipientId,
+    actionUrl,
+    actionLabel: "Signer à mon tour",
+    metadata: { edlId, edlType, signerRole, recipientRole },
+  });
+}
+
+/**
+ * Notifie que l'EDL est entièrement signé (les deux parties).
+ */
+export async function notifyEDLFullySigned(
+  recipientId: string,
+  edlId: string,
+  edlType: "entree" | "sortie",
+  propertyAddress: string,
+  recipientRole: "owner" | "tenant",
+): Promise<Notification | null> {
+  const kind = edlType === "entree" ? "d'entrée" : "de sortie";
+  const actionUrl =
+    recipientRole === "owner"
+      ? `/owner/inspections/${edlId}`
+      : `/tenant/inspections/${edlId}`;
+  return createNotification({
+    type: "edl_fully_signed",
+    title: "État des lieux signé par toutes les parties",
+    message: `L'EDL ${kind} pour ${propertyAddress} est signé. Le PDF scellé est disponible.`,
+    recipientId,
+    actionUrl,
+    actionLabel: "Voir le PDF",
+    metadata: { edlId, edlType, recipientRole },
+  });
+}
+
 export default {
   createNotification,
   getNotifications,
@@ -733,6 +832,9 @@ export default {
   notifyLeaseSigned,
   notifyTicketCreated,
   notifyMessageReceived,
+  notifyEDLReadyToSign,
+  notifyEDLSignedByCounterparty,
+  notifyEDLFullySigned,
   notificationConfig,
 };
 


### PR DESCRIPTION
## Summary
Implements comprehensive notification and email system for État des Lieux (EDL) double signature workflow. When an EDL is signed by one party, the other party receives in-app notifications and transactional emails. When both parties have signed, both receive completion notifications.

## Key Changes

### Notifications & In-App Alerts
- Added three new notification types: `edl_ready_to_sign`, `edl_signed_by_counterparty`, `edl_fully_signed`
- Implemented `notifyEDLReadyToSign()`, `notifyEDLSignedByCounterparty()`, and `notifyEDLFullySigned()` functions in notification service
- Notifications include contextual action URLs and metadata for tracking

### Email Templates & Transactional Emails
- Created three new email templates in `templates.ts`:
  - `edlSignatureRequest`: Invitation for tenant to sign EDL
  - `edlCounterpartySigned`: Notification when one party signs, prompting the other
  - `edlFullySigned`: Confirmation when both parties have signed
- Implemented corresponding email service functions with proper idempotency keys and Resend tags

### EDL Signature Flow
- **On invite** (`/api/edl/[id]/invite/route.ts`): Sends `sendEDLSignatureRequest` email with signature token
- **On sign** (`/api/edl/[id]/sign/route.ts`): 
  - Detects if both parties have signed (double signature complete)
  - Sends counterparty notification if only one party signed
  - Sends fully-signed notification to both parties if complete
  - Resolves recipient emails from profiles and auth.users as fallback

### UI Enhancements
- Added visual indicators in inspections list showing signature status:
  - "À signer" badge (blue) when owner hasn't signed
  - "En attente locataire" badge (amber) when waiting for tenant
- Added prominent "Signer" button in actions column for unsigned EDLs
- Auto-opens signature modal when accessing inspection with `?sign=1` query parameter
- Imported new icons: `FileSignature`, `Hourglass`

### Data Enrichment
- Enhanced inspection data fetching to include:
  - `owner_signed`: Boolean indicating owner signature status
  - `tenant_signed`: Boolean indicating tenant signature status
  - `tenant_invited_at`: Timestamp of tenant invitation
- Signature detection based on presence of `signed_at` and `signature_image_path`

## Implementation Details
- Non-blocking error handling for notifications (logged as warnings, don't interrupt flow)
- Email sending uses idempotency keys to prevent duplicates
- Recipient resolution handles both direct profile emails and fallback to auth.users
- Proper role-based URL routing (owner vs tenant inspection pages)
- Maintains existing audit trail and cache invalidation patterns

https://claude.ai/code/session_01N1zYiwEiGz4DLScPpARLTT