### PR TITLE
Add CSRF token protection to admin API mutations

### DIFF
--- a/lib/hooks/use-admin-queries.ts
+++ b/lib/hooks/use-admin-queries.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getClientCsrfToken } from "@/lib/security/csrf";
 
 // ─── Query Keys ────────────────────────────────────────────
 export const adminKeys = {
@@ -35,10 +36,21 @@ async function adminMutate<T>(
   method: string,
   body?: unknown
 ): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+  const upperMethod = method.toUpperCase();
+  if (["POST", "PUT", "DELETE", "PATCH"].includes(upperMethod)) {
+    const csrfToken = getClientCsrfToken();
+    if (csrfToken) {
+      headers["x-csrf-token"] = csrfToken;
+    }
+  }
+
   const res = await fetch(url, {
     method,
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: body ? JSON.stringify(body) : undefined,
+    credentials: "same-origin",
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));


### PR DESCRIPTION
## Summary
Enhanced security for admin API mutations by implementing CSRF token protection. The `adminMutate` function now automatically includes CSRF tokens in request headers for state-changing operations (POST, PUT, DELETE, PATCH).

## Key Changes
- Import `getClientCsrfToken` utility from the security module
- Dynamically build request headers to include CSRF token for mutation methods
- Add CSRF token (`x-csrf-token` header) to POST, PUT, DELETE, and PATCH requests
- Include `credentials: "same-origin"` in fetch options to ensure cookies are sent with requests
- Maintain backward compatibility by only adding CSRF token when available

## Implementation Details
- CSRF tokens are only added for state-changing HTTP methods (POST, PUT, DELETE, PATCH), not for GET requests
- The implementation gracefully handles cases where `getClientCsrfToken()` returns null or undefined
- The `credentials: "same-origin"` setting ensures that same-origin requests include authentication cookies, which is necessary for proper CSRF validation

https://claude.ai/code/session_01VF4HrjyLXUFPodZmyx6Q4x