### PR TITLE
Wire accounting events to double-entry engine with per-entity opt-in

### DIFF
--- a/app/api/accounting/settings/route.ts
+++ b/app/api/accounting/settings/route.ts
@@ -1,0 +1,183 @@
+/**
+ * API Route: Accounting settings per entity.
+ *
+ * GET   /api/accounting/settings?entityId=... → read accounting_enabled +
+ *                                               declaration_mode for the entity
+ * PATCH /api/accounting/settings              → update accounting_enabled,
+ *                                               declaration_mode, regime_fiscal
+ *
+ * Gated by requireAccountingAccess (plan Confort+). The owner must also own
+ * the entity (checked via owner_profile_id match).
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+
+const PatchSettingsSchema = z.object({
+  entityId: z.string().uuid(),
+  accountingEnabled: z.boolean().optional(),
+  declarationMode: z.enum(["micro_foncier", "reel", "is_comptable"]).optional(),
+});
+
+async function resolveProfileId(supabase: ReturnType<typeof getServiceClient>, userId: string) {
+  const { data: profile } = await (supabase as any)
+    .from("profiles")
+    .select("id")
+    .eq("user_id", userId)
+    .single();
+  return (profile as { id: string } | null)?.id ?? null;
+}
+
+async function assertEntityOwnership(
+  supabase: ReturnType<typeof getServiceClient>,
+  entityId: string,
+  profileId: string,
+) {
+  const { data } = await (supabase as any)
+    .from("legal_entities")
+    .select("id, owner_profile_id")
+    .eq("id", entityId)
+    .maybeSingle();
+  const row = data as { id: string; owner_profile_id: string } | null;
+  if (!row) {
+    throw new ApiError(404, "Entité introuvable");
+  }
+  if (row.owner_profile_id !== profileId) {
+    throw new ApiError(403, "Accès refusé à cette entité");
+  }
+}
+
+/**
+ * GET /api/accounting/settings?entityId=<uuid>
+ */
+export async function GET(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new ApiError(401, "Non authentifié");
+
+    const serviceClient = getServiceClient();
+    const profileId = await resolveProfileId(serviceClient, user.id);
+    if (!profileId) throw new ApiError(403, "Profil introuvable");
+
+    const gate = await requireAccountingAccess(profileId, "entries");
+    if (gate) return gate;
+
+    const { searchParams } = new URL(request.url);
+    const entityId = searchParams.get("entityId");
+    if (!entityId) throw new ApiError(400, "entityId requis");
+
+    await assertEntityOwnership(serviceClient, entityId, profileId);
+
+    const { data } = await (serviceClient as any)
+      .from("legal_entities")
+      .select("id, accounting_enabled, declaration_mode, regime_fiscal")
+      .eq("id", entityId)
+      .single();
+
+    const row = data as {
+      id: string;
+      accounting_enabled: boolean | null;
+      declaration_mode: string | null;
+      regime_fiscal: string | null;
+    };
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        entityId: row.id,
+        accountingEnabled: row.accounting_enabled ?? false,
+        declarationMode: (row.declaration_mode ?? "reel") as
+          | "micro_foncier"
+          | "reel"
+          | "is_comptable",
+        regimeFiscal: row.regime_fiscal,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+/**
+ * PATCH /api/accounting/settings
+ * Body: { entityId, accountingEnabled?, declarationMode? }
+ */
+export async function PATCH(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new ApiError(401, "Non authentifié");
+
+    const serviceClient = getServiceClient();
+    const profileId = await resolveProfileId(serviceClient, user.id);
+    if (!profileId) throw new ApiError(403, "Profil introuvable");
+
+    const gate = await requireAccountingAccess(profileId, "entries");
+    if (gate) return gate;
+
+    const body = await request.json();
+    const validation = PatchSettingsSchema.safeParse(body);
+    if (!validation.success) {
+      throw new ApiError(400, validation.error.errors[0].message);
+    }
+
+    const { entityId, accountingEnabled, declarationMode } = validation.data;
+    await assertEntityOwnership(serviceClient, entityId, profileId);
+
+    const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (typeof accountingEnabled === "boolean") {
+      update.accounting_enabled = accountingEnabled;
+    }
+    if (declarationMode) {
+      update.declaration_mode = declarationMode;
+    }
+
+    if (Object.keys(update).length === 1) {
+      // Only updated_at — nothing to change
+      throw new ApiError(400, "Aucun champ à mettre à jour");
+    }
+
+    const { data, error } = await (serviceClient as any)
+      .from("legal_entities")
+      .update(update)
+      .eq("id", entityId)
+      .select("id, accounting_enabled, declaration_mode")
+      .single();
+
+    if (error) {
+      console.error("[Accounting Settings] update failed:", error);
+      throw new ApiError(500, "Mise à jour impossible");
+    }
+
+    const row = data as {
+      id: string;
+      accounting_enabled: boolean;
+      declaration_mode: string;
+    };
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        entityId: row.id,
+        accountingEnabled: row.accounting_enabled,
+        declarationMode: row.declaration_mode as
+          | "micro_foncier"
+          | "reel"
+          | "is_comptable",
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/leases/[id]/deposit/refund/route.ts
+++ b/app/api/leases/[id]/deposit/refund/route.ts
@@ -180,6 +180,26 @@ export async function POST(
       },
     });
 
