### PR TITLE
Add CSRF protection to admin API requests

### DIFF
--- a/app/admin/site-content/page.tsx
+++ b/app/admin/site-content/page.tsx
@@ -18,6 +18,7 @@ import {
   PenLine,
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
+import { fetchWithCsrf } from "@/lib/security/csrf";
 
 interface SiteContentItem {
   id: string;
@@ -132,7 +133,7 @@ export default function SiteContentAdminPage() {
     setSaving(true);
 
     try {
-      const res = await fetch("/api/admin/site-content", {
+      const res = await fetchWithCsrf("/api/admin/site-content", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/app/admin/subscriptions/page.tsx
+++ b/app/admin/subscriptions/page.tsx
@@ -82,6 +82,7 @@ import {
 import { cn } from "@/lib/utils";
 import { exportCSV } from "@/lib/utils/export-csv";
 import { useToast } from "@/components/ui/use-toast";
+import { fetchWithCsrf } from "@/lib/security/csrf";
 
 // ============================================
 // STATS CARDS
@@ -295,7 +296,7 @@ function AdminActionModal({ open, onClose, user, action, onSuccess }: ActionModa
         };
       }
 
-      const res = await fetch(endpoint, {
+      const res = await fetchWithCsrf(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
This PR adds CSRF (Cross-Site Request Forgery) protection to admin API requests by replacing standard `fetch` calls with a `fetchWithCsrf` wrapper function.

## Key Changes
- Imported `fetchWithCsrf` security utility in admin pages
- Updated site content admin page to use `fetchWithCsrf` for POST requests to `/api/admin/site-content`
- Updated subscriptions admin page to use `fetchWithCsrf` for admin action modal API requests

## Implementation Details
The changes replace direct `fetch()` calls with `fetchWithCsrf()` wrapper, which automatically handles CSRF token inclusion in requests. This ensures that state-changing operations (POST requests) in the admin panel are protected against cross-site request forgery attacks.

Both modified pages handle sensitive admin operations:
- Site content management (create/update operations)
- User subscription management (admin actions on user accounts)

https://claude.ai/code/session_01Wwzf6o8A4ufSaQBqwKac8H