### PR TITLE
Fix CSRF token desynchronization on admin gift endpoint

### DIFF
--- a/AUDIT_ADMIN_GIFT_DAYS_CSRF.md
+++ b/AUDIT_ADMIN_GIFT_DAYS_CSRF.md
@@ -1,0 +1,275 @@
+# AUDIT — 403 "Token CSRF invalide" sur l'endpoint Offrir des jours
+
+> **Phase 0 — audit en lecture seule. Aucune modification appliquée.**
+> Branche : `claude/fix-csrf-gift-days-vOAWr` (clean)
+> Date : 2026-04-22
+
+---
+
+## TL;DR
+
+- L'endpoint réel est **`/api/admin/subscriptions/gift`** (pas `gift-days` — URL tronquée dans DevTools du rapport initial).
+- Client et serveur sont câblés correctement : `fetchWithCsrf` côté UI → header `x-csrf-token` → `validateCsrfFromRequest` côté API.
+- Le bug vient du **double-submit cookie** : `CsrfTokenInjector` régénère un token aléatoire à chaque render du layout, pousse toujours un meta tag frais, mais le `cookies().set(...)` côté Server Component est **non fiable** (cf. docs Next.js App Router + commentaire explicite dans le fichier). Résultat : après toute re-render du layout (soft nav, prefetch RSC, second onglet), le cookie `csrf_token` reste à l'ancienne valeur pendant que le meta tag (et donc le header envoyé) pointe vers la nouvelle → `cookieToken !== headerToken` → **403**.
+- **Hypothèse P0** = H2 (mismatch cookie/meta). Subsidiaire **H_env** si `CSRF_SECRET` absent en prod, mais 6 endpoints protégés seraient affectés identiquement — donc pas spécifique à gift.
+- **Surface additionnelle détectée** : `override`, `refund`, `site-content`, `impersonate`, `apply-migration` partagent exactement la même faille latente. Sur ~55 routes admin mutantes, **seules 6 valident le CSRF** — tout le reste (suspend, plans, promo-codes, users, flags, providers, broadcasts, moderation…) **n'a aucune validation CSRF**, ce qui explique pourquoi l'utilisateur ne voit le symptôme que sur gift/override/refund.
+
+---
+
+## 1. Localisation de l'endpoint
+
+Fichier : `app/api/admin/subscriptions/gift/route.ts` (L1–74).
+
+- Méthode : `POST /api/admin/subscriptions/gift`
+- Runtime : Node.js (`export const runtime = 'nodejs'`)
+- Imports pertinents :
+  - `validateCsrfFromRequest` (lib/security/csrf.ts)
+  - `requireAdminPermissions` + `isAdminAuthError` (lib/middleware/admin-rbac)
+  - `adminGiftDays` (lib/subscriptions/subscription-service)
+- Schéma Zod : `user_id (uuid)`, `days (1..365)`, `reason (≥3)`, `notify_user (bool)`, `plan_slug (enum optionnel)`.
+
+Handler (extrait clé, L23–40) :
+
+```ts
+export async function POST(request: Request) {
+  try {
+    // CSRF validation
+    try {
+      const csrfValid = await validateCsrfFromRequest(request);
+      if (!csrfValid) {
+        return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
+      }
+    } catch {
+      // CSRF_SECRET not configured — degrade gracefully
+    }
+
+    // RBAC + rate limit + audit
+    const auth = await requireAdminPermissions(request, ["admin.subscriptions.write"], {
+      rateLimit: "adminCritical",
+      auditAction: "Gift de jours gratuits",
+    });
+    if (isAdminAuthError(auth)) return auth;
+    …
+```
+
+> Le `try { … } catch {}` autour de `validateCsrfFromRequest` est **du code mort** : `validateCsrfFromRequest` ne `throw` jamais (cf. §3) ; elle renvoie `true`/`false`. Donc le commentaire « degrade gracefully » est trompeur — si `CSRF_SECRET` est absent, on part *tout de même* en 403 (header manquant côté client, pas de meta).
+
+---
+
+## 2. Localisation du client
+
+Fichier : `app/admin/subscriptions/page.tsx` (composant `AdminActionModal`, L229–346).
+
+- Import : `import { fetchWithCsrf } from "@/lib/security/csrf";` (L85)
+- Construction URL : `` `/api/admin/subscriptions/${action}` `` (L265), où `action ∈ {"override", "gift", "suspend", "unsuspend", "refund"}`.
+- Body pour `gift` (L274–278) :
+  ```ts
+  body.days = giftDays;
+  if (giftPlan && giftPlan !== GIFT_KEEP_PLAN) body.plan_slug = giftPlan;
+  ```
+- Appel (L299–303) :
+  ```ts
+  const res = await fetchWithCsrf(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  ```
+
+Le helper `fetchWithCsrf` (lib/security/csrf.ts L178–194) :
+
+```ts
+const csrfToken = getClientCsrfToken();
+const headers = new Headers(options.headers);
+if (csrfToken) headers.set("x-csrf-token", csrfToken);
+return fetch(url, { ...options, headers, credentials: "same-origin" });
+```
+
+Et `getClientCsrfToken` (L167–173) lit exclusivement le meta tag :
+```ts
+const meta = document.querySelector('meta[name="csrf-token"]');
+return meta?.getAttribute("content") ?? null;
+```
+
+> Si la meta est absente (CSRF_SECRET manquant en prod), le header **n'est même pas envoyé** — et le serveur refusera systématiquement (L116 `if (!headerToken) return false;`).
+
+---
+
+## 3. Middleware / helper CSRF
+
+### 3.1 Source unique : `lib/security/csrf.ts`
+
+- Pas de validation CSRF dans `middleware.ts` (edge runtime, aucun import `@supabase/*` ni `csrf`).
+- Tout passe par `validateCsrfFromRequest(request)` appelé explicitement par chaque route qui l'opt-in.
+- Deuxième chemin (plus récent) : `lib/api/with-security.ts` (HOC) — non utilisé par les routes admin investiguées ici.
+
+### 3.2 Génération du token (L55–62)
+
+```ts
+const token = randomBytes(32).toString("hex");         // 64 hex
+const expiry = Date.now() + 24 * 3600 * 1000;          // +24h
+const signature = HMAC_SHA256(CSRF_SECRET, `${token}:${expiry}`);
+return `${token}:${expiry}:${signature}`;              // 3 segments, pas de `=`
+```
+
+- Secret : `process.env.CSRF_SECRET`, doit faire ≥ 32 chars. `getCsrfSecret()` **throw** sinon.
+- Donc `generateCsrfToken()` throw si secret absent ou court.
+
+### 3.3 Validation (L106–140)
+
+Ordre exact des checks :
+1. `GET|HEAD|OPTIONS` → `true` (méthode sûre).
+2. Lire header `x-csrf-token` ; si absent → `false`.
+3. `validateCsrfToken(header)` : split 3 segments, vérifie l'expiry puis HMAC timing-safe. Retourne `false` sur toute erreur (dont `CSRF_SECRET` manquant, car le `try/catch` interne renvoie `false`).
+4. Parse le cookie `csrf_token` depuis le header `Cookie`.
+5. **Double-submit** : `if (cookieToken && cookieToken !== headerToken) return false;`
+   - Note : si le cookie est **absent**, le check est sauté. Le commentaire L126–127 justifie ce fallback par la fragilité de `cookies().set()` en Server Component.
+
+`validateCsrfFromRequest` ne `throw` *jamais* → le `try/catch` des routes est inutile (voir §1).
+
+### 3.4 Distribution du token : `components/security/CsrfTokenInjector.tsx`
+
+Server Component rendu dans `app/admin/layout.tsx:46` (et aussi `owner`, `agency`, `tenant`, `syndic`, `provider`, `copro`, `guarantor`). Flow :
+
+1. `generateCsrfToken()` — try/catch ; si throw (ex: pas de secret) → `return null` (pas de meta, pas de cookie).
+2. `cookies().set({ name: "csrf_token", value: token, path:"/", httpOnly, sameSite:"strict", secure: prod, maxAge: 24h })` — **try/catch silencieux** :
+   ```ts
+   } catch {
+     // En Server Component read-only, le set cookie peut échouer silencieusement
+   }
+   ```
+3. `return <meta name="csrf-token" content={token} />` — injecté dans le DOM.
+
+> **Problème clé** : d'après la doc Next.js App Router, `cookies().set()` n'est fiable que dans un Route Handler ou une Server Action. Dans un Server Component rendu pendant un RSC payload (soft nav) ou un prefetch, la consigne `Set-Cookie` peut ne pas être propagée au navigateur. Résultat : la valeur **en DOM** et la valeur **dans le cookie** peuvent diverger.
+
+### 3.5 Panorama des endpoints admin CSRF-protégés vs exemptés
+
+| Validation CSRF | Route(s) |
+|---|---|
+| ✅ (6 routes) | `subscriptions/gift`, `subscriptions/override`, `subscriptions/refund`, `site-content`, `impersonate` (POST uniquement — DELETE/GET non protégés), `apply-migration` |
+| ❌ (≈ 50 routes) | `subscriptions/suspend`, `plans` (POST/PUT), `promo-codes`, `broadcasts`, `flags`, `users/[id]` (PATCH), `providers/*`, `branding`, `email-templates`, `moderation/*`, `notifications`, `support`, `addons`, `cleanup`, `reset-lease`, `reseal-edl`, `reseal-lease`, `sync-lease-statuses`, `fix-*`, `landing-images/upload`, `properties/*`, `templates/update-legislation`, `compliance/*`, `integrations/*`, `site-config` (PUT)… |
+
+> Liste produite par un scan `grep -c "validateCsrfFromRequest"` sur tous les `route.ts` sous `app/api/admin/**`.
+>
+> **Conséquence immédiate** : la majorité des actions admin passent sans jamais être confrontées au double-submit cassé — ce qui explique pourquoi l'utilisateur rapporte l'incident uniquement sur **gift** (et pourrait aussi le rapporter sur override / refund / site-content, qu'il n'a peut-être pas retesté aujourd'hui).
+>
+> **Problème de sécurité additionnel** : cette asymétrie est aussi un trou CSRF — les 50 routes exemptées sont vulnérables à une attaque CSRF en prod.
+
+---
+
+## 4. Comparaison avec endpoints admin qui fonctionnent
+
+### 4.1 `POST /api/admin/subscriptions/override` (change plan)
+
+Même code CSRF que gift (L23–32), même helper client (`fetchWithCsrf` depuis le même modal `AdminActionModal` — `app/admin/subscriptions/page.tsx:299`), même couche d'auth (`requireAdminPermissions`). **Diff = 0** sur la partie sécurité.
+
+> Si gift échoue en 403, override doit échouer aussi. Le titre « quels endpoints admin POST répondent 200 aujourd'hui » de la Phase 0 est donc trompeur : parmi les endpoints **CSRF-protégés**, aucun n'est en pratique mieux loti. Parmi les endpoints **non protégés** (suspend, promo-codes, plans…), tous répondent 200 parce qu'ils ne regardent même pas le token.
+
+### 4.2 `POST /api/admin/impersonate`
+
+CSRF check identique (L47–55). Mais le code client n'appelle **jamais** `POST /api/admin/impersonate` — `components/admin/impersonation-banner.tsx` n'utilise que `GET` et `DELETE` (les deux exemptés de CSRF). Ce qui fait qu'on ne voit pas le symptôme. Si un jour on câble un bouton « Impersonner » qui poste réellement, on aura le même 403.
+
+### 4.3 `POST /api/admin/site-content`
+
+CSRF check + `fetchWithCsrf` côté UI (`app/admin/site-content/page.tsx:136`). Même pattern, même faille latente.
+
+### 4.4 Requête « diff header par header »
+
+Pour gift comme pour override / refund / site-content, la requête en DevTools est **identique** en structure :
+- `Content-Type: application/json`
+- `x-csrf-token: <hex>:<ts>:<hmac>` ← valeur du meta actuel
+- `Cookie: sb-*=…; csrf_token=<hex>:<ts>:<hmac>` ← peut différer du meta si RSC a régénéré sans propager
+- `credentials: "same-origin"` → cookies joints
+
+Le diff qui fait 403 vs 200 n'est pas dans la route — c'est **l'égalité exacte cookie ↔ header au moment T**.
+
+---
+
+## 5. Hypothèses classées (P0 → P3)
+
+### H1 — P0 : Mismatch cookie ↔ meta après re-render du layout (double-submit cassé)
+
+**Mécanisme** :
+1. Chargement dur de `/admin/...` → `CsrfTokenInjector` génère `TOKEN_A`, `cookies().set(…TOKEN_A…)` (peut marcher), meta = `TOKEN_A`.
+2. Soft nav / RSC prefetch / 2ᵉ onglet → layout re-rendu → `TOKEN_B` généré. DOM mis à jour : meta = `TOKEN_B`. Mais `cookies().set()` depuis un RSC n'attache pas de `Set-Cookie` fiable → cookie reste `TOKEN_A`.
+3. L'utilisateur soumet gift → `fetchWithCsrf` lit meta → `x-csrf-token: TOKEN_B` ; navigateur joint `csrf_token=TOKEN_A`.
+4. Serveur : header valide HMAC (OK), cookie présent et `!==` header → `return false` → **403 "Token CSRF invalide"**.
+
+**Preuves** :
+- `lib/security/csrf.ts:135` : `if (cookieToken && cookieToken !== headerToken) return false;`
+- `components/security/CsrfTokenInjector.tsx:55-57` : commentaire explicite « le set cookie peut échouer silencieusement ».
+- Token = `randomBytes(32)` → chaque `generateCsrfToken()` produit une **nouvelle** valeur. Aucune idempotence, aucun caching.
+- Doc Next.js : `cookies().set()` interdit/déconseillé en Server Component hors Server Action/Route Handler.
+
+**Impact attendu si H1 vraie** :
+- Premier submit après hard refresh de la page concernée : 200.
+- Tout submit après une nav client (sidebar → autre page admin → retour) : 403 probable.
+- Multi-onglets : 403 systématique sur l'onglet non dernier-rendu.
+
+**Reproductibilité** : à valider en Phase 1 par un test E2E ou un log serveur `{cookie, header}` côté route.
+
+---
+
+### H2 — P0 (subsidiaire) : `CSRF_SECRET` non configuré dans l'environnement courant
+
+**Mécanisme** :
+1. `generateCsrfToken()` throw dans `CsrfTokenInjector` → `return null` → **pas de meta, pas de cookie**.
+2. `fetchWithCsrf` : `getClientCsrfToken()` → `null` → header non envoyé.
+3. `validateCsrfFromRequest` L116 : `!headerToken` → `return false` → **403**.
+
+**Preuves** :
+- `lib/security/csrf.ts:16-39` : `getCsrfSecret` throw si absent ou < 32 chars.
+- `components/security/CsrfTokenInjector.tsx:21-32` : catch → `return null` → rien d'injecté.
+- `.env.example:165` : `# CSRF_SECRET=xxxxx` (commenté — donc si l'ops n'a pas pushé la var, elle manque).
+- Note : le commentaire « degrade gracefully » dans les routes est **incorrect** — rien ne dégrade : c'est 403 sec.
+
+**Contradiction partielle avec H1** : si H2 est vraie, les 6 endpoints CSRF-protégés échouent tous identiquement, pas seulement gift. À confirmer en demandant un `echo $CSRF_SECRET | wc -c` côté prod (ou log serveur).
+
+---
+
+### H3 — P2 : Rotation du token après login admin non propagée
+
+**Mécanisme hypothétique** : un flow de login/refresh aurait régénéré le cookie sans rafraîchir le DOM (donc l'inverse de H1 : meta ancien, cookie frais).
+
+**Preuve contre** : aucune logique de rotation CSRF spécifique à l'auth dans le repo. Aucun appel à `generateCsrfToken` ailleurs que dans le layout injector et les tests. Improbable.
+
+---
+
+### H4 — P3 : Middleware applique CSRF à une route exemptée ailleurs
+
+**Preuve contre** : `middleware.ts` laisse passer `/api/*` sans toucher aux cookies (L104–117 : bypass). Aucune autre source de validation CSRF globale. **Écartée**.
+
+---
+
+### H5 — P3 : Route demande un token mais n'est pas listée dans une whitelist de génération
+
+**Preuve contre** : pas de whitelist de génération ; le token est injecté pour **toute** page rendue sous `admin/layout.tsx`. `/admin/subscriptions` l'est. **Écartée**.
+
+---
+
+## 6. Conclusion de la Phase 0
+
+- **RCA la plus probable** : H1 (mismatch cookie ↔ meta à cause de `cookies().set()` non fiable en Server Component après re-render du layout). H2 (secret manquant) est subsidiaire et trivialement testable.
+- **Le bug n'est pas spécifique à gift** : il affecte potentiellement les 6 endpoints CSRF-protégés (gift, override, refund, site-content, impersonate-POST, apply-migration).
+- **Dette CSRF additionnelle** : ~50 routes admin POST/PATCH/DELETE n'ont **aucune validation CSRF**. C'est un trou de sécurité à traiter en parallèle du fix (Phase 1+).
+- **Le `try/catch` autour de `validateCsrfFromRequest` est du code mort** — à nettoyer pour éviter de futures confusions sur la sémantique « degrade gracefully ».
+
+---
+
+## 7. Questions à lever avant Phase 1
+
+1. En prod Netlify actuelle, `CSRF_SECRET` est-il défini et ≥ 32 chars ? (test rapide : poster sur `site-content` et voir si 403 aussi).
+2. Le 403 sur gift est-il **systématique** ou **intermittent** (corrobore H1 si lié à la nav client) ?
+3. Fix à retenir en Phase 1 (à confirmer) :
+   - **Option A** (minimal) : supprimer la comparaison cookie ↔ header et ne garder que HMAC+expiry sur le header. Le token est signé et tourne en 24h — c'est suffisant contre un attaquant externe, à condition que le meta soit en same-origin (vrai). Retire la dépendance au `cookies().set()` fragile.
+   - **Option B** : déplacer la génération du token dans un Route Handler `GET /api/csrf` invoqué au mount client (ou Server Action), qui pose fiablement le cookie et renvoie la valeur. `fetchWithCsrf` fait un round-trip si la meta est absente.
+   - **Option C** : ne régénérer la paire (meta, cookie) que si le cookie est absent/expiré (idempotence) — mais on reste en Server Component, donc on garde la fragilité.
+   - Recommandation : **A** (la plus simple, sans perte réelle de sécurité) + étendre la protection CSRF via `withSecurity` à tous les endpoints admin mutants.
+4. Pattern réutilisable côté tests : ajouter 3 cas Vitest (header valide → 200, absent → 403, expiré → 403) dans `tests/unit/security/`.
+
+---
+
+## 8. Livrables Phase 0
+
+- ✅ Ce fichier `AUDIT_ADMIN_GIFT_DAYS_CSRF.md`
+- ⏸ Aucune modification de code. Attente GO pour Phase 1.

--- a/FIX_ADMIN_GIFT_DAYS_CSRF.md
+++ b/FIX_ADMIN_GIFT_DAYS_CSRF.md
@@ -1,0 +1,163 @@
+# FIX — 403 "Token CSRF invalide" sur `/api/admin/subscriptions/gift`
+
+> Phase 1 — correction appliquée sur la branche `claude/fix-csrf-gift-days-vOAWr`.
+> Date : 2026-04-22
+> Préambule : voir `AUDIT_ADMIN_GIFT_DAYS_CSRF.md` (Phase 0).
+
+---
+
+## Diagnostic retenu
+
+**RCA (H1 de l'audit) : désynchronisation meta ↔ cookie après re-render du layout.**
+
+`CsrfTokenInjector` régénérait un token aléatoire à *chaque* render du layout admin :
+- la `<meta name="csrf-token">` embarquait toujours la nouvelle valeur (TOKEN_B),
+- mais `cookies().set()` depuis un Server Component est non fiable pendant un RSC soft nav / prefetch (cf. docs Next.js App Router et commentaire explicite du fichier lui-même),
+- le cookie `csrf_token` restait donc collé à l'ancienne valeur (TOKEN_A).
+
+Côté serveur, `validateCsrfFromRequest` applique un double-submit strict :
+```ts
+if (cookieToken && cookieToken !== headerToken) return false;
+```
+→ `TOKEN_A !== TOKEN_B` → `403 "Token CSRF invalide"`.
+
+Le même symptôme était latent sur les 5 autres endpoints admin qui valident le CSRF (`override`, `refund`, `site-content`, `impersonate` (POST), `apply-migration`).
+
+---
+
+## Fix appliqué
+
+### 1. Token idempotent côté injector — fix racine
+
+`components/security/CsrfTokenInjector.tsx` relit désormais le cookie existant avant de générer :
+
+```ts
+const existing = cookieStore.get(CSRF_COOKIE_NAME)?.value;
+if (existing && validateCsrfToken(existing)) {
+  return existing;           // réutilise → meta et cookie restent en phase
+}
+const fresh = generateCsrfToken();
+try { cookieStore.set({ name: CSRF_COOKIE_NAME, value: fresh, … }); } catch {}
+return fresh;
+```
+
+- 1ʳᵉ hard load : pas de cookie → génère TOKEN_A, set cookie=TOKEN_A, meta=TOKEN_A.
+- Soft nav / RSC prefetch / 2ᵉ onglet : cookie TOKEN_A déjà envoyé par le navigateur → `validateCsrfToken(existing)` passe → on **réutilise** TOKEN_A. Pas de `cookies().set()` inutile, pas de nouvelle valeur qui divergerait.
+- Cookie expiré (>24h) ou signature invalidée (changement de `CSRF_SECRET`) : régénération propre.
+
+### 2. Validateur détaillé + Sentry — `lib/security/csrf.ts`
+
+Ajout de deux exports :
+
+```ts
+export type CsrfFailureReason =
+  | "missing_header"
+  | "invalid_signature_or_expired"
+  | "cookie_mismatch";
+
+export async function validateCsrfFromRequestDetailed(request): Promise<{ valid: boolean; reason?: CsrfFailureReason }>;
+export async function logCsrfFailure(request, reason, endpoint): Promise<void>;
+```
+
+- `validateCsrfFromRequestDetailed` conserve la même logique mais retourne la raison précise de l'échec. `validateCsrfFromRequest` (API booléenne) est conservée pour la rétrocompat et appelle désormais la détaillée en interne — aucun appelant externe à changer.
+- `logCsrfFailure` émet un log JSON structuré (`console.warn`) et capture un message Sentry taggé `{ type:"csrf_violation", endpoint, reason }`. Safe si Sentry n'est pas importé (fallback silencieux).
+
+### 3. Migration des 6 routes CSRF-protégées
+
+Les 6 routes admin qui validaient le CSRF ont été migrées vers le nouveau pattern (suppression du `try/catch` mort + logging structuré) :
+
+| Route | Endpoint tag pour Sentry |
+|---|---|
+| `app/api/admin/subscriptions/gift/route.ts` | `admin.subscriptions.gift` |
+| `app/api/admin/subscriptions/override/route.ts` | `admin.subscriptions.override` |
+| `app/api/admin/subscriptions/refund/route.ts` | `admin.subscriptions.refund` |
+| `app/api/admin/site-content/route.ts` | `admin.site-content` |
+| `app/api/admin/impersonate/route.ts` (POST) | `admin.impersonate` |
+| `app/api/admin/apply-migration/route.ts` | `admin.apply-migration` |
+
+Pattern unifié dans chaque handler :
+```ts
+const csrf = await validateCsrfFromRequestDetailed(request);
+if (!csrf.valid) {
+  await logCsrfFailure(request, csrf.reason!, "admin.xxx");
+  return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
+}
+```
+
+### 4. Ce qui n'a **pas** été touché (volontairement)
+
+- **`lib/api/with-security.ts`** — le HOC utilise déjà `validateCsrfFromRequest` et gère sa propre journalisation. Refactor inutile pour le bug ciblé.
+- **Les ~50 routes admin mutantes sans protection CSRF** (suspend, plans, promo-codes, users, providers, broadcasts, flags, moderation, etc.). C'est une dette de sécurité réelle, documentée dans l'audit Phase 0, mais hors-scope du ticket « gift ». À traiter dans une PR dédiée.
+
+---
+
+## Vérifications
+
+### 1. Tests unitaires — `pnpm test tests/unit/security/csrf-validation.test.ts`
+
+```
+ ✓ tests/unit/security/csrf-validation.test.ts  (18 tests) 63ms
+ Test Files  1 passed (1)
+      Tests  18 passed (18)
+```
+
+Nouveaux cas couverts par `describe("validateCsrfFromRequestDetailed")` :
+- GET sans token → `valid: true` (méthode sûre).
+- POST avec token valide (header seul) → `valid: true`.
+- POST avec header + cookie identiques → `valid: true` (double-submit OK).
+- POST sans header → `valid: false, reason: "missing_header"`.
+- POST avec signature falsifiée → `valid: false, reason: "invalid_signature_or_expired"`.
+- POST avec token expiré → `valid: false, reason: "invalid_signature_or_expired"`.
+- POST avec cookie ≠ header → `valid: false, reason: "cookie_mismatch"`.
+
+### 2. Typecheck — `pnpm tsc --noEmit`
+
+- **339 erreurs TS pré-existantes** dans le repo (baseline : `lib/services/lrar-providers/*`, `lib/subscriptions/subscription-service.ts`, `tests/setup.ts`, `tests/unit/api/stripe-connect-routes.test.ts`, `tests/unit/security/otp-store.test.ts`, etc.). Aucune n'est introduite par ce fix.
+- **0 erreur TS** sur les fichiers modifiés par ce commit :
+  ```
+  $ npx tsc --noEmit 2>&1 | grep -E "security/csrf|CsrfTokenInjector|subscriptions/gift|subscriptions/override|subscriptions/refund|admin/site-content|admin/impersonate|admin/apply-migration|csrf-validation.test"
+  (vide)
+  ```
+
+### 3. Flow manuel attendu (à rejouer par l'humain en prod/staging)
+
+1. Se connecter admin → `/admin/subscriptions`.
+2. Ouvrir « Offrir des jours » sur Pierre Test → 90 jours → plan Pro → « Notifier par email » ON → Valider.
+3. DevTools Network : requête `POST /api/admin/subscriptions/gift` → **200**, body `{ "success": true }`.
+4. Vérifier en DB : `subscriptions.status = 'trialing'`, `trial_end ≈ now() + 90 days` pour ce user.
+5. Rappel fonctionnel : `ENTITLED_STATUSES` inclut `trialing` → l'utilisateur bénéficie immédiatement du plan Pro.
+6. Si « Notifier par email » = ON : mail envoyé au user (à vérifier via Resend / provider mail).
+7. Régression : rejouer `POST /api/admin/subscriptions/override` (change plan) et `POST /api/admin/site-content` — doivent aussi répondre 200 (mêmes clients, même helper CSRF).
+
+> Pas d'UI à tester dans le sandbox CI — c'est une action admin sur données live.
+
+---
+
+## Impact & risques
+
+- **Sécurité** : aucun affaiblissement. Le double-submit reste en vigueur lorsque le cookie est présent. Le fix supprime le faux négatif qui faisait rejeter des requêtes légitimes. HMAC + expiry sur le header restent la défense principale.
+- **Helper global** : `validateCsrfFromRequest` (signature booléenne historique) est conservée. Tout appelant externe (HOC, tests, futures routes) continue de fonctionner sans changement.
+- **Observabilité** : tous les échecs CSRF partent désormais dans Sentry avec tag `type=csrf_violation`, endpoint et raison précise — utile pour distinguer un vrai attaquant (`missing_header` / `invalid_signature_or_expired`) d'un client mal synchronisé (`cookie_mismatch` qui ne devrait plus apparaître après ce fix).
+- **Migration SQL** : aucune, pas de drift SQL Editor ↔ git.
+
+---
+
+## Fichiers modifiés
+
+| Fichier | Type |
+|---|---|
+| `components/security/CsrfTokenInjector.tsx` | Fix racine (idempotence token) |
+| `lib/security/csrf.ts` | Ajout `validateCsrfFromRequestDetailed` + `logCsrfFailure` + types |
+| `app/api/admin/subscriptions/gift/route.ts` | Migration au nouveau pattern |
+| `app/api/admin/subscriptions/override/route.ts` | Migration au nouveau pattern |
+| `app/api/admin/subscriptions/refund/route.ts` | Migration au nouveau pattern |
+| `app/api/admin/site-content/route.ts` | Migration au nouveau pattern |
+| `app/api/admin/impersonate/route.ts` | Migration au nouveau pattern (POST) |
+| `app/api/admin/apply-migration/route.ts` | Migration au nouveau pattern |
+| `tests/unit/security/csrf-validation.test.ts` | 7 nouveaux cas sur `validateCsrfFromRequestDetailed` |
+
+## Suivi recommandé (hors-scope de ce PR)
+
+1. Protéger les ~50 routes admin mutantes actuellement sans CSRF (liste exhaustive dans l'audit §3.5).
+2. Sur le HOC `lib/api/with-security.ts`, basculer sur `validateCsrfFromRequestDetailed` + `logCsrfFailure` pour unifier le pattern (même trace Sentry).
+3. Ajouter un dashboard Sentry filtré sur `tags.type = "csrf_violation"` pour monitorer les tentatives et valider que `cookie_mismatch` tombe à zéro après déploiement.

--- a/app/api/admin/apply-migration/route.ts
+++ b/app/api/admin/apply-migration/route.ts
@@ -4,7 +4,7 @@ export const dynamic = 'force-dynamic';
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { requireAdmin } from "@/lib/helpers/auth-helper";
-import { validateCsrfFromRequest } from "@/lib/security/csrf";
+import { validateCsrfFromRequestDetailed, logCsrfFailure } from "@/lib/security/csrf";
 
 /**
  * @maintenance Route utilitaire admin — usage ponctuel
@@ -13,14 +13,10 @@ import { validateCsrfFromRequest } from "@/lib/security/csrf";
  */
 
 export async function POST(request: Request) {
-  // CSRF validation
-  try {
-    const csrfValid = await validateCsrfFromRequest(request);
-    if (!csrfValid) {
-      return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
-    }
-  } catch {
-    // CSRF_SECRET not configured — degrade gracefully
+  const csrf = await validateCsrfFromRequestDetailed(request);
+  if (!csrf.valid) {
+    await logCsrfFailure(request, csrf.reason!, "admin.apply-migration");
+    return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
   }
 
   // 1. Vérifier que l'utilisateur est admin

--- a/app/api/admin/impersonate/route.ts
+++ b/app/api/admin/impersonate/route.ts
@@ -23,7 +23,7 @@ import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { requireAdminPermissions, isAdminAuthError } from "@/lib/middleware/admin-rbac";
-import { validateCsrfFromRequest } from "@/lib/security/csrf";
+import { validateCsrfFromRequestDetailed, logCsrfFailure } from "@/lib/security/csrf";
 
 const IMPERSONATION_COOKIE = "impersonation_session";
 const MAX_DURATION_HOURS = 1;
@@ -44,14 +44,10 @@ interface ImpersonationSession {
  */
 export async function POST(request: NextRequest) {
   try {
-    // CSRF validation
-    try {
-      const csrfValid = await validateCsrfFromRequest(request);
-      if (!csrfValid) {
-        return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
-      }
-    } catch {
-      // CSRF_SECRET not configured — degrade gracefully
+    const csrf = await validateCsrfFromRequestDetailed(request);
+    if (!csrf.valid) {
+      await logCsrfFailure(request, csrf.reason!, "admin.impersonate");
+      return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
     }
 
     // RBAC: seuls les platform_admin peuvent impersonner

--- a/app/api/admin/site-content/route.ts
+++ b/app/api/admin/site-content/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/helpers/auth-helper";
-import { validateCsrfFromRequest } from "@/lib/security/csrf";
+import { validateCsrfFromRequestDetailed, logCsrfFailure } from "@/lib/security/csrf";
 
 /**
  * GET /api/admin/site-content
@@ -36,14 +36,10 @@ export async function GET(request: Request) {
  * Créer ou mettre à jour le contenu d'une page
  */
 export async function POST(request: NextRequest) {
-  // CSRF validation
-  try {
-    const csrfValid = await validateCsrfFromRequest(request);
-    if (!csrfValid) {
-      return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
-    }
-  } catch {
-    // CSRF_SECRET not configured — degrade gracefully
+  const csrf = await validateCsrfFromRequestDetailed(request);
+  if (!csrf.valid) {
+    await logCsrfFailure(request, csrf.reason!, "admin.site-content");
+    return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
   }
 
   const { error: authError, user, supabase } = await requireAdmin(request);

--- a/app/api/admin/subscriptions/gift/route.ts
+++ b/app/api/admin/subscriptions/gift/route.ts
@@ -10,7 +10,7 @@ import { NextResponse } from "next/server";
 import { adminGiftDays } from "@/lib/subscriptions/subscription-service";
 import { z } from "zod";
 import { requireAdminPermissions, isAdminAuthError } from "@/lib/middleware/admin-rbac";
-import { validateCsrfFromRequest } from "@/lib/security/csrf";
+import { validateCsrfFromRequestDetailed, logCsrfFailure } from "@/lib/security/csrf";
 
 const giftSchema = z.object({
   user_id: z.string().uuid(),
@@ -22,14 +22,10 @@ const giftSchema = z.object({
 
 export async function POST(request: Request) {
   try {
-    // CSRF validation
-    try {
-      const csrfValid = await validateCsrfFromRequest(request);
-      if (!csrfValid) {
-        return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
-      }
-    } catch {
-      // CSRF_SECRET not configured — degrade gracefully
+    const csrf = await validateCsrfFromRequestDetailed(request);
+    if (!csrf.valid) {
+      await logCsrfFailure(request, csrf.reason!, "admin.subscriptions.gift");
+      return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
     }
 
     // RBAC + rate limit + audit

--- a/app/api/admin/subscriptions/override/route.ts
+++ b/app/api/admin/subscriptions/override/route.ts
@@ -10,7 +10,7 @@ import { NextResponse } from "next/server";
 import { adminOverridePlan } from "@/lib/subscriptions/subscription-service";
 import { z } from "zod";
 import { requireAdminPermissions, isAdminAuthError } from "@/lib/middleware/admin-rbac";
-import { validateCsrfFromRequest } from "@/lib/security/csrf";
+import { validateCsrfFromRequestDetailed, logCsrfFailure } from "@/lib/security/csrf";
 
 const overrideSchema = z.object({
   user_id: z.string().uuid(),
@@ -21,14 +21,10 @@ const overrideSchema = z.object({
 
 export async function POST(request: Request) {
   try {
-    // CSRF validation
-    try {
-      const csrfValid = await validateCsrfFromRequest(request);
-      if (!csrfValid) {
-        return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
-      }
-    } catch {
-      // CSRF_SECRET not configured — degrade gracefully
+    const csrf = await validateCsrfFromRequestDetailed(request);
+    if (!csrf.valid) {
+      await logCsrfFailure(request, csrf.reason!, "admin.subscriptions.override");
+      return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
     }
 
     // RBAC + rate limit + audit

--- a/app/api/admin/subscriptions/refund/route.ts
+++ b/app/api/admin/subscriptions/refund/route.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import { stripe, isStripeServerConfigured } from "@/lib/stripe";
 import { createServiceRoleClient } from "@/lib/supabase/server";
 import { requireAdminPermissions, isAdminAuthError } from "@/lib/middleware/admin-rbac";
-import { validateCsrfFromRequest } from "@/lib/security/csrf";
+import { validateCsrfFromRequestDetailed, logCsrfFailure } from "@/lib/security/csrf";
 
 const refundSchema = z
   .object({
@@ -43,13 +43,10 @@ export async function POST(request: Request) {
       );
     }
 
-    try {
-      const csrfValid = await validateCsrfFromRequest(request);
-      if (!csrfValid) {
-        return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
-      }
-    } catch {
-      // CSRF_SECRET non configuré — on n'échoue pas
+    const csrf = await validateCsrfFromRequestDetailed(request);
+    if (!csrf.valid) {
+      await logCsrfFailure(request, csrf.reason!, "admin.subscriptions.refund");
+      return NextResponse.json({ error: "Token CSRF invalide" }, { status: 403 });
     }
 
     const auth = await requireAdminPermissions(request, ["admin.subscriptions.write"], {

--- a/components/security/CsrfTokenInjector.tsx
+++ b/components/security/CsrfTokenInjector.tsx
@@ -1,10 +1,11 @@
 /**
  * Composant Server pour injecter le token CSRF dans la page
- * 
+ *
  * Ce composant doit être placé dans les layouts authentifiés (owner, tenant, admin, etc.)
- * Il génère un token CSRF côté serveur et l'injecte via :
- * - Une meta tag <meta name="csrf-token"> lisible par le JS client
- * - Un cookie HttpOnly pour la double-vérification côté API
+ * Il réutilise le cookie `csrf_token` existant s'il est toujours valide, et n'en
+ * génère un nouveau (+ set cookie) que s'il est absent ou expiré. Cette
+ * idempotence évite la divergence meta ↔ cookie sur soft nav / RSC prefetch
+ * (où `cookies().set()` depuis un Server Component est non fiable).
  *
  * Côté client, utiliser `fetchWithCsrf()` depuis `@/lib/security/csrf`
  * pour envoyer automatiquement le token dans les requêtes.
@@ -14,16 +15,41 @@
 
 import { cookies } from "next/headers";
 
-/**
- * Génère un token CSRF de manière sûre.
- * Si CSRF_SECRET n'est pas configuré, retourne null (mode dégradé).
- */
-async function generateSafeCsrfToken(): Promise<string | null> {
+const CSRF_COOKIE_NAME = "csrf_token";
+const CSRF_COOKIE_MAX_AGE_SECONDS = 24 * 60 * 60;
+
+async function resolveCsrfToken(): Promise<string | null> {
   try {
-    const { generateCsrfToken } = await import("@/lib/security/csrf");
-    return generateCsrfToken();
+    const { generateCsrfToken, validateCsrfToken } = await import("@/lib/security/csrf");
+
+    const cookieStore = await cookies();
+    const existing = cookieStore.get(CSRF_COOKIE_NAME)?.value;
+
+    // Réutiliser le cookie existant s'il est valide (HMAC + expiry) : meta et
+    // cookie restent en phase entre soft navs.
+    if (existing && validateCsrfToken(existing)) {
+      return existing;
+    }
+
+    const fresh = generateCsrfToken();
+    const isProduction = process.env.NODE_ENV === "production";
+    try {
+      cookieStore.set({
+        name: CSRF_COOKIE_NAME,
+        value: fresh,
+        path: "/",
+        httpOnly: true,
+        sameSite: "strict",
+        secure: isProduction,
+        maxAge: CSRF_COOKIE_MAX_AGE_SECONDS,
+      });
+    } catch {
+      // Server Component en lecture seule : la pose du cookie peut échouer.
+      // La validation côté API retombe sur un check HMAC-only si le cookie
+      // est absent (cf. lib/security/csrf.ts).
+    }
+    return fresh;
   } catch {
-    // CSRF_SECRET non configuré — mode dégradé
     if (process.env.NODE_ENV === "development") {
       console.warn("[CsrfTokenInjector] CSRF_SECRET non configuré. Protection CSRF désactivée en dev.");
     }
@@ -32,32 +58,7 @@ async function generateSafeCsrfToken(): Promise<string | null> {
 }
 
 export default async function CsrfTokenInjector() {
-  const token = await generateSafeCsrfToken();
-  
-  if (!token) {
-    return null;
-  }
-
-  // Injecter le cookie CSRF (HttpOnly, SameSite=Strict)
-  const cookieStore = await cookies();
-  const isProduction = process.env.NODE_ENV === "production";
-  
-  try {
-    cookieStore.set({
-      name: "csrf_token",
-      value: token,
-      path: "/",
-      httpOnly: true,
-      sameSite: "strict",
-      secure: isProduction,
-      maxAge: 24 * 60 * 60, // 24h
-    });
-  } catch {
-    // En Server Component read-only, le set cookie peut échouer silencieusement
-  }
-
-  // Injecter la meta tag pour que le JS client puisse lire le token
-  return (
-    <meta name="csrf-token" content={token} />
-  );
+  const token = await resolveCsrfToken();
+  if (!token) return null;
+  return <meta name="csrf-token" content={token} />;
 }

--- a/lib/security/csrf.ts
+++ b/lib/security/csrf.ts
@@ -99,32 +99,41 @@ export function validateCsrfToken(token: string | null): boolean {
   }
 }
 
+export type CsrfFailureReason =
+  | "missing_header"
+  | "invalid_signature_or_expired"
+  | "cookie_mismatch";
+
+export interface CsrfValidationResult {
+  valid: boolean;
+  reason?: CsrfFailureReason;
+}
+
 /**
- * Middleware de validation CSRF pour les API routes
- * À utiliser pour les routes sensibles (POST, PUT, DELETE)
+ * Variante détaillée : renvoie la raison précise d'un échec, pour permettre
+ * aux route handlers (ou au HOC `withSecurity`) de logger via Sentry.
  */
-export async function validateCsrfFromRequest(request: Request): Promise<boolean> {
+export async function validateCsrfFromRequestDetailed(
+  request: Request
+): Promise<CsrfValidationResult> {
   // Les requêtes GET sont safe
   if (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") {
-    return true;
+    return { valid: true };
   }
 
-  // Récupérer le token du header
   const headerToken = request.headers.get(CSRF_HEADER_NAME);
-
-  // Le header token est obligatoire
   if (!headerToken) {
-    return false;
+    return { valid: false, reason: "missing_header" };
   }
 
-  // Valider la signature HMAC et l'expiration du token
   if (!validateCsrfToken(headerToken)) {
-    return false;
+    return { valid: false, reason: "invalid_signature_or_expired" };
   }
 
-  // Si le cookie est présent, vérifier qu'il correspond (defense-in-depth)
-  // Le cookie peut être absent car cookies().set() dans un Server Component
-  // Next.js App Router est non fiable et peut échouer silencieusement.
+  // Defense-in-depth : si le cookie est présent et diffère du header, on
+  // rejette. Le cookie peut être absent si `cookies().set()` depuis un Server
+  // Component a échoué silencieusement — dans ce cas on retombe sur la seule
+  // vérif HMAC+expiry du header (suffisante en same-origin).
   const cookieHeader = request.headers.get("cookie");
   const cookieToken = cookieHeader
     ?.split(";")
@@ -133,10 +142,52 @@ export async function validateCsrfFromRequest(request: Request): Promise<boolean
     ?.trim();
 
   if (cookieToken && cookieToken !== headerToken) {
-    return false;
+    return { valid: false, reason: "cookie_mismatch" };
   }
 
-  return true;
+  return { valid: true };
+}
+
+/**
+ * Middleware de validation CSRF pour les API routes
+ * À utiliser pour les routes sensibles (POST, PUT, DELETE)
+ */
+export async function validateCsrfFromRequest(request: Request): Promise<boolean> {
+  const result = await validateCsrfFromRequestDetailed(request);
+  return result.valid;
+}
+
+/**
+ * Logue un échec CSRF via Sentry + console (format JSON structuré).
+ * À appeler côté route handler lorsque `validateCsrfFromRequestDetailed`
+ * renvoie `valid: false`.
+ */
+export async function logCsrfFailure(
+  request: Request,
+  reason: CsrfFailureReason,
+  endpoint: string
+): Promise<void> {
+  const payload = {
+    level: "warn",
+    type: "csrf_violation",
+    endpoint,
+    reason,
+    method: request.method,
+    origin: request.headers.get("origin"),
+    referer: request.headers.get("referer"),
+    timestamp: new Date().toISOString(),
+  };
+  console.warn(JSON.stringify(payload));
+  try {
+    const Sentry = await import("@sentry/nextjs");
+    Sentry.captureMessage(`CSRF rejected: ${reason}`, {
+      level: "warning",
+      tags: { type: "csrf_violation", endpoint, reason },
+      extra: payload,
+    });
+  } catch {
+    // Sentry indisponible — le console.warn suffit.
+  }
 }
 
 /**
@@ -220,6 +271,8 @@ export default {
   generateCsrfToken,
   validateCsrfToken,
   validateCsrfFromRequest,
+  validateCsrfFromRequestDetailed,
+  logCsrfFailure,
   setCsrfCookie,
   getClientCsrfToken,
   fetchWithCsrf,

--- a/tests/unit/security/csrf-validation.test.ts
+++ b/tests/unit/security/csrf-validation.test.ts
@@ -99,6 +99,96 @@ describe("CSRF Token Validation", () => {
   });
 });
 
+describe("validateCsrfFromRequestDetailed", () => {
+  beforeAll(() => {
+    vi.stubEnv("CSRF_SECRET", MOCK_SECRET);
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const buildRequest = (init: { method?: string; headers?: Record<string, string> } = {}) =>
+    new Request("https://example.com/api/admin/subscriptions/gift", {
+      method: init.method ?? "POST",
+      headers: init.headers ?? {},
+    });
+
+  it("accepte un GET sans token (méthode sûre)", async () => {
+    const { validateCsrfFromRequestDetailed } = await import("@/lib/security/csrf");
+    const result = await validateCsrfFromRequestDetailed(buildRequest({ method: "GET" }));
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepte un POST avec token valide (header seul)", async () => {
+    const { generateCsrfToken, validateCsrfFromRequestDetailed } = await import("@/lib/security/csrf");
+    const token = generateCsrfToken();
+    const result = await validateCsrfFromRequestDetailed(
+      buildRequest({ headers: { "x-csrf-token": token } })
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepte un POST avec header et cookie identiques (double-submit OK)", async () => {
+    const { generateCsrfToken, validateCsrfFromRequestDetailed } = await import("@/lib/security/csrf");
+    const token = generateCsrfToken();
+    const result = await validateCsrfFromRequestDetailed(
+      buildRequest({
+        headers: {
+          "x-csrf-token": token,
+          cookie: `sb-auth=foo; csrf_token=${token}; other=bar`,
+        },
+      })
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejette un POST sans header x-csrf-token (missing_header)", async () => {
+    const { validateCsrfFromRequestDetailed } = await import("@/lib/security/csrf");
+    const result = await validateCsrfFromRequestDetailed(buildRequest());
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("missing_header");
+  });
+
+  it("rejette un POST avec header à signature falsifiée (invalid_signature_or_expired)", async () => {
+    const { generateCsrfToken, validateCsrfFromRequestDetailed } = await import("@/lib/security/csrf");
+    const token = generateCsrfToken();
+    const [value, expiry] = token.split(":");
+    const tampered = `${value}:${expiry}:${"f".repeat(64)}`;
+    const result = await validateCsrfFromRequestDetailed(
+      buildRequest({ headers: { "x-csrf-token": tampered } })
+    );
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("invalid_signature_or_expired");
+  });
+
+  it("rejette un POST avec token expiré (invalid_signature_or_expired)", async () => {
+    const { validateCsrfFromRequestDetailed } = await import("@/lib/security/csrf");
+    const expired = `${"a".repeat(64)}:${Date.now() - 1000}:${"b".repeat(64)}`;
+    const result = await validateCsrfFromRequestDetailed(
+      buildRequest({ headers: { "x-csrf-token": expired } })
+    );
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("invalid_signature_or_expired");
+  });
+
+  it("rejette un POST avec cookie et header divergents (cookie_mismatch)", async () => {
+    const { generateCsrfToken, validateCsrfFromRequestDetailed } = await import("@/lib/security/csrf");
+    const tokenHeader = generateCsrfToken();
+    const tokenCookie = generateCsrfToken();
+    const result = await validateCsrfFromRequestDetailed(
+      buildRequest({
+        headers: {
+          "x-csrf-token": tokenHeader,
+          cookie: `csrf_token=${tokenCookie}`,
+        },
+      })
+    );
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("cookie_mismatch");
+  });
+});
+
 describe("CSRF Secret Validation", () => {
   it("rejette un secret trop court", async () => {
     vi.stubEnv("CSRF_SECRET", "short");


### PR DESCRIPTION
## Summary

Fixes a 403 "Token CSRF invalide" error on the `/api/admin/subscriptions/gift` endpoint (and 5 other CSRF-protected admin routes) caused by desynchronization between the CSRF token in the DOM meta tag and the cookie value after layout re-renders.

## Root Cause

`CsrfTokenInjector` was generating a new random token on every layout render, updating the meta tag immediately but failing to reliably set the cookie via `cookies().set()` in a Server Component (per Next.js App Router limitations). This caused:
1. Hard page load: meta and cookie both have TOKEN_A ✓
2. Soft navigation/RSC prefetch: layout re-renders, generates TOKEN_B, meta updated to TOKEN_B, but cookie remains TOKEN_A
3. User submits form: header sends TOKEN_B (from meta), cookie sends TOKEN_A → double-submit validation fails → 403

## Key Changes

- **`components/security/CsrfTokenInjector.tsx`**: Implement token idempotence by reusing the existing cookie if it's still valid (HMAC + expiry check), only generating a fresh token if absent or expired. This keeps meta and cookie synchronized across soft navigations.

- **`lib/security/csrf.ts`**: 
  - Add `validateCsrfFromRequestDetailed()` that returns the specific failure reason (`missing_header`, `invalid_signature_or_expired`, or `cookie_mismatch`)
  - Add `logCsrfFailure()` for structured logging to console and Sentry with endpoint and reason tags
  - Keep `validateCsrfFromRequest()` as a boolean wrapper for backward compatibility

- **Admin route handlers** (`gift`, `override`, `refund`, `site-content`, `impersonate` POST, `apply-migration`): 
  - Replace dead `try/catch` around CSRF validation with direct call to `validateCsrfFromRequestDetailed()`
  - Add structured logging via `logCsrfFailure()` for observability
  - Remove misleading "degrade gracefully" comment

- **`tests/unit/security/csrf-validation.test.ts`**: Add 7 new test cases covering all validation paths (safe methods, valid token, header+cookie match, missing header, invalid signature, expired token, cookie mismatch).

## Implementation Details

- Token format remains unchanged: `{randomBytes(32)}:{expiry}:{HMAC-SHA256}`
- Double-submit defense retained: if cookie is present and differs from header, reject (but this should no longer occur after the fix)
- If cookie is absent, validation falls back to HMAC+expiry check on header alone (sufficient for same-origin)
- Sentry integration is graceful: if Sentry import fails, console.warn still captures the event
- No database migrations or schema changes required

https://claude.ai/code/session_01MVwVhrEgyAdyfR3pdVaE98