### PR TITLE
Add error handling and logging to provider layout

### DIFF
--- a/app/provider/layout.tsx
+++ b/app/provider/layout.tsx
@@ -53,6 +53,7 @@ export default async function VendorLayout({
 }: {
   children: React.ReactNode;
 }) {
+  try {
   const supabase = await createClient();
   const {
     data: { user },
@@ -162,4 +163,32 @@ export default async function VendorLayout({
       </div>
     </ErrorBoundary>
   );
+  } catch (e) {
+    // Re-throw redirect()/notFound() untouched so Next.js can process them
+    const digest =
+      typeof e === "object" && e !== null && "digest" in e
+        ? String((e as { digest?: unknown }).digest)
+        : null;
+    if (digest && (digest.startsWith("NEXT_REDIRECT") || digest === "NEXT_NOT_FOUND")) {
+      throw e;
+    }
+
+    // Surface the real error in Netlify/Vercel function logs — Next.js hides it
+    // behind a generic digest in production. This lets us diagnose the root cause
+    // of the intermittent "Oups ! Une erreur est survenue" seen on /provider/dashboard.
+    const err = e instanceof Error ? e : new Error(String(e));
+    console.error(
+      JSON.stringify({
+        level: "error",
+        source: "app/provider/layout",
+        name: err.name,
+        message: err.message,
+        stack: err.stack,
+        cause: err.cause ? String(err.cause) : undefined,
+        timestamp: new Date().toISOString(),
+      })
+    );
+
+    throw e;
+  }
 }


### PR DESCRIPTION
## Summary
Added comprehensive error handling to the provider layout component to improve debugging and error visibility in production environments.

## Key Changes
- Wrapped the entire layout component logic in a try-catch block
- Implemented special handling for Next.js redirect and notFound errors to allow them to propagate correctly
- Added structured JSON logging for all other errors to surface root causes in Netlify/Vercel function logs
- Logs include error name, message, stack trace, cause, and timestamp for better diagnostics

## Implementation Details
The error handler distinguishes between Next.js framework errors (which must be re-thrown untouched) and application errors (which are logged before re-throwing). This addresses intermittent "Oups ! Une erreur est survenue" errors on the `/provider/dashboard` route by ensuring error details are visible in production logs, where Next.js normally hides them behind generic digests.

https://claude.ai/code/session_01KAGc4aYC6oUHPKi1WhK3py