### PR TITLE
Fix Radix Select empty value handling with sentinel values

### DIFF
--- a/app/admin/subscriptions/page.tsx
+++ b/app/admin/subscriptions/page.tsx
@@ -238,7 +238,9 @@ function AdminActionModal({ open, onClose, user, action, onSuccess }: ActionModa
   const [loading, setLoading] = useState(false);
   const [targetPlan, setTargetPlan] = useState<PlanSlug>("confort");
   const [giftDays, setGiftDays] = useState(30);
-  const [giftPlan, setGiftPlan] = useState<PlanSlug | "">("");
+  // Sentinel: Radix Select disallows SelectItem with value="".
+  const GIFT_KEEP_PLAN = "__keep_current__";
+  const [giftPlan, setGiftPlan] = useState<PlanSlug | typeof GIFT_KEEP_PLAN>(GIFT_KEEP_PLAN);
   const [reason, setReason] = useState("");
   const [notifyUser, setNotifyUser] = useState(true);
   // Refund-specific state
@@ -270,7 +272,7 @@ function AdminActionModal({ open, onClose, user, action, onSuccess }: ActionModa
         body.target_plan = targetPlan;
       } else if (action === "gift") {
         body.days = giftDays;
-        if (giftPlan) {
+        if (giftPlan && giftPlan !== GIFT_KEEP_PLAN) {
           body.plan_slug = giftPlan;
         }
       } else if (action === "refund") {
@@ -435,12 +437,12 @@ function AdminActionModal({ open, onClose, user, action, onSuccess }: ActionModa
               </div>
               <div className="space-y-2">
                 <Label className="text-foreground">Plan (optionnel — change le forfait pendant l&apos;essai)</Label>
-                <Select value={giftPlan} onValueChange={(v) => setGiftPlan(v as PlanSlug | "")}>
+                <Select value={giftPlan} onValueChange={(v) => setGiftPlan(v as PlanSlug | typeof GIFT_KEEP_PLAN)}>
                   <SelectTrigger className="bg-background border-input">
                     <SelectValue placeholder="Garder le plan actuel" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Garder le plan actuel</SelectItem>
+                    <SelectItem value={GIFT_KEEP_PLAN}>Garder le plan actuel</SelectItem>
                     {(["starter", "confort", "pro", "enterprise_s", "enterprise_m", "enterprise_l", "enterprise_xl"] as PlanSlug[]).map((slug) => (
                       <SelectItem key={slug} value={slug}>
                         {PLANS[slug].name}

--- a/components/ged/ged-upload-dialog.tsx
+++ b/components/ged/ged-upload-dialog.tsx
@@ -59,10 +59,13 @@ export function GedUploadDialog({
   const { toast } = useToast();
   const uploadMutation = useGedUpload();
 
+  // Sentinel: Radix Select disallows SelectItem with value="".
+  const NO_PROPERTY = "__none__";
+
   const [file, setFile] = useState<File | null>(null);
   const [docType, setDocType] = useState<string>(defaultType || "autre");
   const [title, setTitle] = useState("");
-  const [propertyId, setPropertyId] = useState<string>(defaultPropertyId || "");
+  const [propertyId, setPropertyId] = useState<string>(defaultPropertyId || NO_PROPERTY);
   const [validUntil, setValidUntil] = useState("");
   const [dragActive, setDragActive] = useState(false);
 
@@ -70,7 +73,7 @@ export function GedUploadDialog({
     setFile(null);
     setDocType(defaultType || "autre");
     setTitle("");
-    setPropertyId(defaultPropertyId || "");
+    setPropertyId(defaultPropertyId || NO_PROPERTY);
     setValidUntil("");
   }, [defaultType, defaultPropertyId]);
 
@@ -132,7 +135,7 @@ export function GedUploadDialog({
       file,
       type: docType as DocumentType,
       title: title || undefined,
-      property_id: propertyId || defaultPropertyId || null,
+      property_id: (propertyId && propertyId !== NO_PROPERTY) ? propertyId : (defaultPropertyId || null),
       lease_id: defaultLeaseId || null,
       entity_id: defaultEntityId || null,
       valid_until: validUntil || null,
@@ -258,7 +261,7 @@ export function GedUploadDialog({
                   <SelectValue placeholder="Sélectionner un bien (optionnel)" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">Aucun bien</SelectItem>
+                  <SelectItem value={NO_PROPERTY}>Aucun bien</SelectItem>
                   {properties.map((p) => (
                     <SelectItem key={p.id} value={p.id}>
                       {p.adresse_complete} - {p.ville}


### PR DESCRIPTION
## Summary
Radix UI's Select component doesn't allow `SelectItem` elements with `value=""`. This PR fixes two components that were using empty strings as placeholder values by replacing them with sentinel constants.

## Key Changes
- **GedUploadDialog**: Replaced empty string `""` with `NO_PROPERTY` sentinel for the "no property selected" option
  - Updated initial state to use `NO_PROPERTY` instead of `""`
  - Updated form reset logic to use the sentinel value
  - Updated property_id submission logic to check for the sentinel value before sending to API
  
- **AdminActionModal (Subscriptions)**: Replaced empty string `""` with `GIFT_KEEP_PLAN` sentinel for the "keep current plan" option
  - Updated initial state to use `GIFT_KEEP_PLAN` instead of `""`
  - Updated gift plan submission logic to check for the sentinel value before including in request body
  - Updated type annotations to reflect the new sentinel constant

## Implementation Details
- Both components now use descriptive sentinel constants (`NO_PROPERTY` and `GIFT_KEEP_PLAN`) instead of empty strings
- The sentinel values are never sent to the API; they're converted to `null` or omitted based on the business logic
- Type safety is maintained by including the sentinel constants in union types where appropriate

https://claude.ai/code/session_01CchnVjBMR1xnoJRgam4GBF