### PR TITLE
Add tenant self-service service booking with owner approval workflow

### DIFF
--- a/app/api/owner/leases/[id]/tenant-service-bookings/route.ts
+++ b/app/api/owner/leases/[id]/tenant-service-bookings/route.ts
@@ -1,0 +1,125 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import { TENANT_BOOKABLE_CATEGORIES } from "@/lib/tickets/tenant-service-permissions";
+
+/**
+ * PATCH /api/owner/leases/[id]/tenant-service-bookings
+ *
+ * Permet au propriétaire (ou admin) de configurer sur un bail quelles
+ * catégories de services le locataire peut réserver directement.
+ */
+const bodySchema = z.object({
+  enabled: z.boolean(),
+  allowed_categories: z.array(z.enum(TENANT_BOOKABLE_CATEGORIES)).default([]),
+  max_amount_cents: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional(),
+  requires_owner_approval: z.boolean().default(false),
+});
+
+export const PATCH = withSecurity(
+  async function PATCH(
+    request: Request,
+    context: { params: Promise<{ id: string }> }
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) {
+        return NextResponse.json(
+          { error: authError.message },
+          { status: authError.status || 401 }
+        );
+      }
+      if (!user) {
+        return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+      }
+
+      const { id: leaseId } = await context.params;
+
+      const body = await request.json();
+      const validated = bodySchema.parse(body);
+
+      const serviceClient = getServiceClient();
+
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (!profile) {
+        return NextResponse.json(
+          { error: "Profil non trouvé", code: "NO_PROFILE" },
+          { status: 404 }
+        );
+      }
+
+      const profileData = profile as { id: string; role: string };
+
+      const { data: lease } = await serviceClient
+        .from("leases")
+        .select("id, property_id")
+        .eq("id", leaseId)
+        .maybeSingle();
+
+      if (!lease) {
+        return NextResponse.json(
+          { error: "Bail introuvable", code: "LEASE_NOT_FOUND" },
+          { status: 404 }
+        );
+      }
+
+      const leaseData = lease as { id: string; property_id: string };
+
+      if (profileData.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", leaseData.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileData.id) {
+          return NextResponse.json(
+            {
+              error: "Vous n'êtes pas propriétaire de ce bail",
+              code: "NO_ACCESS",
+            },
+            { status: 403 }
+          );
+        }
+      }
+
+      const payload = {
+        enabled: validated.enabled,
+        allowed_categories: validated.enabled ? validated.allowed_categories : [],
+        max_amount_cents: validated.max_amount_cents ?? null,
+        requires_owner_approval: validated.requires_owner_approval,
+      };
+
+      const { error: updateError } = await serviceClient
+        .from("leases")
+        .update({ tenant_service_bookings: payload })
+        .eq("id", leaseId);
+
+      if (updateError) throw updateError;
+
+      return NextResponse.json({ tenant_service_bookings: payload });
+    } catch (error: unknown) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "PATCH /api/owner/leases/[id]/tenant-service-bookings",
+    csrf: true,
+  }
+);

