### PR TITLE
fix(tenant): render sealed lease via srcDoc html (not pdf proxy)

### DIFF
--- a/app/api/leases/[id]/html/route.ts
+++ b/app/api/leases/[id]/html/route.ts
@@ -79,23 +79,38 @@ export async function GET(
       );
 
       if (hasNonEmptyFile) {
-        // On NE renvoie PAS la signed URL Supabase directement : Supabase
-        // Storage ajoute un header `Content-Security-Policy: sandbox` sur
-        // les PDFs, ce qui empeche le rendu dans un <iframe>. On passe par
-        // la route proxy `/api/leases/[id]/pdf?inline=1` qui re-sert les
-        // bytes avec les bons headers.
-        return NextResponse.json({
-          sealed: true,
-          pdfUrl: `/api/leases/${leaseId}/pdf?inline=1`,
-          fileName: `Bail_Signe_${(leaseCheck.property as any)?.ville || "document"}.pdf`,
-          html: null,
-        });
+        // Le "signed_pdf_path" est historiquement un chemin HTML
+        // (bails/{id}/signed_final.html) — pas un PDF. On download le
+        // contenu et on le renvoie tel quel pour injection via
+        // <iframe srcDoc={html}> cote client (meme pattern que la vue
+        // owner, qui ne passe pas par un iframe PDF).
+        const { data: fileBlob, error: dlError } = await serviceClient.storage
+          .from("documents")
+          .download(signedPath);
+
+        if (!dlError && fileBlob) {
+          const htmlContent = await fileBlob.text();
+          if (htmlContent && htmlContent.length > 0) {
+            return NextResponse.json({
+              sealed: true,
+              sealedAt: leaseCheck.sealed_at,
+              html: htmlContent,
+              fileName: `Bail_Signe_${(leaseCheck.property as any)?.ville || "document"}.pdf`,
+              pdfUrl: null,
+            });
+          }
+        }
+
+        console.warn(
+          "[Lease HTML] sealed file download failed, falling back to HTML regeneration",
+          { leaseId, signed_pdf_path: signedPath, error: dlError?.message }
+        );
+      } else {
+        console.warn(
+          "[Lease HTML] sealed_at set but signed_pdf_path missing in storage, falling back to HTML",
+          { leaseId, signed_pdf_path: signedPath }
+        );
       }
-      // File is missing or empty — fall through to HTML regeneration
-      console.warn(
-        "[Lease HTML] sealed_at set but signed_pdf_path missing in storage, falling back to HTML",
-        { leaseId, signed_pdf_path: signedPath }
-      );
     }
 
     // Build bail data via unified builder

--- a/app/api/leases/[id]/pdf/route.ts
+++ b/app/api/leases/[id]/pdf/route.ts
@@ -21,13 +21,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const { id: leaseId } = await params;
     if (!leaseId) return NextResponse.json({ error: "ID du bail requis" }, { status: 400 });
 
