### PR TITLE
Fix EDL signature detection when seal fails after signing

### DIFF
--- a/app/owner/_data/fetchLeaseDetails.ts
+++ b/app/owner/_data/fetchLeaseDetails.ts
@@ -537,7 +537,9 @@ async function fetchLeaseDetailsFallback(
     signed_pdf_path: leaseData.signed_pdf_path ?? null,
     loyer: leaseData.loyer ?? property.loyer_hc ?? 0,
     charges_forfaitaires: leaseData.charges_forfaitaires ?? property.charges_mensuelles ?? 0,
-    has_signed_edl: edl?.status === "signed",
+    has_signed_edl:
+      edl?.status === "signed" ||
+      (edl?.status === "completed" && (edlStats?.signatures_count ?? 0) >= 2),
     has_paid_initial: initialInvoiceSettlement?.isSettled ?? false,
     property_id: leaseData.property_id,
     unit_id: leaseData.unit_id,

--- a/app/owner/_data/lease-readiness.ts
+++ b/app/owner/_data/lease-readiness.ts
@@ -56,6 +56,11 @@ export interface LeaseReadinessDocument {
 export interface LeaseReadinessEdl {
   id: string;
   status: EdlStatus;
+  // Nombre de signatures effectives (bailleur + locataire) présentes sur l'EDL.
+  // Utilisé comme filet de sécurité : lorsqu'un seal a échoué après l'enregistrement
+  // des 2 signatures, le status reste parfois à "completed" alors que l'EDL est
+  // déjà signé par les deux parties. On considère alors l'EDL comme "signed".
+  signatures_count?: number;
 }
 
 export interface LeaseDpeStatus {
@@ -466,7 +471,7 @@ export function deriveLeaseReadinessState(
         "L'état des lieux existe mais n'est pas encore finalisé ni signé.",
       href: `/owner/inspections/${edl.id}`,
     };
-  } else if (edl.status === "completed") {
+  } else if (edl.status === "completed" && (edl.signatures_count ?? 0) < 2) {
     edlState = {
       status: "awaiting_signature",
       label: "Signature EDL requise",
@@ -475,6 +480,8 @@ export function deriveLeaseReadinessState(
       href: `/owner/inspections/${edl.id}`,
     };
   } else {
+    // status === "signed" OU status === "completed" avec 2/2 signatures
+    // (cas où le seal a échoué après signature — l'EDL est bien signé).
     edlState = {
       status: "signed",
       label: "EDL signé",

--- a/app/owner/leases/[id]/tabs/LeaseEdlTab.tsx
+++ b/app/owner/leases/[id]/tabs/LeaseEdlTab.tsx
@@ -162,7 +162,11 @@ export function LeaseEdlTab({
     ? Math.round(((edl.completed_items || 0) / edl.total_items) * 100)
     : 0;
   const isIncomplete = ["draft", "scheduled", "in_progress"].includes(edl.status);
-  const isCompleted = edl.status === "completed";
+  // Un EDL "completed" avec déjà 2/2 signatures est en réalité signé : on évite
+  // d'afficher "Signer l'EDL" à un utilisateur qui a déjà signé (cas d'un seal
+  // qui a échoué après enregistrement des 2 signatures).
+  const isCompleted =
+    edl.status === "completed" && (edl.signatures_count ?? 0) < 2;
 
   return (
     <motion.div

--- a/features/edl/components/edl-preview.tsx
+++ b/features/edl/components/edl-preview.tsx
@@ -71,6 +71,20 @@ export function EDLPreview({
   const lastHashRef = useRef<string>("");
   const { toast } = useToast();
 
+  // Refs pour accéder aux dernières valeurs sans retrigger l'effet de debounce.
+  // Sans ces refs, chaque nouveau `edlData` reçu du parent (nouvelle référence à
+  // chaque render) relance le timer et la page reste bloquée sur "Génération…".
+  const edlDataRef = useRef(edlData);
+  const roomsRef = useRef(rooms);
+  const toastRef = useRef(toast);
+  const htmlRef = useRef(html);
+  useEffect(() => {
+    edlDataRef.current = edlData;
+    roomsRef.current = rooms;
+    toastRef.current = toast;
+    htmlRef.current = html;
+  });
+
   // === MÉMORISATION: Hash des données clés pour éviter re-renders inutiles ===
   const dataHash = useMemo(() => {
     const hashData = JSON.stringify({
@@ -219,14 +233,22 @@ export function EDLPreview({
     const { errors, warnings } = validateEDLData();
     setValidationErrors(errors);
     setValidationWarnings(warnings);
-  }, [previewHtml, validateEDLData]);
+    // validateEDLData est volontairement hors des deps : on veut déclencher
+    // cet effet sur le changement de previewHtml uniquement, et lire les
+    // données les plus récentes via la closure au moment du run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewHtml]);
 
   // === DEBOUNCE: Génération de l'aperçu avec délai ===
+  // IMPORTANT: les dépendances sont volontairement réduites à des primitives
+  // stables (dataHash / edlId / isVierge / previewHtml). Inclure `edlData`,
+  // `validateEDLData`, `toast` ou `html` relançait l'effet à chaque render du
+  // parent (nouvelle référence d'objet), ce qui réinitialisait le timer de
+  // debounce et laissait l'aperçu bloqué sur "Génération de l'aperçu…".
   useEffect(() => {
-    // Si le HTML est fourni en prop, ne pas appeler l'API
     if (previewHtml !== undefined) return;
 
-    if (lastHashRef.current === dataHash && html) {
+    if (lastHashRef.current === dataHash && htmlRef.current) {
       return;
     }
 
@@ -240,9 +262,6 @@ export function EDLPreview({
       try {
         const { errors, warnings } = validateEDLData();
 
-        // 🔧 FIX P0: Quand un edlId est fourni, l'API charge les données complètes
-        // depuis la BDD → les erreurs de validation locales ne sont pas pertinentes
-        // et créent une contradiction visuelle (erreurs en rouge + document complet en-dessous)
         if (edlId) {
           setValidationErrors([]);
           setValidationWarnings([]);
@@ -253,18 +272,19 @@ export function EDLPreview({
 
         if (errors.length > 0 && !isVierge && !edlId) {
           setHtml("");
-          setLoading(false);
           return;
         }
 
+        const currentEdlData = edlDataRef.current;
+        const currentRooms = roomsRef.current;
         const response = await fetch("/api/edl/preview", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            edlData,
+            edlData: currentEdlData,
             edlId,
             isVierge,
-            rooms: isVierge ? rooms : undefined,
+            rooms: isVierge ? currentRooms : undefined,
           }),
         });
 
@@ -278,7 +298,7 @@ export function EDLPreview({
         setLastGenerated(new Date());
       } catch (error) {
         console.error("Erreur génération EDL:", error);
-        toast({
+        toastRef.current({
           title: "Erreur",
           description: "Impossible de générer l'aperçu de l'état des lieux",
           variant: "destructive",
@@ -293,7 +313,8 @@ export function EDLPreview({
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [dataHash, edlData, edlId, isVierge, rooms, validateEDLData, toast, html, previewHtml]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataHash, edlId, isVierge, previewHtml]);
 
   // Mettre à jour l'iframe quand le HTML change
   useEffect(() => {

--- a/tests/unit/lease-readiness.test.ts
+++ b/tests/unit/lease-readiness.test.ts
@@ -212,6 +212,67 @@ describe("deriveLeaseReadinessState", () => {
     expect(state.nextAction.key).toBe("activate_lease");
   });
 
+  it("traite un EDL 'completed' avec 2/2 signatures comme signé (filet seal échoué)", () => {
+    const state = deriveLeaseReadinessState(
+      buildInput({
+        lease: {
+          id: "lease-1",
+          statut: "fully_signed",
+          has_signed_edl: true,
+        },
+        edl: {
+          id: "edl-1",
+          status: "completed",
+          signatures_count: 2,
+        },
+        invoices: [
+          {
+            id: "inv-1",
+            montant_total: 1200,
+            statut: "sent",
+            created_at: "2026-01-01T00:00:00.000Z",
+            metadata: { type: "initial_invoice" },
+          },
+        ],
+      })
+    );
+
+    expect(state.edlState.status).toBe("signed");
+    expect(state.documentState.edl).toBe("available");
+    expect(state.blockingReasons).not.toContain(
+      "L'état des lieux d'entrée n'est pas encore signé."
+    );
+  });
+
+  it("reste 'awaiting_signature' pour un EDL 'completed' avec <2 signatures", () => {
+    const state = deriveLeaseReadinessState(
+      buildInput({
+        lease: {
+          id: "lease-1",
+          statut: "fully_signed",
+          has_signed_edl: false,
+        },
+        edl: {
+          id: "edl-1",
+          status: "completed",
+          signatures_count: 1,
+        },
+        invoices: [
+          {
+            id: "inv-1",
+            montant_total: 1200,
+            statut: "sent",
+            created_at: "2026-01-01T00:00:00.000Z",
+            metadata: { type: "initial_invoice" },
+          },
+        ],
+      })
+    );
+
+    expect(state.edlState.status).toBe("awaiting_signature");
+    expect(state.edlState.label).toBe("Signature EDL requise");
+  });
+
   it("retourne active_stable quand le bail est actif et complet", () => {
     const state = deriveLeaseReadinessState(
       buildInput({


### PR DESCRIPTION
## Summary
This PR fixes an issue where EDLs (état des lieux/property inspection reports) were incorrectly marked as unsigned when a seal operation failed after both parties had already signed. The fix adds a safety net by checking the actual signature count to determine if an EDL is truly signed, even when the status remains "completed" due to a failed seal.

## Key Changes

- **EDL signature detection logic**: Modified `deriveLeaseReadinessState()` to treat an EDL with status "completed" and 2+ signatures as "signed", accounting for cases where the seal operation failed after signatures were recorded
- **Lease readiness state**: Updated `has_signed_edl` calculation in `fetchLeaseDetailsFallback()` to recognize both "signed" status and "completed" status with 2+ signatures
- **UI state handling**: Fixed `LeaseEdlTab` to avoid showing "Sign EDL" prompt when an EDL already has 2 signatures, even if status is "completed"
- **React hooks optimization**: Fixed debounce and validation logic in `EDLPreview` component by:
  - Using refs to access latest values without retriggering debounce timers
  - Reducing effect dependencies to stable primitives (dataHash, edlId, isVierge, previewHtml)
  - Preventing infinite re-renders caused by new object references from parent component
- **Data model**: Added `signatures_count` field to `LeaseReadinessEdl` interface to track actual signature count

## Implementation Details

The core issue was that when a seal operation failed after both parties signed, the EDL status would remain "completed" instead of transitioning to "signed". The fix uses `signatures_count` as a safety net to detect this scenario and treat the EDL as properly signed.

The EDLPreview component optimization addresses a separate but related issue where debounce timers were constantly reset due to new object references, leaving the preview stuck on "Generating...". Using refs allows the effect to read current values without being retriggered.

## Tests Added
- Test for EDL with "completed" status and 2/2 signatures (treated as signed)
- Test for EDL with "completed" status and <2 signatures (remains awaiting signature)

https://claude.ai/code/session_01XrQCx6r8EMW3Sk4C11geU6