--- a/app/api/tenant/providers/route.ts
+++ b/app/api/tenant/providers/route.ts
@@ -1,0 +1,124 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import {
+  TENANT_BOOKABLE_CATEGORIES,
+  checkTenantBookingPermission,
+  type TenantBookableCategory,
+} from "@/lib/tickets/tenant-service-permissions";
+
+/**
+ * GET /api/tenant/providers?category=jardinage
+ *
+ * Liste les prestataires marketplace disponibles pour une catégorie donnée,
+ * à condition que le locataire soit autorisé par son bail à la réserver.
+ */
+export async function GET(request: Request) {
+  try {
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError) {
+      return NextResponse.json(
+        { error: authError.message },
+        { status: authError.status || 401 }
+      );
+    }
+    if (!user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const url = new URL(request.url);
+    const category = url.searchParams.get("category");
+    if (!category) {
+      return NextResponse.json(
+        { error: "category requis", code: "MISSING_CATEGORY" },
+        { status: 400 }
+      );
+    }
+    if (!(TENANT_BOOKABLE_CATEGORIES as readonly string[]).includes(category)) {
+      return NextResponse.json(
+        { error: "Catégorie non réservable", code: "INVALID_CATEGORY" },
+        { status: 400 }
+      );
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, email")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: "Profil non trouvé", code: "NO_PROFILE" },
+        { status: 404 }
+      );
+    }
+
+    const profileData = profile as { id: string; email: string | null };
+
+    const decision = await checkTenantBookingPermission({
+      serviceClient,
+      profileId: profileData.id,
+      userEmail: profileData.email ?? user.email ?? null,
+      category,
+    });
+
+    if (!decision.allowed) {
+      return NextResponse.json(
+        { error: decision.message, code: decision.code },
+        { status: decision.status }
+      );
+    }
+
+    // Filtrer par département de la propriété si disponible (rayon = service_radius_km)
+    const { data: property } = await serviceClient
+      .from("properties")
+      .select("departement")
+      .eq("id", decision.property_id)
+      .maybeSingle();
+
+    const department = (property as { departement: string | null } | null)?.departement ?? null;
+
+    let query = serviceClient
+      .from("providers")
+      .select(
+        "id, profile_id, company_name, contact_name, city, postal_code, department, avg_rating, total_reviews, total_interventions, is_verified, trade_categories"
+      )
+      .eq("status", "active")
+      .eq("is_marketplace", true)
+      .contains("trade_categories", [category])
+      .order("avg_rating", { ascending: false, nullsFirst: false })
+      .limit(30);
+
+    if (department) {
+      query = query.eq("department", department);
+    }
+
+    const { data: providers, error } = await query;
+    if (error) {
+      console.error("[GET /api/tenant/providers] Supabase error:", error.message);
+      return NextResponse.json(
+        { error: "Erreur lors de la recherche des prestataires" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      category: category as TenantBookableCategory,
+      requires_owner_approval: decision.permissions.requires_owner_approval,
+      max_amount_cents: decision.permissions.max_amount_cents,
+      providers: providers ?? [],
+    });
+  } catch (error: unknown) {
+    console.error("[GET /api/tenant/providers] Erreur:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/tenant/services/request/route.ts
+++ b/app/api/tenant/services/request/route.ts
@@ -11,6 +11,7 @@ import {
   TENANT_BOOKABLE_CATEGORIES,
   checkTenantBookingPermission,
 } from "@/lib/tickets/tenant-service-permissions";
+import { suggestForTenantBookableCategory } from "@/lib/tickets/charges-classification";
 
 const bodySchema = z.object({
   provider_id: z.string().uuid(),
@@ -136,6 +137,10 @@ export const POST = withSecurity(
       const requiresApproval = decision.permissions.requires_owner_approval;
       const approvalStatus = requiresApproval ? "pending" : "not_required";
 
+      // Classification charges récupérables (décret 87-713). Le self-service
+      // locataire est par nature récupérable : c'est le locataire qui initie.
+      const chargeSuggestion = suggestForTenantBookableCategory(validated.category);
+
       // 3. Créer le ticket (déclencheur du parcours pour le propriétaire aussi)
       const { data: ticket, error: ticketError } = await serviceClient
         .from("tickets")
@@ -150,6 +155,8 @@ export const POST = withSecurity(
           owner_id: decision.owner_profile_id,
           assigned_to: providerData.profile_id,
           statut: requiresApproval ? "open" : "assigned",
+          is_tenant_chargeable: chargeSuggestion.is_tenant_chargeable,
+          charge_category_code: chargeSuggestion.charge_category_code,
         })
         .select("id, reference")
         .single();
@@ -157,7 +164,7 @@ export const POST = withSecurity(
       if (ticketError) throw ticketError;
       const ticketRow = ticket as { id: string; reference: string | null };
 
-      // 4. Créer le work_order
+      // 4. Créer le work_order (hérite de la classification du ticket)
       const { data: workOrder, error: woError } = await serviceClient
         .from("work_orders")
         .insert({
@@ -172,6 +179,8 @@ export const POST = withSecurity(
           statut: requiresApproval ? "assigned" : "assigned",
           requester_role: "tenant",
           owner_approval_status: approvalStatus,
+          is_tenant_chargeable: chargeSuggestion.is_tenant_chargeable,
+          charge_category_code: chargeSuggestion.charge_category_code,
         })
         .select("id")
         .single();

--- a/app/api/tenant/services/request/route.ts
+++ b/app/api/tenant/services/request/route.ts
@@ -1,0 +1,247 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import {
+  TENANT_BOOKABLE_CATEGORIES,
+  checkTenantBookingPermission,
+} from "@/lib/tickets/tenant-service-permissions";
+
+const bodySchema = z.object({
+  provider_id: z.string().uuid(),
+  category: z.enum(TENANT_BOOKABLE_CATEGORIES),
+  title: z.string().min(3).max(120),
+  description: z.string().min(10).max(2000),
+  preferred_date: z.string().optional().nullable(),
+});
+
+/**
+ * POST /api/tenant/services/request
+ *
+ * Parcours self-service : un locataire réserve un prestataire directement.
+ * Crée :
+ *   - un ticket (rattaché au bail, visible owner + tenant)
+ *   - un work_order assigné au provider choisi
+ * Notifie l'owner (informatif) et le provider (nouvelle mission).
+ *
+ * Si le bail exige `requires_owner_approval`, le work_order est créé en
+ * owner_approval_status='pending' et le provider n'est notifié qu'après
+ * validation explicite de l'owner (route dédiée, à venir).
+ */
+export const POST = withSecurity(
+  async function POST(request: Request) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) {
+        return NextResponse.json(
+          { error: authError.message },
+          { status: authError.status || 401 }
+        );
+      }
+      if (!user) {
+        return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+      }
+
+      const body = await request.json();
+      const validated = bodySchema.parse(body);
+
+      const serviceClient = getServiceClient();
+
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, email")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (!profile) {
+        return NextResponse.json(
+          { error: "Profil non trouvé", code: "NO_PROFILE" },
+          { status: 404 }
+        );
+      }
+
+      const profileData = profile as { id: string; email: string | null };
+
+      // 1. Vérifier la permission
+      const decision = await checkTenantBookingPermission({
+        serviceClient,
+        profileId: profileData.id,
+        userEmail: profileData.email ?? user.email ?? null,
+        category: validated.category,
+      });
+
+      if (!decision.allowed) {
+        return NextResponse.json(
+          { error: decision.message, code: decision.code },
+          { status: decision.status }
+        );
+      }
+
+      // 2. Vérifier que le provider existe, est actif, et couvre la catégorie
+      const { data: provider } = await serviceClient
+        .from("providers")
+        .select("id, profile_id, company_name, status, is_marketplace, trade_categories")
+        .eq("id", validated.provider_id)
+        .maybeSingle();
+
+      const providerData = provider as
+        | {
+            id: string;
+            profile_id: string | null;
+            company_name: string;
+            status: string;
+            is_marketplace: boolean;
+            trade_categories: string[] | null;
+          }
+        | null;
+
+      if (!providerData) {
+        return NextResponse.json(
+          { error: "Prestataire introuvable", code: "PROVIDER_NOT_FOUND" },
+          { status: 404 }
+        );
+      }
+      if (providerData.status !== "active" || !providerData.is_marketplace) {
+        return NextResponse.json(
+          {
+            error: "Ce prestataire n'est pas disponible actuellement",
+            code: "PROVIDER_UNAVAILABLE",
+          },
+          { status: 409 }
+        );
+      }
+      if (!(providerData.trade_categories || []).includes(validated.category)) {
+        return NextResponse.json(
+          {
+            error: "Ce prestataire ne couvre pas cette catégorie",
+            code: "CATEGORY_MISMATCH",
+          },
+          { status: 409 }
+        );
+      }
+
+      const requiresApproval = decision.permissions.requires_owner_approval;
+      const approvalStatus = requiresApproval ? "pending" : "not_required";
+
+      // 3. Créer le ticket (déclencheur du parcours pour le propriétaire aussi)
+      const { data: ticket, error: ticketError } = await serviceClient
+        .from("tickets")
+        .insert({
+          titre: validated.title,
+          description: validated.description,
+          category: validated.category,
+          priorite: "normal",
+          property_id: decision.property_id,
+          lease_id: decision.lease_id,
+          created_by_profile_id: profileData.id,
+          owner_id: decision.owner_profile_id,
+          assigned_to: providerData.profile_id,
+          statut: requiresApproval ? "open" : "assigned",
+        })
+        .select("id, reference")
+        .single();
+
+      if (ticketError) throw ticketError;
+      const ticketRow = ticket as { id: string; reference: string | null };
+
+      // 4. Créer le work_order
+      const { data: workOrder, error: woError } = await serviceClient
+        .from("work_orders")
+        .insert({
+          ticket_id: ticketRow.id,
+          property_id: decision.property_id,
+          lease_id: decision.lease_id,
+          provider_id: providerData.profile_id,
+          title: validated.title,
+          description: validated.description,
+          category: validated.category,
+          date_intervention_prevue: validated.preferred_date ?? null,
+          statut: requiresApproval ? "assigned" : "assigned",
+          requester_role: "tenant",
+          owner_approval_status: approvalStatus,
+        })
+        .select("id")
+        .single();
+
+      if (woError) throw woError;
+      const workOrderRow = workOrder as { id: string };
+
+      // 5. Lier le work_order au ticket
+      await serviceClient
+        .from("tickets")
+        .update({ work_order_id: workOrderRow.id })
+        .eq("id", ticketRow.id);
+
+      // 6. Notifications : owner toujours, provider seulement si pas d'approbation
+      const { data: ownerProfile } = await serviceClient
+        .from("profiles")
+        .select("user_id")
+        .eq("id", decision.owner_profile_id)
+        .maybeSingle();
+
+      const ownerUserId = (ownerProfile as { user_id: string } | null)?.user_id ?? null;
+
+      const { data: providerProfile } = providerData.profile_id
+        ? await serviceClient
+            .from("profiles")
+            .select("user_id")
+            .eq("id", providerData.profile_id)
+            .maybeSingle()
+        : { data: null };
+
+      const providerUserId =
+        (providerProfile as { user_id: string } | null)?.user_id ?? null;
+
+      const outboxEvents: any[] = [
+        {
+          event_type: requiresApproval
+            ? "TenantService.ApprovalRequested"
+            : "TenantService.Booked",
+          payload: {
+            ticket_id: ticketRow.id,
+            ticket_reference: ticketRow.reference,
+            work_order_id: workOrderRow.id,
+            category: validated.category,
+            title: validated.title,
+            provider_id: providerData.profile_id,
+            provider_company: providerData.company_name,
+            recipient_user_id: ownerUserId,
+            requester_role: "tenant",
+          },
+        },
+      ];
+
+      if (!requiresApproval && providerUserId) {
+        outboxEvents.push({
+          event_type: "WorkOrder.AssignedToProvider",
+          payload: {
+            ticket_id: ticketRow.id,
+            ticket_reference: ticketRow.reference,
+            work_order_id: workOrderRow.id,
+            category: validated.category,
+            title: validated.title,
+            preferred_date: validated.preferred_date ?? null,
+            recipient_user_id: providerUserId,
+          },
+        });
+      }
+
+      await serviceClient.from("outbox").insert(outboxEvents);
+
+      return NextResponse.json({
+        ticket_id: ticketRow.id,
+        ticket_reference: ticketRow.reference,
+        work_order_id: workOrderRow.id,
+        requires_owner_approval: requiresApproval,
+      });
+    } catch (error: unknown) {
+      return handleApiError(error);
+    }
+  },
+  { routeName: "POST /api/tenant/services/request", csrf: true }
+);

--- a/app/api/tenant/services/request/route.ts
+++ b/app/api/tenant/services/request/route.ts
@@ -54,7 +54,7 @@ export const POST = withSecurity(
 
       const { data: profile } = await serviceClient
         .from("profiles")
-        .select("id, email")
+        .select("id, email, prenom, nom")
         .eq("user_id", user.id)
         .maybeSingle();
 
@@ -65,7 +65,15 @@ export const POST = withSecurity(
         );
       }
 
-      const profileData = profile as { id: string; email: string | null };
+      const profileData = profile as {
+        id: string;
+        email: string | null;
+        prenom: string | null;
+        nom: string | null;
+      };
+      const tenantName =
+        `${profileData.prenom ?? ""} ${profileData.nom ?? ""}`.trim() ||
+        "Votre locataire";
 
       // 1. Vérifier la permission
       const decision = await checkTenantBookingPermission({
@@ -210,6 +218,8 @@ export const POST = withSecurity(
             title: validated.title,
             provider_id: providerData.profile_id,
             provider_company: providerData.company_name,
+            tenant_name: tenantName,
+            preferred_date: validated.preferred_date ?? null,
             recipient_user_id: ownerUserId,
             requester_role: "tenant",
           },

--- a/app/api/tickets/[id]/charge-classification/route.ts
+++ b/app/api/tickets/[id]/charge-classification/route.ts
@@ -1,0 +1,120 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+
+/**
+ * PATCH /api/tickets/[id]/charge-classification
+ *
+ * Permet au propriétaire (ou admin) de confirmer/modifier la suggestion
+ * automatique de classification "charges récupérables" sur un ticket.
+ * Met à jour aussi le work_order lié si présent, pour cohérence.
+ */
+const bodySchema = z.object({
+  is_tenant_chargeable: z.boolean().nullable(),
+  charge_category_code: z
+    .enum([
+      "ascenseurs",
+      "eau_chauffage",
+      "installations_individuelles",
+      "parties_communes",
+      "espaces_exterieurs",
+      "taxes_redevances",
+    ])
+    .nullable(),
+});
+
+export const PATCH = withSecurity(
+  async function PATCH(
+    request: Request,
+    context: { params: Promise<{ id: string }> }
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: ticketId } = await context.params;
+      const body = await request.json();
+      const validated = bodySchema.parse(body);
+
+      // Cohérence : si pas récupérable, on force category à null
+      if (validated.is_tenant_chargeable !== true) {
+        validated.charge_category_code = null;
+      }
+
+      const serviceClient = getServiceClient();
+
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const profileData = profile as { id: string; role: string };
+
+      const { data: ticket } = await serviceClient
+        .from("tickets")
+        .select("id, property_id, work_order_id")
+        .eq("id", ticketId)
+        .maybeSingle();
+
+      if (!ticket) throw new ApiError(404, "Ticket introuvable");
+      const ticketData = ticket as {
+        id: string;
+        property_id: string | null;
+        work_order_id: string | null;
+      };
+
+      // Autorisation : owner de la propriété ou admin
+      if (profileData.role !== "admin" && ticketData.property_id) {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", ticketData.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileData.id) {
+          throw new ApiError(403, "Seul le propriétaire peut modifier la classification");
+        }
+      }
+
+      // Mise à jour du ticket
+      const { error: tErr } = await serviceClient
+        .from("tickets")
+        .update({
+          is_tenant_chargeable: validated.is_tenant_chargeable,
+          charge_category_code: validated.charge_category_code,
+        })
+        .eq("id", ticketId);
+      if (tErr) throw tErr;
+
+      // Miroir sur le work_order lié s'il existe
+      if (ticketData.work_order_id) {
+        await serviceClient
+          .from("work_orders")
+          .update({
+            is_tenant_chargeable: validated.is_tenant_chargeable,
+            charge_category_code: validated.charge_category_code,
+          })
+          .eq("id", ticketData.work_order_id);
+      }
+
+      return NextResponse.json({
+        is_tenant_chargeable: validated.is_tenant_chargeable,
+        charge_category_code: validated.charge_category_code,
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "PATCH /api/tickets/[id]/charge-classification",
+    csrf: true,
+  }
+);

--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -6,9 +6,10 @@ import { ticketSchema } from "@/lib/validations";
 import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
 import { handleApiError } from "@/lib/helpers/api-error";
 import { createClient } from "@supabase/supabase-js";
-import type { ProfileRow, TicketRow } from "@/lib/supabase/typed-client";
+import type { TicketRow } from "@/lib/supabase/typed-client";
 import { ticketsQuerySchema, validateQueryParams } from "@/lib/validations/params";
 import { withSecurity } from "@/lib/api/with-security";
+import { resolveTicketContext } from "@/lib/tickets/resolve-ticket-context";
 
 /**
  * GET /api/tickets - Récupérer les tickets de l'utilisateur
@@ -221,64 +222,37 @@ export const POST = withSecurity(async function POST(request: Request) {
     // Récupérer le profil avec service client
     const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id, role")
+      .select("id, role, email")
       .eq("user_id", user.id as any)
       .single();
 
     if (!profile) {
-      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Profil non trouvé", code: "NO_PROFILE" },
+        { status: 404 }
+      );
     }
 
-    const profileData = profile as any;
+    const profileData = profile as { id: string; role: string; email: string | null };
 
-    // Vérifier que l'utilisateur a accès à cette propriété (propriétaire ou locataire signataire)
-    if (validated.property_id) {
-      const isAdmin = profileData.role === "admin";
-      const { data: property } = await serviceClient
-        .from("properties")
-        .select("owner_id")
-        .eq("id", validated.property_id)
-        .single();
-      const isOwner = property?.owner_id === profileData.id;
+    // Résoudre le contexte du ticket (property_id, lease_id, owner) et vérifier
+    // l'accès. Le helper gère locataire invité par email (cas courant : invitation
+    // non encore "healed") et renvoie des codes d'erreur distincts.
+    const userEmail = profileData.email ?? user.email ?? null;
+    const context = await resolveTicketContext({
+      serviceClient,
+      profileId: profileData.id,
+      role: profileData.role,
+      userEmail,
+      propertyId: validated.property_id ?? null,
+      leaseId: validated.lease_id ?? null,
+    });
 
-      if (!isAdmin && !isOwner) {
-        const { data: leasesForProperty } = await serviceClient
-          .from("leases")
-          .select("id")
-          .eq("property_id", validated.property_id);
-        const leaseIds = (leasesForProperty || []).map((l: { id: string }) => l.id);
-
-        if (leaseIds.length > 0) {
-          const { data: signer } = await serviceClient
-            .from("lease_signers")
-            .select("id")
-            .eq("profile_id", profileData.id)
-            .in("lease_id", leaseIds)
-            .maybeSingle();
-          if (!signer) {
-            return NextResponse.json(
-              { error: "Vous n'avez pas accès à cette propriété" },
-              { status: 403 }
-            );
-          }
-        } else {
-          return NextResponse.json(
-            { error: "Vous n'avez pas accès à cette propriété" },
-            { status: 403 }
-          );
-        }
-      }
-    }
-
-    // Résoudre owner_id depuis la propriété
-    let propertyOwnerId: string | null = null;
-    if (validated.property_id) {
-      const { data: propOwner } = await serviceClient
-        .from("properties")
-        .select("owner_id")
-        .eq("id", validated.property_id)
-        .single();
-      propertyOwnerId = propOwner?.owner_id || null;
+    if (!context.ok) {
+      return NextResponse.json(
+        { error: context.message, code: context.code },
+        { status: context.status }
+      );
     }
 
     // Créer le ticket avec service client
@@ -286,8 +260,10 @@ export const POST = withSecurity(async function POST(request: Request) {
       .from("tickets")
       .insert({
         ...validated,
+        property_id: context.property_id,
+        lease_id: context.lease_id ?? validated.lease_id ?? null,
         created_by_profile_id: profileData.id,
-        owner_id: propertyOwnerId,
+        owner_id: context.owner_profile_id,
         statut: "open",
       })
       .select()
@@ -295,33 +271,18 @@ export const POST = withSecurity(async function POST(request: Request) {
 
     if (insertError) throw insertError;
 
-    // Émettre un événement — résoudre le owner_id pour la notification
-    let ownerUserId: string | null = null;
-    if (validated.property_id) {
-      const { data: propForOwner } = await serviceClient
-        .from("properties")
-        .select("owner_id")
-        .eq("id", validated.property_id)
-        .single();
-      if (propForOwner?.owner_id) {
-        const { data: ownerProfile } = await serviceClient
-          .from("profiles")
-          .select("user_id")
-          .eq("id", propForOwner.owner_id)
-          .single();
-        ownerUserId = ownerProfile?.user_id || null;
-      }
-    }
-
     await serviceClient.from("outbox").insert({
       event_type: "Ticket.Opened",
       payload: {
         ticket_id: ticket.id,
-        property_id: validated.property_id,
+        property_id: context.property_id,
+        lease_id: context.lease_id,
         priority: validated.priorite,
         title: validated.titre,
-        owner_id: ownerUserId,
+        category: validated.category ?? null,
+        owner_id: context.owner_user_id,
         created_by: profileData.id,
+        creator_role: context.creator_role,
       },
     } as any);
 

--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -10,6 +10,7 @@ import type { TicketRow } from "@/lib/supabase/typed-client";
 import { ticketsQuerySchema, validateQueryParams } from "@/lib/validations/params";
 import { withSecurity } from "@/lib/api/with-security";
 import { resolveTicketContext } from "@/lib/tickets/resolve-ticket-context";
+import { resolveSyndicForProperty } from "@/lib/tickets/resolve-syndic";
 
 /**
  * GET /api/tickets - Récupérer les tickets de l'utilisateur
@@ -255,6 +256,14 @@ export const POST = withSecurity(async function POST(request: Request) {
       );
     }
 
+    // Routage parties communes → syndic (si la propriété est rattachée à une
+    // copropriété avec un syndic affecté). Sinon, pas d'effet : on retombe
+    // sur le destinataire propriétaire standard.
+    const isPartiesCommunes = validated.category === "parties_communes";
+    const syndicRouting = isPartiesCommunes
+      ? await resolveSyndicForProperty(serviceClient, context.property_id)
+      : { entity_id: null, syndic_profile_id: null, syndic_user_id: null };
+
     // Créer le ticket avec service client
     const { data: ticket, error: insertError } = await serviceClient
       .from("tickets")
@@ -264,23 +273,36 @@ export const POST = withSecurity(async function POST(request: Request) {
         lease_id: context.lease_id ?? validated.lease_id ?? null,
         created_by_profile_id: profileData.id,
         owner_id: context.owner_profile_id,
-        statut: "open",
+        entity_id: syndicRouting.entity_id,
+        assigned_to: syndicRouting.syndic_profile_id,
+        statut: syndicRouting.syndic_profile_id ? "acknowledged" : "open",
       })
       .select()
       .single();
 
     if (insertError) throw insertError;
 
+    // Destinataire de la notification :
+    //   - parties communes + syndic identifié → le syndic
+    //   - sinon → le propriétaire
+    const recipientUserId =
+      syndicRouting.syndic_user_id ?? context.owner_user_id;
+
     await serviceClient.from("outbox").insert({
-      event_type: "Ticket.Opened",
+      event_type: isPartiesCommunes && syndicRouting.syndic_profile_id
+        ? "Ticket.OpenedPartiesCommunes"
+        : "Ticket.Opened",
       payload: {
         ticket_id: ticket.id,
         property_id: context.property_id,
         lease_id: context.lease_id,
+        entity_id: syndicRouting.entity_id,
         priority: validated.priorite,
         title: validated.titre,
         category: validated.category ?? null,
         owner_id: context.owner_user_id,
+        syndic_user_id: syndicRouting.syndic_user_id,
+        recipient_user_id: recipientUserId,
         created_by: profileData.id,
         creator_role: context.creator_role,
       },

--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -11,6 +11,7 @@ import { ticketsQuerySchema, validateQueryParams } from "@/lib/validations/param
 import { withSecurity } from "@/lib/api/with-security";
 import { resolveTicketContext } from "@/lib/tickets/resolve-ticket-context";
 import { resolveSyndicForProperty } from "@/lib/tickets/resolve-syndic";
+import { suggestForTicketCategory } from "@/lib/tickets/charges-classification";
 
 /**
  * GET /api/tickets - Récupérer les tickets de l'utilisateur
@@ -264,6 +265,11 @@ export const POST = withSecurity(async function POST(request: Request) {
       ? await resolveSyndicForProperty(serviceClient, context.property_id)
       : { entity_id: null, syndic_profile_id: null, syndic_user_id: null };
 
+    // Suggestion de classification "charges récupérables" (décret 87-713).
+    // Pose les colonnes à la création ; le propriétaire peut changer
+    // ensuite via l'UI ticket. NULL = ambigu, à décider manuellement.
+    const chargeSuggestion = suggestForTicketCategory(validated.category ?? null);
+
     // Créer le ticket avec service client
     const { data: ticket, error: insertError } = await serviceClient
       .from("tickets")
@@ -276,6 +282,8 @@ export const POST = withSecurity(async function POST(request: Request) {
         entity_id: syndicRouting.entity_id,
         assigned_to: syndicRouting.syndic_profile_id,
         statut: syndicRouting.syndic_profile_id ? "acknowledged" : "open",
+        is_tenant_chargeable: chargeSuggestion.is_tenant_chargeable,
+        charge_category_code: chargeSuggestion.charge_category_code,
       })
       .select()
       .single();

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -904,6 +904,19 @@ export async function POST(request: NextRequest) {
         const paymentIntent = event.data.object as Stripe.PaymentIntent;
         const invoiceId = paymentIntent.metadata?.invoice_id;
 
+        // Paiement d'intervention (work_order_payment) — parcours isolé :
+        // aucun invoiceId, le flux est complètement séparé des loyers.
+        if (paymentIntent.metadata?.type === "work_order_payment") {
+          try {
+            await handleWorkOrderPaymentSucceeded(supabase, paymentIntent);
+          } catch (woErr) {
+            console.error("[Stripe Webhook] work_order payment handling failed:", woErr);
+          }
+          // On sort ici : le reste du handler traite uniquement les invoices
+          // (loyer / régul charges).
+          return new Response(JSON.stringify({ received: true }), { status: 200 });
+        }
+
         // Sync rent_payments if this is a Connect rent payment
         if (paymentIntent.metadata?.type === "rent") {
           try {
@@ -1758,6 +1771,120 @@ export async function POST(request: NextRequest) {
       { error: error instanceof Error ? error.message : "Une erreur est survenue" },
       { status: 500 }
     );
+  }
+}
+
+// ============================================================================
+// Work Order payment — handler dédié
+// ============================================================================
+// Déclenché quand un paiement Stripe (Connect) d'une intervention aboutit.
+// Le montant net est déjà routé vers le compte du prestataire par Stripe
+// (transfer_data.destination + application_fee). Ici on met à jour la
+// ligne work_order_payments, on fait avancer le work_order, et — si la
+// classification marque l'intervention comme récupérable — on injecte
+// automatiquement l'écriture dans charge_entries.
+
+async function handleWorkOrderPaymentSucceeded(
+  supabase: any,
+  paymentIntent: Stripe.PaymentIntent
+) {
+  const workOrderId = paymentIntent.metadata?.work_order_id;
+  const paymentType = paymentIntent.metadata?.payment_type || "full";
+  if (!workOrderId) {
+    console.warn("[Stripe Webhook] work_order_payment: missing work_order_id in metadata");
+    return;
+  }
+
+  // Marquer la ligne work_order_payments correspondante comme succeeded.
+  // On matche par stripe_payment_intent_id (posé à la création de la session)
+  // sinon fallback sur metadata.checkout_session_id.
+  const { data: existing } = await supabase
+    .from("work_order_payments")
+    .select("id")
+    .eq("work_order_id", workOrderId)
+    .eq("stripe_payment_intent_id", paymentIntent.id)
+    .maybeSingle();
+
+  const transferId =
+    typeof paymentIntent.latest_charge === "string"
+      ? paymentIntent.latest_charge
+      : (paymentIntent.latest_charge as any)?.transfer || null;
+
+  if (existing) {
+    await supabase
+      .from("work_order_payments")
+      .update({
+        status: "succeeded",
+        escrow_status: "released",
+        stripe_transfer_id: transferId,
+      })
+      .eq("id", (existing as { id: string }).id);
+  } else {
+    // Fallback : la Checkout Session a été créée sans PaymentIntent connu,
+    // on cherche par payment_type restant en 'pending'.
+    await supabase
+      .from("work_order_payments")
+      .update({
+        status: "succeeded",
+        escrow_status: "released",
+        stripe_payment_intent_id: paymentIntent.id,
+        stripe_transfer_id: transferId,
+      })
+      .eq("work_order_id", workOrderId)
+      .eq("payment_type", paymentType)
+      .eq("status", "pending");
+  }
+
+  // Avancer le statut du work_order :
+  //   'deposit' → deposit_paid
+  //   'balance' ou 'full' → fully_paid
+  const nextStatut =
+    paymentType === "deposit" ? "deposit_paid" : "fully_paid";
+  await supabase
+    .from("work_orders")
+    .update({ statut: nextStatut })
+    .eq("id", workOrderId);
+
+  // Injection automatique dans charge_entries si is_tenant_chargeable=true
+  // (idempotent côté helper — safe à appeler même si le WO n'est pas
+  // complètement payé, il ne fera rien tant qu'aucun paiement n'est
+  // succeeded avec montant > 0).
+  if (nextStatut === "fully_paid") {
+    try {
+      const { injectChargeEntryForWorkOrder } = await import(
+        "@/lib/tickets/inject-charge-entry"
+      );
+      await injectChargeEntryForWorkOrder(supabase, workOrderId);
+    } catch (err) {
+      console.error(
+        "[Stripe Webhook] work_order auto-inject charge failed:",
+        err
+      );
+    }
+  }
+
+  // Outbox : notifier le prestataire que les fonds sont transférés
+  const payeeProfileId = paymentIntent.metadata?.payee_profile_id;
+  if (payeeProfileId) {
+    const { data: payeeProfile } = await supabase
+      .from("profiles")
+      .select("user_id")
+      .eq("id", payeeProfileId)
+      .maybeSingle();
+    const payeeUserId =
+      (payeeProfile as { user_id: string | null } | null)?.user_id ?? null;
+
+    if (payeeUserId) {
+      await supabase.from("outbox").insert({
+        event_type: "WorkOrder.PaymentReceived",
+        payload: {
+          work_order_id: workOrderId,
+          payment_type: paymentType,
+          amount_cents: paymentIntent.amount,
+          recipient_user_id: payeeUserId,
+        },
+      });
+    }
   }
 }
 

--- a/app/api/work-orders/[id]/approve-booking/route.ts
+++ b/app/api/work-orders/[id]/approve-booking/route.ts
@@ -1,0 +1,150 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+
+/**
+ * POST /api/work-orders/[id]/approve-booking
+ *
+ * Le propriétaire valide une réservation initiée par son locataire en
+ * self-service (cf. POST /api/tenant/services/request avec
+ * requires_owner_approval=true). Une fois approuvé :
+ *   - owner_approval_status passe à 'approved'
+ *   - le ticket passe en 'assigned'
+ *   - le prestataire reçoit la notification WorkOrder.AssignedToProvider
+ */
+export const POST = withSecurity(
+  async function POST(
+    request: Request,
+    context: { params: Promise<{ id: string }> }
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: workOrderId } = await context.params;
+      const serviceClient = getServiceClient();
+
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const profileData = profile as { id: string; role: string };
+
+      const { data: workOrder } = await serviceClient
+        .from("work_orders")
+        .select(
+          "id, ticket_id, property_id, provider_id, requester_role, owner_approval_status, title, date_intervention_prevue"
+        )
+        .eq("id", workOrderId)
+        .maybeSingle();
+
+      if (!workOrder) throw new ApiError(404, "Intervention introuvable");
+
+      const wo = workOrder as {
+        id: string;
+        ticket_id: string | null;
+        property_id: string;
+        provider_id: string | null;
+        requester_role: string | null;
+        owner_approval_status: string;
+        title: string | null;
+        date_intervention_prevue: string | null;
+      };
+
+      if (wo.owner_approval_status !== "pending") {
+        throw new ApiError(
+          409,
+          `Cette réservation n'est pas en attente de validation (statut : ${wo.owner_approval_status})`
+        );
+      }
+
+      if (profileData.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", wo.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileData.id) {
+          throw new ApiError(403, "Vous n'êtes pas propriétaire de ce bien");
+        }
+      }
+
+      const now = new Date().toISOString();
+
+      const { error: updateError } = await serviceClient
+        .from("work_orders")
+        .update({
+          owner_approval_status: "approved",
+          owner_approval_decided_at: now,
+        })
+        .eq("id", workOrderId);
+      if (updateError) throw updateError;
+
+      if (wo.ticket_id) {
+        await serviceClient
+          .from("tickets")
+          .update({ statut: "assigned" })
+          .eq("id", wo.ticket_id);
+      }
+
+      // Notifier le prestataire — ce qui n'avait pas été fait à la création
+      // puisque la réservation était en attente.
+      let providerUserId: string | null = null;
+      if (wo.provider_id) {
+        const { data: providerProfile } = await serviceClient
+          .from("profiles")
+          .select("user_id")
+          .eq("id", wo.provider_id)
+          .maybeSingle();
+        providerUserId =
+          (providerProfile as { user_id: string | null } | null)?.user_id ?? null;
+      }
+
+      let ticketReference: string | null = null;
+      if (wo.ticket_id) {
+        const { data: ticketRow } = await serviceClient
+          .from("tickets")
+          .select("reference")
+          .eq("id", wo.ticket_id)
+          .maybeSingle();
+        ticketReference =
+          (ticketRow as { reference: string | null } | null)?.reference ?? null;
+      }
+
+      if (providerUserId) {
+        await serviceClient.from("outbox").insert({
+          event_type: "WorkOrder.AssignedToProvider",
+          payload: {
+            ticket_id: wo.ticket_id,
+            ticket_reference: ticketReference,
+            work_order_id: wo.id,
+            title: wo.title,
+            preferred_date: wo.date_intervention_prevue,
+            recipient_user_id: providerUserId,
+            via: "owner_approval",
+          },
+        } as any);
+      }
+
+      return NextResponse.json({
+        work_order_id: wo.id,
+        owner_approval_status: "approved",
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "POST /api/work-orders/[id]/approve-booking",
+    csrf: true,
+  }
+);

--- a/app/api/work-orders/[id]/approve-booking/route.ts
+++ b/app/api/work-orders/[id]/approve-booking/route.ts
@@ -41,7 +41,7 @@ export const POST = withSecurity(
       const { data: workOrder } = await serviceClient
         .from("work_orders")
         .select(
-          "id, ticket_id, property_id, provider_id, requester_role, owner_approval_status, title, date_intervention_prevue"
+          "id, ticket_id, property_id, provider_id, requester_role, owner_approval_status, title, category, date_intervention_prevue"
         )
         .eq("id", workOrderId)
         .maybeSingle();
@@ -56,6 +56,7 @@ export const POST = withSecurity(
         requester_role: string | null;
         owner_approval_status: string;
         title: string | null;
+        category: string | null;
         date_intervention_prevue: string | null;
       };
 
@@ -128,6 +129,7 @@ export const POST = withSecurity(
             ticket_reference: ticketReference,
             work_order_id: wo.id,
             title: wo.title,
+            category: wo.category,
             preferred_date: wo.date_intervention_prevue,
             recipient_user_id: providerUserId,
             via: "owner_approval",

--- a/app/api/work-orders/[id]/checkout-session/route.ts
+++ b/app/api/work-orders/[id]/checkout-session/route.ts
@@ -1,0 +1,248 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import { stripe, formatAmountForStripe } from "@/lib/stripe";
+
+/**
+ * POST /api/work-orders/[id]/checkout-session
+ *
+ * Crée une Stripe Checkout Session pour payer l'intervention au prestataire.
+ * Le propriétaire paie par CB (ou moyen configuré) via la page Stripe hébergée,
+ * puis est redirigé vers success_url. Les side-effects (marquer le paiement
+ * succeeded, avancer le work_order, injecter en charge récupérable) sont
+ * déclenchés par le webhook Stripe (checkout.session.completed).
+ *
+ * Architecture : Stripe Connect — le montant net va sur le compte Connect
+ * du prestataire, les frais plateforme restent sur le compte plateforme.
+ */
+const bodySchema = z.object({
+  /** Par défaut 'full' — on paye la totalité en un coup. */
+  payment_type: z.enum(["deposit", "balance", "full"]).default("full"),
+  /** Montant surchargé si fourni (cents). Sinon auto : basé sur quote ou split 2/3-1/3. */
+  amount_cents: z.number().int().positive().optional(),
+});
+
+const PLATFORM_FEE_PCT = 0.01; // 1% — aligné payment_fee_config default
+const PLATFORM_FEE_FIXED_CENTS = 50; // 0,50 €
+
+export const POST = withSecurity(
+  async function POST(
+    request: Request,
+    context: { params: Promise<{ id: string }> }
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: workOrderId } = await context.params;
+      const body = await request.json().catch(() => ({}));
+      const { payment_type, amount_cents } = bodySchema.parse(body);
+
+      if (!process.env.STRIPE_SECRET_KEY) {
+        throw new ApiError(503, "Paiement indisponible : Stripe non configuré");
+      }
+
+      const serviceClient = getServiceClient();
+
+      // 1. Profil payeur (owner ou admin)
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role, email, prenom, nom")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const payerProfile = profile as {
+        id: string;
+        role: string;
+        email: string | null;
+        prenom: string | null;
+        nom: string | null;
+      };
+
+      // 2. Work order + vérif accès + résolution provider Stripe Connect
+      const { data: wo } = await serviceClient
+        .from("work_orders")
+        .select(
+          "id, property_id, title, description, provider_id, statut, accepted_quote_id"
+        )
+        .eq("id", workOrderId)
+        .maybeSingle();
+      if (!wo) throw new ApiError(404, "Intervention introuvable");
+      const workOrder = wo as {
+        id: string;
+        property_id: string;
+        title: string | null;
+        description: string | null;
+        provider_id: string | null;
+        statut: string | null;
+        accepted_quote_id: string | null;
+      };
+
+      if (payerProfile.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", workOrder.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== payerProfile.id) {
+          throw new ApiError(403, "Seul le propriétaire peut régler cette intervention");
+        }
+      }
+
+      if (!workOrder.provider_id) {
+        throw new ApiError(409, "Aucun prestataire n'est assigné à cette intervention");
+      }
+
+      // 3. Compte Stripe Connect du prestataire
+      const { data: payoutAccount } = await serviceClient
+        .from("provider_payout_accounts")
+        .select("stripe_account_id, stripe_account_status")
+        .eq("profile_id", workOrder.provider_id)
+        .maybeSingle();
+      const payout = payoutAccount as
+        | { stripe_account_id: string; stripe_account_status: string }
+        | null;
+      if (!payout?.stripe_account_id) {
+        throw new ApiError(
+          409,
+          "Le prestataire n'a pas encore configuré son compte de paiement"
+        );
+      }
+      if (payout.stripe_account_status !== "enabled") {
+        throw new ApiError(
+          409,
+          "Le compte de paiement du prestataire n'est pas encore actif"
+        );
+      }
+
+      // 4. Montant : soit surchargé, soit résolu depuis le devis accepté
+      let grossCents = amount_cents ?? 0;
+      if (grossCents === 0 && workOrder.accepted_quote_id) {
+        const { data: quote } = await serviceClient
+          .from("provider_quotes")
+          .select("total_amount")
+          .eq("id", workOrder.accepted_quote_id)
+          .maybeSingle();
+        const quoteTotal = Number(
+          (quote as { total_amount: number | string } | null)?.total_amount ?? 0
+        );
+        if (quoteTotal > 0) {
+          const fullCents = Math.round(quoteTotal * 100);
+          if (payment_type === "deposit") {
+            grossCents = Math.round(fullCents * (2 / 3));
+          } else if (payment_type === "balance") {
+            grossCents = fullCents - Math.round(fullCents * (2 / 3));
+          } else {
+            grossCents = fullCents;
+          }
+        }
+      }
+      if (grossCents <= 0) {
+        throw new ApiError(
+          400,
+          "Montant à payer introuvable : fournissez amount_cents ou acceptez d'abord un devis."
+        );
+      }
+
+      // 5. Frais plateforme (à retenir sur le transfer vers le provider)
+      const applicationFeeCents =
+        Math.round(grossCents * PLATFORM_FEE_PCT) + PLATFORM_FEE_FIXED_CENTS;
+
+      // 6. URLs de retour
+      const appUrl =
+        process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
+      const successUrl = `${appUrl}/owner/tickets?wo_paid=${workOrder.id}`;
+      const cancelUrl = `${appUrl}/owner/tickets?wo_cancel=${workOrder.id}`;
+
+      // 7. Création de la Checkout Session — Stripe Connect (destination charge)
+      const customerEmail = payerProfile.email ?? user.email ?? undefined;
+      const session = await stripe.checkout.sessions.create({
+        mode: "payment",
+        payment_method_types: ["card"],
+        customer_email: customerEmail,
+        line_items: [
+          {
+            price_data: {
+              currency: "eur",
+              unit_amount: grossCents,
+              product_data: {
+                name: `Intervention : ${workOrder.title || "Prestation"}`,
+                description:
+                  payment_type === "deposit"
+                    ? "Acompte (2/3)"
+                    : payment_type === "balance"
+                      ? "Solde (1/3)"
+                      : "Paiement intégral",
+              },
+            },
+            quantity: 1,
+          },
+        ],
+        payment_intent_data: {
+          application_fee_amount: applicationFeeCents,
+          transfer_data: {
+            destination: payout.stripe_account_id,
+          },
+          metadata: {
+            type: "work_order_payment",
+            work_order_id: workOrder.id,
+            payment_type,
+            payer_profile_id: payerProfile.id,
+            payee_profile_id: workOrder.provider_id,
+            property_id: workOrder.property_id,
+          },
+        },
+        metadata: {
+          type: "work_order_payment",
+          work_order_id: workOrder.id,
+          payment_type,
+        },
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+      });
+
+      // 8. Insertion work_order_payments en 'pending' pour traçabilité
+      //    Le webhook passera status='succeeded' à réception.
+      await serviceClient.from("work_order_payments").insert({
+        work_order_id: workOrder.id,
+        payment_type,
+        payer_profile_id: payerProfile.id,
+        payee_profile_id: workOrder.provider_id,
+        gross_amount: formatAmountFromCents(grossCents),
+        platform_fee: formatAmountFromCents(applicationFeeCents),
+        stripe_fee: 0,
+        total_fees: formatAmountFromCents(applicationFeeCents),
+        net_amount: formatAmountFromCents(grossCents - applicationFeeCents),
+        status: "pending",
+        escrow_status: "pending",
+        stripe_payment_intent_id: session.payment_intent as string | null,
+        metadata: {
+          checkout_session_id: session.id,
+        },
+      } as any);
+
+      return NextResponse.json({
+        url: session.url,
+        session_id: session.id,
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "POST /api/work-orders/[id]/checkout-session",
+    csrf: true,
+  }
+);
+
+function formatAmountFromCents(cents: number): number {
+  return Math.round(cents) / 100;
+}

--- a/app/api/work-orders/[id]/inject-charges/route.ts
+++ b/app/api/work-orders/[id]/inject-charges/route.ts
@@ -1,0 +1,93 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import { injectChargeEntryForWorkOrder } from "@/lib/tickets/inject-charge-entry";
+
+/**
+ * POST /api/work-orders/[id]/inject-charges
+ *
+ * Injecte manuellement le coût d'une intervention dans les charges
+ * récupérables (charge_entries), si `is_tenant_chargeable=true` et
+ * `charge_category_code` posé. Idempotent.
+ *
+ * Appel typique : le propriétaire, une fois le prestataire payé, clique
+ * "Ajouter aux charges récupérables" sur la page ticket. L'écriture sera
+ * agrégée par la régularisation annuelle du bail.
+ */
+export const POST = withSecurity(
+  async function POST(
+    request: Request,
+    context: { params: Promise<{ id: string }> }
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: workOrderId } = await context.params;
+      const serviceClient = getServiceClient();
+
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const profileData = profile as { id: string; role: string };
+
+      // Autorisation owner/admin sur la propriété
+      const { data: wo } = await serviceClient
+        .from("work_orders")
+        .select("id, property_id")
+        .eq("id", workOrderId)
+        .maybeSingle();
+      if (!wo) throw new ApiError(404, "Intervention introuvable");
+      const workOrder = wo as { id: string; property_id: string };
+
+      if (profileData.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", workOrder.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileData.id) {
+          throw new ApiError(
+            403,
+            "Seul le propriétaire peut imputer cette intervention aux charges"
+          );
+        }
+      }
+
+      const result = await injectChargeEntryForWorkOrder(
+        serviceClient,
+        workOrderId
+      );
+
+      if (!result.ok) {
+        const status = result.code === "WORK_ORDER_NOT_FOUND" ? 404 : 409;
+        return NextResponse.json(
+          { error: result.message, code: result.code },
+          { status }
+        );
+      }
+
+      return NextResponse.json({
+        charge_entry_id: result.charge_entry_id,
+        amount_cents: result.amount_cents,
+        created: result.created,
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "POST /api/work-orders/[id]/inject-charges",
+    csrf: true,
+  }
+);

--- a/app/api/work-orders/[id]/pay/route.ts
+++ b/app/api/work-orders/[id]/pay/route.ts
@@ -3,9 +3,11 @@ export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getServiceClient } from '@/lib/supabase/service-client';
 import { handleApiError, ApiError, validateWithZod } from '@/lib/helpers/api-error';
 import { markAsPaid } from '@/features/providers/services/work-orders-extended.service';
 import { markPaidSchema } from '@/lib/validations/providers';
+import { injectChargeEntryForWorkOrder } from '@/lib/tickets/inject-charge-entry';
 
 interface RouteParams { params: Promise<{ id: string }> }
 
@@ -19,6 +21,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const body = await request.json();
     const input = validateWithZod(markPaidSchema, body);
     const result = await markAsPaid(supabase, id, input);
+
+    // Fire-and-forget : si l'intervention est récupérable auprès du locataire,
+    // on injecte automatiquement la dépense dans charge_entries. Le helper est
+    // idempotent (unique index sur source_work_order_id) et tolérant aux cas
+    // non-chargeable / category manquante / pas encore payé — aucun effet de
+    // bord si une condition manque. Service client pour bypass RLS sur
+    // charge_entries.
+    void (async () => {
+      try {
+        await injectChargeEntryForWorkOrder(getServiceClient(), id);
+      } catch (err) {
+        console.error('[work-orders/pay] auto-inject charge failed:', err);
+      }
+    })();
 
     return NextResponse.json({ success: true, workOrder: result });
   } catch (error) {

--- a/app/api/work-orders/[id]/reject-booking/route.ts
+++ b/app/api/work-orders/[id]/reject-booking/route.ts
@@ -1,0 +1,158 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+
+const bodySchema = z.object({
+  reason: z.string().min(3).max(500).optional(),
+});
+
+/**
+ * POST /api/work-orders/[id]/reject-booking
+ *
+ * Le propriétaire refuse une réservation self-service de son locataire.
+ * Bascule :
+ *   - owner_approval_status → 'rejected'
+ *   - work_order.statut → 'cancelled'
+ *   - ticket.statut → 'rejected'
+ * Le locataire est notifié avec la raison donnée.
+ */
+export const POST = withSecurity(
+  async function POST(
+    request: Request,
+    context: { params: Promise<{ id: string }> }
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: workOrderId } = await context.params;
+      const serviceClient = getServiceClient();
+
+      let reason: string | undefined;
+      try {
+        const body = await request.json();
+        const parsed = bodySchema.parse(body ?? {});
+        reason = parsed.reason;
+      } catch {
+        reason = undefined;
+      }
+
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const profileData = profile as { id: string; role: string };
+
+      const { data: workOrder } = await serviceClient
+        .from("work_orders")
+        .select("id, ticket_id, property_id, owner_approval_status, requester_role")
+        .eq("id", workOrderId)
+        .maybeSingle();
+
+      if (!workOrder) throw new ApiError(404, "Intervention introuvable");
+
+      const wo = workOrder as {
+        id: string;
+        ticket_id: string | null;
+        property_id: string;
+        owner_approval_status: string;
+        requester_role: string | null;
+      };
+
+      if (wo.owner_approval_status !== "pending") {
+        throw new ApiError(
+          409,
+          `Cette réservation n'est pas en attente de validation (statut : ${wo.owner_approval_status})`
+        );
+      }
+
+      if (profileData.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", wo.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileData.id) {
+          throw new ApiError(403, "Vous n'êtes pas propriétaire de ce bien");
+        }
+      }
+
+      const now = new Date().toISOString();
+
+      const { error: updateError } = await serviceClient
+        .from("work_orders")
+        .update({
+          owner_approval_status: "rejected",
+          owner_approval_decided_at: now,
+          owner_approval_rejection_reason: reason ?? null,
+          statut: "cancelled",
+        })
+        .eq("id", workOrderId);
+      if (updateError) throw updateError;
+
+      // Notifier le locataire créateur du ticket
+      let tenantUserId: string | null = null;
+      let ticketReference: string | null = null;
+      if (wo.ticket_id) {
+        await serviceClient
+          .from("tickets")
+          .update({ statut: "rejected", resolution_notes: reason ?? null })
+          .eq("id", wo.ticket_id);
+
+        const { data: ticketRow } = await serviceClient
+          .from("tickets")
+          .select("reference, created_by_profile_id")
+          .eq("id", wo.ticket_id)
+          .maybeSingle();
+        const ticketData = ticketRow as
+          | { reference: string | null; created_by_profile_id: string | null }
+          | null;
+        ticketReference = ticketData?.reference ?? null;
+
+        if (ticketData?.created_by_profile_id) {
+          const { data: tenantProfile } = await serviceClient
+            .from("profiles")
+            .select("user_id")
+            .eq("id", ticketData.created_by_profile_id)
+            .maybeSingle();
+          tenantUserId =
+            (tenantProfile as { user_id: string | null } | null)?.user_id ?? null;
+        }
+      }
+
+      if (tenantUserId) {
+        await serviceClient.from("outbox").insert({
+          event_type: "TenantService.Rejected",
+          payload: {
+            ticket_id: wo.ticket_id,
+            ticket_reference: ticketReference,
+            work_order_id: wo.id,
+            reason: reason ?? null,
+            recipient_user_id: tenantUserId,
+          },
+        } as any);
+      }
+
+      return NextResponse.json({
+        work_order_id: wo.id,
+        owner_approval_status: "rejected",
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "POST /api/work-orders/[id]/reject-booking",
+    csrf: true,
+  }
+);

--- a/app/api/work-orders/[id]/reject-booking/route.ts
+++ b/app/api/work-orders/[id]/reject-booking/route.ts
@@ -54,7 +54,7 @@ export const POST = withSecurity(
 
       const { data: workOrder } = await serviceClient
         .from("work_orders")
-        .select("id, ticket_id, property_id, owner_approval_status, requester_role")
+        .select("id, ticket_id, property_id, owner_approval_status, requester_role, title")
         .eq("id", workOrderId)
         .maybeSingle();
 
@@ -66,6 +66,7 @@ export const POST = withSecurity(
         property_id: string;
         owner_approval_status: string;
         requester_role: string | null;
+        title: string | null;
       };
 
       if (wo.owner_approval_status !== "pending") {
@@ -137,6 +138,7 @@ export const POST = withSecurity(
             ticket_id: wo.ticket_id,
             ticket_reference: ticketReference,
             work_order_id: wo.id,
+            title: wo.title,
             reason: reason ?? null,
             recipient_user_id: tenantUserId,
           },

--- a/app/copro/tickets/new/page.tsx
+++ b/app/copro/tickets/new/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft, Send, Loader2, AlertCircle, Building2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+
+const PRIORITIES = [
+  { value: "normal", label: "Normale", helper: "Sous quelques jours" },
+  { value: "urgent", label: "Urgent", helper: "Sous 48h" },
+  { value: "emergency", label: "Urgence", helper: "Immédiat" },
+];
+
+export default function NewCoproTicketPage() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [form, setForm] = useState({
+    titre: "",
+    description: "",
+    priorite: "normal",
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.titre || !form.description) {
+      toast({
+        title: "Champs manquants",
+        description: "Indiquez l'objet et la description du signalement.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch("/api/tickets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          titre: form.titre,
+          description: form.description,
+          priorite: form.priorite,
+          category: "parties_communes",
+        }),
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data?.error || "Impossible de créer le signalement");
+      }
+
+      toast({
+        title: "Signalement envoyé",
+        description: "Votre syndic a été notifié.",
+      });
+      router.push("/copro/tickets");
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de créer le signalement",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-3xl space-y-6">
+      <Link
+        href="/copro/tickets"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Retour aux signalements
+      </Link>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-indigo-600 rounded-lg shadow-lg shadow-indigo-200 dark:shadow-indigo-900/30">
+            <Building2 className="h-6 w-6 text-white" />
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            Nouveau signalement
+          </h1>
+        </div>
+        <p className="text-muted-foreground">
+          Signalez un incident sur les parties communes (ascenseur, hall, parking, espaces verts...).
+          Votre syndic en sera immédiatement informé.
+        </p>
+      </div>
+
+      <Card className="bg-card border border-border">
+        <CardContent className="p-6">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="titre" className="text-sm font-semibold">
+                Objet du signalement
+              </Label>
+              <Input
+                id="titre"
+                placeholder="Ex : Panne d'ascenseur, fuite parking, éclairage en panne..."
+                value={form.titre}
+                onChange={(e) => setForm({ ...form, titre: e.target.value })}
+                className="h-12"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label className="text-sm font-semibold">Degré d'urgence</Label>
+              <div className="grid grid-cols-3 gap-2">
+                {PRIORITIES.map((p) => (
+                  <button
+                    key={p.value}
+                    type="button"
+                    onClick={() => setForm({ ...form, priorite: p.value })}
+                    className={cn(
+                      "p-3 rounded-xl border-2 text-left transition-all",
+                      form.priorite === p.value
+                        ? "border-indigo-600 bg-indigo-50 dark:bg-indigo-950/30"
+                        : "border-border hover:border-indigo-200"
+                    )}
+                  >
+                    <div className="font-bold text-sm">{p.label}</div>
+                    <div className="text-xs text-muted-foreground mt-0.5">{p.helper}</div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description" className="text-sm font-semibold">
+                Description détaillée
+              </Label>
+              <Textarea
+                id="description"
+                placeholder="Décrivez précisément le problème, sa localisation et depuis quand il est constaté."
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                className="min-h-[160px] p-4"
+                required
+              />
+            </div>
+
+            <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-900">
+              <AlertCircle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
+              <div className="text-xs text-amber-900 dark:text-amber-200">
+                <strong>En cas d'urgence vitale</strong> (incendie, fuite de gaz majeure,
+                effondrement), contactez immédiatement les pompiers (18) ou le SAMU (15)
+                avant tout signalement.
+              </div>
+            </div>
+
+            <Button
+              type="submit"
+              disabled={loading}
+              className="w-full h-12 bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 font-bold"
+            >
+              {loading ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <>
+                  Envoyer le signalement
+                  <Send className="ml-2 h-4 w-4" />
+                </>
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/copro/tickets/page.tsx
+++ b/app/copro/tickets/page.tsx
@@ -168,9 +168,11 @@ export default function CoproTicketsPage() {
             Suivez les incidents et demandes de votre copropriété
           </p>
         </div>
-        <Button className="bg-gradient-to-r from-indigo-600 to-purple-600">
-          <Plus className="mr-2 h-4 w-4" />
-          Nouveau signalement
+        <Button asChild className="bg-gradient-to-r from-indigo-600 to-purple-600">
+          <Link href="/copro/tickets/new">
+            <Plus className="mr-2 h-4 w-4" />
+            Nouveau signalement
+          </Link>
         </Button>
       </motion.div>
 
@@ -256,9 +258,17 @@ export default function CoproTicketsPage() {
               <h3 className="text-lg font-semibold mb-2">Aucun signalement</h3>
               <p className="text-muted-foreground mb-6">
                 {tickets.length === 0
-                  ? "Aucun signalement n'a été créé."
+                  ? "Signalez un incident sur les parties communes pour alerter votre syndic."
                   : "Aucun résultat ne correspond à vos critères."}
               </p>
+              {tickets.length === 0 && (
+                <Button asChild className="bg-gradient-to-r from-indigo-600 to-purple-600">
+                  <Link href="/copro/tickets/new">
+                    <Plus className="mr-2 h-4 w-4" />
+                    Nouveau signalement
+                  </Link>
+                </Button>
+              )}
             </CardContent>
           </Card>
         </motion.div>

--- a/app/owner/approvals/OwnerApprovalActions.tsx
+++ b/app/owner/approvals/OwnerApprovalActions.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, X, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+
+interface Props {
+  workOrderId: string;
+}
+
+export function OwnerApprovalActions({ workOrderId }: Props) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [loading, setLoading] = useState<"approve" | "reject" | null>(null);
+  const [rejecting, setRejecting] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const approve = async () => {
+    setLoading("approve");
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/approve-booking`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || "Validation impossible");
+      toast({
+        title: "Validé",
+        description: "Le prestataire a été notifié.",
+      });
+      router.refresh();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Validation impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  const reject = async () => {
+    setLoading("reject");
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/reject-booking`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(reason.trim() ? { reason: reason.trim() } : {}),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || "Refus impossible");
+      toast({
+        title: "Réservation refusée",
+        description: "Votre locataire a été notifié.",
+      });
+      router.refresh();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Refus impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(null);
+      setRejecting(false);
+      setReason("");
+    }
+  };
+
+  if (rejecting) {
+    return (
+      <div className="space-y-2">
+        <Textarea
+          placeholder="Raison du refus (optionnel, envoyée au locataire)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          className="min-h-[80px]"
+          maxLength={500}
+        />
+        <div className="flex items-center gap-2 flex-wrap">
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={reject}
+            disabled={loading !== null}
+          >
+            {loading === "reject" ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                <X className="mr-1.5 h-4 w-4" />
+                Confirmer le refus
+              </>
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setRejecting(false);
+              setReason("");
+            }}
+            disabled={loading !== null}
+          >
+            Annuler
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <Button
+        size="sm"
+        onClick={approve}
+        disabled={loading !== null}
+        className="bg-emerald-600 hover:bg-emerald-700 font-bold"
+      >
+        {loading === "approve" ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <>
+            <Check className="mr-1.5 h-4 w-4" />
+            Valider
+          </>
+        )}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setRejecting(true)}
+        disabled={loading !== null}
+      >
+        <X className="mr-1.5 h-4 w-4" />
+        Refuser
+      </Button>
+    </div>
+  );
+}

--- a/app/owner/approvals/page.tsx
+++ b/app/owner/approvals/page.tsx
@@ -1,0 +1,253 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { format } from "date-fns";
+import { fr } from "date-fns/locale";
+import { Calendar, CheckCircle2, ChevronLeft, ClipboardCheck, Info, MapPin } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { TENANT_BOOKABLE_CATEGORY_LABELS } from "@/lib/tickets/tenant-service-permissions";
+import { OwnerApprovalActions } from "./OwnerApprovalActions";
+
+interface PendingBooking {
+  work_order_id: string;
+  ticket_id: string | null;
+  ticket_reference: string | null;
+  title: string | null;
+  description: string | null;
+  category: string | null;
+  preferred_date: string | null;
+  created_at: string;
+  property_address: string | null;
+  tenant_name: string | null;
+  provider_company: string | null;
+}
+
+export default async function OwnerApprovalsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/signin?redirect=/owner/approvals");
+
+  const serviceClient = getServiceClient();
+
+  const { data: profile } = await serviceClient
+    .from("profiles")
+    .select("id, role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!profile) redirect("/auth/signin");
+  const profileData = profile as { id: string; role: string };
+
+  const { data: properties } = await serviceClient
+    .from("properties")
+    .select("id, adresse_complete, ville, code_postal")
+    .eq("owner_id", profileData.id);
+
+  const propertyMap = new Map<
+    string,
+    { address: string }
+  >();
+  for (const p of (properties || []) as Array<{
+    id: string;
+    adresse_complete: string;
+    ville: string;
+    code_postal: string;
+  }>) {
+    propertyMap.set(p.id, {
+      address: `${p.adresse_complete}, ${p.code_postal} ${p.ville}`,
+    });
+  }
+
+  const propertyIds = Array.from(propertyMap.keys());
+
+  let bookings: PendingBooking[] = [];
+  if (propertyIds.length > 0) {
+    const { data: workOrders } = await serviceClient
+      .from("work_orders")
+      .select(
+        `id, ticket_id, property_id, title, description, category,
+         date_intervention_prevue, created_at, provider_id`
+      )
+      .in("property_id", propertyIds)
+      .eq("owner_approval_status", "pending")
+      .eq("requester_role", "tenant")
+      .order("created_at", { ascending: false });
+
+    const rows = (workOrders || []) as Array<{
+      id: string;
+      ticket_id: string | null;
+      property_id: string;
+      title: string | null;
+      description: string | null;
+      category: string | null;
+      date_intervention_prevue: string | null;
+      created_at: string;
+      provider_id: string | null;
+    }>;
+
+    // Résoudre ticket reference + tenant name + provider company en batch
+    const ticketIds = rows.map((r) => r.ticket_id).filter((x): x is string => !!x);
+    const providerIds = rows.map((r) => r.provider_id).filter((x): x is string => !!x);
+
+    const [ticketsRes, providersRes] = await Promise.all([
+      ticketIds.length
+        ? serviceClient
+            .from("tickets")
+            .select(
+              "id, reference, created_by_profile_id, creator:profiles!created_by_profile_id(prenom, nom)"
+            )
+            .in("id", ticketIds)
+        : Promise.resolve({ data: [] as any[] }),
+      providerIds.length
+        ? serviceClient
+            .from("providers")
+            .select("profile_id, company_name")
+            .in("profile_id", providerIds)
+        : Promise.resolve({ data: [] as any[] }),
+    ]);
+
+    const ticketMap = new Map<string, { reference: string | null; tenant_name: string | null }>();
+    for (const t of (ticketsRes.data || []) as any[]) {
+      const creator = Array.isArray(t.creator) ? t.creator[0] : t.creator;
+      const name = creator
+        ? `${creator.prenom ?? ""} ${creator.nom ?? ""}`.trim()
+        : null;
+      ticketMap.set(t.id, { reference: t.reference ?? null, tenant_name: name || null });
+    }
+
+    const providerMap = new Map<string, string>();
+    for (const p of (providersRes.data || []) as any[]) {
+      if (p.profile_id) providerMap.set(p.profile_id, p.company_name);
+    }
+
+    bookings = rows.map((r) => ({
+      work_order_id: r.id,
+      ticket_id: r.ticket_id,
+      ticket_reference: r.ticket_id
+        ? ticketMap.get(r.ticket_id)?.reference ?? null
+        : null,
+      title: r.title,
+      description: r.description,
+      category: r.category,
+      preferred_date: r.date_intervention_prevue,
+      created_at: r.created_at,
+      property_address: propertyMap.get(r.property_id)?.address ?? null,
+      tenant_name: r.ticket_id ? ticketMap.get(r.ticket_id)?.tenant_name ?? null : null,
+      provider_company: r.provider_id ? providerMap.get(r.provider_id) ?? null : null,
+    }));
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-5xl space-y-6">
+      <Link
+        href="/owner/tickets"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Retour aux tickets
+      </Link>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-amber-500 rounded-lg shadow-lg shadow-amber-200 dark:shadow-amber-900/30">
+            <ClipboardCheck className="h-6 w-6 text-white" />
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            Validations en attente
+          </h1>
+        </div>
+        <p className="text-muted-foreground">
+          Réservations de services initiées par vos locataires. Validez pour
+          notifier le prestataire, ou refusez en expliquant la raison.
+        </p>
+      </div>
+
+      {bookings.length === 0 ? (
+        <Card>
+          <CardContent className="p-12 text-center space-y-3">
+            <CheckCircle2 className="h-10 w-10 text-emerald-500 mx-auto" />
+            <p className="text-muted-foreground">
+              Aucune réservation en attente pour le moment.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {bookings.map((b) => (
+            <Card key={b.work_order_id} className="border border-border">
+              <CardContent className="p-5 space-y-4">
+                <div className="flex items-start justify-between gap-4 flex-wrap">
+                  <div className="space-y-1 flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {b.ticket_reference && (
+                        <span className="font-mono text-[11px] font-bold text-muted-foreground">
+                          {b.ticket_reference}
+                        </span>
+                      )}
+                      {b.category && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          {TENANT_BOOKABLE_CATEGORY_LABELS[
+                            b.category as keyof typeof TENANT_BOOKABLE_CATEGORY_LABELS
+                          ] || b.category}
+                        </Badge>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        {format(new Date(b.created_at), "d MMM HH:mm", { locale: fr })}
+                      </span>
+                    </div>
+                    <h3 className="font-semibold text-foreground">
+                      {b.title || "Réservation sans titre"}
+                    </h3>
+                    {b.description && (
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {b.description}
+                      </p>
+                    )}
+                    <div className="flex items-center gap-3 text-xs text-muted-foreground flex-wrap mt-2">
+                      {b.tenant_name && (
+                        <span>Demandé par <strong>{b.tenant_name}</strong></span>
+                      )}
+                      {b.provider_company && (
+                        <span>→ <strong>{b.provider_company}</strong></span>
+                      )}
+                      {b.property_address && (
+                        <span className="inline-flex items-center gap-1">
+                          <MapPin className="h-3 w-3" />
+                          {b.property_address}
+                        </span>
+                      )}
+                      {b.preferred_date && (
+                        <span className="inline-flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          Souhaité le {format(new Date(b.preferred_date), "d MMM yyyy", { locale: fr })}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <OwnerApprovalActions workOrderId={b.work_order_id} />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-start gap-3 p-4 rounded-xl bg-muted/50 text-xs text-muted-foreground">
+        <Info className="h-4 w-4 shrink-0 mt-0.5" />
+        <p>
+          Pour désactiver la validation systématique, allez sur le bail
+          concerné (<em>Services réservables</em>) et décochez « Valider
+          chaque réservation ».
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/owner/leases/[id]/services-config/page.tsx
+++ b/app/owner/leases/[id]/services-config/page.tsx
@@ -1,0 +1,89 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { normalizePermissions } from "@/lib/tickets/tenant-service-permissions";
+import { TenantServiceBookingsConfig } from "@/features/tickets/components/tenant-service-bookings-config";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: leaseId } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect(`/auth/signin?redirect=/owner/leases/${leaseId}/services-config`);
+
+  const serviceClient = getServiceClient();
+
+  const { data: profile } = await serviceClient
+    .from("profiles")
+    .select("id, role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!profile) redirect("/auth/signin");
+
+  const profileData = profile as { id: string; role: string };
+
+  const { data: lease } = await serviceClient
+    .from("leases")
+    .select("id, property_id, tenant_service_bookings, statut")
+    .eq("id", leaseId)
+    .maybeSingle();
+
+  if (!lease) notFound();
+  const leaseData = lease as {
+    id: string;
+    property_id: string;
+    tenant_service_bookings: any;
+    statut: string;
+  };
+
+  if (profileData.role !== "admin") {
+    const { data: property } = await serviceClient
+      .from("properties")
+      .select("owner_id")
+      .eq("id", leaseData.property_id)
+      .maybeSingle();
+    const ownerId = (property as { owner_id: string } | null)?.owner_id;
+    if (ownerId !== profileData.id) {
+      redirect(`/owner/leases/${leaseId}`);
+    }
+  }
+
+  const permissions = normalizePermissions(leaseData.tenant_service_bookings);
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-2xl space-y-6">
+      <Link
+        href={`/owner/leases/${leaseId}`}
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Retour au bail
+      </Link>
+
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">
+          Services réservables par le locataire
+        </h1>
+        <p className="text-muted-foreground">
+          Choisissez les catégories que votre locataire peut réserver
+          directement auprès de nos prestataires partenaires.
+        </p>
+      </div>
+
+      <TenantServiceBookingsConfig leaseId={leaseId} initial={permissions} />
+    </div>
+  );
+}

--- a/app/owner/tickets/page.tsx
+++ b/app/owner/tickets/page.tsx
@@ -1,19 +1,60 @@
 import { Suspense } from "react";
 import Link from "next/link";
-import { Hammer, Plus, Users, Wrench } from "lucide-react";
+import { ClipboardCheck, Hammer, Plus, Users, Wrench } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TicketListUnified } from "@/features/tickets/components/ticket-list-unified";
 import { TicketKPIs } from "@/features/tickets/components/ticket-kpis";
 import { getTickets, getTicketKPIs } from "@/features/tickets/server/data-fetching";
 import { PullToRefreshContainer } from "@/components/ui/pull-to-refresh-container";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { TicketsTabNav } from "./TicketsTabNav";
 
+async function getPendingApprovalsCount(): Promise<number> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return 0;
+
+    const serviceClient = getServiceClient();
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) return 0;
+
+    const { data: properties } = await serviceClient
+      .from("properties")
+      .select("id")
+      .eq("owner_id", (profile as { id: string }).id);
+
+    const propertyIds = (properties || []).map((p) => (p as { id: string }).id);
+    if (propertyIds.length === 0) return 0;
+
+    const { count } = await serviceClient
+      .from("work_orders")
+      .select("id", { count: "exact", head: true })
+      .in("property_id", propertyIds)
+      .eq("owner_approval_status", "pending")
+      .eq("requester_role", "tenant");
+
+    return count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
 export default async function OwnerTicketsPage() {
-  const [tickets, kpis] = await Promise.all([
+  const [tickets, kpis, pendingApprovals] = await Promise.all([
     getTickets("owner"),
     getTicketKPIs(),
+    getPendingApprovalsCount(),
   ]);
 
   return (
@@ -31,6 +72,17 @@ export default async function OwnerTicketsPage() {
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
+            {pendingApprovals > 0 && (
+              <Button asChild variant="outline" className="border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-800 dark:text-amber-300">
+                <Link href="/owner/approvals">
+                  <ClipboardCheck className="mr-2 h-4 w-4" />
+                  {pendingApprovals} à valider
+                  <Badge variant="secondary" className="ml-2 bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                    {pendingApprovals}
+                  </Badge>
+                </Link>
+              </Button>
+            )}
             <Button asChild variant="outline">
               <Link href="/owner/providers">
                 <Users className="mr-2 h-4 w-4" /> Consulter les prestataires

--- a/app/provider/tickets/page.tsx
+++ b/app/provider/tickets/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
-import { Wrench } from "lucide-react";
+import Link from "next/link";
+import { FileText, Wrench } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TicketListUnified } from "@/features/tickets/components/ticket-list-unified";
 import { getTickets } from "@/features/tickets/server/data-fetching";
@@ -13,18 +15,26 @@ export default async function ProviderTicketsPage() {
     <PullToRefreshContainer>
       <div className="container mx-auto px-4 py-8 max-w-7xl space-y-8">
         {/* Header */}
-        <div>
-          <div className="flex items-center gap-3 mb-2">
-            <div className="p-2 bg-indigo-600 rounded-lg shadow-lg shadow-indigo-200 dark:shadow-indigo-900/30">
-              <Wrench className="h-6 w-6 text-white" />
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3 mb-2">
+              <div className="p-2 bg-indigo-600 rounded-lg shadow-lg shadow-indigo-200 dark:shadow-indigo-900/30">
+                <Wrench className="h-6 w-6 text-white" />
+              </div>
+              <h1 className="text-3xl font-bold tracking-tight text-foreground">
+                Tickets assignés
+              </h1>
             </div>
-            <h1 className="text-3xl font-bold tracking-tight text-foreground">
-              Tickets assignés
-            </h1>
+            <p className="text-muted-foreground">
+              Tickets et interventions qui vous sont assignés.
+            </p>
           </div>
-          <p className="text-muted-foreground">
-            Tickets et interventions qui vous sont assignés.
-          </p>
+
+          <Button asChild className="shadow-lg shadow-indigo-500/20">
+            <Link href="/provider/quotes/new">
+              <FileText className="mr-2 h-4 w-4" /> Proposer un devis
+            </Link>
+          </Button>
         </div>
 
         {/* List */}

--- a/app/tenant/requests/new/page.tsx
+++ b/app/tenant/requests/new/page.tsx
@@ -149,15 +149,6 @@ export default function NewTenantRequestPage() {
   };
 
   const handleTomTicketCreated = async (args: CreateTicketArgs) => {
-    if (!propertyId) {
-      toast({
-        title: "Erreur",
-        description: "Impossible d'identifier votre logement.",
-        variant: "destructive"
-      });
-      return;
-    }
-
     setLoading(true);
     try {
       const response = await fetch("/api/tickets", {
@@ -168,23 +159,27 @@ export default function NewTenantRequestPage() {
           description: args.description,
           priorite: args.priorite,
           category: "autre",
-          property_id: propertyId,
+          // property_id optionnel : résolu côté serveur à partir du bail actif
+          ...(propertyId ? { property_id: propertyId } : {}),
         }),
       });
 
-      if (!response.ok) throw new Error("Erreur");
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data?.error || "Erreur lors de la création du ticket.");
+      }
 
       try { localStorage.removeItem(DRAFT_STORAGE_KEY); } catch { /* ignore */ }
       toast({
         title: "Demande créée !",
         description: "Votre ticket a été créé et qualifié par Tom.",
       });
-      
+
       setTimeout(() => router.push("/tenant/requests"), 1500);
     } catch (error) {
       toast({
          title: "Erreur",
-         description: "Erreur lors de la création du ticket.",
+         description: error instanceof Error ? error.message : "Erreur lors de la création du ticket.",
          variant: "destructive"
       });
     } finally {
@@ -199,15 +194,6 @@ export default function NewTenantRequestPage() {
       return;
     }
 
-    if (!propertyId) {
-      toast({
-        title: "Erreur",
-        description: "Impossible d'identifier votre logement.",
-        variant: "destructive"
-      });
-      return;
-    }
-
     setLoading(true);
     try {
       const response = await fetch("/api/tickets", {
@@ -218,12 +204,13 @@ export default function NewTenantRequestPage() {
           description: form.description,
           priorite: form.priorite,
           category: form.categorie || null,
-          property_id: propertyId,
+          // property_id optionnel : résolu côté serveur à partir du bail actif
+          ...(propertyId ? { property_id: propertyId } : {}),
         }),
       });
 
       const data = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(data?.error || "Erreur");
+      if (!response.ok) throw new Error(data?.error || "Impossible de créer la demande");
 
       const ticketId = data.ticket?.id;
       if (ticketId && files.length > 0) {
@@ -241,7 +228,11 @@ export default function NewTenantRequestPage() {
       toast({ title: "Demande envoyée", description: "Votre ticket est en cours de traitement." });
       router.push("/tenant/requests");
     } catch (error) {
-      toast({ title: "Erreur", description: "Impossible de créer la demande", variant: "destructive" });
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Impossible de créer la demande",
+        variant: "destructive"
+      });
     } finally {
       setLoading(false);
     }

--- a/app/tenant/requests/page.tsx
+++ b/app/tenant/requests/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import Link from "next/link";
-import { Plus, Wrench, MessageSquare, Info, ShieldAlert, Calendar } from "lucide-react";
+import { Plus, Wrench, MessageSquare, Info, ShieldAlert, Calendar, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -64,11 +64,18 @@ export default async function TenantRequestsPage() {
             </p>
           </div>
           
-          <Button asChild className="h-12 px-6 bg-indigo-600 hover:bg-indigo-700 shadow-lg shadow-indigo-200 dark:shadow-indigo-900/30 font-bold rounded-xl transition-all hover:scale-105 active:scale-95">
-            <Link href="/tenant/requests/new">
-              <Plus className="mr-2 h-5 w-5" /> Nouvelle demande
-            </Link>
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline" className="h-12 px-5 rounded-xl font-bold">
+              <Link href="/tenant/services">
+                <Sparkles className="mr-2 h-5 w-5" /> Réserver un service
+              </Link>
+            </Button>
+            <Button asChild className="h-12 px-6 bg-indigo-600 hover:bg-indigo-700 shadow-lg shadow-indigo-200 dark:shadow-indigo-900/30 font-bold rounded-xl transition-all hover:scale-105 active:scale-95">
+              <Link href="/tenant/requests/new">
+                <Plus className="mr-2 h-5 w-5" /> Nouvelle demande
+              </Link>
+            </Button>
+          </div>
         </div>
 
         {/* Note informative SOTA */}

--- a/app/tenant/services/[category]/TenantServiceBookingClient.tsx
+++ b/app/tenant/services/[category]/TenantServiceBookingClient.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  ChevronLeft,
+  Loader2,
+  Send,
+  Star,
+  MapPin,
+  ShieldCheck,
+  Info,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+
+interface Provider {
+  id: string;
+  profile_id: string | null;
+  company_name: string;
+  contact_name: string | null;
+  city: string | null;
+  postal_code: string | null;
+  department: string | null;
+  avg_rating: number | null;
+  total_reviews: number | null;
+  total_interventions: number | null;
+  is_verified: boolean;
+  trade_categories: string[] | null;
+}
+
+interface Props {
+  category: string;
+  categoryLabel: string;
+}
+
+export default function TenantServiceBookingClient({ category, categoryLabel }: Props) {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [loadingProviders, setLoadingProviders] = useState(true);
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [requiresApproval, setRequiresApproval] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<Provider | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    preferred_date: "",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoadingProviders(true);
+      try {
+        const res = await fetch(`/api/tenant/providers?category=${category}`);
+        const data = await res.json().catch(() => ({}));
+        if (cancelled) return;
+        if (!res.ok) {
+          toast({
+            title: "Accès refusé",
+            description: data?.error || "Impossible de charger les prestataires.",
+            variant: "destructive",
+          });
+          setProviders([]);
+          return;
+        }
+        setProviders(data.providers || []);
+        setRequiresApproval(Boolean(data.requires_owner_approval));
+      } finally {
+        if (!cancelled) setLoadingProviders(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [category, toast]);
+
+  const handleBook = async () => {
+    if (!selectedProvider) return;
+    if (!form.title || form.title.length < 3) {
+      toast({
+        title: "Objet requis",
+        description: "Décrivez brièvement l'intervention souhaitée.",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (!form.description || form.description.length < 10) {
+      toast({
+        title: "Description trop courte",
+        description: "Donnez un minimum de contexte au prestataire.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/tenant/services/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider_id: selectedProvider.id,
+          category,
+          title: form.title,
+          description: form.description,
+          preferred_date: form.preferred_date || null,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || "Réservation impossible");
+      }
+
+      toast({
+        title: data.requires_owner_approval ? "Demande envoyée" : "Réservation confirmée",
+        description: data.requires_owner_approval
+          ? "Votre propriétaire doit valider avant que le prestataire intervienne."
+          : `Le prestataire a été notifié. Référence : ${data.ticket_reference ?? ""}`,
+      });
+      router.push("/tenant/requests");
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description: error instanceof Error ? error.message : "Réservation impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-5xl space-y-6">
+      <Link
+        href="/tenant/services"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Retour aux services
+      </Link>
+
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">
+          {categoryLabel}
+        </h1>
+        <p className="text-muted-foreground">
+          Choisissez un prestataire, puis décrivez votre besoin.
+        </p>
+      </div>
+
+      {requiresApproval && (
+        <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-900">
+          <Info className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
+          <p className="text-sm text-amber-900 dark:text-amber-200">
+            Votre propriétaire valide chaque réservation avant l'intervention.
+          </p>
+        </div>
+      )}
+
+      {loadingProviders ? (
+        <Card>
+          <CardContent className="p-12 flex items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </CardContent>
+        </Card>
+      ) : providers.length === 0 ? (
+        <Card>
+          <CardContent className="p-8 text-center">
+            <p className="text-muted-foreground">
+              Aucun prestataire disponible pour cette catégorie dans votre zone.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {providers.map((p) => {
+            const selected = selectedProvider?.id === p.id;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setSelectedProvider(p)}
+                className={cn(
+                  "text-left rounded-2xl border-2 p-5 transition-all bg-card",
+                  selected
+                    ? "border-indigo-600 shadow-lg shadow-indigo-200 dark:shadow-indigo-900/30"
+                    : "border-border hover:border-indigo-200"
+                )}
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <h3 className="font-semibold text-foreground">
+                    {p.company_name}
+                  </h3>
+                  {p.is_verified && (
+                    <Badge variant="outline" className="gap-1 text-[10px] border-emerald-200 text-emerald-600">
+                      <ShieldCheck className="h-3 w-3" />
+                      Vérifié
+                    </Badge>
+                  )}
+                </div>
+                {p.contact_name && (
+                  <p className="text-sm text-muted-foreground">{p.contact_name}</p>
+                )}
+                <div className="flex items-center gap-3 mt-3 text-xs text-muted-foreground">
+                  {p.avg_rating != null && (
+                    <span className="inline-flex items-center gap-1">
+                      <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                      {Number(p.avg_rating).toFixed(1)}
+                      {p.total_reviews ? ` (${p.total_reviews})` : ""}
+                    </span>
+                  )}
+                  {p.city && (
+                    <span className="inline-flex items-center gap-1">
+                      <MapPin className="h-3 w-3" />
+                      {p.city}
+                    </span>
+                  )}
+                  {p.total_interventions != null && p.total_interventions > 0 && (
+                    <span>{p.total_interventions} interventions</span>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {selectedProvider && (
+        <Card className="border border-indigo-200 dark:border-indigo-900">
+          <CardContent className="p-6 space-y-4">
+            <h2 className="text-lg font-semibold">
+              Décrivez votre besoin à {selectedProvider.company_name}
+            </h2>
+
+            <div className="space-y-2">
+              <Label htmlFor="title">Objet</Label>
+              <Input
+                id="title"
+                placeholder="Ex : Tonte de la pelouse du jardin"
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                maxLength={120}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                placeholder="Surface approximative, accès, contraintes d'horaires..."
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                className="min-h-[120px]"
+                maxLength={2000}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="preferred_date">Date souhaitée (optionnel)</Label>
+              <Input
+                id="preferred_date"
+                type="date"
+                value={form.preferred_date}
+                onChange={(e) => setForm({ ...form, preferred_date: e.target.value })}
+              />
+            </div>
+
+            <Button
+              onClick={handleBook}
+              disabled={submitting}
+              className="w-full h-12 bg-indigo-600 hover:bg-indigo-700 font-bold"
+            >
+              {submitting ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <>
+                  {requiresApproval
+                    ? "Envoyer pour validation"
+                    : "Confirmer la réservation"}
+                  <Send className="ml-2 h-4 w-4" />
+                </>
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/tenant/services/[category]/page.tsx
+++ b/app/tenant/services/[category]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+import TenantServiceBookingClient from "./TenantServiceBookingClient";
+import {
+  TENANT_BOOKABLE_CATEGORIES,
+  TENANT_BOOKABLE_CATEGORY_LABELS,
+  type TenantBookableCategory,
+} from "@/lib/tickets/tenant-service-permissions";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export default async function Page({
+  params,
+}: {
+  params: { category: string };
+}) {
+  const category = params.category as TenantBookableCategory;
+  if (!(TENANT_BOOKABLE_CATEGORIES as readonly string[]).includes(category)) {
+    notFound();
+  }
+
+  return (
+    <TenantServiceBookingClient
+      category={category}
+      categoryLabel={TENANT_BOOKABLE_CATEGORY_LABELS[category]}
+    />
+  );
+}

--- a/app/tenant/services/page.tsx
+++ b/app/tenant/services/page.tsx
@@ -1,0 +1,227 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import {
+  ChevronRight,
+  Leaf,
+  Sparkles,
+  Truck,
+  PaintBucket,
+  Hammer,
+  Info,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import {
+  TENANT_BOOKABLE_CATEGORIES,
+  TENANT_BOOKABLE_CATEGORY_LABELS,
+  normalizePermissions,
+  type TenantBookableCategory,
+} from "@/lib/tickets/tenant-service-permissions";
+
+const CATEGORY_META: Record<
+  TenantBookableCategory,
+  { icon: typeof Leaf; tagline: string; bg: string; fg: string }
+> = {
+  jardinage: {
+    icon: Leaf,
+    tagline: "Tonte, taille, entretien des espaces verts",
+    bg: "bg-emerald-50 dark:bg-emerald-950/30",
+    fg: "text-emerald-600 dark:text-emerald-400",
+  },
+  nettoyage: {
+    icon: Sparkles,
+    tagline: "Ménage ponctuel, grand nettoyage, vitres",
+    bg: "bg-sky-50 dark:bg-sky-950/30",
+    fg: "text-sky-600 dark:text-sky-400",
+  },
+  demenagement: {
+    icon: Truck,
+    tagline: "Manutention, transport, aide au déménagement",
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+    fg: "text-amber-600 dark:text-amber-400",
+  },
+  peinture: {
+    icon: PaintBucket,
+    tagline: "Rafraîchissement des murs, retouches",
+    bg: "bg-fuchsia-50 dark:bg-fuchsia-950/30",
+    fg: "text-fuchsia-600 dark:text-fuchsia-400",
+  },
+  petits_travaux: {
+    icon: Hammer,
+    tagline: "Montage, fixations, petits bricolages",
+    bg: "bg-indigo-50 dark:bg-indigo-950/30",
+    fg: "text-indigo-600 dark:text-indigo-400",
+  },
+};
+
+interface AggregatedPermissions {
+  anyEnabled: boolean;
+  allowedCategories: Set<string>;
+  requiresOwnerApproval: boolean;
+}
+
+async function loadPermissions(): Promise<AggregatedPermissions | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const serviceClient = getServiceClient();
+
+  const { data: profile } = await serviceClient
+    .from("profiles")
+    .select("id, email")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!profile) return null;
+  const profileData = profile as { id: string; email: string | null };
+  const email = profileData.email ?? user.email ?? null;
+
+  const leaseIds = new Set<string>();
+  const { data: byProfile } = await serviceClient
+    .from("lease_signers")
+    .select("lease_id")
+    .eq("profile_id", profileData.id)
+    .in("role", ["locataire_principal", "colocataire"]);
+  for (const s of byProfile || []) leaseIds.add((s as { lease_id: string }).lease_id);
+
+  if (email) {
+    const { data: byEmail } = await serviceClient
+      .from("lease_signers")
+      .select("lease_id")
+      .ilike("invited_email", email)
+      .in("role", ["locataire_principal", "colocataire"]);
+    for (const s of byEmail || []) leaseIds.add((s as { lease_id: string }).lease_id);
+  }
+
+  if (leaseIds.size === 0) {
+    return { anyEnabled: false, allowedCategories: new Set(), requiresOwnerApproval: false };
+  }
+
+  const { data: leases } = await serviceClient
+    .from("leases")
+    .select("tenant_service_bookings, statut")
+    .in("id", Array.from(leaseIds))
+    .in("statut", ["active", "fully_signed"]);
+
+  const allowed = new Set<string>();
+  let anyEnabled = false;
+  let requiresApproval = false;
+
+  for (const lease of (leases || []) as Array<{ tenant_service_bookings: any }>) {
+    const perms = normalizePermissions(lease.tenant_service_bookings);
+    if (perms.enabled) {
+      anyEnabled = true;
+      if (perms.requires_owner_approval) requiresApproval = true;
+      for (const cat of perms.allowed_categories) allowed.add(cat);
+    }
+  }
+
+  return { anyEnabled, allowedCategories: allowed, requiresOwnerApproval: requiresApproval };
+}
+
+export default async function TenantServicesPage() {
+  const perms = await loadPermissions();
+  if (!perms) redirect("/auth/signin?redirect=/tenant/services");
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-5xl space-y-8">
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-indigo-600 rounded-lg shadow-lg shadow-indigo-200 dark:shadow-indigo-900/30">
+            <Sparkles className="h-6 w-6 text-white" />
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            Réserver un service
+          </h1>
+        </div>
+        <p className="text-muted-foreground">
+          Accédez à des prestataires de confiance sélectionnés par votre propriétaire.
+        </p>
+      </div>
+
+      {!perms.anyEnabled ? (
+        <Card className="bg-card border border-border">
+          <CardContent className="p-8 text-center space-y-4">
+            <div className="mx-auto h-12 w-12 rounded-full bg-muted flex items-center justify-center">
+              <Info className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <h2 className="text-lg font-semibold">Service non activé</h2>
+            <p className="text-muted-foreground max-w-md mx-auto">
+              Votre propriétaire n'a pas (encore) activé la réservation directe de
+              prestataires. Contactez-le ou créez une demande classique via votre
+              espace « Mes demandes ».
+            </p>
+            <Button asChild variant="outline">
+              <Link href="/tenant/requests/new">Créer une demande classique</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {perms.requiresOwnerApproval && (
+            <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-900">
+              <Info className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
+              <div className="text-sm text-amber-900 dark:text-amber-200">
+                Votre propriétaire doit valider chaque réservation avant que le
+                prestataire intervienne. Vous serez notifié dès la validation.
+              </div>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {(TENANT_BOOKABLE_CATEGORIES as readonly TenantBookableCategory[]).map(
+              (category) => {
+                const meta = CATEGORY_META[category];
+                const Icon = meta.icon;
+                const allowed = perms.allowedCategories.has(category);
+                return (
+                  <Card
+                    key={category}
+                    className={`border border-border transition-all ${allowed ? "hover:shadow-md cursor-pointer" : "opacity-60"}`}
+                  >
+                    <Link
+                      href={allowed ? `/tenant/services/${category}` : "#"}
+                      aria-disabled={!allowed}
+                      className={allowed ? "" : "pointer-events-none"}
+                    >
+                      <CardContent className="p-6 flex items-start gap-4">
+                        <div className={`p-3 rounded-xl ${meta.bg}`}>
+                          <Icon className={`h-6 w-6 ${meta.fg}`} />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-semibold text-foreground">
+                            {TENANT_BOOKABLE_CATEGORY_LABELS[category]}
+                          </h3>
+                          <p className="text-sm text-muted-foreground mt-1">
+                            {meta.tagline}
+                          </p>
+                          {!allowed && (
+                            <p className="text-xs text-muted-foreground mt-2 italic">
+                              Non activé par votre propriétaire
+                            </p>
+                          )}
+                        </div>
+                        {allowed && (
+                          <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
+                        )}
+                      </CardContent>
+                    </Link>
+                  </Card>
+                );
+              }
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/features/tickets/components/tenant-service-bookings-config.tsx
+++ b/features/tickets/components/tenant-service-bookings-config.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles, Save, Loader2, Info } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import {
+  TENANT_BOOKABLE_CATEGORIES,
+  TENANT_BOOKABLE_CATEGORY_LABELS,
+  type TenantBookableCategory,
+  type TenantBookingPermissions,
+} from "@/lib/tickets/tenant-service-permissions";
+
+interface Props {
+  leaseId: string;
+  initial: TenantBookingPermissions;
+}
+
+/**
+ * Bloc de configuration à intégrer sur la page bail côté propriétaire.
+ * Permet d'activer le self-service locataire, choisir les catégories,
+ * un plafond par intervention, et un workflow d'approbation.
+ */
+export function TenantServiceBookingsConfig({ leaseId, initial }: Props) {
+  const { toast } = useToast();
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const [categories, setCategories] = useState<Set<string>>(
+    new Set(initial.allowed_categories)
+  );
+  const [maxAmountEuros, setMaxAmountEuros] = useState<string>(
+    initial.max_amount_cents != null
+      ? String(Math.round(initial.max_amount_cents / 100))
+      : ""
+  );
+  const [requiresApproval, setRequiresApproval] = useState(
+    initial.requires_owner_approval
+  );
+  const [saving, setSaving] = useState(false);
+
+  const toggleCategory = (cat: string) => {
+    setCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const parsedMax = maxAmountEuros.trim()
+        ? Math.round(Number(maxAmountEuros) * 100)
+        : null;
+      if (parsedMax !== null && (Number.isNaN(parsedMax) || parsedMax <= 0)) {
+        toast({
+          title: "Plafond invalide",
+          description: "Indiquez un montant en euros ou laissez vide.",
+          variant: "destructive",
+        });
+        setSaving(false);
+        return;
+      }
+
+      const res = await fetch(
+        `/api/owner/leases/${leaseId}/tenant-service-bookings`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            enabled,
+            allowed_categories: Array.from(categories),
+            max_amount_cents: parsedMax,
+            requires_owner_approval: requiresApproval,
+          }),
+        }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || "Enregistrement impossible");
+      }
+      toast({
+        title: "Configuration enregistrée",
+        description: enabled
+          ? `Votre locataire peut réserver ${categories.size} catégorie(s).`
+          : "La réservation directe a été désactivée.",
+      });
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description:
+          error instanceof Error ? error.message : "Enregistrement impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="bg-card border border-border">
+      <CardContent className="p-6 space-y-5">
+        <div className="flex items-start gap-3">
+          <div className="p-2 bg-indigo-50 dark:bg-indigo-950/30 rounded-lg">
+            <Sparkles className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="font-semibold text-foreground">
+              Services réservables par le locataire
+            </h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              Autorisez votre locataire à réserver directement certains
+              prestataires (jardinage, ménage...). Le ticket vous est toujours
+              notifié.
+            </p>
+          </div>
+          <Switch checked={enabled} onCheckedChange={setEnabled} aria-label="Activer" />
+        </div>
+
+        {enabled && (
+          <>
+            <div className="space-y-2">
+              <Label className="text-sm font-semibold">
+                Catégories autorisées
+              </Label>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {(TENANT_BOOKABLE_CATEGORIES as readonly TenantBookableCategory[]).map(
+                  (cat) => {
+                    const active = categories.has(cat);
+                    return (
+                      <button
+                        key={cat}
+                        type="button"
+                        onClick={() => toggleCategory(cat)}
+                        className={cn(
+                          "px-3 py-2 rounded-xl border-2 text-sm font-medium transition-all",
+                          active
+                            ? "border-indigo-600 bg-indigo-50 dark:bg-indigo-950/30 text-indigo-700 dark:text-indigo-300"
+                            : "border-border hover:border-indigo-200 text-muted-foreground"
+                        )}
+                      >
+                        {TENANT_BOOKABLE_CATEGORY_LABELS[cat]}
+                      </button>
+                    );
+                  }
+                )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="max_amount" className="text-sm font-semibold">
+                  Plafond par intervention (€)
+                </Label>
+                <Input
+                  id="max_amount"
+                  type="number"
+                  min="1"
+                  placeholder="Laissez vide = illimité"
+                  value={maxAmountEuros}
+                  onChange={(e) => setMaxAmountEuros(e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-sm font-semibold">
+                  Valider chaque réservation
+                </Label>
+                <div className="flex items-center gap-2 h-10">
+                  <Switch
+                    checked={requiresApproval}
+                    onCheckedChange={setRequiresApproval}
+                  />
+                  <span className="text-sm text-muted-foreground">
+                    {requiresApproval ? "Oui" : "Non (réservation directe)"}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/50 text-xs text-muted-foreground">
+              <Info className="h-4 w-4 shrink-0 mt-0.5" />
+              <p>
+                Vous êtes toujours notifié quand une réservation est créée et
+                vous pouvez l'annuler à tout moment depuis la page ticket.
+              </p>
+            </div>
+          </>
+        )}
+
+        <Button
+          onClick={handleSave}
+          disabled={saving}
+          className="w-full bg-indigo-600 hover:bg-indigo-700 font-bold"
+        >
+          {saving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <>
+              <Save className="mr-2 h-4 w-4" />
+              Enregistrer
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/tickets/components/ticket-charges-classification.tsx
+++ b/features/tickets/components/ticket-charges-classification.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Loader2,
+  Save,
+  Receipt,
+  Info,
+  Check,
+  User,
+  Building2,
+  AlertCircle,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import type { CanonicalChargeCategory } from "@/lib/tickets/charges-classification";
+
+const CATEGORY_OPTIONS: Array<{ value: CanonicalChargeCategory; label: string }> = [
+  { value: "ascenseurs", label: "Ascenseurs" },
+  { value: "eau_chauffage", label: "Eau & chauffage" },
+  { value: "installations_individuelles", label: "Installations individuelles" },
+  { value: "parties_communes", label: "Parties communes" },
+  { value: "espaces_exterieurs", label: "Espaces extérieurs" },
+  { value: "taxes_redevances", label: "Taxes & redevances" },
+];
+
+type Choice = "tenant" | "owner" | "unset";
+
+function statusFromProps(
+  is_tenant_chargeable: boolean | null | undefined
+): Choice {
+  if (is_tenant_chargeable === true) return "tenant";
+  if (is_tenant_chargeable === false) return "owner";
+  return "unset";
+}
+
+interface Props {
+  ticketId: string;
+  workOrderId?: string | null;
+  initial: {
+    is_tenant_chargeable: boolean | null;
+    charge_category_code: CanonicalChargeCategory | null;
+  };
+  /** Autoriser le bouton "Imputer aux charges" (après paiement prestataire). */
+  canInjectCharges?: boolean;
+}
+
+export function TicketChargesClassification({
+  ticketId,
+  workOrderId,
+  initial,
+  canInjectCharges,
+}: Props) {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [choice, setChoice] = useState<Choice>(statusFromProps(initial.is_tenant_chargeable));
+  const [category, setCategory] = useState<CanonicalChargeCategory | "">(
+    initial.charge_category_code ?? ""
+  );
+  const [saving, setSaving] = useState(false);
+  const [injecting, setInjecting] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const is_tenant_chargeable =
+        choice === "tenant" ? true : choice === "owner" ? false : null;
+      const charge_category_code =
+        is_tenant_chargeable === true && category ? category : null;
+
+      const res = await fetch(`/api/tickets/${ticketId}/charge-classification`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_tenant_chargeable, charge_category_code }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || "Enregistrement impossible");
+
+      toast({
+        title: "Classification enregistrée",
+        description:
+          is_tenant_chargeable === true
+            ? "Intervention imputée au locataire."
+            : is_tenant_chargeable === false
+              ? "Intervention à la charge du propriétaire."
+              : "Décision reportée.",
+      });
+      router.refresh();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description:
+          error instanceof Error ? error.message : "Enregistrement impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleInject = async () => {
+    if (!workOrderId) return;
+    setInjecting(true);
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/inject-charges`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || "Injection impossible");
+
+      const euros = ((data.amount_cents as number) / 100).toFixed(2);
+      toast({
+        title: data.created ? "Ajouté aux charges récupérables" : "Déjà imputé",
+        description: data.created
+          ? `${euros} € seront intégrés à la prochaine régularisation.`
+          : `Cette intervention est déjà dans les charges (${euros} €).`,
+      });
+      router.refresh();
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description:
+          error instanceof Error ? error.message : "Injection impossible",
+        variant: "destructive",
+      });
+    } finally {
+      setInjecting(false);
+    }
+  };
+
+  const showCategory = choice === "tenant";
+  const canSave =
+    choice !== statusFromProps(initial.is_tenant_chargeable) ||
+    (category || null) !== (initial.charge_category_code ?? null);
+
+  return (
+    <Card className="bg-card border border-border">
+      <CardContent className="p-5 space-y-4">
+        <div className="flex items-start gap-3">
+          <div className="p-2 bg-emerald-50 dark:bg-emerald-950/30 rounded-lg">
+            <Receipt className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="font-semibold text-foreground text-sm">
+              Qui paie cette intervention ?
+            </h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Décret 87-713 — certains frais peuvent être refacturés au
+              locataire via la régularisation annuelle des charges.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <ChoicePill
+            active={choice === "owner"}
+            icon={Building2}
+            label="Propriétaire"
+            onClick={() => setChoice("owner")}
+          />
+          <ChoicePill
+            active={choice === "tenant"}
+            icon={User}
+            label="Locataire"
+            onClick={() => setChoice("tenant")}
+          />
+          <ChoicePill
+            active={choice === "unset"}
+            icon={AlertCircle}
+            label="À décider"
+            onClick={() => setChoice("unset")}
+          />
+        </div>
+
+        {showCategory && (
+          <div className="space-y-2">
+            <Label className="text-xs font-semibold">
+              Catégorie de charge récupérable
+            </Label>
+            <Select
+              value={category}
+              onValueChange={(v) => setCategory(v as CanonicalChargeCategory)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Choisir une catégorie..." />
+              </SelectTrigger>
+              <SelectContent>
+                {CATEGORY_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={handleSave}
+            disabled={saving || !canSave}
+            size="sm"
+            className="bg-emerald-600 hover:bg-emerald-700"
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                <Save className="mr-1.5 h-3.5 w-3.5" />
+                Enregistrer
+              </>
+            )}
+          </Button>
+
+          {canInjectCharges &&
+            workOrderId &&
+            initial.is_tenant_chargeable === true &&
+            initial.charge_category_code && (
+              <Button
+                onClick={handleInject}
+                disabled={injecting}
+                size="sm"
+                variant="outline"
+              >
+                {injecting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <>
+                    <Check className="mr-1.5 h-3.5 w-3.5" />
+                    Ajouter aux charges récupérables
+                  </>
+                )}
+              </Button>
+            )}
+        </div>
+
+        {choice === "unset" && (
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-muted/50 text-xs text-muted-foreground">
+            <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+            <p>
+              Tant qu'aucune décision n'est prise, l'intervention reste à la
+              charge du propriétaire et ne sera pas ajoutée à la régularisation.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChoicePill({
+  active,
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  icon: typeof User;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all text-xs font-medium",
+        active
+          ? "border-emerald-600 bg-emerald-50 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300"
+          : "border-border hover:border-emerald-200 text-muted-foreground"
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {label}
+    </button>
+  );
+}

--- a/features/tickets/components/ticket-charges-tenant-badge.tsx
+++ b/features/tickets/components/ticket-charges-tenant-badge.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Info, Receipt } from "lucide-react";
+
+interface Props {
+  /** État courant de la classification côté serveur */
+  is_tenant_chargeable: boolean | null | undefined;
+  charge_category_code: string | null | undefined;
+  /** Statut du ticket pour adapter le message */
+  ticketStatus?: string;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ascenseurs: "Ascenseurs",
+  eau_chauffage: "Eau & chauffage",
+  installations_individuelles: "Installations individuelles",
+  parties_communes: "Parties communes",
+  espaces_exterieurs: "Espaces extérieurs",
+  taxes_redevances: "Taxes & redevances",
+};
+
+/**
+ * Bloc informatif côté locataire : explique si le coût de l'intervention
+ * lui sera refacturé (via régularisation annuelle) ou reste à la charge
+ * du propriétaire.
+ *
+ * Volontairement neutre quand la décision n'est pas prise (null) — on
+ * évite de spéculer sur ce que le propriétaire va faire.
+ */
+export function TicketChargesTenantBadge({
+  is_tenant_chargeable,
+  charge_category_code,
+  ticketStatus,
+}: Props) {
+  // Cas ambigu : on n'affiche rien pour ne pas induire en erreur
+  if (is_tenant_chargeable === null || is_tenant_chargeable === undefined) {
+    return null;
+  }
+
+  if (is_tenant_chargeable === false) {
+    return (
+      <div className="flex items-start gap-3 p-4 rounded-xl bg-emerald-50 dark:bg-emerald-950/20 border border-emerald-200 dark:border-emerald-900">
+        <Info className="h-5 w-5 text-emerald-600 shrink-0 mt-0.5" />
+        <div className="flex-1">
+          <p className="text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+            À la charge du propriétaire
+          </p>
+          <p className="text-xs text-emerald-800 dark:text-emerald-300 mt-1">
+            Vous n'aurez rien à payer pour cette intervention.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // is_tenant_chargeable === true
+  const categoryLabel = charge_category_code
+    ? CATEGORY_LABELS[charge_category_code] ?? charge_category_code
+    : null;
+  const isResolved = ticketStatus === "resolved" || ticketStatus === "closed";
+
+  return (
+    <div className="flex items-start gap-3 p-4 rounded-xl bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-900">
+      <Receipt className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
+      <div className="flex-1">
+        <p className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+          {isResolved
+            ? "Ajouté à vos charges récupérables"
+            : "Sera refacturé sur vos charges"}
+        </p>
+        <p className="text-xs text-amber-800 dark:text-amber-300 mt-1">
+          {isResolved
+            ? "Ce montant apparaîtra sur votre prochaine régularisation annuelle des charges."
+            : "Une fois l'intervention terminée et payée, le coût sera intégré à votre régularisation annuelle."}
+          {categoryLabel && (
+            <>
+              {" "}
+              Catégorie : <strong>{categoryLabel}</strong>
+              {" "}
+              (décret 87-713).
+            </>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/features/tickets/components/ticket-detail.tsx
+++ b/features/tickets/components/ticket-detail.tsx
@@ -26,6 +26,7 @@ import { PriorityBadge } from "./priority-badge";
 import { TicketTimeline } from "./ticket-timeline";
 import { TicketChargesClassification } from "./ticket-charges-classification";
 import { TicketChargesTenantBadge } from "./ticket-charges-tenant-badge";
+import { WorkOrderPayButton } from "./work-order-pay-button";
 import { TicketComments } from "./ticket-comments";
 import { AssignProviderModal } from "./assign-provider-modal";
 import { CreateWorkOrderButton } from "./create-work-order-button";
@@ -253,6 +254,48 @@ export function TicketDetailView({ ticketId, userRole, backHref }: TicketDetailV
 
         {/* Sidebar */}
         <div className="space-y-4">
+          {/* Paiement du prestataire (owner uniquement, work_order non soldé) */}
+          {userRole === "owner" &&
+            (() => {
+              const activeWo = ticket.work_orders?.find(
+                (wo: any) => wo.statut !== "cancelled" && wo.statut !== "fully_paid"
+              );
+              const woId = ticket.work_order_id ?? activeWo?.id ?? null;
+              if (!woId || !activeWo) return null;
+              // On autorise le paiement une fois un devis accepté
+              const canPay =
+                activeWo.statut === "quote_accepted" ||
+                activeWo.statut === "deposit_paid" ||
+                activeWo.statut === "work_completed" ||
+                activeWo.statut === "balance_pending";
+              if (!canPay) return null;
+              const paymentType =
+                activeWo.statut === "deposit_paid" ||
+                activeWo.statut === "balance_pending"
+                  ? "balance"
+                  : "full";
+              return (
+                <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+                  <p className="text-sm font-semibold text-foreground">
+                    {paymentType === "balance"
+                      ? "Solde à régler"
+                      : "Régler l'intervention"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Paiement sécurisé par carte. Les fonds sont transférés
+                    directement au prestataire.
+                  </p>
+                  <WorkOrderPayButton
+                    workOrderId={woId}
+                    paymentType={paymentType}
+                    hintLabel={
+                      paymentType === "balance" ? "Payer le solde" : "Payer"
+                    }
+                  />
+                </div>
+              );
+            })()}
+
           {/* Classification charges récupérables (owner uniquement) */}
           {userRole === "owner" && (
             <TicketChargesClassification

--- a/features/tickets/components/ticket-detail.tsx
+++ b/features/tickets/components/ticket-detail.tsx
@@ -152,6 +152,11 @@ export function TicketDetailView({ ticketId, userRole, backHref }: TicketDetailV
 
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div className="space-y-1">
+            {ticket.reference && (
+              <p className="font-mono text-xs font-bold text-muted-foreground tracking-wider">
+                {ticket.reference}
+              </p>
+            )}
             <h1 className="text-2xl font-black tracking-tight text-foreground">
               {ticket.titre}
             </h1>

--- a/features/tickets/components/ticket-detail.tsx
+++ b/features/tickets/components/ticket-detail.tsx
@@ -24,6 +24,7 @@ import { cn } from "@/lib/utils";
 import { TicketStatusBadge } from "./ticket-status-badge";
 import { PriorityBadge } from "./priority-badge";
 import { TicketTimeline } from "./ticket-timeline";
+import { TicketChargesClassification } from "./ticket-charges-classification";
 import { TicketComments } from "./ticket-comments";
 import { AssignProviderModal } from "./assign-provider-modal";
 import { CreateWorkOrderButton } from "./create-work-order-button";
@@ -242,6 +243,21 @@ export function TicketDetailView({ ticketId, userRole, backHref }: TicketDetailV
 
         {/* Sidebar */}
         <div className="space-y-4">
+          {/* Classification charges récupérables (owner uniquement) */}
+          {userRole === "owner" && (
+            <TicketChargesClassification
+              ticketId={ticketId}
+              workOrderId={ticket.work_order_id ?? ticket.work_orders?.[0]?.id ?? null}
+              initial={{
+                is_tenant_chargeable: ticket.is_tenant_chargeable ?? null,
+                charge_category_code: ticket.charge_category_code ?? null,
+              }}
+              canInjectCharges={
+                ticket.statut === "resolved" || ticket.statut === "closed"
+              }
+            />
+          )}
+
           {/* Ticket info */}
           <GlassCard className="p-5 border-border bg-card space-y-4">
             <h3 className="text-sm font-bold text-muted-foreground uppercase tracking-wider">

--- a/features/tickets/components/ticket-detail.tsx
+++ b/features/tickets/components/ticket-detail.tsx
@@ -25,6 +25,7 @@ import { TicketStatusBadge } from "./ticket-status-badge";
 import { PriorityBadge } from "./priority-badge";
 import { TicketTimeline } from "./ticket-timeline";
 import { TicketChargesClassification } from "./ticket-charges-classification";
+import { TicketChargesTenantBadge } from "./ticket-charges-tenant-badge";
 import { TicketComments } from "./ticket-comments";
 import { AssignProviderModal } from "./assign-provider-modal";
 import { CreateWorkOrderButton } from "./create-work-order-button";
@@ -177,6 +178,15 @@ export function TicketDetailView({ ticketId, userRole, backHref }: TicketDetailV
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main column */}
         <div className="lg:col-span-2 space-y-6">
+          {/* Badge charges récupérables (locataire uniquement) */}
+          {userRole === "tenant" && (
+            <TicketChargesTenantBadge
+              is_tenant_chargeable={ticket.is_tenant_chargeable}
+              charge_category_code={ticket.charge_category_code}
+              ticketStatus={ticket.statut}
+            />
+          )}
+
           {/* Description */}
           <GlassCard className="p-6 border-border bg-card">
             <h3 className="text-sm font-bold text-muted-foreground uppercase tracking-wider mb-3">

--- a/features/tickets/components/ticket-list-unified.tsx
+++ b/features/tickets/components/ticket-list-unified.tsx
@@ -50,6 +50,7 @@ interface WorkOrder {
 
 interface Ticket {
   id: string;
+  reference?: string | null;
   titre: string;
   description: string;
   statut: string;
@@ -116,8 +117,13 @@ export function TicketListUnified({ tickets, variant }: TicketListProps) {
               <div className="absolute left-0 top-0 bottom-0 w-1 bg-border group-hover:bg-blue-500 transition-colors" />
 
               <div className="flex-1 space-y-1">
-                {/* Priority + Category + Date */}
+                {/* Reference + Priority + Category + Date */}
                 <div className="flex items-center gap-2 mb-1 flex-wrap">
+                  {ticket.reference && (
+                    <span className="font-mono text-[11px] font-bold text-muted-foreground tracking-wide">
+                      {ticket.reference}
+                    </span>
+                  )}
                   <PriorityBadge priority={ticket.priorite} size="sm" />
                   {ticket.category && (
                     <Badge variant="secondary" className="text-[10px] py-0 capitalize">

--- a/features/tickets/components/ticket-list-unified.tsx
+++ b/features/tickets/components/ticket-list-unified.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { cn } from "@/lib/utils";
+import { getWorkOrderStatusLabel } from "@/lib/tickets/statuses";
 import { TicketStatusBadge } from "./ticket-status-badge";
 import { PriorityBadge } from "./priority-badge";
 
@@ -30,13 +31,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   parties_communes: "Parties communes",
   equipement: "Équipement",
   autre: "Autre",
-};
-
-const WORK_ORDER_STATUS_LABELS: Record<string, string> = {
-  assigned: "Assigné",
-  scheduled: "Planifié",
-  done: "Terminé",
-  cancelled: "Annulé",
 };
 
 interface WorkOrder {
@@ -187,8 +181,7 @@ export function TicketListUnified({ tickets, variant }: TicketListProps) {
                       </p>
                       <div className="flex items-center gap-2 text-[10px] text-indigo-500 dark:text-indigo-400/70">
                         <span>
-                          {WORK_ORDER_STATUS_LABELS[activeWorkOrder.statut] ||
-                            activeWorkOrder.statut}
+                          {getWorkOrderStatusLabel(activeWorkOrder.statut)}
                         </span>
                         {activeWorkOrder.date_intervention_prevue && (
                           <>

--- a/features/tickets/components/ticket-status-badge.tsx
+++ b/features/tickets/components/ticket-status-badge.tsx
@@ -4,7 +4,6 @@ import { Badge } from "@/components/ui/badge";
 import {
   AlertCircle,
   CheckCircle2,
-  Clock,
   Eye,
   UserCheck,
   Wrench,
@@ -13,57 +12,55 @@ import {
   PauseCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TICKET_STATUS_LABELS, type TicketStatus } from "@/lib/tickets/statuses";
 
-const STATUS_CONFIG: Record<
-  string,
-  { label: string; color: string; icon: typeof AlertCircle }
-> = {
+// Couleur + icône sont UI-only et restent ici. Les libellés viennent de
+// la source canonique (lib/tickets/statuses.ts).
+const STATUS_UI: Record<TicketStatus, { color: string; icon: typeof AlertCircle }> = {
   open: {
-    label: "Ouvert",
     color: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 border-blue-200 dark:border-blue-800",
     icon: AlertCircle,
   },
   acknowledged: {
-    label: "Pris en compte",
     color: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400 border-cyan-200 dark:border-cyan-800",
     icon: Eye,
   },
   assigned: {
-    label: "Assigné",
     color: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400 border-purple-200 dark:border-purple-800",
     icon: UserCheck,
   },
   in_progress: {
-    label: "En cours",
     color: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 border-amber-200 dark:border-amber-800",
     icon: Wrench,
   },
   resolved: {
-    label: "Résolu",
     color: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800",
     icon: CheckCircle2,
   },
   closed: {
-    label: "Clôturé",
     color: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400 border-slate-200 dark:border-slate-700",
     icon: CheckCircle2,
   },
   rejected: {
-    label: "Rejeté",
     color: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800",
     icon: XCircle,
   },
   reopened: {
-    label: "Rouvert",
     color: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400 border-orange-200 dark:border-orange-800",
     icon: RotateCcw,
   },
   paused: {
-    label: "En pause",
     color: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-400 border-slate-200 dark:border-slate-700",
     icon: PauseCircle,
   },
 };
+
+const STATUS_CONFIG = Object.fromEntries(
+  (Object.keys(STATUS_UI) as TicketStatus[]).map((key) => [
+    key,
+    { ...STATUS_UI[key], label: TICKET_STATUS_LABELS[key] },
+  ])
+) as Record<TicketStatus, { label: string; color: string; icon: typeof AlertCircle }>;
 
 interface TicketStatusBadgeProps {
   status: string;
@@ -72,7 +69,7 @@ interface TicketStatusBadgeProps {
 }
 
 export function TicketStatusBadge({ status, size = "md", className }: TicketStatusBadgeProps) {
-  const config = STATUS_CONFIG[status] || STATUS_CONFIG.open;
+  const config = STATUS_CONFIG[status as TicketStatus] || STATUS_CONFIG.open;
   const Icon = config.icon;
 
   return (

--- a/features/tickets/components/work-order-pay-button.tsx
+++ b/features/tickets/components/work-order-pay-button.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { CreditCard, Loader2, ExternalLink } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+interface Props {
+  workOrderId: string;
+  /** Affiché pour info, pas utilisé côté API (le backend calcule). */
+  hintLabel?: string;
+  /** full / deposit / balance — par défaut 'full' */
+  paymentType?: "deposit" | "balance" | "full";
+  size?: "sm" | "default" | "lg";
+  variant?: "default" | "outline";
+}
+
+/**
+ * Bouton "Payer par carte" — crée une Stripe Checkout Session côté serveur
+ * et redirige l'utilisateur vers la page Stripe hébergée. Le webhook prend
+ * le relais à la confirmation pour marquer le paiement succeeded et avancer
+ * le work_order.
+ */
+export function WorkOrderPayButton({
+  workOrderId,
+  hintLabel,
+  paymentType = "full",
+  size = "default",
+  variant = "default",
+}: Props) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  const handlePay = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/work-orders/${workOrderId}/checkout-session`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ payment_type: paymentType }),
+        }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data?.url) {
+        throw new Error(data?.error || "Impossible de préparer le paiement");
+      }
+      // Redirection vers Stripe Checkout
+      window.location.href = data.url;
+    } catch (error) {
+      toast({
+        title: "Erreur",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Impossible de préparer le paiement",
+        variant: "destructive",
+      });
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      onClick={handlePay}
+      disabled={loading}
+      size={size}
+      variant={variant}
+      className={
+        variant === "default"
+          ? "bg-indigo-600 hover:bg-indigo-700 text-white font-bold"
+          : undefined
+      }
+    >
+      {loading ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <>
+          <CreditCard className="mr-2 h-4 w-4" />
+          {hintLabel || "Payer par carte"}
+          <ExternalLink className="ml-2 h-3.5 w-3.5 opacity-70" />
+        </>
+      )}
+    </Button>
+  );
+}

--- a/features/tickets/server/data-fetching.ts
+++ b/features/tickets/server/data-fetching.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
+import { TICKET_OPEN_STATUSES } from "@/lib/tickets/statuses";
 
 /**
  * getTickets — SSR fetcher for the owner/tenant/provider tickets list.
@@ -198,7 +199,7 @@ export async function getTicketKPIs() {
   const tickets = ticketsRaw as TicketKPIRow[];
 
   const open = tickets.filter((t) =>
-    ["open", "acknowledged", "assigned", "reopened"].includes(t.statut)
+    (TICKET_OPEN_STATUSES as readonly string[]).includes(t.statut)
   ).length;
   const inProgress = tickets.filter((t) => t.statut === "in_progress").length;
   const resolved = tickets.filter((t) => t.statut === "resolved").length;

--- a/lib/tickets/charges-classification.ts
+++ b/lib/tickets/charges-classification.ts
@@ -1,0 +1,149 @@
+/**
+ * Classification "charges récupérables" d'un ticket / work_order.
+ *
+ * Règle métier : décret n° 87-713 du 26 août 1987 (liste limitative des
+ * charges récupérables sur le locataire).
+ *
+ * Le helper renvoie une **suggestion** pour une catégorie d'intervention
+ * donnée. Le propriétaire reste libre de confirmer ou modifier au cas par
+ * cas — une fuite de plomberie peut être causée par la vétusté (non
+ * récupérable) ou par un mauvais usage du locataire (récupérable).
+ *
+ * Convention :
+ *   - `suggested = true`  : par défaut on coche "à charge du locataire"
+ *   - `suggested = false` : par défaut on laisse à charge du propriétaire
+ *   - `suggested = null`  : ambigu, on n'impose pas de default → l'owner décide
+ */
+
+import type { TenantBookableCategory } from "./tenant-service-permissions";
+
+/** Catégories canoniques du système de régularisation (décret 87-713). */
+export type CanonicalChargeCategory =
+  | "ascenseurs"
+  | "eau_chauffage"
+  | "installations_individuelles"
+  | "parties_communes"
+  | "espaces_exterieurs"
+  | "taxes_redevances";
+
+export interface ChargeClassificationSuggestion {
+  /** Suggestion initiale ; null = à décider par le propriétaire. */
+  is_tenant_chargeable: boolean | null;
+  /** Catégorie canonique à utiliser quand la charge est récupérable. */
+  charge_category_code: CanonicalChargeCategory | null;
+  /** Raison synthétique (pour tooltip UI / audit). */
+  rationale: string;
+}
+
+const AMBIGUOUS: ChargeClassificationSuggestion = {
+  is_tenant_chargeable: null,
+  charge_category_code: null,
+  rationale:
+    "Ambigu : dépend de la cause (vétusté = propriétaire, usage = locataire). À décider au cas par cas.",
+};
+
+/**
+ * Suggère la classification pour une catégorie de TICKET (tickets.category).
+ * Valeurs acceptées : les 10 catégories de tickets_module_sota.
+ */
+export function suggestForTicketCategory(
+  category: string | null | undefined
+): ChargeClassificationSuggestion {
+  switch (category) {
+    // Entretien sanitaire courant, mais beaucoup de cas vétusté → ambigu
+    case "plomberie":
+    case "electricite":
+    case "serrurerie":
+    case "chauffage":
+      return AMBIGUOUS;
+
+    // Problème structurel, toujours à la charge du propriétaire
+    case "humidite":
+      return {
+        is_tenant_chargeable: false,
+        charge_category_code: null,
+        rationale: "Humidité/infiltration = défaut du bâti, à la charge du propriétaire.",
+      };
+
+    // Traitement nuisibles ponctuel = entretien récupérable (jurisprudence
+    // constante si l'infestation n'est pas liée à un défaut du bâti)
+    case "nuisibles":
+      return {
+        is_tenant_chargeable: true,
+        charge_category_code: "parties_communes",
+        rationale:
+          "Traitement nuisibles ponctuel = entretien récupérable (décret 87-713 art. 2).",
+      };
+
+    // Pas une intervention matérielle — ne se classe pas en charge
+    case "bruit":
+      return {
+        is_tenant_chargeable: false,
+        charge_category_code: null,
+        rationale: "Pas une dépense récupérable.",
+      };
+
+    // Géré par le syndic ; le coût passe par la copropriété, pas par le ticket
+    case "parties_communes":
+      return {
+        is_tenant_chargeable: false,
+        charge_category_code: null,
+        rationale:
+          "Les interventions sur parties communes sont refacturées par le syndic via l'état des charges.",
+      };
+
+    case "equipement":
+    case "autre":
+    default:
+      return AMBIGUOUS;
+  }
+}
+
+/**
+ * Suggère la classification pour une catégorie de SELF-SERVICE locataire
+ * (TENANT_BOOKABLE_CATEGORIES). Par construction ces catégories sont
+ * toutes récupérables : le locataire réserve lui-même → le coût doit
+ * lui être imputé.
+ */
+export function suggestForTenantBookableCategory(
+  category: TenantBookableCategory
+): ChargeClassificationSuggestion {
+  switch (category) {
+    case "jardinage":
+      return {
+        is_tenant_chargeable: true,
+        charge_category_code: "espaces_exterieurs",
+        rationale:
+          "Entretien des espaces verts = charge récupérable (décret 87-713 art. 3).",
+      };
+    case "nettoyage":
+      return {
+        is_tenant_chargeable: true,
+        charge_category_code: "parties_communes",
+        rationale:
+          "Nettoyage courant = charge récupérable (décret 87-713 art. 2).",
+      };
+    case "petits_travaux":
+      return {
+        is_tenant_chargeable: true,
+        charge_category_code: "installations_individuelles",
+        rationale:
+          "Menues réparations = charge récupérable (décret 87-713 art. 4).",
+      };
+    case "peinture":
+      return {
+        is_tenant_chargeable: true,
+        charge_category_code: "installations_individuelles",
+        rationale:
+          "Rafraîchissement peinture à l'initiative du locataire = à sa charge.",
+      };
+    case "demenagement":
+      return {
+        is_tenant_chargeable: true,
+        charge_category_code: null,
+        rationale: "Frais de déménagement = toujours à la charge du locataire.",
+      };
+    default:
+      return AMBIGUOUS;
+  }
+}

--- a/lib/tickets/inject-charge-entry.ts
+++ b/lib/tickets/inject-charge-entry.ts
@@ -1,0 +1,191 @@
+/**
+ * Injection d'une charge_entry à partir d'un work_order clôturé.
+ *
+ * Règle métier : un work_order dont `is_tenant_chargeable=true` et qui a
+ * un `charge_category_code` valide doit apparaître dans les charges
+ * récupérables du locataire pour l'exercice en cours. Le calcul de la
+ * régularisation annuelle (lib/charges/engine.ts) agrège ensuite toutes
+ * les charge_entries de la `fiscal_year` pour la propriété.
+ *
+ * L'injection est idempotente : un work_order ne produit qu'une seule
+ * charge_entry (garanti par l'unique index sur source_work_order_id).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { CanonicalChargeCategory } from "./charges-classification";
+
+export type InjectionResult =
+  | { ok: true; charge_entry_id: string; amount_cents: number; created: boolean }
+  | { ok: false; code: InjectionSkipCode; message: string };
+
+export type InjectionSkipCode =
+  | "NOT_CHARGEABLE"
+  | "NO_CATEGORY"
+  | "CATEGORY_NOT_FOUND"
+  | "WORK_ORDER_NOT_FOUND"
+  | "NO_PAYMENTS"
+  | "ALREADY_INJECTED";
+
+/**
+ * Tente d'injecter une charge_entry pour le work_order donné.
+ * Retourne un résultat détaillé (pas d'exception pour les cas attendus).
+ */
+export async function injectChargeEntryForWorkOrder(
+  supabase: SupabaseClient<any>,
+  workOrderId: string
+): Promise<InjectionResult> {
+  // 1. Charger le work_order + ses colonnes de classification
+  const { data: wo } = await supabase
+    .from("work_orders")
+    .select(
+      "id, property_id, title, is_tenant_chargeable, charge_category_code, work_completed_at, created_at"
+    )
+    .eq("id", workOrderId)
+    .maybeSingle();
+
+  if (!wo) {
+    return {
+      ok: false,
+      code: "WORK_ORDER_NOT_FOUND",
+      message: "Intervention introuvable",
+    };
+  }
+
+  const workOrder = wo as {
+    id: string;
+    property_id: string;
+    title: string | null;
+    is_tenant_chargeable: boolean | null;
+    charge_category_code: CanonicalChargeCategory | null;
+    work_completed_at: string | null;
+    created_at: string;
+  };
+
+  if (workOrder.is_tenant_chargeable !== true) {
+    return {
+      ok: false,
+      code: "NOT_CHARGEABLE",
+      message: "Cette intervention n'est pas à la charge du locataire",
+    };
+  }
+
+  if (!workOrder.charge_category_code) {
+    return {
+      ok: false,
+      code: "NO_CATEGORY",
+      message: "Aucune catégorie de charge affectée à cette intervention",
+    };
+  }
+
+  // 2. Idempotence : si une entry existe déjà pour ce work_order, on la renvoie
+  const { data: existing } = await supabase
+    .from("charge_entries")
+    .select("id, amount_cents")
+    .eq("source_work_order_id", workOrderId)
+    .maybeSingle();
+
+  if (existing) {
+    const existingRow = existing as { id: string; amount_cents: number };
+    return {
+      ok: true,
+      charge_entry_id: existingRow.id,
+      amount_cents: existingRow.amount_cents,
+      created: false,
+    };
+  }
+
+  // 3. Résoudre la catégorie canonique (category_id UUID)
+  const { data: category } = await supabase
+    .from("charge_categories")
+    .select("id")
+    .eq("code", workOrder.charge_category_code)
+    .maybeSingle();
+
+  if (!category) {
+    return {
+      ok: false,
+      code: "CATEGORY_NOT_FOUND",
+      message: `Catégorie de charge '${workOrder.charge_category_code}' introuvable`,
+    };
+  }
+
+  const categoryRow = category as { id: string };
+
+  // 4. Calculer le montant total payé (somme des work_order_payments succeeded)
+  const { data: payments } = await supabase
+    .from("work_order_payments")
+    .select("gross_amount, status, payment_type")
+    .eq("work_order_id", workOrderId)
+    .eq("status", "succeeded")
+    .in("payment_type", ["deposit", "balance", "full"]);
+
+  const rows = (payments || []) as Array<{ gross_amount: string | number }>;
+  const totalEuros = rows.reduce(
+    (sum, p) => sum + Number(p.gross_amount || 0),
+    0
+  );
+  const amountCents = Math.round(totalEuros * 100);
+
+  if (amountCents <= 0) {
+    return {
+      ok: false,
+      code: "NO_PAYMENTS",
+      message:
+        "Aucun paiement encaissé pour cette intervention — impossible de déterminer le montant récupérable.",
+    };
+  }
+
+  // 5. Déterminer la date effective (work_completed_at sinon created_at)
+  const effectiveDate = workOrder.work_completed_at ?? workOrder.created_at;
+  const dateOnly = effectiveDate.slice(0, 10); // YYYY-MM-DD
+  const fiscalYear = Number(effectiveDate.slice(0, 4));
+
+  // 6. Insertion
+  const label = workOrder.title
+    ? `Intervention : ${workOrder.title}`
+    : "Intervention prestataire";
+
+  const { data: inserted, error } = await supabase
+    .from("charge_entries")
+    .insert({
+      property_id: workOrder.property_id,
+      category_id: categoryRow.id,
+      label,
+      amount_cents: amountCents,
+      date: dateOnly,
+      is_recoverable: true,
+      fiscal_year: fiscalYear,
+      source_work_order_id: workOrderId,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    // Contournement rare : course entre deux injections simultanées
+    if (error.code === "23505") {
+      const { data: raced } = await supabase
+        .from("charge_entries")
+        .select("id, amount_cents")
+        .eq("source_work_order_id", workOrderId)
+        .maybeSingle();
+      if (raced) {
+        const row = raced as { id: string; amount_cents: number };
+        return {
+          ok: true,
+          charge_entry_id: row.id,
+          amount_cents: row.amount_cents,
+          created: false,
+        };
+      }
+    }
+    throw error;
+  }
+
+  const row = inserted as { id: string };
+  return {
+    ok: true,
+    charge_entry_id: row.id,
+    amount_cents: amountCents,
+    created: true,
+  };
+}

--- a/lib/tickets/resolve-syndic.ts
+++ b/lib/tickets/resolve-syndic.ts
@@ -1,0 +1,77 @@
+/**
+ * Résolution du syndic pour les tickets "parties communes".
+ *
+ * Chaîne : property.building_id → buildings.site_id → sites.syndic_profile_id
+ *
+ * Si la propriété n'est pas rattachée à une copropriété (pas de building_id),
+ * le retour est vide et l'appelant retombe sur le flux propriétaire standard.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface SyndicRouting {
+  /** site_id = identifiant du syndicat de copropriété (table sites) */
+  entity_id: string | null;
+  /** profile_id du syndic (sur lequel assigner le ticket) */
+  syndic_profile_id: string | null;
+  /** auth user_id du syndic (pour la notification outbox) */
+  syndic_user_id: string | null;
+}
+
+const EMPTY: SyndicRouting = {
+  entity_id: null,
+  syndic_profile_id: null,
+  syndic_user_id: null,
+};
+
+export async function resolveSyndicForProperty(
+  supabase: SupabaseClient<any>,
+  propertyId: string | null
+): Promise<SyndicRouting> {
+  if (!propertyId) return EMPTY;
+
+  const { data: property } = await supabase
+    .from("properties")
+    .select("building_id")
+    .eq("id", propertyId)
+    .maybeSingle();
+
+  const buildingId = (property as { building_id: string | null } | null)?.building_id;
+  if (!buildingId) return EMPTY;
+
+  const { data: building } = await supabase
+    .from("buildings")
+    .select("site_id")
+    .eq("id", buildingId)
+    .maybeSingle();
+
+  const siteId = (building as { site_id: string | null } | null)?.site_id;
+  if (!siteId) return EMPTY;
+
+  const { data: site } = await supabase
+    .from("sites")
+    .select("syndic_profile_id")
+    .eq("id", siteId)
+    .maybeSingle();
+
+  const syndicProfileId =
+    (site as { syndic_profile_id: string | null } | null)?.syndic_profile_id ?? null;
+
+  if (!syndicProfileId) {
+    // Site trouvé mais pas de syndic affecté — on expose tout de même l'entity_id
+    // pour tracer la copropriété.
+    return { entity_id: siteId, syndic_profile_id: null, syndic_user_id: null };
+  }
+
+  const { data: syndicProfile } = await supabase
+    .from("profiles")
+    .select("user_id")
+    .eq("id", syndicProfileId)
+    .maybeSingle();
+
+  return {
+    entity_id: siteId,
+    syndic_profile_id: syndicProfileId,
+    syndic_user_id: (syndicProfile as { user_id: string | null } | null)?.user_id ?? null,
+  };
+}

--- a/lib/tickets/resolve-ticket-context.ts
+++ b/lib/tickets/resolve-ticket-context.ts
@@ -1,0 +1,300 @@
+/**
+ * Résolution du contexte d'un ticket pour un créateur donné.
+ *
+ * Centralise la logique d'accès : un locataire peut être lié à un bail via
+ * `lease_signers.profile_id` (nominal) OU via `lease_signers.invited_email`
+ * (cas où l'invitation n'a pas encore été "healed"). La route POST /api/tickets
+ * ignorait le second cas, ce qui causait des 403 alors que l'utilisateur a
+ * légitimement accès à la propriété.
+ *
+ * Résout aussi :
+ *   - property_id à partir du bail actif si non fourni par le client
+ *   - lease_id à partir de la propriété
+ *   - owner_id de la propriété (pour notification + colonne tickets.owner_id)
+ *
+ * Renvoie un discriminated union pour forcer le handler à traiter tous les cas.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type TicketCreatorRole = "owner" | "tenant" | "agency" | "admin" | "other";
+
+export interface ResolvedTicketContext {
+  ok: true;
+  property_id: string | null;
+  lease_id: string | null;
+  owner_profile_id: string | null;
+  owner_user_id: string | null;
+  creator_role: TicketCreatorRole;
+}
+
+export type TicketContextError =
+  | { ok: false; code: "NO_PROFILE"; status: 404; message: string }
+  | { ok: false; code: "PROPERTY_NOT_FOUND"; status: 404; message: string }
+  | { ok: false; code: "NO_ACCESS"; status: 403; message: string }
+  | { ok: false; code: "NO_ACTIVE_LEASE"; status: 400; message: string };
+
+interface ResolveArgs {
+  serviceClient: SupabaseClient<any>;
+  profileId: string;
+  role: string;
+  userEmail?: string | null;
+  propertyId?: string | null;
+  leaseId?: string | null;
+}
+
+const TENANT_SIGNER_ROLES = ["locataire_principal", "colocataire"];
+
+export async function resolveTicketContext(
+  args: ResolveArgs
+): Promise<ResolvedTicketContext | TicketContextError> {
+  const { serviceClient, profileId, role, userEmail, propertyId, leaseId } = args;
+
+  const normalizedEmail = userEmail?.trim().toLowerCase() || null;
+
+  if (role === "admin") {
+    return resolveForAdmin(serviceClient, propertyId, leaseId);
+  }
+
+  if (role === "owner") {
+    return resolveForOwner(serviceClient, profileId, propertyId, leaseId);
+  }
+
+  // tenant (par défaut) — couvre aussi les rôles non standard qui ont un bail
+  return resolveForTenant(serviceClient, profileId, normalizedEmail, propertyId, leaseId);
+}
+
+async function resolveForAdmin(
+  supabase: SupabaseClient<any>,
+  propertyId: string | null | undefined,
+  leaseId: string | null | undefined
+): Promise<ResolvedTicketContext | TicketContextError> {
+  if (!propertyId) {
+    return {
+      ok: false,
+      code: "NO_ACTIVE_LEASE",
+      status: 400,
+      message: "property_id requis pour un ticket créé par un administrateur",
+    };
+  }
+
+  const property = await fetchProperty(supabase, propertyId);
+  if (!property) {
+    return {
+      ok: false,
+      code: "PROPERTY_NOT_FOUND",
+      status: 404,
+      message: "Propriété introuvable",
+    };
+  }
+
+  const ownerUserId = await fetchOwnerUserId(supabase, property.owner_id);
+  return {
+    ok: true,
+    property_id: propertyId,
+    lease_id: leaseId ?? null,
+    owner_profile_id: property.owner_id,
+    owner_user_id: ownerUserId,
+    creator_role: "admin",
+  };
+}
+
+async function resolveForOwner(
+  supabase: SupabaseClient<any>,
+  profileId: string,
+  propertyId: string | null | undefined,
+  leaseId: string | null | undefined
+): Promise<ResolvedTicketContext | TicketContextError> {
+  if (!propertyId) {
+    return {
+      ok: false,
+      code: "NO_ACTIVE_LEASE",
+      status: 400,
+      message: "Veuillez sélectionner une propriété",
+    };
+  }
+
+  const property = await fetchProperty(supabase, propertyId);
+  if (!property) {
+    return {
+      ok: false,
+      code: "PROPERTY_NOT_FOUND",
+      status: 404,
+      message: "Propriété introuvable",
+    };
+  }
+
+  if (property.owner_id !== profileId) {
+    return {
+      ok: false,
+      code: "NO_ACCESS",
+      status: 403,
+      message: "Vous n'êtes pas propriétaire de ce bien",
+    };
+  }
+
+  const ownerUserId = await fetchOwnerUserId(supabase, property.owner_id);
+  return {
+    ok: true,
+    property_id: propertyId,
+    lease_id: leaseId ?? null,
+    owner_profile_id: property.owner_id,
+    owner_user_id: ownerUserId,
+    creator_role: "owner",
+  };
+}
+
+async function resolveForTenant(
+  supabase: SupabaseClient<any>,
+  profileId: string,
+  userEmail: string | null,
+  propertyId: string | null | undefined,
+  leaseId: string | null | undefined
+): Promise<ResolvedTicketContext | TicketContextError> {
+  // 1. Trouver tous les baux auxquels le locataire est rattaché
+  //    (via profile_id OU invited_email), avec leur propriété.
+  const tenantLeases = await fetchTenantLeases(supabase, profileId, userEmail);
+
+  if (tenantLeases.length === 0) {
+    return {
+      ok: false,
+      code: "NO_ACTIVE_LEASE",
+      status: 400,
+      message:
+        "Aucun bail actif trouvé sur votre compte. Contactez votre propriétaire ou votre agence.",
+    };
+  }
+
+  // 2. Si le client a fourni property_id, vérifier qu'un bail correspond.
+  if (propertyId) {
+    const property = await fetchProperty(supabase, propertyId);
+    if (!property) {
+      return {
+        ok: false,
+        code: "PROPERTY_NOT_FOUND",
+        status: 404,
+        message: "Propriété introuvable",
+      };
+    }
+
+    const matching = tenantLeases.find((l) => l.property_id === propertyId);
+    if (!matching) {
+      return {
+        ok: false,
+        code: "NO_ACCESS",
+        status: 403,
+        message: "Vous n'êtes pas rattaché à cette propriété",
+      };
+    }
+
+    // Cohérence lease_id si fourni
+    const finalLeaseId = leaseId && matching.id === leaseId ? leaseId : matching.id;
+
+    const ownerUserId = await fetchOwnerUserId(supabase, property.owner_id);
+    return {
+      ok: true,
+      property_id: propertyId,
+      lease_id: finalLeaseId,
+      owner_profile_id: property.owner_id,
+      owner_user_id: ownerUserId,
+      creator_role: "tenant",
+    };
+  }
+
+  // 3. Pas de property_id fourni : auto-résoudre depuis le premier bail actif.
+  const primary =
+    tenantLeases.find((l) => l.statut === "active") ??
+    tenantLeases.find((l) => l.statut === "fully_signed") ??
+    tenantLeases[0];
+
+  const property = await fetchProperty(supabase, primary.property_id);
+  if (!property) {
+    return {
+      ok: false,
+      code: "PROPERTY_NOT_FOUND",
+      status: 404,
+      message: "Propriété introuvable pour votre bail",
+    };
+  }
+
+  const ownerUserId = await fetchOwnerUserId(supabase, property.owner_id);
+  return {
+    ok: true,
+    property_id: primary.property_id,
+    lease_id: primary.id,
+    owner_profile_id: property.owner_id,
+    owner_user_id: ownerUserId,
+    creator_role: "tenant",
+  };
+}
+
+async function fetchProperty(
+  supabase: SupabaseClient<any>,
+  propertyId: string
+): Promise<{ id: string; owner_id: string } | null> {
+  const { data } = await supabase
+    .from("properties")
+    .select("id, owner_id")
+    .eq("id", propertyId)
+    .maybeSingle();
+  return (data as { id: string; owner_id: string } | null) || null;
+}
+
+async function fetchOwnerUserId(
+  supabase: SupabaseClient<any>,
+  ownerProfileId: string | null
+): Promise<string | null> {
+  if (!ownerProfileId) return null;
+  const { data } = await supabase
+    .from("profiles")
+    .select("user_id")
+    .eq("id", ownerProfileId)
+    .maybeSingle();
+  return (data as { user_id: string | null } | null)?.user_id ?? null;
+}
+
+interface TenantLease {
+  id: string;
+  property_id: string;
+  statut: string;
+}
+
+async function fetchTenantLeases(
+  supabase: SupabaseClient<any>,
+  profileId: string,
+  userEmail: string | null
+): Promise<TenantLease[]> {
+  // Lease ids via profile_id
+  const { data: signersByProfile } = await supabase
+    .from("lease_signers")
+    .select("lease_id")
+    .eq("profile_id", profileId)
+    .in("role", TENANT_SIGNER_ROLES);
+
+  const leaseIds = new Set<string>(
+    (signersByProfile || []).map((s: { lease_id: string }) => s.lease_id)
+  );
+
+  // Lease ids via invited_email (auto-heal passif : on ne réécrit pas ici,
+  // c'est le rôle du dashboard. On se contente d'accepter l'accès.)
+  if (userEmail) {
+    const { data: signersByEmail } = await supabase
+      .from("lease_signers")
+      .select("lease_id")
+      .ilike("invited_email", userEmail)
+      .in("role", TENANT_SIGNER_ROLES);
+
+    for (const s of signersByEmail || []) {
+      leaseIds.add((s as { lease_id: string }).lease_id);
+    }
+  }
+
+  if (leaseIds.size === 0) return [];
+
+  const { data: leases } = await supabase
+    .from("leases")
+    .select("id, property_id, statut")
+    .in("id", Array.from(leaseIds));
+
+  return (leases as TenantLease[] | null) || [];
+}

--- a/lib/tickets/statuses.ts
+++ b/lib/tickets/statuses.ts
@@ -1,0 +1,172 @@
+/**
+ * Source de vérité unique pour les statuts tickets & work_orders.
+ *
+ * Avant : chaque composant redéfinissait son propre tableau/map, avec des
+ * valeurs qui dérivaient (ex. "done" vs "work_completed" pour le même état
+ * métier). Le mapping ticket ↔ work_order était implicite et cassait
+ * régulièrement l'UI.
+ *
+ * Règle : toute nouvelle UI consomme ces enums et labels. Aucune chaîne
+ * de statut hardcodée ailleurs.
+ */
+
+// ------------------------------------------------------------------
+// TICKET STATUTS — 9 valeurs autorisées par tickets_statut_check
+// (cf. migration 20260408140000_tickets_module_sota.sql)
+// ------------------------------------------------------------------
+
+export const TICKET_STATUSES = [
+  "open",
+  "acknowledged",
+  "assigned",
+  "in_progress",
+  "resolved",
+  "closed",
+  "rejected",
+  "reopened",
+  "paused",
+] as const;
+
+export type TicketStatus = (typeof TICKET_STATUSES)[number];
+
+export const TICKET_STATUS_LABELS: Record<TicketStatus, string> = {
+  open: "Ouvert",
+  acknowledged: "Pris en compte",
+  assigned: "Assigné",
+  in_progress: "En cours",
+  resolved: "Résolu",
+  closed: "Clôturé",
+  rejected: "Rejeté",
+  reopened: "Rouvert",
+  paused: "En pause",
+};
+
+/** États "ouverts" = le ticket requiert encore une action */
+export const TICKET_OPEN_STATUSES: readonly TicketStatus[] = [
+  "open",
+  "acknowledged",
+  "assigned",
+  "reopened",
+];
+
+/** États terminaux = le ticket n'attend plus rien */
+export const TICKET_TERMINAL_STATUSES: readonly TicketStatus[] = [
+  "resolved",
+  "closed",
+  "rejected",
+];
+
+export function isTicketOpen(status: string): boolean {
+  return (TICKET_OPEN_STATUSES as readonly string[]).includes(status);
+}
+
+export function isTicketTerminal(status: string): boolean {
+  return (TICKET_TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
+export function getTicketStatusLabel(status: string): string {
+  return TICKET_STATUS_LABELS[status as TicketStatus] ?? status;
+}
+
+// ------------------------------------------------------------------
+// WORK_ORDER STATUTS — flux intervention SOTA (18 valeurs)
+// (cf. migration 20251205800000_intervention_flow_complete.sql)
+// ------------------------------------------------------------------
+
+export const WORK_ORDER_STATUSES = [
+  "assigned",
+  "accepted",
+  "refused",
+  "visit_scheduled",
+  "visit_completed",
+  "quote_sent",
+  "quote_accepted",
+  "quote_refused",
+  "deposit_pending",
+  "deposit_paid",
+  "work_scheduled",
+  "in_progress",
+  "work_completed",
+  "balance_pending",
+  "fully_paid",
+  "pending_review",
+  "closed",
+  "cancelled",
+  "disputed",
+] as const;
+
+export type WorkOrderStatus = (typeof WORK_ORDER_STATUSES)[number];
+
+export const WORK_ORDER_STATUS_LABELS: Record<WorkOrderStatus, string> = {
+  assigned: "Assigné",
+  accepted: "Accepté",
+  refused: "Refusé",
+  visit_scheduled: "Visite planifiée",
+  visit_completed: "Visite effectuée",
+  quote_sent: "Devis envoyé",
+  quote_accepted: "Devis accepté",
+  quote_refused: "Devis refusé",
+  deposit_pending: "Acompte en attente",
+  deposit_paid: "Acompte payé",
+  work_scheduled: "Travaux planifiés",
+  in_progress: "En cours",
+  work_completed: "Travaux terminés",
+  balance_pending: "Solde en attente",
+  fully_paid: "Soldé",
+  pending_review: "À valider",
+  closed: "Clôturé",
+  cancelled: "Annulé",
+  disputed: "Litige",
+};
+
+export function getWorkOrderStatusLabel(status: string): string {
+  return WORK_ORDER_STATUS_LABELS[status as WorkOrderStatus] ?? status;
+}
+
+// ------------------------------------------------------------------
+// MAPPING work_order -> ticket
+// ------------------------------------------------------------------
+// Le ticket reflète la visibilité "client" (locataire/propriétaire).
+// Le work_order reflète le détail opérationnel (prestataire + paiements).
+// Cette fonction renvoie le statut ticket correspondant à l'état actuel
+// du work_order, pour garder les deux vues cohérentes.
+
+export function mapWorkOrderStatusToTicketStatus(
+  woStatus: WorkOrderStatus | string
+): TicketStatus {
+  switch (woStatus) {
+    case "assigned":
+    case "accepted":
+    case "visit_scheduled":
+    case "quote_sent":
+    case "quote_accepted":
+    case "deposit_pending":
+    case "deposit_paid":
+    case "work_scheduled":
+      return "assigned";
+
+    case "visit_completed":
+    case "in_progress":
+      return "in_progress";
+
+    case "work_completed":
+    case "balance_pending":
+    case "pending_review":
+      return "resolved";
+
+    case "fully_paid":
+    case "closed":
+      return "closed";
+
+    case "refused":
+    case "quote_refused":
+    case "cancelled":
+      return "rejected";
+
+    case "disputed":
+      return "in_progress";
+
+    default:
+      return "open";
+  }
+}

--- a/lib/tickets/tenant-service-permissions.ts
+++ b/lib/tickets/tenant-service-permissions.ts
@@ -1,0 +1,177 @@
+/**
+ * Permissions self-service du locataire.
+ *
+ * Le propriétaire configure dans le bail les catégories que le locataire
+ * peut réserver directement (ex. jardinage, nettoyage) — sans attendre
+ * que l'owner approuve. Ce module lit et valide ces permissions.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface TenantBookingPermissions {
+  enabled: boolean;
+  allowed_categories: string[];
+  max_amount_cents: number | null;
+  requires_owner_approval: boolean;
+}
+
+const DEFAULT_PERMISSIONS: TenantBookingPermissions = {
+  enabled: false,
+  allowed_categories: [],
+  max_amount_cents: null,
+  requires_owner_approval: false,
+};
+
+export type PermissionDecision =
+  | { allowed: true; permissions: TenantBookingPermissions; lease_id: string; property_id: string; owner_profile_id: string }
+  | { allowed: false; code: "NO_LEASE" | "DISABLED" | "CATEGORY_NOT_ALLOWED"; status: 403 | 404; message: string };
+
+/**
+ * Vérifie qu'un profil locataire a le droit de booker un service d'une
+ * catégorie donnée, en s'appuyant sur ses baux actifs (via profile_id
+ * OU invited_email, cf. resolve-ticket-context).
+ */
+export async function checkTenantBookingPermission(args: {
+  serviceClient: SupabaseClient<any>;
+  profileId: string;
+  userEmail: string | null;
+  category: string;
+}): Promise<PermissionDecision> {
+  const { serviceClient, profileId, userEmail, category } = args;
+
+  // 1. Récupérer les lease_ids du locataire (profile_id + invited_email)
+  const leaseIds = new Set<string>();
+
+  const { data: byProfile } = await serviceClient
+    .from("lease_signers")
+    .select("lease_id")
+    .eq("profile_id", profileId)
+    .in("role", ["locataire_principal", "colocataire"]);
+
+  for (const s of byProfile || []) {
+    leaseIds.add((s as { lease_id: string }).lease_id);
+  }
+
+  if (userEmail) {
+    const { data: byEmail } = await serviceClient
+      .from("lease_signers")
+      .select("lease_id")
+      .ilike("invited_email", userEmail)
+      .in("role", ["locataire_principal", "colocataire"]);
+    for (const s of byEmail || []) {
+      leaseIds.add((s as { lease_id: string }).lease_id);
+    }
+  }
+
+  if (leaseIds.size === 0) {
+    return {
+      allowed: false,
+      code: "NO_LEASE",
+      status: 404,
+      message: "Aucun bail actif trouvé pour votre compte.",
+    };
+  }
+
+  // 2. Chercher un bail actif autorisant cette catégorie
+  const { data: leases } = await serviceClient
+    .from("leases")
+    .select("id, property_id, tenant_service_bookings")
+    .in("id", Array.from(leaseIds))
+    .in("statut", ["active", "fully_signed"]);
+
+  const activeLeases = (leases || []) as Array<{
+    id: string;
+    property_id: string;
+    tenant_service_bookings: TenantBookingPermissions | null;
+  }>;
+
+  if (activeLeases.length === 0) {
+    return {
+      allowed: false,
+      code: "NO_LEASE",
+      status: 404,
+      message: "Aucun bail actif trouvé pour votre compte.",
+    };
+  }
+
+  // Un locataire peut avoir plusieurs baux ; on prend le premier qui autorise
+  // la catégorie demandée (l'owner_id peut différer d'un bail à l'autre).
+  for (const lease of activeLeases) {
+    const perms = normalizePermissions(lease.tenant_service_bookings);
+    if (perms.enabled && perms.allowed_categories.includes(category)) {
+      const { data: property } = await serviceClient
+        .from("properties")
+        .select("owner_id")
+        .eq("id", lease.property_id)
+        .maybeSingle();
+      const ownerProfileId = (property as { owner_id: string } | null)?.owner_id;
+      if (!ownerProfileId) continue;
+
+      return {
+        allowed: true,
+        permissions: perms,
+        lease_id: lease.id,
+        property_id: lease.property_id,
+        owner_profile_id: ownerProfileId,
+      };
+    }
+  }
+
+  // Aucun bail n'autorise cette catégorie — on distingue le cas "self-service
+  // jamais activé" du cas "catégorie non listée" pour un message clair.
+  const anyEnabled = activeLeases.some((l) => normalizePermissions(l.tenant_service_bookings).enabled);
+  if (!anyEnabled) {
+    return {
+      allowed: false,
+      code: "DISABLED",
+      status: 403,
+      message: "Votre propriétaire n'a pas activé la réservation directe de prestataires.",
+    };
+  }
+
+  return {
+    allowed: false,
+    code: "CATEGORY_NOT_ALLOWED",
+    status: 403,
+    message: "Cette catégorie de service n'est pas autorisée dans votre bail.",
+  };
+}
+
+export function normalizePermissions(
+  raw: TenantBookingPermissions | null | undefined
+): TenantBookingPermissions {
+  if (!raw || typeof raw !== "object") return { ...DEFAULT_PERMISSIONS };
+  return {
+    enabled: Boolean(raw.enabled),
+    allowed_categories: Array.isArray(raw.allowed_categories) ? raw.allowed_categories : [],
+    max_amount_cents:
+      typeof raw.max_amount_cents === "number" && raw.max_amount_cents > 0
+        ? raw.max_amount_cents
+        : null,
+    requires_owner_approval: Boolean(raw.requires_owner_approval),
+  };
+}
+
+/**
+ * Catégories que nous exposons au locataire pour le self-service.
+ * Se limite aux catégories "non urgentes + faible risque" où le locataire
+ * n'a pas besoin de l'expertise de l'owner pour décider.
+ * Source : providers.trade_categories (cf. 20260408120000_providers_module_sota.sql).
+ */
+export const TENANT_BOOKABLE_CATEGORIES = [
+  "jardinage",
+  "nettoyage",
+  "demenagement",
+  "peinture",
+  "petits_travaux",
+] as const;
+
+export type TenantBookableCategory = (typeof TENANT_BOOKABLE_CATEGORIES)[number];
+
+export const TENANT_BOOKABLE_CATEGORY_LABELS: Record<TenantBookableCategory, string> = {
+  jardinage: "Jardinage",
+  nettoyage: "Ménage",
+  demenagement: "Déménagement",
+  peinture: "Peinture",
+  petits_travaux: "Petits travaux",
+};

--- a/lib/validations/index.ts
+++ b/lib/validations/index.ts
@@ -819,8 +819,12 @@ export const chargeUpdateSchema = z.object({
 });
 
 // Validation des tickets
+// property_id est optionnel : côté serveur, le contexte est résolu via
+// resolveTicketContext() qui le déduit du bail actif du locataire si absent.
+// Cela évite les 403 parasites quand le client n'a pas encore les données
+// du dashboard (ex. première connexion, onboarding en cours).
 export const ticketSchema = z.object({
-  property_id: z.string().uuid(),
+  property_id: z.string().uuid().optional().nullable(),
   lease_id: z.string().uuid().optional().nullable(),
   titre: z.string().min(1, "Le titre est requis"),
   description: z.string().min(1, "La description est requise"),

--- a/supabase/functions/_shared/email-templates.ts
+++ b/supabase/functions/_shared/email-templates.ts
@@ -494,3 +494,215 @@ export function visitFeedbackRequest(params: {
   </div>
 </div>`;
 }
+
+// ============================================
+// Tenant Self-Service — parcours locataire → prestataire
+// ============================================
+
+function bookingSummaryBox(params: {
+  reference: string | null;
+  title: string;
+  category: string | null;
+  providerCompany: string | null;
+  preferredDate: string | null;
+}): string {
+  const rows: string[] = [];
+  if (params.reference) {
+    rows.push(
+      `<tr><td style="padding: 6px 0; color: #64748b; font-size: 14px;">Référence</td><td style="padding: 6px 0; text-align: right; font-family: monospace; color: #1e293b;">${params.reference}</td></tr>`
+    );
+  }
+  rows.push(
+    `<tr><td style="padding: 6px 0; color: #64748b; font-size: 14px;">Objet</td><td style="padding: 6px 0; text-align: right; color: #1e293b;">${params.title}</td></tr>`
+  );
+  if (params.category) {
+    rows.push(
+      `<tr><td style="padding: 6px 0; color: #64748b; font-size: 14px;">Catégorie</td><td style="padding: 6px 0; text-align: right; color: #1e293b; text-transform: capitalize;">${params.category}</td></tr>`
+    );
+  }
+  if (params.providerCompany) {
+    rows.push(
+      `<tr><td style="padding: 6px 0; color: #64748b; font-size: 14px;">Prestataire</td><td style="padding: 6px 0; text-align: right; color: #1e293b;">${params.providerCompany}</td></tr>`
+    );
+  }
+  if (params.preferredDate) {
+    rows.push(
+      `<tr><td style="padding: 6px 0; color: #64748b; font-size: 14px;">Date souhaitée</td><td style="padding: 6px 0; text-align: right; color: #1e293b;">${params.preferredDate}</td></tr>`
+    );
+  }
+  return `
+    <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; padding: 20px; margin: 20px 0;">
+      <table style="width: 100%; border-collapse: collapse;">
+        ${rows.join("\n")}
+      </table>
+    </div>
+  `;
+}
+
+/** Email au propriétaire : son locataire vient de réserver un prestataire. */
+export function tenantServiceBooked(params: {
+  ownerName: string;
+  tenantName: string;
+  reference: string | null;
+  title: string;
+  category: string | null;
+  providerCompany: string | null;
+  preferredDate: string | null;
+  ticketId: string;
+}): string {
+  return baseWrapper(`
+    <h2 style="color: #1e293b; margin: 0 0 20px; font-size: 22px; font-weight: 600;">
+      Nouvelle réservation de service
+    </h2>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Bonjour ${params.ownerName},
+    </p>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      ${params.tenantName} vient de réserver un prestataire via son espace Talok.
+      Vous êtes notifié à titre informatif — aucune action n'est requise.
+    </p>
+    ${bookingSummaryBox({
+      reference: params.reference,
+      title: params.title,
+      category: params.category,
+      providerCompany: params.providerCompany,
+      preferredDate: params.preferredDate,
+    })}
+    ${ctaButton("Voir le ticket", `${APP_URL()}/owner/tickets/${params.ticketId}`)}
+  `);
+}
+
+/** Email au propriétaire : validation requise pour une réservation locataire. */
+export function tenantServiceApprovalRequested(params: {
+  ownerName: string;
+  tenantName: string;
+  reference: string | null;
+  title: string;
+  category: string | null;
+  providerCompany: string | null;
+  preferredDate: string | null;
+}): string {
+  return baseWrapper(`
+    <div style="background: #fef3c7; border-left: 4px solid #f59e0b; padding: 16px; border-radius: 8px; margin: 0 0 24px;">
+      <p style="margin: 0; color: #92400e; font-weight: 600; font-size: 15px;">
+        ⏳ Action requise : votre locataire attend votre validation
+      </p>
+    </div>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Bonjour ${params.ownerName},
+    </p>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      ${params.tenantName} souhaite réserver un prestataire. Le prestataire ne
+      sera notifié qu'une fois votre validation confirmée.
+    </p>
+    ${bookingSummaryBox({
+      reference: params.reference,
+      title: params.title,
+      category: params.category,
+      providerCompany: params.providerCompany,
+      preferredDate: params.preferredDate,
+    })}
+    ${ctaButton("Valider ou refuser", `${APP_URL()}/owner/approvals`, "#f59e0b")}
+  `);
+}
+
+/** Email au locataire : le propriétaire a refusé sa réservation. */
+export function tenantServiceRejected(params: {
+  tenantName: string;
+  reference: string | null;
+  title: string;
+  reason: string | null;
+}): string {
+  const reasonBlock = params.reason
+    ? `<div style="background: #fef2f2; border-left: 4px solid #ef4444; padding: 16px; border-radius: 8px; margin: 20px 0;">
+        <p style="margin: 0 0 8px; color: #991b1b; font-weight: 600;">Raison indiquée</p>
+        <p style="margin: 0; color: #7f1d1d; font-style: italic;">« ${params.reason} »</p>
+      </div>`
+    : "";
+
+  return baseWrapper(`
+    <h2 style="color: #1e293b; margin: 0 0 20px; font-size: 22px; font-weight: 600;">
+      Votre réservation a été refusée
+    </h2>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Bonjour ${params.tenantName},
+    </p>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Votre propriétaire n'a pas validé la réservation ${params.reference ? `<strong>${params.reference}</strong> ` : ""}concernant&nbsp;: <strong>${params.title}</strong>.
+    </p>
+    ${reasonBlock}
+    <p style="color: #475569; font-size: 15px; line-height: 1.6; margin: 0 0 24px;">
+      Vous pouvez échanger avec votre propriétaire depuis votre espace, ou
+      créer une demande classique qu'il prendra en charge lui-même.
+    </p>
+    ${ctaButton("Retourner à mes demandes", `${APP_URL()}/tenant/requests`, "#64748b")}
+  `);
+}
+
+/** Email au prestataire : nouvelle mission assignée. */
+export function workOrderAssignedToProvider(params: {
+  providerName: string;
+  reference: string | null;
+  title: string;
+  category: string | null;
+  preferredDate: string | null;
+  workOrderId: string;
+}): string {
+  return baseWrapper(`
+    <div style="background: #ecfdf5; border-left: 4px solid #10b981; padding: 16px; border-radius: 8px; margin: 0 0 24px;">
+      <p style="margin: 0; color: #065f46; font-weight: 600; font-size: 15px;">
+        🛠️ Nouvelle mission assignée
+      </p>
+    </div>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Bonjour ${params.providerName},
+    </p>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Une nouvelle intervention vous a été confiée via Talok. Connectez-vous
+      pour accepter la mission et proposer un devis.
+    </p>
+    ${bookingSummaryBox({
+      reference: params.reference,
+      title: params.title,
+      category: params.category,
+      providerCompany: null,
+      preferredDate: params.preferredDate,
+    })}
+    ${ctaButton("Voir la mission", `${APP_URL()}/provider/tickets`, "#10b981")}
+  `);
+}
+
+/** Email au syndic : signalement parties communes. */
+export function ticketPartiesCommunesToSyndic(params: {
+  syndicName: string;
+  reference: string | null;
+  title: string;
+  priority: string | null;
+  ticketId: string;
+}): string {
+  const priorityLabel =
+    params.priority === "urgent" || params.priority === "urgente"
+      ? `<span style="display: inline-block; padding: 2px 10px; background: #fee2e2; color: #991b1b; border-radius: 999px; font-size: 12px; font-weight: 600; margin-left: 8px;">URGENT</span>`
+      : "";
+
+  return baseWrapper(`
+    <h2 style="color: #1e293b; margin: 0 0 20px; font-size: 22px; font-weight: 600;">
+      Signalement parties communes ${priorityLabel}
+    </h2>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Bonjour ${params.syndicName},
+    </p>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Un locataire d'une propriété que vous syndiquez vient d'ouvrir un
+      signalement sur les parties communes.
+    </p>
+    ${bookingSummaryBox({
+      reference: params.reference,
+      title: params.title,
+      category: "Parties communes",
+      providerCompany: null,
+      preferredDate: null,
+    })}
+    ${ctaButton("Traiter le signalement", `${APP_URL()}/copro/tickets`, "#6366f1")}
+  `);
+}

--- a/supabase/functions/process-outbox/index.ts
+++ b/supabase/functions/process-outbox/index.ts
@@ -334,6 +334,122 @@ async function processEvent(supabase: any, event: any) {
       break;
     }
 
+    // Ticket sur les parties communes routé vers le syndic
+    case "Ticket.OpenedPartiesCommunes": {
+      const recipient = payload.recipient_user_id || payload.syndic_user_id;
+      if (recipient) {
+        const refSuffix = payload.ticket_reference ? ` (${payload.ticket_reference})` : "";
+        await sendNotification(supabase, {
+          type: "ticket_parties_communes",
+          user_id: recipient,
+          title: "Signalement parties communes",
+          message: `Un locataire a signalé un incident sur les parties communes : ${payload.title || "sans titre"}${refSuffix}`,
+          metadata: {
+            ticket_id: payload.ticket_id,
+            entity_id: payload.entity_id,
+            category: payload.category,
+          },
+        });
+      }
+      break;
+    }
+
+    // Réservation self-service locataire → prestataire, pas de validation owner requise
+    case "TenantService.Booked": {
+      const recipient = payload.recipient_user_id;
+      if (recipient) {
+        const refSuffix = payload.ticket_reference ? ` (${payload.ticket_reference})` : "";
+        await sendNotification(supabase, {
+          type: "tenant_service_booked",
+          user_id: recipient,
+          title: "Votre locataire a réservé un service",
+          message: `${payload.provider_company || "Un prestataire"} a été sollicité pour : ${payload.title || "service"}${refSuffix}`,
+          metadata: {
+            ticket_id: payload.ticket_id,
+            work_order_id: payload.work_order_id,
+            category: payload.category,
+          },
+        });
+      }
+      break;
+    }
+
+    // Réservation self-service en attente de validation propriétaire
+    case "TenantService.ApprovalRequested": {
+      const recipient = payload.recipient_user_id;
+      if (recipient) {
+        const refSuffix = payload.ticket_reference ? ` (${payload.ticket_reference})` : "";
+        await sendNotification(supabase, {
+          type: "tenant_service_approval_required",
+          user_id: recipient,
+          title: "Réservation à valider",
+          message: `Votre locataire souhaite réserver ${payload.provider_company || "un prestataire"} pour : ${payload.title || "service"}${refSuffix}`,
+          metadata: {
+            ticket_id: payload.ticket_id,
+            work_order_id: payload.work_order_id,
+            category: payload.category,
+            action: "approval_required",
+            action_url: "/owner/approvals",
+          },
+        });
+      }
+      break;
+    }
+
+    // Propriétaire a refusé la réservation
+    case "TenantService.Rejected": {
+      const recipient = payload.recipient_user_id;
+      if (recipient) {
+        const refSuffix = payload.ticket_reference ? ` (${payload.ticket_reference})` : "";
+        const reasonSuffix = payload.reason ? ` : « ${payload.reason} »` : ".";
+        await sendNotification(supabase, {
+          type: "tenant_service_rejected",
+          user_id: recipient,
+          title: "Réservation refusée",
+          message: `Votre propriétaire a refusé la réservation${refSuffix}${reasonSuffix}`,
+          metadata: {
+            ticket_id: payload.ticket_id,
+            work_order_id: payload.work_order_id,
+            reason: payload.reason,
+          },
+        });
+      }
+      break;
+    }
+
+    // Work order assigné à un prestataire (post self-service ou post validation owner)
+    case "WorkOrder.AssignedToProvider": {
+      const recipient = payload.recipient_user_id;
+      if (recipient) {
+        const refSuffix = payload.ticket_reference ? ` (${payload.ticket_reference})` : "";
+        const dateSuffix = payload.preferred_date
+          ? ` — souhaité le ${payload.preferred_date}`
+          : "";
+        await sendNotification(supabase, {
+          type: "work_order_assigned",
+          user_id: recipient,
+          title: "Nouvelle mission",
+          message: `${payload.title || "Mission"}${refSuffix}${dateSuffix}`,
+          metadata: {
+            ticket_id: payload.ticket_id,
+            work_order_id: payload.work_order_id,
+            action_url: `/provider/tickets`,
+          },
+        });
+        // SMS non-bloquant pour signaler la mission
+        try {
+          await sendSmsNotification(
+            supabase,
+            recipient,
+            `Talok : nouvelle mission assignée${refSuffix}. Connectez-vous pour répondre.`
+          );
+        } catch {
+          /* non-blocking */
+        }
+      }
+      break;
+    }
+
     case "Lease.Activated":
       // Notifier le locataire que le bail est actif
       if (payload.tenant_user_id) {

--- a/supabase/functions/process-outbox/index.ts
+++ b/supabase/functions/process-outbox/index.ts
@@ -545,6 +545,46 @@ async function processEvent(supabase: any, event: any) {
       break;
     }
 
+    // Paiement reçu côté prestataire (Stripe Connect a transféré les fonds)
+    case "WorkOrder.PaymentReceived": {
+      const recipient = payload.recipient_user_id;
+      if (recipient) {
+        const amountCents = Number(payload.amount_cents || 0);
+        const amountEuros = (amountCents / 100).toFixed(2);
+        const paymentType = payload.payment_type || "full";
+        const label =
+          paymentType === "deposit"
+            ? "acompte"
+            : paymentType === "balance"
+              ? "solde"
+              : "paiement";
+
+        await sendNotification(supabase, {
+          type: "work_order_payment_received",
+          user_id: recipient,
+          title: "Paiement reçu",
+          message: `Le ${label} de ${amountEuros} € a été versé sur votre compte.`,
+          metadata: {
+            work_order_id: payload.work_order_id,
+            payment_type: paymentType,
+            amount_cents: amountCents,
+          },
+        });
+
+        // SMS non-bloquant : le prestataire est souvent sur le terrain
+        try {
+          await sendSmsNotification(
+            supabase,
+            recipient,
+            `Talok : ${amountEuros}€ versés sur votre compte. Détails dans votre espace.`
+          );
+        } catch {
+          /* non-blocking */
+        }
+      }
+      break;
+    }
+
     case "Lease.Activated":
       // Notifier le locataire que le bail est actif
       if (payload.tenant_user_id) {

--- a/supabase/functions/process-outbox/index.ts
+++ b/supabase/functions/process-outbox/index.ts
@@ -14,6 +14,11 @@ import {
   visitBookingCancelled as visitBookingCancelledTemplate,
   visitFeedbackRequest as visitFeedbackRequestTemplate,
   initialInvoiceEmail as initialInvoiceEmailTemplate,
+  tenantServiceBooked as tenantServiceBookedTemplate,
+  tenantServiceApprovalRequested as tenantServiceApprovalRequestedTemplate,
+  tenantServiceRejected as tenantServiceRejectedTemplate,
+  workOrderAssignedToProvider as workOrderAssignedToProviderTemplate,
+  ticketPartiesCommunesToSyndic as ticketPartiesCommunesToSyndicTemplate,
 } from "../_shared/email-templates.ts";
 import { normalizePhoneE164, maskPhone } from "../_shared/phone.ts";
 
@@ -350,6 +355,23 @@ async function processEvent(supabase: any, event: any) {
             category: payload.category,
           },
         });
+
+        const recipientInfo = await resolveEmailRecipient(supabase, recipient);
+        if (recipientInfo) {
+          const html = ticketPartiesCommunesToSyndicTemplate({
+            syndicName: recipientInfo.name,
+            reference: payload.ticket_reference ?? null,
+            title: payload.title || "Signalement",
+            priority: payload.priority ?? null,
+            ticketId: payload.ticket_id,
+          });
+          await sendOutboxEmail({
+            to: recipientInfo.email,
+            subject: `Signalement parties communes${refSuffix}`,
+            html,
+            tags: [{ name: "type", value: "ticket_parties_communes" }],
+          });
+        }
       }
       break;
     }
@@ -370,6 +392,26 @@ async function processEvent(supabase: any, event: any) {
             category: payload.category,
           },
         });
+
+        const recipientInfo = await resolveEmailRecipient(supabase, recipient);
+        if (recipientInfo) {
+          const html = tenantServiceBookedTemplate({
+            ownerName: recipientInfo.name,
+            tenantName: payload.tenant_name || "Votre locataire",
+            reference: payload.ticket_reference ?? null,
+            title: payload.title || "Service",
+            category: payload.category ?? null,
+            providerCompany: payload.provider_company ?? null,
+            preferredDate: payload.preferred_date ?? null,
+            ticketId: payload.ticket_id,
+          });
+          await sendOutboxEmail({
+            to: recipientInfo.email,
+            subject: `Votre locataire a réservé ${payload.provider_company || "un prestataire"}`,
+            html,
+            tags: [{ name: "type", value: "tenant_service_booked" }],
+          });
+        }
       }
       break;
     }
@@ -392,6 +434,25 @@ async function processEvent(supabase: any, event: any) {
             action_url: "/owner/approvals",
           },
         });
+
+        const recipientInfo = await resolveEmailRecipient(supabase, recipient);
+        if (recipientInfo) {
+          const html = tenantServiceApprovalRequestedTemplate({
+            ownerName: recipientInfo.name,
+            tenantName: payload.tenant_name || "Votre locataire",
+            reference: payload.ticket_reference ?? null,
+            title: payload.title || "Service",
+            category: payload.category ?? null,
+            providerCompany: payload.provider_company ?? null,
+            preferredDate: payload.preferred_date ?? null,
+          });
+          await sendOutboxEmail({
+            to: recipientInfo.email,
+            subject: `Action requise : validation d'une réservation${refSuffix}`,
+            html,
+            tags: [{ name: "type", value: "tenant_service_approval_required" }],
+          });
+        }
       }
       break;
     }
@@ -413,6 +474,22 @@ async function processEvent(supabase: any, event: any) {
             reason: payload.reason,
           },
         });
+
+        const recipientInfo = await resolveEmailRecipient(supabase, recipient);
+        if (recipientInfo) {
+          const html = tenantServiceRejectedTemplate({
+            tenantName: recipientInfo.name,
+            reference: payload.ticket_reference ?? null,
+            title: payload.title || "votre réservation",
+            reason: payload.reason ?? null,
+          });
+          await sendOutboxEmail({
+            to: recipientInfo.email,
+            subject: `Votre réservation a été refusée${refSuffix}`,
+            html,
+            tags: [{ name: "type", value: "tenant_service_rejected" }],
+          });
+        }
       }
       break;
     }
@@ -445,6 +522,24 @@ async function processEvent(supabase: any, event: any) {
           );
         } catch {
           /* non-blocking */
+        }
+
+        const recipientInfo = await resolveEmailRecipient(supabase, recipient);
+        if (recipientInfo) {
+          const html = workOrderAssignedToProviderTemplate({
+            providerName: recipientInfo.name,
+            reference: payload.ticket_reference ?? null,
+            title: payload.title || "Mission",
+            category: payload.category ?? null,
+            preferredDate: payload.preferred_date ?? null,
+            workOrderId: payload.work_order_id,
+          });
+          await sendOutboxEmail({
+            to: recipientInfo.email,
+            subject: `Nouvelle mission${refSuffix}`,
+            html,
+            tags: [{ name: "type", value: "work_order_assigned" }],
+          });
         }
       }
       break;
@@ -1380,6 +1475,42 @@ async function sendSignatureEmail(supabase: any, params: {
     }
   } catch (error) {
     console.error(`[Email] Erreur envoi:`, error);
+  }
+}
+
+/**
+ * Résout l'email + prénom d'un user_id pour l'envoi d'email transactionnel.
+ * Honore la préférence notification_settings.email_enabled.
+ * Retourne null si l'email ne peut pas être envoyé.
+ */
+async function resolveEmailRecipient(
+  supabase: any,
+  userId: string
+): Promise<{ email: string; name: string } | null> {
+  try {
+    const { data: settings } = await supabase
+      .from("notification_settings")
+      .select("email_enabled")
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (settings?.email_enabled === false) return null;
+
+    const { data: authUser } = await supabase.auth.admin.getUserById(userId);
+    const email = authUser?.user?.email;
+    if (!email) return null;
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("prenom, nom")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    const name =
+      profile?.prenom || profile?.nom || email.split("@")[0];
+    return { email, name };
+  } catch (error) {
+    console.error(`[Email] resolveEmailRecipient failed for ${userId}:`, error);
+    return null;
   }
 }
 

--- a/supabase/migrations/20260421100000_tickets_human_reference.sql
+++ b/supabase/migrations/20260421100000_tickets_human_reference.sql
@@ -49,17 +49,31 @@ CREATE TRIGGER trg_set_ticket_reference
   FOR EACH ROW
   EXECUTE FUNCTION set_ticket_reference();
 
--- 5. Backfill : attribue une référence aux tickets existants par ordre
---    chronologique. On reconstruit les compteurs pour rester cohérent.
+-- 5. Backfill IDEMPOTENT : attribue une référence aux tickets existants.
+--    Reste correct si la migration est rejouée (ex. après échec partiel).
+--
+--    Étapes :
+--      a) Seed ticket_counters depuis les références déjà en base (MAX par année)
+--      b) Boucle uniquement sur les tickets sans référence, chronologiquement
+--      c) L'incrémentation continue au-dessus du MAX existant → aucune collision
 DO $$
 DECLARE
   r RECORD;
   v_year INTEGER;
   v_next INTEGER;
 BEGIN
-  -- Réinitialise les compteurs si le backfill a déjà tourné partiellement
-  TRUNCATE ticket_counters;
+  -- a) Seed : extraire l'année + le numéro des références existantes
+  INSERT INTO ticket_counters (year, last_number)
+  SELECT
+    (substring(reference FROM 'TKT-(\d{4})-'))::INTEGER AS year,
+    MAX((substring(reference FROM 'TKT-\d{4}-(\d+)'))::INTEGER) AS last_number
+  FROM tickets
+  WHERE reference ~ '^TKT-\d{4}-\d+$'
+  GROUP BY (substring(reference FROM 'TKT-(\d{4})-'))::INTEGER
+  ON CONFLICT (year)
+  DO UPDATE SET last_number = GREATEST(ticket_counters.last_number, EXCLUDED.last_number);
 
+  -- b) Backfill des tickets sans référence
   FOR r IN
     SELECT id, created_at
     FROM tickets

--- a/supabase/migrations/20260421100000_tickets_human_reference.sql
+++ b/supabase/migrations/20260421100000_tickets_human_reference.sql
@@ -1,0 +1,87 @@
+-- =============================================
+-- TICKETS : numérotation humaine TKT-YYYY-NNNN
+-- =============================================
+-- Ajoute une référence lisible (ex. TKT-2026-0042) pour que les utilisateurs
+-- puissent citer un ticket par téléphone/email au lieu d'un UUID.
+-- La séquence est annuelle et atomique (UPSERT sur ticket_counters).
+
+-- 1. Table de compteurs par année
+CREATE TABLE IF NOT EXISTS ticket_counters (
+  year INTEGER PRIMARY KEY,
+  last_number INTEGER NOT NULL DEFAULT 0
+);
+
+-- 2. Colonne reference sur tickets
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS reference TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tickets_reference ON tickets(reference);
+
+-- 3. Fonction d'incrémentation atomique
+CREATE OR REPLACE FUNCTION generate_ticket_reference()
+RETURNS TEXT AS $$
+DECLARE
+  v_year INTEGER := EXTRACT(YEAR FROM NOW())::INTEGER;
+  v_number INTEGER;
+BEGIN
+  INSERT INTO ticket_counters (year, last_number)
+  VALUES (v_year, 1)
+  ON CONFLICT (year)
+  DO UPDATE SET last_number = ticket_counters.last_number + 1
+  RETURNING last_number INTO v_number;
+
+  RETURN 'TKT-' || v_year || '-' || LPAD(v_number::TEXT, 4, '0');
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4. Trigger BEFORE INSERT : attribue la référence si non fournie
+CREATE OR REPLACE FUNCTION set_ticket_reference()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.reference IS NULL OR NEW.reference = '' THEN
+    NEW.reference := generate_ticket_reference();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_set_ticket_reference ON tickets;
+CREATE TRIGGER trg_set_ticket_reference
+  BEFORE INSERT ON tickets
+  FOR EACH ROW
+  EXECUTE FUNCTION set_ticket_reference();
+
+-- 5. Backfill : attribue une référence aux tickets existants par ordre
+--    chronologique. On reconstruit les compteurs pour rester cohérent.
+DO $$
+DECLARE
+  r RECORD;
+  v_year INTEGER;
+  v_next INTEGER;
+BEGIN
+  -- Réinitialise les compteurs si le backfill a déjà tourné partiellement
+  TRUNCATE ticket_counters;
+
+  FOR r IN
+    SELECT id, created_at
+    FROM tickets
+    WHERE reference IS NULL OR reference = ''
+    ORDER BY created_at ASC, id ASC
+  LOOP
+    v_year := EXTRACT(YEAR FROM r.created_at)::INTEGER;
+
+    INSERT INTO ticket_counters (year, last_number)
+    VALUES (v_year, 1)
+    ON CONFLICT (year)
+    DO UPDATE SET last_number = ticket_counters.last_number + 1
+    RETURNING last_number INTO v_next;
+
+    UPDATE tickets
+    SET reference = 'TKT-' || v_year || '-' || LPAD(v_next::TEXT, 4, '0')
+    WHERE id = r.id;
+  END LOOP;
+END $$;
+
+-- 6. Après backfill, les futures insertions reprennent le compteur de l'année
+--    en cours (le trigger ré-incrémente depuis last_number courant).
+
+-- 7. NOT NULL après backfill
+ALTER TABLE tickets ALTER COLUMN reference SET NOT NULL;

--- a/supabase/migrations/20260421110000_tenant_self_service_bookings.sql
+++ b/supabase/migrations/20260421110000_tenant_self_service_bookings.sql
@@ -1,0 +1,59 @@
+-- =============================================
+-- TENANT SELF-SERVICE : le locataire peut réserver directement
+-- un prestataire pour certaines catégories, selon l'autorisation
+-- donnée par le propriétaire dans le bail.
+-- =============================================
+
+-- 1. Autorisations de booking côté bail
+-- Schéma JSONB :
+--   {
+--     "enabled": true,
+--     "allowed_categories": ["jardinage", "nettoyage"],
+--     "max_amount_cents": 20000,           -- plafond par intervention (null = illimité)
+--     "requires_owner_approval": false     -- si true, owner doit valider avant que le provider soit notifié
+--   }
+ALTER TABLE leases
+  ADD COLUMN IF NOT EXISTS tenant_service_bookings JSONB
+  NOT NULL DEFAULT '{
+    "enabled": false,
+    "allowed_categories": [],
+    "max_amount_cents": null,
+    "requires_owner_approval": false
+  }'::jsonb;
+
+COMMENT ON COLUMN leases.tenant_service_bookings IS
+  'Permissions self-service données au locataire (booking direct de prestataires) — config posée par le propriétaire à la signature du bail';
+
+-- 2. Sur work_orders : savoir qui a demandé l'intervention
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS requester_role TEXT
+  CHECK (requester_role IN ('owner', 'tenant', 'syndic', 'agency'));
+
+COMMENT ON COLUMN work_orders.requester_role IS
+  'Qui a initié cette intervention. tenant = parcours self-service, owner = flux classique.';
+
+-- 3. Workflow d'approbation (utilisé seulement si le bail exige l'approbation)
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS owner_approval_status TEXT
+  DEFAULT 'not_required'
+  CHECK (owner_approval_status IN ('not_required', 'pending', 'approved', 'rejected'));
+
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS owner_approval_decided_at TIMESTAMPTZ;
+
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS owner_approval_rejection_reason TEXT;
+
+-- 4. Index pour la recherche tenant → providers par catégorie + département
+CREATE INDEX IF NOT EXISTS idx_providers_marketplace_categories
+  ON providers USING GIN (trade_categories)
+  WHERE is_marketplace = true AND status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_providers_department_active
+  ON providers (department)
+  WHERE status = 'active';
+
+-- 5. Index work_orders par demandeur (stats + filtrage UI)
+CREATE INDEX IF NOT EXISTS idx_work_orders_requester_role
+  ON work_orders (requester_role)
+  WHERE requester_role IS NOT NULL;

--- a/supabase/migrations/20260421120000_tickets_charges_classification.sql
+++ b/supabase/migrations/20260421120000_tickets_charges_classification.sql
@@ -1,0 +1,73 @@
+-- =============================================
+-- TICKETS / WORK_ORDERS : classification "charges récupérables"
+-- (décret 87-713 du 26 août 1987)
+-- =============================================
+-- Ajoute 2 colonnes qui permettront à terme d'imputer automatiquement
+-- le coût d'une intervention au locataire (charge récupérable) ou
+-- au propriétaire (non récupérable), puis de générer les entrées
+-- correspondantes dans le système canonique de régularisation
+-- (lease_charge_regularizations / charge_entries).
+--
+-- Cette migration pose UNIQUEMENT la structure + une suggestion par
+-- défaut à la création. L'écriture dans charge_entries est traitée
+-- dans un commit séparé (étape 2 de la feuille de route).
+
+-- 1. Tickets : classification suggérée à la création (modifiable par owner)
+ALTER TABLE tickets
+  ADD COLUMN IF NOT EXISTS is_tenant_chargeable BOOLEAN;
+ALTER TABLE tickets
+  ADD COLUMN IF NOT EXISTS charge_category_code TEXT;
+
+COMMENT ON COLUMN tickets.is_tenant_chargeable IS
+  'Le coût de cette intervention est-il récupérable auprès du locataire (décret 87-713) ? NULL = à décider par le propriétaire.';
+COMMENT ON COLUMN tickets.charge_category_code IS
+  'Code de la catégorie canonique (charge_categories.code) : ascenseurs, eau_chauffage, installations_individuelles, parties_communes, espaces_exterieurs, taxes_redevances. NULL si non récupérable.';
+
+-- 2. Work orders : même logique, c'est lui qui porte le paiement et donc
+--    la source de l'écriture comptable à venir.
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS is_tenant_chargeable BOOLEAN;
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS charge_category_code TEXT;
+
+COMMENT ON COLUMN work_orders.is_tenant_chargeable IS
+  'Récupérable auprès du locataire ? Hérité du ticket par défaut, modifiable par owner. Utilisé à la clôture pour injecter la dépense dans la régularisation annuelle.';
+COMMENT ON COLUMN work_orders.charge_category_code IS
+  'Catégorie canonique décret 87-713 (voir tickets.charge_category_code).';
+
+-- 3. FK souple : on référence charge_categories.code quand il est posé,
+--    mais NULL reste autorisé (ticket non classifié). Index btree pour les
+--    requêtes de reporting "charges récupérables sur la période X".
+CREATE INDEX IF NOT EXISTS idx_tickets_chargeable
+  ON tickets (is_tenant_chargeable)
+  WHERE is_tenant_chargeable IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_work_orders_chargeable
+  ON work_orders (is_tenant_chargeable)
+  WHERE is_tenant_chargeable IS NOT NULL;
+
+-- 4. Contrainte cohérence : si charge_category_code est posé et non NULL,
+--    il doit correspondre à une catégorie connue. Pas de FK stricte pour
+--    ne pas bloquer si charge_categories.code évolue, mais un CHECK sur
+--    la liste des 6 valeurs canoniques.
+ALTER TABLE tickets
+  DROP CONSTRAINT IF EXISTS tickets_charge_category_check;
+ALTER TABLE tickets
+  ADD CONSTRAINT tickets_charge_category_check
+  CHECK (
+    charge_category_code IS NULL OR charge_category_code IN (
+      'ascenseurs', 'eau_chauffage', 'installations_individuelles',
+      'parties_communes', 'espaces_exterieurs', 'taxes_redevances'
+    )
+  );
+
+ALTER TABLE work_orders
+  DROP CONSTRAINT IF EXISTS work_orders_charge_category_check;
+ALTER TABLE work_orders
+  ADD CONSTRAINT work_orders_charge_category_check
+  CHECK (
+    charge_category_code IS NULL OR charge_category_code IN (
+      'ascenseurs', 'eau_chauffage', 'installations_individuelles',
+      'parties_communes', 'espaces_exterieurs', 'taxes_redevances'
+    )
+  );

--- a/supabase/migrations/20260421130000_charges_entries_work_order_link.sql
+++ b/supabase/migrations/20260421130000_charges_entries_work_order_link.sql
@@ -1,0 +1,25 @@
+-- =============================================
+-- CHARGE_ENTRIES : lien vers le work_order source
+-- =============================================
+-- Quand un work_order is_tenant_chargeable=true est clôturé, on injecte
+-- automatiquement une ligne dans charge_entries. Ce lien permet :
+--   - Idempotence (éviter le doublon si l'injection est rejouée)
+--   - Traçabilité (audit : d'où vient cette charge ?)
+--   - Remontée UI : afficher le lien vers l'intervention sur la régul
+
+ALTER TABLE charge_entries
+  ADD COLUMN IF NOT EXISTS source_work_order_id UUID
+  REFERENCES work_orders(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN charge_entries.source_work_order_id IS
+  'Work order source de cette charge (NULL = saisie manuelle). Sert à l''idempotence de l''injection automatique post-clôture.';
+
+-- Unique index partiel : un work_order n'injecte qu'une seule charge_entry
+CREATE UNIQUE INDEX IF NOT EXISTS idx_charge_entries_work_order_unique
+  ON charge_entries (source_work_order_id)
+  WHERE source_work_order_id IS NOT NULL;
+
+-- Index reporting
+CREATE INDEX IF NOT EXISTS idx_charge_entries_source_work_order
+  ON charge_entries (source_work_order_id)
+  WHERE source_work_order_id IS NOT NULL;

--- a/supabase/migrations/20260421140000_fix_ticket_notification_triggers.sql
+++ b/supabase/migrations/20260421140000_fix_ticket_notification_triggers.sql
@@ -1,0 +1,101 @@
+-- =============================================
+-- FIX : triggers notify_owner_on_ticket_created et notify_provider_on_work_order
+-- =============================================
+-- Les fonctions trigger définies en 20260305100001_add_missing_notification_triggers.sql
+-- référencent NEW.title et NEW.priority (colonnes inexistantes — la table tickets
+-- utilise titre et priorite en français). Résultat : le trigger plante à chaque
+-- INSERT de ticket qui a un owner_id (via ERROR 42703 "record 'new' has no field 'title'").
+--
+-- Fix : remplacer les références anglaises inexistantes par les colonnes françaises
+-- réelles, en gardant le même comportement métier.
+
+CREATE OR REPLACE FUNCTION notify_owner_on_ticket_created()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_owner_id UUID;
+  v_property_address TEXT;
+BEGIN
+  SELECT p.owner_id, COALESCE(p.adresse_complete, 'Logement')
+  INTO v_owner_id, v_property_address
+  FROM properties p
+  WHERE p.id = NEW.property_id;
+
+  IF v_owner_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO notifications (
+    profile_id,
+    type,
+    title,
+    message,
+    link,
+    metadata
+  ) VALUES (
+    v_owner_id,
+    'ticket',
+    'Nouveau signalement',
+    'Un signalement a été créé pour ' || v_property_address || ' : ' || COALESCE(NEW.titre, 'Sans titre'),
+    '/owner/tickets/' || NEW.id,
+    jsonb_build_object(
+      'ticket_id', NEW.id,
+      'property_id', NEW.property_id,
+      'priority', COALESCE(NEW.priorite, 'normal')
+    )
+  );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION notify_provider_on_work_order()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_property_address TEXT;
+BEGIN
+  -- Seulement si un prestataire est assigné
+  -- NB : sur tickets, la colonne est assigned_to (pas provider_id)
+  IF NEW.assigned_to IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.assigned_to = NEW.assigned_to THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT COALESCE(p.adresse_complete, 'Logement')
+  INTO v_property_address
+  FROM properties p
+  WHERE p.id = NEW.property_id;
+
+  INSERT INTO notifications (
+    profile_id,
+    type,
+    title,
+    message,
+    link,
+    metadata
+  ) VALUES (
+    NEW.assigned_to,
+    'work_order',
+    'Nouvelle intervention assignée',
+    'Intervention sur ' || COALESCE(v_property_address, 'un bien') || ' : ' || COALESCE(NEW.titre, 'Sans titre'),
+    '/provider/tickets/' || NEW.id,
+    jsonb_build_object(
+      'ticket_id', NEW.id,
+      'property_id', NEW.property_id,
+      'priority', COALESCE(NEW.priorite, 'normal')
+    )
+  );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Ré-attacher le second trigger au bon nom de colonne (assigned_to)
+-- si jamais il pointait encore sur provider_id
+DROP TRIGGER IF EXISTS trg_notify_provider_on_work_order ON tickets;
+CREATE TRIGGER trg_notify_provider_on_work_order
+  AFTER INSERT OR UPDATE OF assigned_to ON tickets
+  FOR EACH ROW
+  EXECUTE FUNCTION notify_provider_on_work_order();

--- a/supabase/migrations/20260421140000_fix_ticket_notification_triggers.sql
+++ b/supabase/migrations/20260421140000_fix_ticket_notification_triggers.sql
@@ -1,101 +1,23 @@
 -- =============================================
--- FIX : triggers notify_owner_on_ticket_created et notify_provider_on_work_order
+-- DROP : triggers notify_owner_on_ticket_created + notify_provider_on_work_order
 -- =============================================
--- Les fonctions trigger définies en 20260305100001_add_missing_notification_triggers.sql
--- référencent NEW.title et NEW.priority (colonnes inexistantes — la table tickets
--- utilise titre et priorite en français). Résultat : le trigger plante à chaque
--- INSERT de ticket qui a un owner_id (via ERROR 42703 "record 'new' has no field 'title'").
+-- Ces deux triggers, définis dans 20260305100001_add_missing_notification_triggers.sql,
+-- sont à la fois CASSÉS (NEW.title et NEW.priority n'existent pas — les colonnes
+-- réelles sont titre / priorite) et REDONDANTS : le parcours canonique passe par
+-- l'outbox + la Edge Function process-outbox, qui utilise sendNotification() avec
+-- les bonnes colonnes et les bonnes préférences utilisateur.
 --
--- Fix : remplacer les références anglaises inexistantes par les colonnes françaises
--- réelles, en gardant le même comportement métier.
+-- Tenter de les "réparer" imposerait de dupliquer le schéma actuel de
+-- notifications (qui a divergé : recipient_id / profile_id, body / message,
+-- action_url / link, etc.) et de maintenir deux chemins de notification en
+-- parallèle. Plus sûr : les dropper.
 
-CREATE OR REPLACE FUNCTION notify_owner_on_ticket_created()
-RETURNS TRIGGER AS $$
-DECLARE
-  v_owner_id UUID;
-  v_property_address TEXT;
-BEGIN
-  SELECT p.owner_id, COALESCE(p.adresse_complete, 'Logement')
-  INTO v_owner_id, v_property_address
-  FROM properties p
-  WHERE p.id = NEW.property_id;
-
-  IF v_owner_id IS NULL THEN
-    RETURN NEW;
-  END IF;
-
-  INSERT INTO notifications (
-    profile_id,
-    type,
-    title,
-    message,
-    link,
-    metadata
-  ) VALUES (
-    v_owner_id,
-    'ticket',
-    'Nouveau signalement',
-    'Un signalement a été créé pour ' || v_property_address || ' : ' || COALESCE(NEW.titre, 'Sans titre'),
-    '/owner/tickets/' || NEW.id,
-    jsonb_build_object(
-      'ticket_id', NEW.id,
-      'property_id', NEW.property_id,
-      'priority', COALESCE(NEW.priorite, 'normal')
-    )
-  );
-
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
-CREATE OR REPLACE FUNCTION notify_provider_on_work_order()
-RETURNS TRIGGER AS $$
-DECLARE
-  v_property_address TEXT;
-BEGIN
-  -- Seulement si un prestataire est assigné
-  -- NB : sur tickets, la colonne est assigned_to (pas provider_id)
-  IF NEW.assigned_to IS NULL THEN
-    RETURN NEW;
-  END IF;
-
-  IF TG_OP = 'UPDATE' AND OLD.assigned_to = NEW.assigned_to THEN
-    RETURN NEW;
-  END IF;
-
-  SELECT COALESCE(p.adresse_complete, 'Logement')
-  INTO v_property_address
-  FROM properties p
-  WHERE p.id = NEW.property_id;
-
-  INSERT INTO notifications (
-    profile_id,
-    type,
-    title,
-    message,
-    link,
-    metadata
-  ) VALUES (
-    NEW.assigned_to,
-    'work_order',
-    'Nouvelle intervention assignée',
-    'Intervention sur ' || COALESCE(v_property_address, 'un bien') || ' : ' || COALESCE(NEW.titre, 'Sans titre'),
-    '/provider/tickets/' || NEW.id,
-    jsonb_build_object(
-      'ticket_id', NEW.id,
-      'property_id', NEW.property_id,
-      'priority', COALESCE(NEW.priorite, 'normal')
-    )
-  );
-
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
--- Ré-attacher le second trigger au bon nom de colonne (assigned_to)
--- si jamais il pointait encore sur provider_id
+DROP TRIGGER IF EXISTS trg_notify_owner_on_ticket_created ON tickets;
 DROP TRIGGER IF EXISTS trg_notify_provider_on_work_order ON tickets;
-CREATE TRIGGER trg_notify_provider_on_work_order
-  AFTER INSERT OR UPDATE OF assigned_to ON tickets
-  FOR EACH ROW
-  EXECUTE FUNCTION notify_provider_on_work_order();
+
+DROP FUNCTION IF EXISTS notify_owner_on_ticket_created();
+DROP FUNCTION IF EXISTS notify_provider_on_work_order();
+
+-- Le trigger trigger_notify_ticket_created (migration 20251205000001) reste en place :
+-- il est correctement écrit (utilise NEW.titre, pas NEW.title) et passe par la
+-- fonction helper create_notification() qui cible les bonnes colonnes.


### PR DESCRIPTION
## Summary

This PR introduces a complete tenant self-service booking system that allows tenants to directly reserve service providers (gardening, cleaning, moving, painting, small repairs) without waiting for owner approval. It includes an optional owner approval workflow, charge classification for cost recovery, and payment processing via Stripe.

## Key Changes

### Core Features
- **Tenant Self-Service Booking**: Tenants can browse and book available providers for specific service categories directly from `/app/tenant/services/[category]`
- **Owner Approval Workflow**: Optional approval gate per lease via `requires_owner_approval` flag; pending bookings appear in `/app/owner/approvals`
- **Service Permissions**: Lease-level configuration (`tenant_service_bookings_config`) allows owners to enable/disable categories, set max amounts, and require approval
- **Charge Classification**: Automatic suggestion and manual override of whether service costs are tenant-chargeable (per décret 87-713)

### API Endpoints
- `POST /api/tenant/services/request` - Create booking + ticket + work order
- `GET /api/tenant/providers?category=X` - List available providers with permission checks
- `POST /api/work-orders/[id]/approve-booking` - Owner approves pending booking
- `POST /api/work-orders/[id]/reject-booking` - Owner rejects with optional reason
- `POST /api/work-orders/[id]/checkout-session` - Create Stripe session for payment
- `POST /api/work-orders/[id]/inject-charges` - Inject charge entry for cost recovery
- `PATCH /api/owner/leases/[id]/tenant-service-bookings` - Configure permissions
- `PATCH /api/tickets/[id]/charge-classification` - Update charge classification

### Database Migrations
- `tenant_service_bookings_config` JSONB column on leases (enabled, allowed_categories, max_amount_cents, requires_owner_approval)
- `owner_approval_status` on work_orders (pending/approved/rejected)
- `is_tenant_chargeable` and `charge_category_code` on tickets & work_orders
- `ticket_reference` (human-readable TKT-YYYY-NNNN format) with atomic counter
- `source_work_order_id` on charge_entries for idempotent injection

### UI Components
- `TenantServiceBookingClient` - Browse and book providers with form submission
- `TenantServiceBookingsConfig` - Owner configuration panel for lease permissions
- `OwnerApprovalActions` - Approve/reject buttons with optional reason
- `TicketChargesClassification` - Charge classification UI with category selection
- `TicketChargesTenantBadge` - Display charge status badge
- `WorkOrderPayButton` - Trigger Stripe checkout

### Business Logic
- `resolveTicketContext()` - Unified ticket context resolution supporting both nominal (profile_id) and invited (email) tenant links
- `checkTenantBookingPermission()` - Verify tenant has permission for category
- `suggestForTenantBookableCategory()` - Auto-suggest charge classification
- `injectChargeEntryForWorkOrder()` - Idempotent charge entry creation
- `resolveSyndicForProperty()` - Route common area tickets to syndic

### Email Notifications
- `tenantServiceBooked` - Notify provider of new booking
- `tenantServiceApprovalRequested` - Notify owner of pending approval
- `tenantServiceRejected` - Notify tenant of rejection
- `workOrderAssignedToProvider` - Notify provider after approval
- `ticketPartiesCommunesToSyndic` - Route common area tickets to syndic

### Stripe Integration
- Work order payment flow isolated from rent/charges payments
- Platform fee calculation (1% + €0.50)
- Webhook handler for `payment_intent.succeeded` with work order state advancement

### Supporting Infrastructure
- `TENANT_BOOKABLE_CATEGORIES` enum (jardinage, nettoyage, demenagement, peinture, petits_travaux)
- `CanonicalChargeCategory` enum (ascenseurs, eau

https://claude.ai/code/session_011LAabAkZzbcb1YoYmNcE1e