-    // Supabase Storage ajoute un header `Content-Security-Policy: sandbox`
-    // sur les signed URLs de PDF, ce qui empeche le rendu dans un <iframe>.
-    // Quand ?inline=1 est passe, on proxy les bytes pour servir le PDF
-    // avec `Content-Disposition: inline` et sans CSP sandbox.
-    const url = new URL(request.url);
-    const inline = url.searchParams.get("inline") === "1";
-
     const supabase = await createClient();
     const serviceClient = getServiceClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -51,30 +44,16 @@ export async function GET(request: Request, { params }: RouteParams) {
     const isSigner = (lease.signers as any[])?.some((s: any) => s.profile_id === profile.id);
     if (!isOwner && !isAdmin && !isSigner) return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
 
-    // Sealed bail: return stored PDF
+    // Sealed bail: return stored document (can be HTML or PDF depending on
+    // historical generation — the `signed_pdf_path` column name is a
+    // misnomer, it may contain a *.html). We redirect to the signed URL so
+    // Supabase serves with the actual stored Content-Type; the tenant
+    // preview no longer goes through this route (it uses srcDoc on the
+    // HTML content returned by /api/leases/[id]/html instead).
     if (lease.sealed_at && lease.signed_pdf_path && !lease.signed_pdf_path.startsWith("pending_generation_")) {
-      await serviceClient.from("audit_log").insert({ user_id: user.id, action: "read", entity_type: "document", entity_id: leaseId, metadata: { type: "bail_signe", sealed: true, inline } } as any);
-
-      if (inline) {
-        const { data: fileBlob, error: dlError } = await serviceClient.storage
-          .from("documents")
-          .download(lease.signed_pdf_path);
-        if (!dlError && fileBlob) {
-          const buffer = Buffer.from(await fileBlob.arrayBuffer());
-          const fileName = `Bail_Signe_${property?.ville || leaseId.slice(0, 8)}.pdf`;
-          return new NextResponse(new Uint8Array(buffer), {
-            headers: {
-              "Content-Type": "application/pdf",
-              "Content-Disposition": `inline; filename="${fileName}"`,
-              "Content-Length": String(buffer.length),
-              "Cache-Control": "private, max-age=300",
-            },
-          });
-        }
-      }
-
       const { data: signedUrl, error: urlError } = await serviceClient.storage.from("documents").createSignedUrl(lease.signed_pdf_path, 3600);
       if (!urlError && signedUrl?.signedUrl) {
+        await serviceClient.from("audit_log").insert({ user_id: user.id, action: "read", entity_type: "document", entity_id: leaseId, metadata: { type: "bail_signe", sealed: true } } as any);
         return NextResponse.redirect(signedUrl.signedUrl);
       }
     }

--- a/components/documents/LeasePreview.tsx
+++ b/components/documents/LeasePreview.tsx
@@ -13,7 +13,6 @@ interface LeasePreviewProps {
 
 export function LeasePreview({ leaseId }: LeasePreviewProps) {
   const [html, setHtml] = useState<string>("");
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [isSealed, setIsSealed] = useState(false);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
@@ -37,19 +36,13 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
 
       const data = await response.json();
 
-      if (data.sealed && data.pdfUrl) {
-        setPdfUrl(data.pdfUrl);
-        setIsSealed(true);
-        setHtml("");
-      } else if (typeof data.html === "string" && data.html.length > 0) {
+      if (typeof data.html === "string" && data.html.length > 0) {
         setHtml(data.html);
-        setPdfUrl(null);
-        setIsSealed(false);
+        setIsSealed(Boolean(data.sealed));
       } else {
-        // Ni PDF signé, ni HTML : impossible d'afficher l'aperçu
-        console.error("[LeasePreview] Réponse API vide — ni pdfUrl ni html", { leaseId, data });
+        // Ni HTML scellé ni HTML live : impossible d'afficher l'aperçu
+        console.error("[LeasePreview] Réponse API vide — ni html scellé ni html live", { leaseId, data });
         setHtml("");
-        setPdfUrl(null);
         setIsSealed(false);
         setFetchError("Le document n'est pas encore disponible");
       }
@@ -59,7 +52,6 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
       const message = error instanceof Error ? error.message : "Erreur inconnue";
       setFetchError(message);
       setHtml("");
-      setPdfUrl(null);
       setIsSealed(false);
       toast({
         title: "Erreur",
@@ -79,16 +71,16 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
   // React's attribute reconciliation may not reliably update srcdoc on
   // existing iframes in all browsers.
   useEffect(() => {
-    if (iframeRef.current && html && !isSealed) {
+    if (iframeRef.current && html) {
       iframeRef.current.srcdoc = html;
     }
-  }, [html, isSealed, iframeKey]);
+  }, [html, iframeKey]);
 
   useEffect(() => {
-    if (fullscreenIframeRef.current && html && !isSealed && fullscreen) {
+    if (fullscreenIframeRef.current && html && fullscreen) {
       fullscreenIframeRef.current.srcdoc = html;
     }
-  }, [html, isSealed, fullscreen, iframeKey]);
+  }, [html, fullscreen, iframeKey]);
 
   return (
     <Card className="h-full flex flex-col">
@@ -109,7 +101,7 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
           </Button>
           <Dialog open={fullscreen} onOpenChange={setFullscreen}>
             <DialogTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" disabled={!html && !pdfUrl}>
+              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" disabled={!html}>
                 <Maximize2 className="h-4 w-4" />
               </Button>
             </DialogTrigger>
@@ -122,21 +114,14 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
               <div className="flex-1 min-h-0 bg-[#525659] overflow-y-auto">
                 <div className="flex justify-center py-6 px-4">
                   <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)]">
-                    {isSealed && pdfUrl ? (
-                      <iframe
-                        src={pdfUrl}
-                        className="w-full border-0"
-                        style={{ height: "calc(297mm * 2)", colorScheme: "light" }}
-                        title="Bail signé plein écran"
-                      />
-                    ) : html ? (
+                    {html ? (
                       <iframe
                         ref={fullscreenIframeRef}
                         key={`fullscreen-${iframeKey}`}
                         srcDoc={html}
                         className="w-full border-0"
-                        style={{ height: "calc(297mm * 2)" }}
-                        title="Aperçu bail plein écran"
+                        style={{ height: "calc(297mm * 2)", colorScheme: "light" }}
+                        title={isSealed ? "Bail signé plein écran" : "Aperçu bail plein écran"}
                       />
                     ) : null}
                   </div>
@@ -154,21 +139,6 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
               <Loader2 className="h-6 w-6 sm:h-8 sm:w-8 animate-spin text-blue-600 mb-2" />
               <p className="text-xs sm:text-sm text-white/80 text-center">Chargement du contrat...</p>
             </div>
-          ) : isSealed && pdfUrl && !iframeFailed ? (
-            <div className="h-full overflow-y-auto flex justify-center py-4 px-2 sm:px-4">
-              <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)] flex-shrink-0 h-fit">
-                <iframe
-                  src={pdfUrl}
-                  className="w-full border-0 bg-white"
-                  style={{ height: "calc(297mm * 1.5)", colorScheme: "light" }}
-                  title="Bail signé (document définitif)"
-                  onError={() => {
-                    console.error("[LeasePreview] iframe PDF failed to load", { leaseId, pdfUrl });
-                    setIframeFailed(true);
-                  }}
-                />
-              </div>
-            </div>
           ) : html && !iframeFailed ? (
             <div className="h-full overflow-y-auto flex justify-center py-4 px-2 sm:px-4">
               <div className="w-full max-w-[210mm] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.3)] flex-shrink-0 h-fit">
@@ -177,10 +147,10 @@ export function LeasePreview({ leaseId }: LeasePreviewProps) {
                   key={`preview-${iframeKey}`}
                   srcDoc={html}
                   className="w-full border-0 bg-white"
-                  style={{ height: "calc(297mm * 1.5)" }}
-                  title="Aperçu du bail"
+                  style={{ height: "calc(297mm * 1.5)", colorScheme: "light" }}
+                  title={isSealed ? "Bail signé (document définitif)" : "Aperçu du bail"}
                   onError={() => {
-                    console.error("[LeasePreview] iframe HTML failed to load", { leaseId });
+                    console.error("[LeasePreview] iframe failed to load", { leaseId, isSealed });
                     setIframeFailed(true);
                   }}
                 />


### PR DESCRIPTION
## Summary

- PR #445 proxied sealed bails as `application/pdf` — but every sealed bail stores HTML in Supabase (`bails/{id}/signed_final.html`). The browser got HTML with a PDF MIME and rendered "Échec de chargement du document PDF".
- Align the tenant preview on the owner pattern: return the stored HTML server-side, inject via `<iframe srcDoc={html}>` — no PDF MIME juggling required.
- Drop the now-unused `?inline=1` branch from `/api/leases/[id]/pdf` (dead code since LeasePreview no longer calls it).

## Changes

- `app/api/leases/[id]/html/route.ts` — for a sealed bail, download the stored file from the `documents` bucket, read as text, return `{ sealed, sealedAt, html, fileName }`. Graceful fallback to live HTML regeneration on download failure (or when the stored file is missing/empty).
- `components/documents/LeasePreview.tsx` — remove the dual PDF/HTML iframe branches; a single `<iframe srcDoc={html}>` path (plus `colorScheme: light` safeguard). Keeps the "Bail signé" title + fullscreen toggle when `sealed=true`.
- `app/api/leases/[id]/pdf/route.ts` — revert to pre-PR#445 redirect-to-signed-URL behavior. The three "Télécharger mon bail" buttons (tenant page, owner contracts list, LeasePreview fallback) keep working unchanged via Supabase's actual stored Content-Type.

## Test plan

- [ ] Login `volberg.thomas@hotmail.fr` → `/tenant/home` → onglet Contrat → le bail s'affiche (HTML rendu dans l'iframe via `srcDoc`)
- [ ] DevTools Network → une seule requête `/api/leases/[id]/html`, aucune `/pdf`
- [ ] DevTools Console → aucune erreur "Échec de chargement du document PDF"
- [ ] Comparer visuellement avec la vue owner → identique
- [ ] Bouton "Télécharger mon bail" → ouvre le document (HTML ou PDF selon stockage Supabase)
- [ ] Bail non scellé → aperçu live HTML toujours fonctionnel

## Follow-up

- Update skill `talok-documents-sota` : `leases.signed_pdf_path` est un path HTML (`bails/{id}/signed_final.html`) malgré son nom. Preview pattern = `<iframe srcDoc={html}>` côté owner ET tenant. TODO : ajouter un vrai export PDF via Puppeteer pour les téléchargements.

https://claude.ai/code/session_01L613qbQoPq2qKwL6GGTZrZ