### PR TITLE
fix(provider): stop passing lucide icons across the RSC→Client boundary

### DIFF
--- a/app/provider/layout.tsx
+++ b/app/provider/layout.tsx
@@ -8,20 +8,6 @@ import { getServerProfile } from "@/lib/helpers/auth-helper";
 import { getRoleDashboardUrl } from "@/lib/helpers/role-redirects";
 import { checkIdentityGate } from "@/lib/helpers/identity-gate";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
-import {
-  LayoutDashboard,
-  Briefcase,
-  Receipt,
-  Calendar,
-  Star,
-  Settings,
-  HelpCircle,
-  FileText,
-  FolderOpen,
-  Shield,
-  Image,
-  MessageSquare,
-} from "lucide-react";
 import { NotificationCenter } from "@/components/notifications/notification-center";
 import { ProviderBottomNav } from "@/components/layout/provider-bottom-nav";
 import { ProviderRailNav } from "@/components/layout/provider-rail-nav";
@@ -29,24 +15,6 @@ import { ProviderSidebar } from "@/components/layout/provider-sidebar";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { OfflineIndicator } from "@/components/ui/offline-indicator";
 import { PlatformBroadcastBanner } from "@/components/platform-broadcast-banner";
-
-const navigation = [
-  { name: "Tableau de bord", href: "/provider/dashboard", icon: LayoutDashboard },
-  { name: "Mes missions", href: "/provider/jobs", icon: Briefcase },
-  { name: "Messages", href: "/provider/messages", icon: MessageSquare },
-  { name: "Calendrier", href: "/provider/calendar", icon: Calendar },
-  { name: "Mes devis", href: "/provider/quotes", icon: FileText },
-  { name: "Mes factures", href: "/provider/invoices", icon: Receipt },
-  { name: "Mes documents", href: "/provider/documents", icon: FolderOpen },
-  { name: "Mes avis", href: "/provider/reviews", icon: Star },
-  { name: "Conformité", href: "/provider/compliance", icon: Shield },
-  { name: "Mon portfolio", href: "/provider/portfolio", icon: Image },
-];
-
-const secondaryNav = [
-  { name: "Paramètres", href: "/provider/settings", icon: Settings },
-  { name: "Aide", href: "/provider/help", icon: HelpCircle },
-];
 
 export default async function VendorLayout({
   children,
@@ -96,14 +64,10 @@ export default async function VendorLayout({
         <OfflineIndicator />
 
         {/* TABLET Rail Nav (md-lg) - Icônes + tooltip hover (client component) */}
-        <ProviderRailNav navigation={navigation} secondaryNav={secondaryNav} />
+        <ProviderRailNav />
 
         {/* Desktop Sidebar (lg+) - Client component avec état actif + déconnexion */}
-        <ProviderSidebar
-          navigation={navigation}
-          secondaryNav={secondaryNav}
-          profile={profile}
-        />
+        <ProviderSidebar profile={profile} />
 
         {/* Mobile header (< md) */}
         <div className="sticky top-0 z-40 flex items-center gap-x-4 bg-background/95 backdrop-blur-sm px-3 xs:px-4 sm:px-6 py-3 shadow-sm border-b border-border md:hidden">

--- a/components/layout/provider-nav-config.ts
+++ b/components/layout/provider-nav-config.ts
@@ -1,0 +1,39 @@
+import {
+  LayoutDashboard,
+  Briefcase,
+  Receipt,
+  Calendar,
+  Star,
+  Settings,
+  HelpCircle,
+  FileText,
+  FolderOpen,
+  Shield,
+  Image,
+  MessageSquare,
+  type LucideIcon,
+} from "lucide-react";
+
+export interface ProviderNavItem {
+  name: string;
+  href: string;
+  icon: LucideIcon;
+}
+
+export const providerNavigation: ProviderNavItem[] = [
+  { name: "Tableau de bord", href: "/provider/dashboard", icon: LayoutDashboard },
+  { name: "Mes missions", href: "/provider/jobs", icon: Briefcase },
+  { name: "Messages", href: "/provider/messages", icon: MessageSquare },
+  { name: "Calendrier", href: "/provider/calendar", icon: Calendar },
+  { name: "Mes devis", href: "/provider/quotes", icon: FileText },
+  { name: "Mes factures", href: "/provider/invoices", icon: Receipt },
+  { name: "Mes documents", href: "/provider/documents", icon: FolderOpen },
+  { name: "Mes avis", href: "/provider/reviews", icon: Star },
+  { name: "Conformité", href: "/provider/compliance", icon: Shield },
+  { name: "Mon portfolio", href: "/provider/portfolio", icon: Image },
+];
+
+export const providerSecondaryNav: ProviderNavItem[] = [
+  { name: "Paramètres", href: "/provider/settings", icon: Settings },
+  { name: "Aide", href: "/provider/help", icon: HelpCircle },
+];

--- a/components/layout/provider-rail-nav.tsx
+++ b/components/layout/provider-rail-nav.tsx
@@ -3,26 +3,17 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { LucideIcon } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { providerNavigation, providerSecondaryNav } from "./provider-nav-config";
 
-interface NavItem {
-  name: string;
-  href: string;
-  icon: LucideIcon;
-}
-
-interface ProviderRailNavProps {
-  navigation: NavItem[];
-  secondaryNav: NavItem[];
-}
-
-export function ProviderRailNav({ navigation, secondaryNav }: ProviderRailNavProps) {
+export function ProviderRailNav() {
+  const navigation = providerNavigation;
+  const secondaryNav = providerSecondaryNav;
   const pathname = usePathname();
 
   const isActive = (href: string) =>

--- a/components/layout/provider-sidebar.tsx
+++ b/components/layout/provider-sidebar.tsx
@@ -4,23 +4,16 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
-import { LucideIcon, LogOut } from "lucide-react";
+import { LogOut } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-
-interface NavItem {
-  name: string;
-  href: string;
-  icon: LucideIcon;
-}
+import { providerNavigation, providerSecondaryNav } from "./provider-nav-config";
 
 interface ProviderSidebarProps {
-  navigation: NavItem[];
-  secondaryNav: NavItem[];
   profile: {
     prenom: string | null;
     nom: string | null;
@@ -28,11 +21,9 @@ interface ProviderSidebarProps {
   };
 }
 
-export function ProviderSidebar({
-  navigation,
-  secondaryNav,
-  profile,
-}: ProviderSidebarProps) {
+export function ProviderSidebar({ profile }: ProviderSidebarProps) {
+  const navigation = providerNavigation;
+  const secondaryNav = providerSecondaryNav;
   const pathname = usePathname();
   const router = useRouter();
 


### PR DESCRIPTION
The Netlify function log at 2026-04-20T19:26:20 surfaced the real cause of digest 164674343:

    Error: Functions cannot be passed directly to Client Components
    unless you explicitly expose it by marking it with "use server".
    {$$typeof: ..., render: function, displayName: ...}

The shape {$$typeof, render, displayName} is lucide-react forwardRef components. app/provider/layout.tsx (server) declared a `navigation` array with icon fields pointing to LayoutDashboard, Briefcase, etc. and passed it as a prop to ProviderRailNav and ProviderSidebar (client). Next.js 14 can't serialize component references across the RSC → Client boundary and threw on every render of /provider/dashboard.

Fix:
- Add components/layout/provider-nav-config.ts holding providerNavigation and providerSecondaryNav alongside the icon imports (plain TS module reached from client components only).
- ProviderRailNav and ProviderSidebar pull the config directly; drop the `navigation` / `secondaryNav` props + the NavItem type.
- app/provider/layout.tsx drops the lucide imports, the two nav constants and the prop wiring.
- ProviderSidebar keeps its `profile` prop (plain JSON, serializable).
- ProviderBottomNav was already self-contained, untouched.

Kept the diagnostic try/catch around the layout body — next time a server error surfaces in production we'll see the real message again instead of staring at digest 164674343.