+    // Accounting auto-entry (non-blocking, idempotent, gated by accounting_enabled)
+    if (refund?.id) {
+      try {
+        const { ensureDepositRefundedEntry } = await import(
+          "@/lib/accounting/deposit-entry"
+        );
+        const result = await ensureDepositRefundedEntry(serviceClient, refund.id, {
+          userId: user.id,
+        });
+        if (result.skippedReason === "error") {
+          console.error("[ACCOUNTING] deposit_returned failed:", result.error);
+        }
+      } catch (accountingError) {
+        console.error(
+          "[ACCOUNTING] deposit_returned hook exception (non-blocking):",
+          accountingError,
+        );
+      }
+    }
+
     return NextResponse.json({
       success: true,
       message: "Restitution enregistrée",

--- a/app/api/leases/[id]/deposit/route.ts
+++ b/app/api/leases/[id]/deposit/route.ts
@@ -112,6 +112,24 @@ export async function POST(
       metadata: { amount, lease_id: id as any },
     } as any);
 
+    // Accounting auto-entry (non-blocking, idempotent, gated by accounting_enabled)
+    try {
+      const { ensureDepositReceivedEntry } = await import(
+        "@/lib/accounting/deposit-entry"
+      );
+      const result = await ensureDepositReceivedEntry(supabase, movementData.id, {
+        userId: user.id,
+      });
+      if (result.skippedReason === "error") {
+        console.error("[ACCOUNTING] deposit_received failed:", result.error);
+      }
+    } catch (accountingError) {
+      console.error(
+        "[ACCOUNTING] deposit_received hook exception (non-blocking):",
+        accountingError,
+      );
+    }
+
     return NextResponse.json({ movement });
   } catch (error: unknown) {
     return NextResponse.json(

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1103,22 +1103,31 @@ export async function POST(request: NextRequest) {
 
               const entityId = invoiceForEntity?.lease?.property?.legal_entity_id;
               if (entityId) {
-                const exercise = await getOrCreateCurrentExercise(supabase, entityId);
-                if (exercise) {
-                  const tenantName = invoiceForEntity?.tenant
-                    ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
-                    : '';
-                  const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
+                const { getEntityAccountingConfig, shouldMarkInformational, markEntryInformational } =
+                  await import('@/lib/accounting/entity-config');
+                const config = await getEntityAccountingConfig(supabase, entityId);
+                if (config?.accountingEnabled) {
+                  const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+                  if (exercise) {
+                    const tenantName = invoiceForEntity?.tenant
+                      ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
+                      : '';
+                    const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
 
-                  await createAutoEntry(supabase, 'rent_received', {
-                    entityId,
-                    exerciseId: exercise.id,
-                    userId: 'system',
-                    amountCents: paymentIntent.amount, // already in cents from Stripe
-                    label: `Loyer ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
-                    date: new Date().toISOString().split('T')[0],
-                    reference: paymentIntent.id,
-                  });
+                    const entry = await createAutoEntry(supabase, 'rent_received', {
+                      entityId,
+                      exerciseId: exercise.id,
+                      userId: 'system',
+                      amountCents: paymentIntent.amount, // already in cents from Stripe
+                      label: `Loyer ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
+                      date: new Date().toISOString().split('T')[0],
+                      reference: paymentIntent.id,
+                    });
+
+                    if (shouldMarkInformational(config)) {
+                      await markEntryInformational(supabase, entry.id);
+                    }
+                  }
                 }
               }
             } catch (accountingError) {
@@ -1203,22 +1212,31 @@ export async function POST(request: NextRequest) {
 
             const entityId = invoiceForEntity?.lease?.property?.legal_entity_id;
             if (entityId) {
-              const exercise = await getOrCreateCurrentExercise(supabase, entityId);
-              if (exercise) {
-                const tenantName = invoiceForEntity?.tenant
-                  ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
-                  : '';
-                const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
+              const { getEntityAccountingConfig, shouldMarkInformational, markEntryInformational } =
+                await import('@/lib/accounting/entity-config');
+              const config = await getEntityAccountingConfig(supabase, entityId);
+              if (config?.accountingEnabled) {
+                const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+                if (exercise) {
+                  const tenantName = invoiceForEntity?.tenant
+                    ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
+                    : '';
+                  const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
 
-                await createAutoEntry(supabase, 'sepa_rejected', {
-                  entityId,
-                  exerciseId: exercise.id,
-                  userId: 'system',
-                  amountCents: paymentIntent.amount,
-                  label: `Rejet prelevement ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
-                  date: new Date().toISOString().split('T')[0],
-                  reference: paymentIntent.id,
-                });
+                  const entry = await createAutoEntry(supabase, 'sepa_rejected', {
+                    entityId,
+                    exerciseId: exercise.id,
+                    userId: 'system',
+                    amountCents: paymentIntent.amount,
+                    label: `Rejet prelevement ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
+                    date: new Date().toISOString().split('T')[0],
+                    reference: paymentIntent.id,
+                  });
+
+                  if (shouldMarkInformational(config)) {
+                    await markEntryInformational(supabase, entry.id);
+                  }
+                }
               }
             }
           } catch (accountingError) {
@@ -1308,23 +1326,52 @@ export async function POST(request: NextRequest) {
               .eq("id", subscription.id);
           }
 
-          await supabase.from("subscription_invoices").upsert(
-            {
-              subscription_id: subscription.id,
-              stripe_invoice_id: invoice.id,
-              amount_due: invoice.amount_due || 0,
-              amount_paid: invoice.amount_paid || 0,
-              amount_remaining: invoice.amount_remaining || 0,
-              status: invoice.status || "paid",
-              hosted_invoice_url: invoice.hosted_invoice_url,
-              invoice_pdf: invoice.invoice_pdf,
-              paid_at: invoice.status_transitions?.paid_at
-                ? new Date(invoice.status_transitions.paid_at * 1000).toISOString()
-                : new Date().toISOString(),
-            },
-            { onConflict: "stripe_invoice_id" }
-          );
+          const { data: upsertedInvoice } = await supabase
+            .from("subscription_invoices")
+            .upsert(
+              {
+                subscription_id: subscription.id,
+                stripe_invoice_id: invoice.id,
+                amount_due: invoice.amount_due || 0,
+                amount_paid: invoice.amount_paid || 0,
+                amount_remaining: invoice.amount_remaining || 0,
+                status: invoice.status || "paid",
+                hosted_invoice_url: invoice.hosted_invoice_url,
+                invoice_pdf: invoice.invoice_pdf,
+                paid_at: invoice.status_transitions?.paid_at
+                  ? new Date(invoice.status_transitions.paid_at * 1000).toISOString()
+                  : new Date().toISOString(),
+              },
+              { onConflict: "stripe_invoice_id" }
+            )
+            .select("id")
+            .maybeSingle();
 
+          // Accounting auto-entry for the paid subscription (non-blocking, idempotent,
+          // gated by accounting_enabled on the owner's primary entity)
+          const subscriptionInvoiceId = (upsertedInvoice as { id?: string } | null)?.id;
+          if (subscriptionInvoiceId) {
+            try {
+              const { ensureSubscriptionPaidEntry } = await import(
+                "@/lib/accounting/subscription-entry"
+              );
+              const result = await ensureSubscriptionPaidEntry(
+                supabase,
+                subscriptionInvoiceId,
+              );
+              if (result.skippedReason === "error") {
+                console.error(
+                  "[ACCOUNTING] subscription_paid failed:",
+                  result.error,
+                );
+              }
+            } catch (accountingError) {
+              console.error(
+                "[ACCOUNTING] subscription_paid hook exception (non-blocking):",
+                accountingError,
+              );
+            }
+          }
         }
 
         // Vérifier si cette invoice Stripe est aussi liée à une facture locative

--- a/app/owner/accounting/entries/EntriesPageClient.tsx
+++ b/app/owner/accounting/entries/EntriesPageClient.tsx
@@ -6,9 +6,10 @@ import {
   useAccountingEntries,
   type AccountingEntryRow as AccountingEntryRowData,
 } from "@/lib/hooks/use-accounting-entries";
+import Link from "next/link";
 import { QuickEntryForm } from "@/components/accounting/QuickEntryForm";
 import { formatCents } from "@/lib/utils/format-cents";
-import { ChevronLeft, ChevronRight, Plus, Loader2 } from "lucide-react";
+import { BookOpen, ChevronLeft, ChevronRight, Plus, Loader2, Settings } from "lucide-react";
 import { EntryFilters, type EntryFilterStatus } from "./components/EntryFilters";
 import { BulkActions } from "./components/BulkActions";
 import {
@@ -209,11 +210,16 @@ function EntriesPageContent() {
           ))}
         </div>
       ) : entries.length === 0 ? (
-        <div className="bg-card rounded-xl border border-border p-12 text-center">
-          <p className="text-sm text-muted-foreground">
-            Aucune ecriture trouvee.
-          </p>
-        </div>
+        <EmptyEntriesState
+          hasActiveFilters={
+            !!search ||
+            !!journalCode ||
+            status !== "all" ||
+            !!source ||
+            !!startDate ||
+            !!endDate
+          }
+        />
       ) : (
         <>
           {/* Desktop table */}
@@ -349,6 +355,44 @@ function EntriesPageContent() {
 
       {/* Quick entry sheet */}
       <QuickEntryForm open={sheetOpen} onOpenChange={setSheetOpen} />
+    </div>
+  );
+}
+
+function EmptyEntriesState({ hasActiveFilters }: { hasActiveFilters: boolean }) {
+  if (hasActiveFilters) {
+    return (
+      <div className="bg-card rounded-xl border border-border p-12 text-center">
+        <p className="text-sm text-muted-foreground">
+          Aucune écriture ne correspond aux filtres sélectionnés.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-card rounded-xl border border-border p-8 sm:p-12 text-center space-y-4">
+      <div className="mx-auto w-12 h-12 rounded-full bg-muted flex items-center justify-center">
+        <BookOpen className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <div className="space-y-1 max-w-md mx-auto">
+        <h3 className="text-base font-medium">Aucune écriture pour le moment</h3>
+        <p className="text-sm text-muted-foreground">
+          Activez la comptabilité automatique dans les paramètres pour que Talok
+          génère une écriture à chaque loyer, paiement, dépôt et dépense.
+          Vous pouvez aussi créer une écriture manuellement ou importer
+          l'historique.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2 justify-center pt-2">
+        <Link
+          href="/owner/accounting/settings"
+          className="inline-flex items-center gap-2 rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted/50 transition-colors"
+        >
+          <Settings className="h-4 w-4" />
+          Ouvrir les paramètres
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/owner/accounting/entries/components/EntryRow.tsx
+++ b/app/owner/accounting/entries/components/EntryRow.tsx
@@ -99,6 +99,17 @@ function StatusBadge({ entry }: { entry: AccountingEntryRowData }) {
   );
 }
 
+function InformationalBadge() {
+  return (
+    <span
+      className="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border bg-blue-500/10 text-blue-500 border-blue-500/20"
+      title="Écriture créée à titre informatif (régime micro-foncier). Non intégrée au FEC."
+    >
+      Info
+    </span>
+  );
+}
+
 // ── Row (desktop table variant) ────────────────────────────────────
 
 interface EntryRowProps {
@@ -154,7 +165,10 @@ export function EntryRow({ entry, isSelected, onToggleSelect }: EntryRowProps) {
         {creditCents > 0 ? formatCents(creditCents) : "-"}
       </td>
       <td className="px-3 py-3 text-center">
-        <StatusBadge entry={entry} />
+        <div className="flex items-center justify-center gap-1">
+          <StatusBadge entry={entry} />
+          {entry.informational && <InformationalBadge />}
+        </div>
       </td>
       <td className="px-3 py-3 text-center">
         <SourceBadge source={entry.source} />
@@ -204,6 +218,7 @@ export function EntryCard({ entry, isSelected, onToggleSelect }: EntryRowProps) 
           </div>
           <div className="flex items-center gap-2 mt-2">
             <StatusBadge entry={entry} />
+            {entry.informational && <InformationalBadge />}
             <SourceBadge source={entry.source} />
           </div>
         </Link>

--- a/app/owner/accounting/layout.tsx
+++ b/app/owner/accounting/layout.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
   TrendingDown,
   UserCheck,
+  Settings,
   type LucideIcon,
 } from "lucide-react";
 
@@ -46,6 +47,7 @@ const accountingTabs: AccountingTab[] = [
     icon: TrendingDown,
   },
   { label: "Expert-comptable", href: "/owner/accounting/ec", icon: UserCheck },
+  { label: "Paramètres", href: "/owner/accounting/settings", icon: Settings },
 ];
 
 /**

--- a/app/owner/accounting/settings/SettingsPageClient.tsx
+++ b/app/owner/accounting/settings/SettingsPageClient.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Building2, CheckCircle2, Info, Loader2 } from "lucide-react";
+
+import { PlanGate } from "@/components/subscription/plan-gate";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/components/ui/use-toast";
+import { apiClient } from "@/lib/api-client";
+import { useEntityStore } from "@/stores/useEntityStore";
+
+type DeclarationMode = "micro_foncier" | "reel" | "is_comptable";
+
+interface SettingsResponse {
+  success: boolean;
+  data: {
+    entityId: string;
+    accountingEnabled: boolean;
+    declarationMode: DeclarationMode;
+    regimeFiscal: string | null;
+  };
+}
+
+interface PatchPayload {
+  entityId: string;
+  accountingEnabled?: boolean;
+  declarationMode?: DeclarationMode;
+}
+
+export default function SettingsPageClient() {
+  return (
+    <PlanGate feature="bank_reconciliation" mode="block">
+      <SettingsContent />
+    </PlanGate>
+  );
+}
+
+function SettingsContent() {
+  const entities = useEntityStore((s) => s.entities);
+  const activeEntityId = useEntityStore((s) => s.activeEntityId);
+  const setActiveEntity = useEntityStore((s) => s.setActiveEntity);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(
+    activeEntityId,
+  );
+
+  const entityId = selectedEntityId ?? activeEntityId;
+
+  const selectedEntity = useMemo(
+    () => entities.find((e) => e.id === entityId) ?? null,
+    [entities, entityId],
+  );
+
+  const { data, isLoading, isFetching } = useQuery<SettingsResponse>({
+    queryKey: ["accounting-settings", entityId],
+    queryFn: () =>
+      apiClient.get<SettingsResponse>(
+        `/accounting/settings?entityId=${entityId}`,
+      ),
+    enabled: !!entityId,
+  });
+
+  const settings = data?.data;
+
+  const mutation = useMutation<SettingsResponse, Error, PatchPayload>({
+    mutationFn: (body) => apiClient.patch<SettingsResponse>("/accounting/settings", body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["accounting-settings", entityId] });
+      toast({
+        title: "Paramètres enregistrés",
+        description: "Les préférences comptables de cette entité ont été mises à jour.",
+      });
+    },
+    onError: (err) => {
+      toast({
+        title: "Erreur",
+        description: err?.message ?? "Mise à jour impossible",
+        variant: "destructive",
+      });
+    },
+  });
+
+  function handleToggleAccounting(checked: boolean) {
+    if (!entityId) return;
+    mutation.mutate({ entityId, accountingEnabled: checked });
+  }
+
+  function handleChangeDeclarationMode(value: string) {
+    if (!entityId) return;
+    if (
+      value !== "micro_foncier" &&
+      value !== "reel" &&
+      value !== "is_comptable"
+    ) {
+      return;
+    }
+    mutation.mutate({ entityId, declarationMode: value });
+  }
+
+  if (entities.length === 0) {
+    return (
+      <div className="p-4 sm:p-6 lg:p-8">
+        <Card>
+          <CardContent className="py-12 text-center space-y-3">
+            <Building2 className="h-10 w-10 mx-auto text-muted-foreground" />
+            <h2 className="text-lg font-medium">Aucune entité juridique</h2>
+            <p className="text-sm text-muted-foreground max-w-md mx-auto">
+              Créez une entité juridique (SCI, SARL, patrimoine personnel…) pour
+              configurer sa comptabilité.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 space-y-6 max-w-3xl">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Paramètres comptables
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Activez et configurez la génération automatique des écritures pour
+          chaque entité juridique.
+        </p>
+      </header>
+
+      {/* Entity picker */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Entité</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Label htmlFor="entity-select">Entité concernée</Label>
+            <Select
+              value={entityId ?? undefined}
+              onValueChange={(v) => {
+                setSelectedEntityId(v);
+                setActiveEntity(v);
+              }}
+            >
+              <SelectTrigger id="entity-select" className="max-w-md">
+                <SelectValue placeholder="Sélectionner une entité" />
+              </SelectTrigger>
+              <SelectContent>
+                {entities.map((e) => (
+                  <SelectItem key={e.id} value={e.id}>
+                    {e.nom}
+                    {e.legalForm ? ` · ${e.legalForm}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Chargement des paramètres…
+        </div>
+      )}
+
+      {settings && (
+        <>
+          {/* Toggle activation */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Activation</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1 flex-1">
+                  <Label htmlFor="accounting-toggle" className="text-sm font-medium">
+                    Comptabilité automatique
+                  </Label>
+                  <p className="text-sm text-muted-foreground">
+                    Lorsqu'elle est activée, Talok génère automatiquement les
+                    écritures correspondant à vos quittances, paiements, dépôts
+                    de garantie et dépenses pour{" "}
+                    <span className="font-medium text-foreground">
+                      {selectedEntity?.nom}
+                    </span>
+                    .
+                  </p>
+                </div>
+                <Switch
+                  id="accounting-toggle"
+                  checked={settings.accountingEnabled}
+                  onCheckedChange={handleToggleAccounting}
+                  disabled={mutation.isPending || isFetching}
+                />
+              </div>
+
+              {settings.accountingEnabled && (
+                <div className="flex items-start gap-2 rounded-lg bg-muted/50 px-3 py-2 text-sm">
+                  <CheckCircle2 className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+                  <p className="text-muted-foreground">
+                    Les événements futurs généreront automatiquement une
+                    écriture. Pour rattraper l'historique, utilisez le bouton
+                    d'import en bas de page.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Declaration mode */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Régime déclaratif</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Détermine le niveau de détail comptable requis et la déclaration
+                fiscale cible. Indépendant du régime juridique (
+                <span className="font-medium text-foreground">
+                  {settings.regimeFiscal?.toUpperCase() ?? "—"}
+                </span>
+                ) configuré à la création de l'entité.
+              </p>
+
+              <RadioGroup
+                value={settings.declarationMode}
+                onValueChange={handleChangeDeclarationMode}
+                disabled={mutation.isPending || isFetching}
+                className="space-y-3"
+              >
+                <DeclarationOption
+                  value="micro_foncier"
+                  title="Micro-foncier"
+                  description="Loyers annuels ≤ 15 000 €, abattement forfaitaire de 30 %. Les écritures sont générées à titre informatif (préparation 2044), non intégrées au FEC."
+                />
+                <DeclarationOption
+                  value="reel"
+                  title="Régime réel (SCI IR au réel)"
+                  description="Comptabilité de trésorerie. Déclaration 2044 détaillée. Export FEC disponible."
+                />
+                <DeclarationOption
+                  value="is_comptable"
+                  title="Impôt sur les sociétés"
+                  description="Comptabilité commerciale complète pour SCI IS, SARL, etc. Bilan, compte de résultat, liasse fiscale."
+                />
+              </RadioGroup>
+            </CardContent>
+          </Card>
+
+          {/* Historical backfill */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Historique</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex items-start gap-2 text-sm">
+                <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+                <p className="text-muted-foreground">
+                  L'import historique rejoue les événements passés (loyers,
+                  paiements, dépôts, dépenses) pour générer les écritures
+                  comptables correspondantes. L'opération est idempotente : elle
+                  peut être relancée sans créer de doublons.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                disabled={!settings.accountingEnabled}
+                onClick={() => {
+                  toast({
+                    title: "Import historique",
+                    description:
+                      "L'import doit être lancé depuis la ligne de commande :\nnpx tsx scripts/backfill-accounting-entries.ts --entity=" +
+                      (entityId ?? "<uuid>"),
+                  });
+                }}
+              >
+                Lancer l'import historique
+              </Button>
+              {!settings.accountingEnabled && (
+                <p className="text-xs text-muted-foreground">
+                  Activez d'abord la comptabilité automatique pour lancer
+                  l'import.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}
+
+function DeclarationOption({
+  value,
+  title,
+  description,
+}: {
+  value: DeclarationMode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <label
+      htmlFor={`decl-${value}`}
+      className="flex items-start gap-3 rounded-lg border border-border p-3 cursor-pointer hover:bg-muted/50 transition-colors"
+    >
+      <RadioGroupItem id={`decl-${value}`} value={value} className="mt-1" />
+      <div className="space-y-1">
+        <div className="text-sm font-medium">{title}</div>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </label>
+  );
+}

--- a/app/owner/accounting/settings/page.tsx
+++ b/app/owner/accounting/settings/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from "react";
+import SettingsPageClient from "./SettingsPageClient";
+
+export const metadata = { title: "Paramètres comptables | Talok" };
+
+export default function SettingsPage() {
+  return (
+    <Suspense fallback={<SettingsPageSkeleton />}>
+      <SettingsPageClient />
+    </Suspense>
+  );
+}
+
+function SettingsPageSkeleton() {
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 space-y-6 animate-pulse">
+      <div className="h-8 bg-muted rounded w-64" />
+      <div className="h-48 bg-muted rounded-xl" />
+      <div className="h-64 bg-muted rounded-xl" />
+    </div>
+  );
+}

--- a/features/providers/services/work-orders-extended.service.ts
+++ b/features/providers/services/work-orders-extended.service.ts
@@ -435,6 +435,17 @@ async function postWorkOrderAutoEntry(
 
     const { createAutoEntry } = await import('@/lib/accounting/engine');
     const { getOrCreateCurrentExercise } = await import('@/lib/accounting/auto-exercise');
+    const { getEntityAccountingConfig, shouldMarkInformational, markEntryInformational } =
+      await import('@/lib/accounting/entity-config');
+
+    const config = await getEntityAccountingConfig(supabase, entityId);
+    if (!config || !config.accountingEnabled) {
+      console.log(
+        '[work-orders] Skipping auto-entry: accounting not enabled for entity',
+        entityId,
+      );
+      return;
+    }
 
     const exercise = await getOrCreateCurrentExercise(supabase, entityId);
     if (!exercise) {
@@ -451,6 +462,10 @@ async function postWorkOrderAutoEntry(
       date: params.date,
       reference: params.reference,
     });
+
+    if (shouldMarkInformational(config)) {
+      await markEntryInformational(supabase, entry.id);
+    }
 
     if (params.persistEntryIdOnWorkOrder && entry?.id) {
       await supabase

--- a/lib/accounting/deposit-entry.ts
+++ b/lib/accounting/deposit-entry.ts
@@ -1,0 +1,327 @@
+/**
+ * Security deposit → accounting entry bridge.
+ *
+ * When a security deposit is received (`POST /api/leases/[id]/deposit`) or
+ * refunded (`POST /api/leases/[id]/deposit/refund`), the engine needs a
+ * matching double-entry booking. This module provides two idempotent helpers
+ * on the same pattern as `ensureReceiptAccountingEntry` (rent receipts):
+ *
+ *   - ensureDepositReceivedEntry: books `deposit_received` (BQ journal)
+ *       debit  512300 (Banque DG)
+ *       credit 165000 (Dépôts de garantie reçus)
+ *
+ *   - ensureDepositRefundedEntry: books `deposit_returned` (BQ journal)
+ *       debit  165000 (Dépôts reçus)
+ *       credit 512300 (Banque DG)      ← amount refunded to tenant
+ *       credit 791000 (Transferts)      ← optional, for retentions
+ *
+ * Idempotency: existing accounting_entries are looked up by
+ * (reference = deposit_movement_id OR refund_id) AND source LIKE 'auto:deposit_*'.
+ * Safe to call multiple times from any code path.
+ *
+ * Gating: respects `legal_entities.accounting_enabled` (skip if false) and
+ * `legal_entities.declaration_mode` (flag as informational if micro_foncier).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAutoEntry } from "@/lib/accounting/engine";
+import { getOrCreateCurrentExercise } from "@/lib/accounting/auto-exercise";
+import {
+  getEntityAccountingConfig,
+  markEntryInformational,
+  shouldMarkInformational,
+} from "@/lib/accounting/entity-config";
+
+export type EnsureDepositSkipReason =
+  | "already_exists"
+  | "source_not_found"
+  | "entity_not_resolved"
+  | "accounting_disabled"
+  | "exercise_not_available"
+  | "amount_invalid"
+  | "error";
+
+export interface EnsureDepositEntryResult {
+  created: boolean;
+  skippedReason?: EnsureDepositSkipReason;
+  entryId?: string;
+  error?: string;
+}
+
+interface ExistingEntryQuery {
+  from: (t: string) => {
+    select: (s: string) => {
+      eq: (k: string, v: string) => {
+        like: (k: string, pattern: string) => {
+          limit: (n: number) => {
+            maybeSingle: () => Promise<{ data: { id: string } | null }>;
+          };
+        };
+      };
+    };
+  };
+}
+
+async function findExistingEntry(
+  supabase: SupabaseClient,
+  reference: string,
+  sourcePrefix: string,
+): Promise<string | null> {
+  const { data } = await (supabase as unknown as ExistingEntryQuery)
+    .from("accounting_entries")
+    .select("id")
+    .eq("reference", reference)
+    .like("source", `${sourcePrefix}%`)
+    .limit(1)
+    .maybeSingle();
+  return data?.id ?? null;
+}
+
+interface LeaseEntityRow {
+  id: string;
+  property: {
+    legal_entity_id: string | null;
+    adresse_complete: string | null;
+  } | null;
+}
+
+async function resolveEntityForLease(
+  supabase: SupabaseClient,
+  leaseId: string,
+): Promise<{ entityId: string | null; propertyAddress: string | null }> {
+  const { data } = await supabase
+    .from("leases")
+    .select(
+      `
+        id,
+        property:properties!inner(
+          legal_entity_id,
+          adresse_complete
+        )
+      `,
+    )
+    .eq("id", leaseId)
+    .maybeSingle();
+
+  const row = data as unknown as LeaseEntityRow | null;
+  return {
+    entityId: row?.property?.legal_entity_id ?? null,
+    propertyAddress: row?.property?.adresse_complete ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Deposit received
+// ---------------------------------------------------------------------------
+
+interface DepositMovementRow {
+  id: string;
+  lease_id: string;
+  amount: number | null;
+  processed_at: string | null;
+  created_at: string;
+  type: string;
+  status: string;
+}
+
+/**
+ * Ensure an accounting entry exists for a `deposit_received` event.
+ * Idempotent: if an entry with the same movement reference already exists,
+ * returns `created: false`.
+ */
+export async function ensureDepositReceivedEntry(
+  supabase: SupabaseClient,
+  movementId: string,
+  options: { userId?: string } = {},
+): Promise<EnsureDepositEntryResult> {
+  try {
+    const existingId = await findExistingEntry(
+      supabase,
+      movementId,
+      "auto:deposit_received",
+    );
+    if (existingId) {
+      return {
+        created: false,
+        skippedReason: "already_exists",
+        entryId: existingId,
+      };
+    }
+
+    const { data: movement } = await supabase
+      .from("deposit_movements")
+      .select("id, lease_id, amount, processed_at, created_at, type, status")
+      .eq("id", movementId)
+      .maybeSingle();
+
+    const row = movement as unknown as DepositMovementRow | null;
+    if (!row || row.type !== "encaissement" || row.status !== "received") {
+      return { created: false, skippedReason: "source_not_found" };
+    }
+
+    const { entityId, propertyAddress } = await resolveEntityForLease(
+      supabase,
+      row.lease_id,
+    );
+    if (!entityId) {
+      return { created: false, skippedReason: "entity_not_resolved" };
+    }
+
+    const config = await getEntityAccountingConfig(supabase, entityId);
+    if (!config || !config.accountingEnabled) {
+      return { created: false, skippedReason: "accounting_disabled" };
+    }
+
+    const amountCents = Math.round(Number(row.amount ?? 0) * 100);
+    if (amountCents <= 0) {
+      return { created: false, skippedReason: "amount_invalid" };
+    }
+
+    const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+    if (!exercise) {
+      return { created: false, skippedReason: "exercise_not_available" };
+    }
+
+    const entryDate =
+      (row.processed_at ?? row.created_at).split("T")[0] ??
+      new Date().toISOString().split("T")[0];
+    const label = `Dépôt de garantie reçu${
+      propertyAddress ? ` - ${propertyAddress}` : ""
+    }`;
+
+    const entry = await createAutoEntry(supabase, "deposit_received", {
+      entityId,
+      exerciseId: exercise.id,
+      userId: options.userId ?? "system",
+      amountCents,
+      label,
+      date: entryDate,
+      reference: movementId,
+    });
+
+    if (shouldMarkInformational(config)) {
+      await markEntryInformational(supabase, entry.id);
+    }
+
+    return { created: true, entryId: entry.id };
+  } catch (err) {
+    console.error("[ensureDepositReceivedEntry] failed:", err);
+    return {
+      created: false,
+      skippedReason: "error",
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Deposit refunded
+// ---------------------------------------------------------------------------
+
+interface DepositRefundRow {
+  id: string;
+  lease_id: string;
+  total_deposit: number | null;
+  total_deductions: number | null;
+  refund_amount: number | null;
+  created_at: string;
+}
+
+/**
+ * Ensure an accounting entry exists for a `deposit_returned` event.
+ * Handles both full refund and partial refund (with retentions) via the
+ * engine's `secondaryAmountCents` parameter.
+ */
+export async function ensureDepositRefundedEntry(
+  supabase: SupabaseClient,
+  refundId: string,
+  options: { userId?: string } = {},
+): Promise<EnsureDepositEntryResult> {
+  try {
+    const existingId = await findExistingEntry(
+      supabase,
+      refundId,
+      "auto:deposit_returned",
+    );
+    if (existingId) {
+      return {
+        created: false,
+        skippedReason: "already_exists",
+        entryId: existingId,
+      };
+    }
+
+    const { data: refund } = await supabase
+      .from("deposit_refunds")
+      .select("id, lease_id, total_deposit, total_deductions, refund_amount, created_at")
+      .eq("id", refundId)
+      .maybeSingle();
+
+    const row = refund as unknown as DepositRefundRow | null;
+    if (!row) {
+      return { created: false, skippedReason: "source_not_found" };
+    }
+
+    const { entityId, propertyAddress } = await resolveEntityForLease(
+      supabase,
+      row.lease_id,
+    );
+    if (!entityId) {
+      return { created: false, skippedReason: "entity_not_resolved" };
+    }
+
+    const config = await getEntityAccountingConfig(supabase, entityId);
+    if (!config || !config.accountingEnabled) {
+      return { created: false, skippedReason: "accounting_disabled" };
+    }
+
+    const refundCents = Math.round(Number(row.refund_amount ?? 0) * 100);
+    const retainedCents = Math.round(Number(row.total_deductions ?? 0) * 100);
+    if (refundCents + retainedCents <= 0) {
+      return { created: false, skippedReason: "amount_invalid" };
+    }
+
+    const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+    if (!exercise) {
+      return { created: false, skippedReason: "exercise_not_available" };
+    }
+
+    const entryDate =
+      row.created_at.split("T")[0] ??
+      new Date().toISOString().split("T")[0];
+    const label = `Restitution dépôt de garantie${
+      propertyAddress ? ` - ${propertyAddress}` : ""
+    }`;
+
+    // Engine builder treats amountCents = refunded, secondaryAmountCents = retained.
+    // When refund is zero (full retention) we still need a non-zero primary amount
+    // so we swap: amountCents = retained, secondaryAmountCents = 0, and the
+    // builder produces a valid 2-line entry.
+    const primaryCents = refundCents > 0 ? refundCents : retainedCents;
+    const secondaryCents = refundCents > 0 ? retainedCents : 0;
+
+    const entry = await createAutoEntry(supabase, "deposit_returned", {
+      entityId,
+      exerciseId: exercise.id,
+      userId: options.userId ?? "system",
+      amountCents: primaryCents,
+      secondaryAmountCents: secondaryCents,
+      label,
+      date: entryDate,
+      reference: refundId,
+    });
+
+    if (shouldMarkInformational(config)) {
+      await markEntryInformational(supabase, entry.id);
+    }
+
+    return { created: true, entryId: entry.id };
+  } catch (err) {
+    console.error("[ensureDepositRefundedEntry] failed:", err);
+    return {
+      created: false,
+      skippedReason: "error",
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+}

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -93,7 +93,8 @@ export type AutoEntryEvent =
   | 'copro_works_fund'
   | 'copro_closing'
   | 'teom_recovered'
-  | 'charge_regularization';
+  | 'charge_regularization'
+  | 'subscription_paid';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -683,6 +684,23 @@ const AUTO_ENTRIES: Record<
       lines,
     };
   },
+
+  subscription_paid: (ctx) => ({
+    entityId: ctx.entityId,
+    exerciseId: ctx.exerciseId,
+    journalCode: 'BQ',
+    entryDate: ctx.date,
+    label: ctx.label || 'Abonnement Talok',
+    source: 'auto:subscription_paid',
+    reference: ctx.reference,
+    userId: ctx.userId,
+    // Platform subscription is booked as a miscellaneous fee (honoraires)
+    // debited against the bank account at settlement date.
+    lines: [
+      { accountNumber: '622800', debitCents: ctx.amountCents, creditCents: 0 },
+      { accountNumber: ctx.bankAccount ?? '512100', debitCents: 0, creditCents: ctx.amountCents },
+    ],
+  }),
 };
 
 /**

--- a/lib/accounting/entity-config.ts
+++ b/lib/accounting/entity-config.ts
@@ -1,0 +1,76 @@
+/**
+ * Entity accounting configuration reader.
+ *
+ * Reads the per-entity toggle (`accounting_enabled`) and declaration mode
+ * (`declaration_mode`) set by the owner in /owner/accounting/settings.
+ * Used by every `ensure*Entry` helper to gate entry creation and decide
+ * whether an entry should be flagged `informational` (micro_foncier mode).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type DeclarationMode = "micro_foncier" | "reel" | "is_comptable";
+
+export interface EntityAccountingConfig {
+  entityId: string;
+  accountingEnabled: boolean;
+  declarationMode: DeclarationMode;
+}
+
+/**
+ * Read the accounting configuration for a legal entity.
+ * Returns `null` if the entity does not exist.
+ */
+export async function getEntityAccountingConfig(
+  supabase: SupabaseClient,
+  entityId: string,
+): Promise<EntityAccountingConfig | null> {
+  const { data } = await supabase
+    .from("legal_entities")
+    .select("id, accounting_enabled, declaration_mode")
+    .eq("id", entityId)
+    .maybeSingle();
+
+  if (!data) return null;
+
+  const row = data as {
+    id: string;
+    accounting_enabled: boolean | null;
+    declaration_mode: DeclarationMode | null;
+  };
+
+  return {
+    entityId: row.id,
+    accountingEnabled: row.accounting_enabled ?? false,
+    declarationMode: row.declaration_mode ?? "reel",
+  };
+}
+
+/**
+ * When an entity is in micro_foncier mode, entries are still created (to feed
+ * the 2044 preparation UI) but flagged `informational = true` so they are
+ * excluded from FEC exports and official reports.
+ */
+export function shouldMarkInformational(config: EntityAccountingConfig): boolean {
+  return config.declarationMode === "micro_foncier";
+}
+
+/**
+ * Apply the informational flag to an entry after creation. Called by
+ * ensure* helpers when the entity is in micro_foncier mode.
+ */
+export async function markEntryInformational(
+  supabase: SupabaseClient,
+  entryId: string,
+): Promise<void> {
+  await (supabase as unknown as {
+    from: (t: string) => {
+      update: (v: object) => {
+        eq: (k: string, v: string) => Promise<unknown>;
+      };
+    };
+  })
+    .from("accounting_entries")
+    .update({ informational: true })
+    .eq("id", entryId);
+}

--- a/lib/accounting/index.ts
+++ b/lib/accounting/index.ts
@@ -67,3 +67,31 @@ export {
   validateOCRAmounts,
   saveDocumentAnalysis,
 } from './chart-amort-ocr';
+
+// Entity-level accounting configuration
+export {
+  getEntityAccountingConfig,
+  shouldMarkInformational,
+  markEntryInformational,
+  type DeclarationMode,
+  type EntityAccountingConfig,
+} from './entity-config';
+
+// Event → entry bridges (idempotent helpers)
+export {
+  ensureReceiptAccountingEntry,
+  type EnsureReceiptAccountingEntryResult,
+} from './receipt-entry';
+
+export {
+  ensureDepositReceivedEntry,
+  ensureDepositRefundedEntry,
+  type EnsureDepositEntryResult,
+  type EnsureDepositSkipReason,
+} from './deposit-entry';
+
+export {
+  ensureSubscriptionPaidEntry,
+  type EnsureSubscriptionEntryResult,
+  type EnsureSubscriptionSkipReason,
+} from './subscription-entry';

--- a/lib/accounting/receipt-entry.ts
+++ b/lib/accounting/receipt-entry.ts
@@ -18,6 +18,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createAutoEntry } from "@/lib/accounting/engine";
 import { getOrCreateCurrentExercise } from "@/lib/accounting/auto-exercise";
+import {
+  getEntityAccountingConfig,
+  markEntryInformational,
+  shouldMarkInformational,
+} from "@/lib/accounting/entity-config";
 
 export interface EnsureReceiptAccountingEntryResult {
   created: boolean;
@@ -26,6 +31,7 @@ export interface EnsureReceiptAccountingEntryResult {
     | "already_exists"
     | "payment_not_found"
     | "entity_not_resolved"
+    | "accounting_disabled"
     | "exercise_not_available"
     | "error";
   entryId?: string;
@@ -125,6 +131,14 @@ export async function ensureReceiptAccountingEntry(
       return { created: false, skippedReason: "entity_not_resolved" };
     }
 
+    // ─── 2b. Per-entity accounting toggle ──────────────────────────
+    // Skip if the owner has not activated automatic accounting for this
+    // entity (avoids polluting the journal during initial setup).
+    const config = await getEntityAccountingConfig(supabase, entityId);
+    if (!config || !config.accountingEnabled) {
+      return { created: false, skippedReason: "accounting_disabled" };
+    }
+
     // ─── 3. Current exercise for that entity ───────────────────────
     const exercise = await getOrCreateCurrentExercise(supabase, entityId);
     if (!exercise) {
@@ -159,6 +173,10 @@ export async function ensureReceiptAccountingEntry(
       date: entryDate,
       reference: paymentId,
     });
+
+    if (shouldMarkInformational(config)) {
+      await markEntryInformational(supabase, entry.id);
+    }
 
     return { created: true, entryId: entry.id };
   } catch (err) {

--- a/lib/accounting/subscription-entry.ts
+++ b/lib/accounting/subscription-entry.ts
@@ -1,0 +1,186 @@
+/**
+ * Talok subscription → accounting entry bridge.
+ *
+ * When a Talok subscription invoice is paid (Stripe `invoice.paid` webhook),
+ * it is booked as a platform fee in the owner's primary accounting-enabled
+ * entity. This is an owner-side expense (SaaS platform fee), not to be
+ * confused with a rent invoice paid by the tenant.
+ *
+ *   debit  622800 (Honoraires et commissions divers)
+ *   credit 512100 (Banque)
+ *
+ * Entity resolution: picks the first `legal_entities` row with
+ * `accounting_enabled = true` belonging to `subscriptions.owner_id`, ordered
+ * by created_at ASC. If the owner has zero accounting-enabled entities,
+ * the entry is skipped — the owner can configure compta later and backfill.
+ * If they have more than one, the primary (oldest) is chosen.
+ *
+ * Idempotency: looked up by (reference = subscription_invoice_id,
+ * source LIKE 'auto:subscription_paid%').
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAutoEntry } from "@/lib/accounting/engine";
+import { getOrCreateCurrentExercise } from "@/lib/accounting/auto-exercise";
+import {
+  getEntityAccountingConfig,
+  markEntryInformational,
+  shouldMarkInformational,
+} from "@/lib/accounting/entity-config";
+
+export type EnsureSubscriptionSkipReason =
+  | "already_exists"
+  | "invoice_not_found"
+  | "subscription_not_found"
+  | "no_enabled_entity"
+  | "exercise_not_available"
+  | "amount_invalid"
+  | "error";
+
+export interface EnsureSubscriptionEntryResult {
+  created: boolean;
+  skippedReason?: EnsureSubscriptionSkipReason;
+  entryId?: string;
+  entityId?: string;
+  error?: string;
+}
+
+interface SubscriptionInvoiceRow {
+  id: string;
+  subscription_id: string;
+  amount_paid: number | null;
+  paid_at: string | null;
+  stripe_invoice_id: string | null;
+}
+
+interface SubscriptionRow {
+  id: string;
+  owner_id: string;
+}
+
+/**
+ * Ensure an accounting entry exists for a paid Talok subscription invoice.
+ * Safe to call multiple times from any code path (Stripe webhook, backfill).
+ */
+export async function ensureSubscriptionPaidEntry(
+  supabase: SupabaseClient,
+  subscriptionInvoiceId: string,
+  options: { userId?: string } = {},
+): Promise<EnsureSubscriptionEntryResult> {
+  try {
+    // ─── 1. Idempotency guard ───────────────────────────────────────
+    const { data: existing } = await (supabase as unknown as {
+      from: (t: string) => {
+        select: (s: string) => {
+          eq: (k: string, v: string) => {
+            like: (k: string, pattern: string) => {
+              limit: (n: number) => {
+                maybeSingle: () => Promise<{ data: { id: string } | null }>;
+              };
+            };
+          };
+        };
+      };
+    })
+      .from("accounting_entries")
+      .select("id")
+      .eq("reference", subscriptionInvoiceId)
+      .like("source", "auto:subscription_paid%")
+      .limit(1)
+      .maybeSingle();
+
+    if (existing?.id) {
+      return {
+        created: false,
+        skippedReason: "already_exists",
+        entryId: existing.id,
+      };
+    }
+
+    // ─── 2. Load the subscription invoice ───────────────────────────
+    const { data: invoice } = await supabase
+      .from("subscription_invoices")
+      .select("id, subscription_id, amount_paid, paid_at, stripe_invoice_id")
+      .eq("id", subscriptionInvoiceId)
+      .maybeSingle();
+
+    const invoiceRow = invoice as unknown as SubscriptionInvoiceRow | null;
+    if (!invoiceRow) {
+      return { created: false, skippedReason: "invoice_not_found" };
+    }
+
+    const amountCents = Math.round(Number(invoiceRow.amount_paid ?? 0));
+    // subscription_invoices.amount_paid is already stored in cents (Stripe format)
+    if (amountCents <= 0) {
+      return { created: false, skippedReason: "amount_invalid" };
+    }
+
+    // ─── 3. Load the subscription to get owner_id ───────────────────
+    const { data: subscription } = await supabase
+      .from("subscriptions")
+      .select("id, owner_id")
+      .eq("id", invoiceRow.subscription_id)
+      .maybeSingle();
+
+    const subRow = subscription as unknown as SubscriptionRow | null;
+    if (!subRow) {
+      return { created: false, skippedReason: "subscription_not_found" };
+    }
+
+    // ─── 4. Find the primary accounting-enabled entity ──────────────
+    // Picks the oldest (usually the particulier/default entity created first).
+    const { data: entity } = await supabase
+      .from("legal_entities")
+      .select("id")
+      .eq("owner_profile_id", subRow.owner_id)
+      .eq("accounting_enabled", true)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    const entityRow = entity as { id: string } | null;
+    if (!entityRow) {
+      return { created: false, skippedReason: "no_enabled_entity" };
+    }
+
+    const entityId = entityRow.id;
+    const config = await getEntityAccountingConfig(supabase, entityId);
+    if (!config) {
+      return { created: false, skippedReason: "no_enabled_entity" };
+    }
+
+    // ─── 5. Current exercise ────────────────────────────────────────
+    const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+    if (!exercise) {
+      return { created: false, skippedReason: "exercise_not_available" };
+    }
+
+    // ─── 6. Post the double-entry ───────────────────────────────────
+    const entryDate =
+      invoiceRow.paid_at?.split("T")[0] ??
+      new Date().toISOString().split("T")[0];
+
+    const entry = await createAutoEntry(supabase, "subscription_paid", {
+      entityId,
+      exerciseId: exercise.id,
+      userId: options.userId ?? "system",
+      amountCents,
+      label: "Abonnement Talok",
+      date: entryDate,
+      reference: subscriptionInvoiceId,
+    });
+
+    if (shouldMarkInformational(config)) {
+      await markEntryInformational(supabase, entry.id);
+    }
+
+    return { created: true, entryId: entry.id, entityId };
+  } catch (err) {
+    console.error("[ensureSubscriptionPaidEntry] failed:", err);
+    return {
+      created: false,
+      skippedReason: "error",
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+}

--- a/lib/hooks/use-accounting-entries.ts
+++ b/lib/hooks/use-accounting-entries.ts
@@ -35,6 +35,7 @@ export interface AccountingEntryRow {
   is_validated: boolean;
   is_locked: boolean;
   reversal_of: string | null;
+  informational?: boolean;
   created_at: string;
   updated_at: string;
   // Legacy fields (may co-exist)

--- a/scripts/backfill-accounting-entries.ts
+++ b/scripts/backfill-accounting-entries.ts
@@ -1,0 +1,376 @@
+/**
+ * Historical backfill: replay business events to generate missing double-entry
+ * bookings for entities where accounting was activated after the fact.
+ *
+ * Idempotent: all ensure* helpers dedupe via (reference, source LIKE 'auto:*%')
+ * so this script can be rerun without creating duplicates.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-accounting-entries.ts --entity=<uuid>
+ *   npx tsx scripts/backfill-accounting-entries.ts --all
+ *   npx tsx scripts/backfill-accounting-entries.ts --entity=<uuid> --from=2024-01-01
+ *   npx tsx scripts/backfill-accounting-entries.ts --entity=<uuid> --dry-run
+ *
+ * Requires SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  ensureReceiptAccountingEntry,
+  ensureDepositReceivedEntry,
+  ensureDepositRefundedEntry,
+  ensureSubscriptionPaidEntry,
+} from "@/lib/accounting";
+
+interface Args {
+  entityId: string | null;
+  all: boolean;
+  from: string | null;
+  dryRun: boolean;
+}
+
+interface Stats {
+  processed: number;
+  created: number;
+  skipped: number;
+  errors: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    entityId: null,
+    all: false,
+    from: null,
+    dryRun: false,
+  };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith("--entity=")) args.entityId = arg.slice("--entity=".length);
+    else if (arg === "--all") args.all = true;
+    else if (arg.startsWith("--from=")) args.from = arg.slice("--from=".length);
+    else if (arg === "--dry-run") args.dryRun = true;
+  }
+  if (!args.entityId && !args.all) {
+    throw new Error("Specify --entity=<uuid> or --all");
+  }
+  return args;
+}
+
+function newStats(): Stats {
+  return { processed: 0, created: 0, skipped: 0, errors: 0 };
+}
+
+function recordResult(
+  stats: Stats,
+  result: { created: boolean; skippedReason?: string; error?: string },
+) {
+  stats.processed++;
+  if (result.created) stats.created++;
+  else if (result.skippedReason === "error") stats.errors++;
+  else stats.skipped++;
+}
+
+function log(label: string, stats: Stats) {
+  console.log(
+    `  ${label}: processed=${stats.processed} created=${stats.created} skipped=${stats.skipped} errors=${stats.errors}`,
+  );
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function resolveEntities(
+  supabase: ReturnType<typeof createClient>,
+  args: Args,
+): Promise<Array<{ id: string; nom: string; accounting_enabled: boolean }>> {
+  const query = (supabase as any)
+    .from("legal_entities")
+    .select("id, nom, accounting_enabled")
+    .eq("accounting_enabled", true)
+    .order("created_at", { ascending: true });
+
+  if (args.entityId) {
+    const { data } = await query.eq("id", args.entityId);
+    return (data as any[]) ?? [];
+  }
+  const { data } = await query;
+  return (data as any[]) ?? [];
+}
+
+async function backfillRentPayments(
+  supabase: ReturnType<typeof createClient>,
+  entityId: string,
+  from: string | null,
+  dryRun: boolean,
+): Promise<Stats> {
+  const stats = newStats();
+
+  // Payments reach this entity via: payments → invoices → leases → properties.legal_entity_id
+  // We filter at the properties level via an inner join.
+  let q: any = (supabase as any)
+    .from("payments")
+    .select(
+      `
+        id,
+        date_paiement,
+        statut,
+        invoice:invoices!inner(
+          id,
+          lease:leases!inner(
+            id,
+            property:properties!inner(id, legal_entity_id)
+          )
+        )
+      `,
+    )
+    .eq("statut", "succeeded")
+    .eq("invoice.lease.property.legal_entity_id", entityId)
+    .order("date_paiement", { ascending: true });
+
+  if (from) q = q.gte("date_paiement", from);
+
+  const { data: payments, error } = await q;
+  if (error) {
+    console.error("  [payments] query failed:", error.message);
+    return stats;
+  }
+
+  for (const p of (payments as Array<{ id: string }> | null) ?? []) {
+    if (dryRun) {
+      stats.processed++;
+      stats.created++;
+      continue;
+    }
+    const result = await ensureReceiptAccountingEntry(supabase as any, p.id);
+    recordResult(stats, result);
+    if (stats.processed % 100 === 0) log("rent_received", stats);
+    await sleep(5);
+  }
+  return stats;
+}
+
+async function backfillDepositReceived(
+  supabase: ReturnType<typeof createClient>,
+  entityId: string,
+  from: string | null,
+  dryRun: boolean,
+): Promise<Stats> {
+  const stats = newStats();
+
+  let q: any = (supabase as any)
+    .from("deposit_movements")
+    .select(
+      `
+        id,
+        processed_at,
+        created_at,
+        lease:leases!inner(
+          id,
+          property:properties!inner(id, legal_entity_id)
+        )
+      `,
+    )
+    .eq("type", "encaissement")
+    .eq("status", "received")
+    .eq("lease.property.legal_entity_id", entityId)
+    .order("created_at", { ascending: true });
+
+  if (from) q = q.gte("created_at", from);
+
+  const { data: movements, error } = await q;
+  if (error) {
+    console.error("  [deposit_received] query failed:", error.message);
+    return stats;
+  }
+
+  for (const m of (movements as Array<{ id: string }> | null) ?? []) {
+    if (dryRun) {
+      stats.processed++;
+      stats.created++;
+      continue;
+    }
+    const result = await ensureDepositReceivedEntry(supabase as any, m.id);
+    recordResult(stats, result);
+    await sleep(5);
+  }
+  return stats;
+}
+
+async function backfillDepositRefunded(
+  supabase: ReturnType<typeof createClient>,
+  entityId: string,
+  from: string | null,
+  dryRun: boolean,
+): Promise<Stats> {
+  const stats = newStats();
+
+  let q: any = (supabase as any)
+    .from("deposit_refunds")
+    .select(
+      `
+        id,
+        created_at,
+        lease:leases!inner(
+          id,
+          property:properties!inner(id, legal_entity_id)
+        )
+      `,
+    )
+    .eq("lease.property.legal_entity_id", entityId)
+    .order("created_at", { ascending: true });
+
+  if (from) q = q.gte("created_at", from);
+
+  const { data: refunds, error } = await q;
+  if (error) {
+    console.error("  [deposit_refunded] query failed:", error.message);
+    return stats;
+  }
+
+  for (const r of (refunds as Array<{ id: string }> | null) ?? []) {
+    if (dryRun) {
+      stats.processed++;
+      stats.created++;
+      continue;
+    }
+    const result = await ensureDepositRefundedEntry(supabase as any, r.id);
+    recordResult(stats, result);
+    await sleep(5);
+  }
+  return stats;
+}
+
+async function backfillSubscriptions(
+  supabase: ReturnType<typeof createClient>,
+  entityId: string,
+  from: string | null,
+  dryRun: boolean,
+): Promise<Stats> {
+  const stats = newStats();
+
+  // subscriptions.owner_id → profiles.id == legal_entities.owner_profile_id
+  const { data: entity } = await (supabase as any)
+    .from("legal_entities")
+    .select("owner_profile_id")
+    .eq("id", entityId)
+    .single();
+
+  const ownerProfileId = (entity as { owner_profile_id?: string } | null)
+    ?.owner_profile_id;
+  if (!ownerProfileId) return stats;
+
+  let q: any = (supabase as any)
+    .from("subscription_invoices")
+    .select(
+      `
+        id,
+        paid_at,
+        status,
+        subscription:subscriptions!inner(id, owner_id)
+      `,
+    )
+    .eq("status", "paid")
+    .eq("subscription.owner_id", ownerProfileId)
+    .order("paid_at", { ascending: true });
+
+  if (from) q = q.gte("paid_at", from);
+
+  const { data: invoices, error } = await q;
+  if (error) {
+    console.error("  [subscription_paid] query failed:", error.message);
+    return stats;
+  }
+
+  for (const inv of (invoices as Array<{ id: string }> | null) ?? []) {
+    if (dryRun) {
+      stats.processed++;
+      stats.created++;
+      continue;
+    }
+    const result = await ensureSubscriptionPaidEntry(supabase as any, inv.id);
+    recordResult(stats, result);
+    await sleep(5);
+  }
+  return stats;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error(
+      "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars are required",
+    );
+  }
+
+  const supabase = createClient(url, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  console.log(
+    `\n=== Accounting backfill ===\nentity=${args.entityId ?? "ALL"} from=${args.from ?? "beginning"} dry-run=${args.dryRun}\n`,
+  );
+
+  const entities = await resolveEntities(supabase, args);
+  if (entities.length === 0) {
+    console.log(
+      "No accounting-enabled entities matched. Set accounting_enabled=true first via the settings UI.",
+    );
+    return;
+  }
+
+  const totals = newStats();
+
+  for (const entity of entities) {
+    console.log(`\n→ ${entity.nom} (${entity.id})`);
+
+    const stats = {
+      rent: await backfillRentPayments(supabase, entity.id, args.from, args.dryRun),
+      depositIn: await backfillDepositReceived(
+        supabase,
+        entity.id,
+        args.from,
+        args.dryRun,
+      ),
+      depositOut: await backfillDepositRefunded(
+        supabase,
+        entity.id,
+        args.from,
+        args.dryRun,
+      ),
+      subscription: await backfillSubscriptions(
+        supabase,
+        entity.id,
+        args.from,
+        args.dryRun,
+      ),
+    };
+
+    log("rent_received", stats.rent);
+    log("deposit_received", stats.depositIn);
+    log("deposit_refunded", stats.depositOut);
+    log("subscription_paid", stats.subscription);
+
+    for (const s of Object.values(stats)) {
+      totals.processed += s.processed;
+      totals.created += s.created;
+      totals.skipped += s.skipped;
+      totals.errors += s.errors;
+    }
+  }
+
+  console.log(
+    `\n=== Done ===\nTotal: processed=${totals.processed} created=${totals.created} skipped=${totals.skipped} errors=${totals.errors}`,
+  );
+  if (args.dryRun) {
+    console.log("(dry-run: no entries were actually created)");
+  }
+}
+
+main().catch((err) => {
+  console.error("Backfill failed:", err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260422150000_accounting_events_bridge.sql
+++ b/supabase/migrations/20260422150000_accounting_events_bridge.sql
@@ -1,0 +1,65 @@
+-- Migration: accounting events bridge foundations
+--
+-- Goal: wire business events (rent receipts, security deposits, provider invoices,
+-- Talok subscriptions) to the existing double-entry engine (lib/accounting/engine.ts,
+-- 14 auto-entry events already implemented).
+--
+-- This migration does NOT recreate the accounting schema — 15 tables already
+-- exist from 20260406210000_accounting_complete.sql. It only adds:
+--   1. Per-entity accounting opt-in toggle (distinct from plan-level gating)
+--   2. Declaration mode (micro_foncier / reel / is_comptable), orthogonal to
+--      the juridical regime_fiscal (ir/is)
+--   3. Informational flag on entries (for micro_foncier mode, excluded from FEC)
+
+BEGIN;
+
+-- ============================================================================
+-- 1. legal_entities: user-level toggle + declaration mode
+-- ============================================================================
+
+ALTER TABLE legal_entities
+  ADD COLUMN IF NOT EXISTS accounting_enabled boolean NOT NULL DEFAULT false;
+
+ALTER TABLE legal_entities
+  ADD COLUMN IF NOT EXISTS declaration_mode text NOT NULL DEFAULT 'reel';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'legal_entities_declaration_mode_check'
+  ) THEN
+    ALTER TABLE legal_entities
+      ADD CONSTRAINT legal_entities_declaration_mode_check
+      CHECK (declaration_mode IN ('micro_foncier', 'reel', 'is_comptable'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN legal_entities.accounting_enabled IS
+  'User-level switch to activate automatic accounting entry generation for this entity. '
+  'Distinct from plan-level feature gating (copro_module): even on eligible plans, '
+  'owners must opt-in per entity to avoid noise during initial setup.';
+
+COMMENT ON COLUMN legal_entities.declaration_mode IS
+  'Tax-declaration mode, orthogonal to regime_fiscal (ir/is). '
+  'Values: micro_foncier (<=15k/an, abattement 30%%, entries are informational), '
+  'reel (standard cash-basis accounting, default), '
+  'is_comptable (full commercial accounting for SCI IS / SARL).';
+
+-- ============================================================================
+-- 2. accounting_entries: informational flag
+-- ============================================================================
+
+ALTER TABLE accounting_entries
+  ADD COLUMN IF NOT EXISTS informational boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN accounting_entries.informational IS
+  'True when the entry was created for information only (micro_foncier preparation). '
+  'Informational entries must be excluded from FEC exports and official reports.';
+
+-- Partial index used by FEC and reports to skip informational entries efficiently
+CREATE INDEX IF NOT EXISTS idx_accounting_entries_non_informational
+  ON accounting_entries(entity_id, entry_date DESC)
+  WHERE informational = false;
+
+COMMIT;


### PR DESCRIPTION
## Summary

This PR connects business events (rent receipts, security deposits, subscriptions) to the existing double-entry accounting engine via idempotent helper functions, and adds per-entity accounting activation with declaration mode support (micro_foncier/reel/is_comptable).

## Key Changes

- **Entity-level accounting configuration** (`lib/accounting/entity-config.ts`):
  - Added `accounting_enabled` toggle and `declaration_mode` columns to `legal_entities`
  - Entries in micro_foncier mode are flagged `informational` (excluded from FEC exports)
  - Configuration reader used by all `ensure*Entry` helpers for gating

- **Event → entry bridges** (idempotent helpers):
  - `ensureReceiptAccountingEntry`: books rent payments (existing, now gated by config)
  - `ensureDepositReceivedEntry`: books security deposit receipts (debit 512300 / credit 165000)
  - `ensureDepositRefundedEntry`: books security deposit refunds with optional retention splits
  - `ensureSubscriptionPaidEntry`: books Talok subscription fees as platform expenses (debit 622800 / credit 512100)
  - All helpers dedupe via `(reference, source LIKE 'auto:*%')` for safe re-execution

- **Accounting settings UI** (`app/owner/accounting/settings/`):
  - New settings page for per-entity accounting activation and declaration mode selection
  - Entity picker, toggle switch, and radio group for declaration mode
  - Gated by `bank_reconciliation` plan feature

- **Backfill script** (`scripts/backfill-accounting-entries.ts`):
  - Replays historical business events to generate missing entries
  - Supports `--entity=<uuid>`, `--all`, `--from=<date>`, `--dry-run` flags
  - Idempotent: safe to rerun without creating duplicates

- **Webhook integration updates**:
  - Stripe webhook handlers now check `accounting_enabled` before creating entries
  - Deposit endpoints call `ensureDepositReceivedEntry` / `ensureDepositRefundedEntry` non-blocking
  - Work order service respects entity config when posting auto-entries

- **Engine extension**:
  - Added `subscription_paid` auto-entry event type with 622800/512100 account mapping

- **UI enhancements**:
  - Entries page shows empty state with link to settings when no entries exist
  - Entry rows display informational badge for micro_foncier entries
  - Accounting layout adds Settings tab

- **Database migration** (`20260422150000_accounting_events_bridge.sql`):
  - Adds `accounting_enabled`, `declaration_mode`, and `informational` columns
  - Adds constraint on declaration_mode enum values

## Implementation Details

- All `ensure*Entry` helpers follow the same pattern: idempotency guard → source validation → entity resolution → config check → exercise lookup → entry creation → informational flag (if needed)
- Entity resolution for deposits/leases uses inner joins to filter by `legal_entity_id`
- Subscription entries pick the primary (oldest) accounting-enabled entity for the owner
- Backfill script includes 5ms delays between operations to avoid rate limiting
- Settings API enforces entity ownership via `owner_profile_id` match

https://claude.ai/code/session_01CYBEZcBFxcTapysSeCp6aq