### PR TITLE
Implement EDL sealing mechanism with atomic PDF generation

### DIFF
--- a/app/api/admin/reseal-edl/route.ts
+++ b/app/api/admin/reseal-edl/route.ts
@@ -1,0 +1,153 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleEDLFullySigned } from "@/lib/services/edl-post-signature.service";
+
+/**
+ * @maintenance Route utilitaire admin — usage ponctuel
+ * @description Force le scellement d'un EDL qui a ses 2 signatures mais
+ * n'a jamais ete scelle (status != 'signed' OU sealed_at null).
+ * Typique pour les EDL signes avant le fix de scellement sync.
+ *
+ * Etapes :
+ *  1. Verifier que l'EDL a bien les 2 signatures (owner + tenant) completes
+ *  2. Forcer status='signed' si necessaire (prerequis pour seal_edl RPC)
+ *  3. Generer le PDF final via generateSignedEdlPdf (force:true si demande)
+ *  4. Sceller via RPC seal_edl (pose sealed_at + signed_pdf_path)
+ *  5. Tracer dans audit_log
+ */
+export async function POST(request: Request) {
+  const { error: authError, user, supabase } = await requireAdmin(request);
+  if (authError || !supabase) {
+    return NextResponse.json(
+      { error: authError?.message || "Accès non autorisé" },
+      { status: authError?.status || 403 }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const edlId: unknown = body?.edl_id;
+    const force: boolean = body?.force === true;
+
+    if (!edlId || typeof edlId !== "string") {
+      return NextResponse.json({ error: "edl_id requis" }, { status: 400 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    // 1. Charger l'EDL pour snapshot avant/apres
+    const { data: edl } = await serviceClient
+      .from("edl")
+      .select("id, status, sealed_at, signed_pdf_path")
+      .eq("id", edlId)
+      .single();
+
+    if (!edl) {
+      return NextResponse.json({ error: "EDL non trouvé" }, { status: 404 });
+    }
+
+    // 2. Safety check : les 2 signatures doivent exister et etre completes
+    const { data: signatures } = await serviceClient
+      .from("edl_signatures")
+      .select("signer_role, signature_image_path, signed_at")
+      .eq("edl_id", edlId);
+
+    const hasOwner = (signatures || []).some(
+      (s: any) =>
+        (s.signer_role === "owner" || s.signer_role === "proprietaire" || s.signer_role === "bailleur") &&
+        s.signature_image_path &&
+        s.signed_at
+    );
+    const hasTenant = (signatures || []).some(
+      (s: any) =>
+        (s.signer_role === "tenant" || s.signer_role === "locataire" || s.signer_role === "locataire_principal") &&
+        s.signature_image_path &&
+        s.signed_at
+    );
+
+    if (!hasOwner || !hasTenant) {
+      return NextResponse.json(
+        {
+          error: "EDL non eligible : signatures owner + tenant requises",
+          hasOwner,
+          hasTenant,
+          signatures_count: signatures?.length ?? 0,
+        },
+        { status: 400 }
+      );
+    }
+
+    const previousStatus = (edl as any).status as string;
+
+    // 3. Forcer status='signed' si besoin (prerequis pour seal_edl RPC)
+    if (previousStatus !== "signed") {
+      const { error: updErr } = await serviceClient
+        .from("edl")
+        .update({ status: "signed" } as any)
+        .eq("id", edlId);
+      if (updErr) {
+        return NextResponse.json(
+          { error: `Echec UPDATE status='signed': ${updErr.message}` },
+          { status: 500 }
+        );
+      }
+    }
+
+    // 4. Generation PDF + scellement atomique
+    let result;
+    try {
+      result = await handleEDLFullySigned(edlId, { force });
+    } catch (sealErr) {
+      // Rollback du status si on l'a force et que le seal a echoue
+      if (previousStatus !== "signed") {
+        await serviceClient
+          .from("edl")
+          .update({ status: previousStatus } as any)
+          .eq("id", edlId);
+      }
+      throw sealErr;
+    }
+
+    // 5. Audit (non bloquant)
+    try {
+      await serviceClient.from("audit_log").insert({
+        user_id: user!.id,
+        action: "admin_reseal_edl",
+        entity_type: "edl",
+        entity_id: edlId,
+        metadata: {
+          previous_status: previousStatus,
+          previous_sealed_at: (edl as any).sealed_at,
+          previous_signed_pdf_path: (edl as any).signed_pdf_path,
+          new_storage_path: result.storagePath,
+          sealed: result.sealed,
+          force,
+        },
+      } as any);
+    } catch {
+      // audit non bloquant
+    }
+
+    return NextResponse.json({
+      success: true,
+      edl_id: edlId,
+      storage_path: result.storagePath,
+      sealed: result.sealed,
+      previous_status: previousStatus,
+    });
+  } catch (error: unknown) {
+    console.error("[admin/reseal-edl] Erreur:", error);
+    try {
+      const Sentry = await import("@sentry/nextjs");
+      Sentry.captureException(error, { tags: { route: "admin.reseal-edl" } });
+    } catch {}
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/edl/[id]/sign/route.ts
+++ b/app/api/edl/[id]/sign/route.ts
@@ -543,6 +543,15 @@ export async function POST(
     );
 
     if (hasOwner && hasTenant) {
+      // Capturer le statut precedent pour rollback en cas d'echec de
+      // scellement (signed sans PDF final = preuve legale manquante).
+      const { data: prevEdl } = await serviceClient
+        .from("edl")
+        .select("status")
+        .eq("id", edlId)
+        .single();
+      const previousStatus = (prevEdl as { status?: string } | null)?.status ?? "in_progress";
+
       const { error: edlUpdateError } = await serviceClient
         .from("edl")
         .update({ status: "signed" } as any)
@@ -582,13 +591,27 @@ export async function POST(
         },
       } as any);
 
-      // Générer le PDF signé de l'EDL — INSERT/UPDATE document + upload Storage
-      // est pris en charge par generateSignedEdlPdf (idempotent, pur PDF).
+      // Générer le PDF signé + sceller l'EDL via RPC seal_edl.
+      // SYNC + rollback : si la génération PDF ou le seal échoue, on
+      // rollback status='signed' vers previousStatus pour éviter un état
+      // incohérent (EDL signed sans PDF final = preuve légale manquante).
       try {
         const { handleEDLFullySigned } = await import("@/lib/services/edl-post-signature.service");
         await handleEDLFullySigned(edlId);
       } catch (postSignErr) {
-        console.warn("[sign-edl] Exception post-signature EDL (non bloquant):", String(postSignErr));
+        log.error("[sign-edl] Echec scellement EDL — rollback status", {
+          edlId,
+          previousStatus,
+          error: String(postSignErr),
+        });
+        await serviceClient
+          .from("edl")
+          .update({ status: previousStatus } as any)
+          .eq("id", edlId);
+        return NextResponse.json(
+          { error: "Scellement EDL échoué. Veuillez réessayer ou contacter le support." },
+          { status: 500 }
+        );
       }
 
       // Générer la facture initiale pour le bail (si pas encore créée)

--- a/app/api/leases/[id]/html/route.ts
+++ b/app/api/leases/[id]/html/route.ts
@@ -79,17 +79,17 @@ export async function GET(
       );
 
       if (hasNonEmptyFile) {
-        const { data: signedUrl } = await serviceClient.storage
-          .from("documents")
-          .createSignedUrl(signedPath, 3600);
-        if (signedUrl?.signedUrl) {
-          return NextResponse.json({
-            sealed: true,
-            pdfUrl: signedUrl.signedUrl,
-            fileName: `Bail_Signe_${(leaseCheck.property as any)?.ville || "document"}.pdf`,
-            html: null,
-          });
-        }
+        // On NE renvoie PAS la signed URL Supabase directement : Supabase
+        // Storage ajoute un header `Content-Security-Policy: sandbox` sur
+        // les PDFs, ce qui empeche le rendu dans un <iframe>. On passe par
+        // la route proxy `/api/leases/[id]/pdf?inline=1` qui re-sert les
+        // bytes avec les bons headers.
+        return NextResponse.json({
+          sealed: true,
+          pdfUrl: `/api/leases/${leaseId}/pdf?inline=1`,
+          fileName: `Bail_Signe_${(leaseCheck.property as any)?.ville || "document"}.pdf`,
+          html: null,
+        });
       }
       // File is missing or empty — fall through to HTML regeneration
       console.warn(

--- a/app/api/leases/[id]/pdf/route.ts
+++ b/app/api/leases/[id]/pdf/route.ts
@@ -21,6 +21,13 @@ export async function GET(request: Request, { params }: RouteParams) {
     const { id: leaseId } = await params;
     if (!leaseId) return NextResponse.json({ error: "ID du bail requis" }, { status: 400 });
 
+    // Supabase Storage ajoute un header `Content-Security-Policy: sandbox`
+    // sur les signed URLs de PDF, ce qui empeche le rendu dans un <iframe>.
+    // Quand ?inline=1 est passe, on proxy les bytes pour servir le PDF
+    // avec `Content-Disposition: inline` et sans CSP sandbox.
+    const url = new URL(request.url);
+    const inline = url.searchParams.get("inline") === "1";
+
     const supabase = await createClient();
     const serviceClient = getServiceClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -46,9 +53,28 @@ export async function GET(request: Request, { params }: RouteParams) {
 
     // Sealed bail: return stored PDF
     if (lease.sealed_at && lease.signed_pdf_path && !lease.signed_pdf_path.startsWith("pending_generation_")) {
+      await serviceClient.from("audit_log").insert({ user_id: user.id, action: "read", entity_type: "document", entity_id: leaseId, metadata: { type: "bail_signe", sealed: true, inline } } as any);
+
+      if (inline) {
+        const { data: fileBlob, error: dlError } = await serviceClient.storage
+          .from("documents")
+          .download(lease.signed_pdf_path);
+        if (!dlError && fileBlob) {
+          const buffer = Buffer.from(await fileBlob.arrayBuffer());
+          const fileName = `Bail_Signe_${property?.ville || leaseId.slice(0, 8)}.pdf`;
+          return new NextResponse(new Uint8Array(buffer), {
+            headers: {
+              "Content-Type": "application/pdf",
+              "Content-Disposition": `inline; filename="${fileName}"`,
+              "Content-Length": String(buffer.length),
+              "Cache-Control": "private, max-age=300",
+            },
+          });
+        }
+      }
+
       const { data: signedUrl, error: urlError } = await serviceClient.storage.from("documents").createSignedUrl(lease.signed_pdf_path, 3600);
       if (!urlError && signedUrl?.signedUrl) {
-        await serviceClient.from("audit_log").insert({ user_id: user.id, action: "read", entity_type: "document", entity_id: leaseId, metadata: { type: "bail_signe", sealed: true } } as any);
         return NextResponse.redirect(signedUrl.signedUrl);
       }
     }

--- a/app/api/signature/edl/[token]/sign/route.ts
+++ b/app/api/signature/edl/[token]/sign/route.ts
@@ -213,6 +213,15 @@ export async function POST(
     );
 
     if (hasOwner && hasTenant) {
+      // Capturer le statut precedent pour rollback en cas d'echec de
+      // scellement (signed sans PDF final = preuve legale manquante).
+      const { data: prevEdl } = await serviceClient
+        .from("edl")
+        .select("status")
+        .eq("id", signatureEntry.edl_id)
+        .single();
+      const previousStatus = (prevEdl as { status?: string } | null)?.status ?? "in_progress";
+
       await serviceClient
         .from("edl")
         .update({ status: "signed" } as any)
@@ -248,14 +257,28 @@ export async function POST(
         },
       } as any);
 
-      // Générer le PDF signé de l'EDL — INSERT/UPDATE document + upload Storage
-      // est pris en charge par generateSignedEdlPdf (idempotent, pur PDF).
+      // Générer le PDF signé + sceller l'EDL via RPC seal_edl.
+      // SYNC + rollback : si la génération PDF ou le seal échoue, on
+      // rollback status='signed' vers previousStatus pour éviter un état
+      // incohérent (EDL signed sans PDF final = preuve légale manquante).
       try {
         const { handleEDLFullySigned } = await import("@/lib/services/edl-post-signature.service");
         const edlResult = await handleEDLFullySigned(signatureEntry.edl_id);
-        log.info("Post-signature EDL via token", { htmlStored: edlResult.htmlStored, path: edlResult.storagePath });
+        log.info("Post-signature EDL via token", { path: edlResult.storagePath, sealed: edlResult.sealed });
       } catch (postSignErr) {
-        log.warn("Exception post-signature EDL via token (non bloquant)", { error: String(postSignErr) });
+        log.error("Echec scellement EDL — rollback status", {
+          edlId: signatureEntry.edl_id,
+          previousStatus,
+          error: String(postSignErr),
+        });
+        await serviceClient
+          .from("edl")
+          .update({ status: previousStatus } as any)
+          .eq("id", signatureEntry.edl_id);
+        return NextResponse.json(
+          { error: "Scellement EDL échoué. Veuillez réessayer ou contacter le support." },
+          { status: 500 }
+        );
       }
 
       // Générer la facture initiale pour le bail (si pas encore créée)

--- a/components/documents/LeasePreview.tsx
+++ b/components/documents/LeasePreview.tsx
@@ -126,7 +126,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
                       <iframe
                         src={pdfUrl}
                         className="w-full border-0"
-                        style={{ height: "calc(297mm * 2)" }}
+                        style={{ height: "calc(297mm * 2)", colorScheme: "light" }}
                         title="Bail signé plein écran"
                       />
                     ) : html ? (
@@ -160,7 +160,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
                 <iframe
                   src={pdfUrl}
                   className="w-full border-0 bg-white"
-                  style={{ height: "calc(297mm * 1.5)" }}
+                  style={{ height: "calc(297mm * 1.5)", colorScheme: "light" }}
                   title="Bail signé (document définitif)"
                   onError={() => {
                     console.error("[LeasePreview] iframe PDF failed to load", { leaseId, pdfUrl });

--- a/lib/services/edl-post-signature.service.ts
+++ b/lib/services/edl-post-signature.service.ts
@@ -25,9 +25,13 @@ export interface EDLPostSignatureResult {
   sealed: boolean;
 }
 
-export async function handleEDLFullySigned(edlId: string): Promise<EDLPostSignatureResult> {
-  // 1. Generation PDF (sync, throw si echec).
-  const generated = await generateSignedEdlPdf(edlId);
+export async function handleEDLFullySigned(
+  edlId: string,
+  options?: { force?: boolean }
+): Promise<EDLPostSignatureResult> {
+  // 1. Generation PDF (sync, throw si echec). `force:true` bypass
+  //    l'idempotence et regenere meme si un doc existe deja.
+  const generated = await generateSignedEdlPdf(edlId, { force: options?.force === true });
 
   if (!generated.storagePath) {
     throw new Error(`[edl-post-signature] Generation PDF EDL ${edlId} echouee (pas de storagePath)`);

--- a/lib/services/edl-post-signature.service.ts
+++ b/lib/services/edl-post-signature.service.ts
@@ -2,31 +2,50 @@
  * Service post-signature EDL — SOTA 2026
  *
  * Genere le PDF definitif de l'etat des lieux signe (entree ou sortie) des
- * que toutes les parties ont signe. Remplace l'ancien signed_document.html.
+ * que toutes les parties ont signe, puis scelle l'EDL via RPC seal_edl
+ * (pattern aligne sur seal_lease).
  *
  * Appele par :
  *  - POST /api/edl/[id]/sign                 (proprietaire signe via l'app)
  *  - POST /api/signature/edl/[token]/sign    (locataire signe via token)
  *
- * Idempotent : si un PDF signe existe deja, retourne l'existant.
+ * Idempotent : si un PDF signe existe deja, retourne l'existant. Si l'EDL
+ * est deja scelle, seal_edl renvoie FALSE sans erreur.
+ *
+ * IMPORTANT : ce service throw en cas d'echec (generation PDF OU seal RPC).
+ * Les routes appelantes DOIVENT wrapper dans try/catch et rollback le
+ * status='signed' pour eviter un etat incoherent (signed sans PDF final).
  */
 
 import { generateSignedEdlPdf } from "@/lib/pdf/edl-signed-pdf";
+import { getServiceClient } from "@/lib/supabase/service-client";
 
 export interface EDLPostSignatureResult {
-  htmlStored: boolean;
-  storagePath: string | null;
+  storagePath: string;
+  sealed: boolean;
 }
 
 export async function handleEDLFullySigned(edlId: string): Promise<EDLPostSignatureResult> {
-  try {
-    const generated = await generateSignedEdlPdf(edlId);
-    return {
-      htmlStored: true,
-      storagePath: generated.storagePath,
-    };
-  } catch (err) {
-    console.warn("[edl-post-signature] Exception (non bloquant):", String(err));
-    return { htmlStored: false, storagePath: null };
+  // 1. Generation PDF (sync, throw si echec).
+  const generated = await generateSignedEdlPdf(edlId);
+
+  if (!generated.storagePath) {
+    throw new Error(`[edl-post-signature] Generation PDF EDL ${edlId} echouee (pas de storagePath)`);
   }
+
+  // 2. Scellement atomique via RPC seal_edl.
+  const serviceClient = getServiceClient();
+  const { data: sealed, error: sealError } = await serviceClient.rpc("seal_edl" as any, {
+    p_edl_id: edlId,
+    p_pdf_path: generated.storagePath,
+  });
+
+  if (sealError) {
+    throw new Error(`[edl-post-signature] seal_edl echoue pour ${edlId}: ${sealError.message}`);
+  }
+
+  return {
+    storagePath: generated.storagePath,
+    sealed: sealed === true,
+  };
 }

--- a/supabase/migrations/20260420120000_seal_edl.sql
+++ b/supabase/migrations/20260420120000_seal_edl.sql
@@ -1,0 +1,67 @@
+-- ============================================
+-- Migration : Scellement EDL (pattern seal_lease)
+-- Date : 2026-04-20
+-- ============================================
+-- Un EDL signe par toutes les parties doit etre fige :
+-- status='signed' + signed_pdf_path + sealed_at non-null.
+-- Aligne sur le pattern `leases` (migration 20251228100000).
+-- ============================================
+
+-- 1. Colonnes de scellement
+ALTER TABLE edl
+  ADD COLUMN IF NOT EXISTS signed_pdf_path TEXT,
+  ADD COLUMN IF NOT EXISTS sealed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN edl.signed_pdf_path IS 'Chemin du PDF final signe dans Storage (immutable apres signature complete)';
+COMMENT ON COLUMN edl.sealed_at IS 'Date a laquelle l''EDL a ete scelle (toutes signatures collectees)';
+
+-- 2. Index pour rechercher les EDL sceles
+CREATE INDEX IF NOT EXISTS idx_edl_sealed_at ON edl(sealed_at)
+  WHERE sealed_at IS NOT NULL;
+
+-- 3. Fonction RPC seal_edl : scellement atomique apres signature complete
+CREATE OR REPLACE FUNCTION seal_edl(
+  p_edl_id UUID,
+  p_pdf_path TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_current_status TEXT;
+  v_sealed_at TIMESTAMPTZ;
+BEGIN
+  SELECT status, sealed_at INTO v_current_status, v_sealed_at
+  FROM edl
+  WHERE id = p_edl_id
+  FOR UPDATE;
+
+  IF v_current_status IS NULL THEN
+    RAISE EXCEPTION 'EDL % introuvable', p_edl_id;
+  END IF;
+
+  -- Idempotent : si deja scelle, ne fait rien
+  IF v_sealed_at IS NOT NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  IF v_current_status != 'signed' THEN
+    RAISE EXCEPTION 'EDL % doit etre au statut ''signed'' avant scellement (statut actuel: %)', p_edl_id, v_current_status;
+  END IF;
+
+  UPDATE edl
+  SET
+    signed_pdf_path = p_pdf_path,
+    sealed_at = NOW()
+  WHERE id = p_edl_id
+    AND sealed_at IS NULL;
+
+  RETURN FOUND;
+END;
+$$;
+
+COMMENT ON FUNCTION seal_edl IS 'Scelle un EDL apres signature complete. Stocke le chemin du PDF final et empeche les modifications futures.';
+
+GRANT EXECUTE ON FUNCTION seal_edl(UUID, TEXT) TO authenticated, service_role;

--- a/supabase/migrations/20260420120000_seal_edl.sql
+++ b/supabase/migrations/20260420120000_seal_edl.sql
@@ -7,6 +7,11 @@
 -- Aligne sur le pattern `leases` (migration 20251228100000).
 -- ============================================
 
+-- 0. Drop l'ancienne version si elle existe avec un autre return type
+--    (drift git<->prod observe le 2026-04-20 : fonction pre-existante
+--    avec signature differente, aucun appelant dans le code app).
+DROP FUNCTION IF EXISTS seal_edl(UUID, TEXT);
+
 -- 1. Colonnes de scellement
 ALTER TABLE edl
   ADD COLUMN IF NOT EXISTS signed_pdf_path TEXT,


### PR DESCRIPTION
## Summary
Implements a robust EDL (État des Lieux) sealing mechanism that ensures atomicity between PDF generation and database state. This prevents inconsistent states where an EDL is marked as "signed" but lacks the final PDF proof required for legal validity.

## Key Changes

- **New RPC function `seal_edl()`**: Database-level sealing that atomically stores the PDF path and sets `sealed_at` timestamp. Idempotent design prevents duplicate sealing attempts.

- **EDL table schema updates**: Added `signed_pdf_path` and `sealed_at` columns with appropriate indexing to track sealed documents.

- **Enhanced `handleEDLFullySigned()` service**: Now performs both PDF generation and RPC sealing in sequence, throwing on any failure to enable proper rollback handling.

- **Transactional rollback in signature routes**: Both `/api/edl/[id]/sign` and `/api/signature/edl/[token]/sign` now capture previous EDL status and rollback to it if PDF generation or sealing fails, preventing orphaned "signed" EDLs without proof documents.

- **Admin utility endpoint `/api/admin/reseal-edl`**: Maintenance route to force-reseal EDLs that have both signatures but were never sealed (common for EDLs signed before the sealing fix was deployed). Includes comprehensive validation and audit logging.

- **Lease PDF inline rendering**: Added `?inline=1` parameter support to proxy PDF bytes with proper `Content-Disposition: inline` headers, bypassing Supabase Storage's CSP sandbox restrictions that prevented iframe rendering.

- **Audit logging**: All sealing operations (normal flow and admin reseal) are logged with metadata tracking status transitions and PDF paths.

## Implementation Details

- The sealing pattern mirrors the existing `seal_lease()` RPC design for consistency
- All signature routes now treat PDF generation/sealing failures as blocking errors with proper user feedback
- The admin reseal endpoint validates both signatures exist before attempting to seal
- Idempotent design allows safe retry of sealing operations without side effects

https://claude.ai/code/session_01L613qbQoPq2qKwL6GGTZrZ