### PR TITLE
fix(sitemap): retire /auth/signup (307 vers /signup/role)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -113,13 +113,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }));
 
+  // /auth/signup redirige (307) vers /signup/role. Seule la cible finale
+  // est listee pour eviter un redirect dans le sitemap.
   const authPages: MetadataRoute.Sitemap = [
-    {
-      url: `${BASE_URL}/auth/signup`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
     {
       url: `${BASE_URL}/signup/role`,
       lastModified: now,


### PR DESCRIPTION
## Summary

Petit follow-up à la PR #454 : la vérification post-merge a montré que 31/32 URLs du sitemap renvoient 200, mais `/auth/signup` renvoie 307 vers `/signup/role`.

Google Search Console classe les URLs redirigées listées dans un sitemap en « Page avec redirection » (exclusion de couverture) et peut tagger le sitemap comme de qualité dégradée. `/signup/role` (la cible finale) est déjà présent dans le sitemap, donc on ne perd aucune cible d'indexation.

## Changes

- `app/sitemap.ts` : retire l'entrée `/auth/signup`, garde uniquement `/signup/role`.

## Test plan

- [x] `curl -sI https://talok.fr/auth/signup` renvoie 307 avec `location: /signup/role`
- [x] `/signup/role` déjà listé dans le sitemap actuel
- [ ] Après deploy : `curl -s https://talok.fr/sitemap.xml | grep -c '<loc>'` doit renvoyer 31
- [ ] Après deploy : aucune entrée `<loc>https://talok.fr/auth/signup</loc>` dans le sitemap

https://claude.ai/code/session_017nvSPQqJaMmrN82etWLYw5