### PR TITLE
Fix owner dashboard EDL signer role matching for FR variants

### DIFF
--- a/app/owner/_data/fetchDashboard.ts
+++ b/app/owner/_data/fetchDashboard.ts
@@ -5,6 +5,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { createServiceRoleClient } from "@/lib/supabase/service-client";
+import { EDL_OWNER_SIGNER_ROLES } from "@/lib/constants/roles";
 import { redirect } from "next/navigation";
 
 export interface OwnerDashboardData {
@@ -148,10 +149,11 @@ async function fetchDashboardDirect(
       .select("id, statut, created_at")
       .in("property_id", propertyIds),
     // ✅ SOTA 2026: EDL query — colonnes correctes: "status" (pas "statut"), pas de "owner_signed"
-    // La signature propriétaire se vérifie via la table edl_signatures
+    // La signature propriétaire se vérifie via la table edl_signatures.
+    // On joint les signatures pour pouvoir décider, comme la RPC, si l'owner a signé.
     supabase
       .from("edl")
-      .select("id, status")
+      .select("id, status, edl_signatures(signer_role, signed_at)")
       .in("property_id", propertyIds),
     // Activité récente - dernières factures et tickets pour le flux d'activité
     supabase
@@ -217,11 +219,24 @@ async function fetchDashboardDirect(
     },
     edl: {
       total: edls.length,
-      // ✅ SOTA 2026: Un EDL en "completed" est en attente de signature.
-      // Un EDL "signed" est entièrement signé. Pas de colonne "owner_signed".
-      pending_owner_signature: (edls as Array<{ status?: string }>).filter((e) =>
-        e.status === "completed"
-      ).length,
+      // ✅ SOTA 2026: Un EDL "completed" est en attente de signature ; "signed" = entièrement signé.
+      // Aligné avec la RPC owner_dashboard : on exclut les EDL déjà signés par l'owner
+      // même si `edl.status` n'a pas (encore) basculé à "signed" (trigger non déclenché,
+      // rollback PDF, etc.). Le rôle owner est accepté sous plusieurs variantes en base.
+      pending_owner_signature: (
+        edls as Array<{
+          status?: string;
+          edl_signatures?: Array<{ signer_role?: string | null; signed_at?: string | null }> | null;
+        }>
+      ).filter((e) => {
+        if (e.status !== "completed") return false;
+        const ownerSigned = (e.edl_signatures ?? []).some(
+          (s) =>
+            !!s.signed_at &&
+            (EDL_OWNER_SIGNER_ROLES as readonly string[]).includes(s.signer_role ?? "")
+        );
+        return !ownerSigned;
+      }).length,
     },
     zone3_portfolio: { compliance: [] },
     recentActivity,

--- a/app/owner/dashboard/DashboardClient.tsx
+++ b/app/owner/dashboard/DashboardClient.tsx
@@ -229,10 +229,11 @@ export function DashboardClient({ profileCompletion }: DashboardClientProps) {
       id: "edl_pending",
       type: "signature" as const,
       priority: "high" as const,
-      title: `${dashboard.edl.pending_owner_signature} État des lieux à signer`,
-      description: "Des états des lieux sont terminés et attendent votre signature pour validation",
+      title: `${dashboard.edl.pending_owner_signature} état des lieux d'entrée à signer`,
+      description:
+        "Le bail est signé. Il reste à signer l'état des lieux d'entrée pour activer le bail et démarrer les loyers.",
       link: "/owner/inspections",
-      linkLabel: "Signer",
+      linkLabel: "Signer l'état des lieux",
       metadata: { count: dashboard.edl.pending_owner_signature },
     }] : []),
     // Tickets ouverts (moyenne)

--- a/lib/constants/roles.ts
+++ b/lib/constants/roles.ts
@@ -137,6 +137,23 @@ export function isAnyTenantRole(role: string | null | undefined): boolean {
 }
 
 /**
+ * Variantes de `edl_signatures.signer_role` considérées comme "propriétaire".
+ * La contrainte CHECK accepte encore les 3 formes historiques (EN + FR).
+ * Utiliser ce tableau partout où l'on lit la table `edl_signatures`, pour éviter
+ * les faux positifs "EDL à signer" sur le dashboard.
+ */
+export const EDL_OWNER_SIGNER_ROLES = ["owner", "proprietaire", "bailleur"] as const;
+
+/**
+ * Variantes de `edl_signatures.signer_role` considérées comme "locataire".
+ */
+export const EDL_TENANT_SIGNER_ROLES = [
+  "tenant",
+  "locataire",
+  "locataire_principal",
+] as const;
+
+/**
  * Normalise un rôle vers la valeur standard
  * Utile pour la migration et l'uniformisation
  */

--- a/supabase/migrations/20260422160000_fix_owner_dashboard_edl_signer_roles.sql
+++ b/supabase/migrations/20260422160000_fix_owner_dashboard_edl_signer_roles.sql
@@ -1,0 +1,172 @@
+-- Fix: owner_dashboard RPC counts EDL "pending_owner_signature" using a strict
+-- match on signer_role = 'owner'. Live data uses the FR variants 'proprietaire'
+-- and 'bailleur' (both accepted by the CHECK constraint on edl_signatures.signer_role),
+-- so a fully-signed EDL remains visible as "à signer" on the owner dashboard.
+--
+-- This migration only replaces the function body to widen the role matching; no
+-- data is touched.
+
+CREATE OR REPLACE FUNCTION owner_dashboard(p_owner_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  -- Vérifier que l'utilisateur est bien le propriétaire
+  IF NOT EXISTS (
+    SELECT 1 FROM profiles
+    WHERE id = p_owner_id
+    AND role = 'owner'
+    AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Accès non autorisé';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'properties', (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', p.id,
+          'ref', p.unique_code,
+          'adresse', p.adresse_complete,
+          'statut', p.etat,
+          'type', p.type,
+          'surface', p.surface,
+          'nb_pieces', p.nb_pieces,
+          'created_at', p.created_at,
+          'updated_at', p.updated_at
+        )
+      )
+      FROM properties p
+      WHERE p.owner_id = p_owner_id
+    ),
+    'properties_stats', (
+      SELECT jsonb_build_object(
+        'total', COUNT(*),
+        'active', COUNT(*) FILTER (WHERE etat = 'published'),
+        'draft', COUNT(*) FILTER (WHERE etat = 'draft')
+      )
+      FROM properties
+      WHERE owner_id = p_owner_id
+    ),
+    'leases', (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', l.id,
+          'property_id', l.property_id,
+          'type_bail', l.type_bail,
+          'loyer', l.loyer,
+          'date_debut', l.date_debut,
+          'date_fin', l.date_fin,
+          'statut', l.statut,
+          'created_at', l.created_at
+        )
+      )
+      FROM leases l
+      INNER JOIN properties p ON p.id = l.property_id
+      WHERE p.owner_id = p_owner_id
+    ),
+    'leases_stats', (
+      SELECT jsonb_build_object(
+        'total', COUNT(*),
+        'active', COUNT(*) FILTER (WHERE l.statut = 'active'),
+        'pending', COUNT(*) FILTER (WHERE l.statut = 'pending_signature')
+      )
+      FROM leases l
+      INNER JOIN properties p ON p.id = l.property_id
+      WHERE p.owner_id = p_owner_id
+    ),
+    'edl_stats', (
+      SELECT jsonb_build_object(
+        'total', COUNT(*),
+        'pending_owner_signature', COUNT(*) FILTER (
+          WHERE e.status = 'completed' AND NOT EXISTS (
+            SELECT 1 FROM edl_signatures es
+            WHERE es.edl_id = e.id
+            AND es.signer_role IN ('owner', 'proprietaire', 'bailleur')
+            AND es.signed_at IS NOT NULL
+          )
+        )
+      )
+      FROM edl e
+      INNER JOIN leases l ON l.id = e.lease_id
+      INNER JOIN properties p ON p.id = l.property_id
+      WHERE p.owner_id = p_owner_id
+    ),
+    'invoices', (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', i.id,
+          'lease_id', i.lease_id,
+          'periode', i.periode,
+          'montant_total', i.montant_total,
+          'statut', i.statut,
+          'created_at', i.created_at
+        )
+      )
+      FROM invoices i
+      WHERE i.owner_id = p_owner_id
+      ORDER BY i.created_at DESC
+      LIMIT 10
+    ),
+    'invoices_stats', (
+      SELECT jsonb_build_object(
+        'total', COUNT(*),
+        'paid', COUNT(*) FILTER (WHERE statut = 'paid'),
+        'pending', COUNT(*) FILTER (WHERE statut = 'sent'),
+        'late', COUNT(*) FILTER (WHERE statut = 'late')
+      )
+      FROM invoices
+      WHERE owner_id = p_owner_id
+    ),
+    'tickets', (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', t.id,
+          'property_id', t.property_id,
+          'titre', t.titre,
+          'priorite', t.priorite,
+          'statut', t.statut,
+          'created_at', t.created_at
+        )
+      )
+      FROM tickets t
+      INNER JOIN properties p ON p.id = t.property_id
+      WHERE p.owner_id = p_owner_id
+      ORDER BY t.created_at DESC
+      LIMIT 10
+    ),
+    'tickets_stats', (
+      SELECT jsonb_build_object(
+        'total', COUNT(*),
+        'open', COUNT(*) FILTER (WHERE t.statut = 'open'),
+        'in_progress', COUNT(*) FILTER (WHERE t.statut = 'in_progress')
+      )
+      FROM tickets t
+      INNER JOIN properties p ON p.id = t.property_id
+      WHERE p.owner_id = p_owner_id
+    ),
+    'recentActivity', (
+      SELECT jsonb_agg(act) FROM (
+        -- Nouvelles factures
+        SELECT 'invoice' as type, 'Facture générée - ' || i.periode as title, i.created_at::text as date
+        FROM invoices i WHERE i.owner_id = p_owner_id
+        UNION ALL
+        -- Nouveaux tickets
+        SELECT 'ticket' as type, 'Nouveau ticket: ' || t.titre as title, t.created_at::text as date
+        FROM tickets t INNER JOIN properties p ON p.id = t.property_id WHERE p.owner_id = p_owner_id
+        UNION ALL
+        -- Nouvelles signatures
+        SELECT 'signature' as type, 'Bail signé - ' || p.adresse_complete as title, l.updated_at::text as date
+        FROM leases l INNER JOIN properties p ON p.id = l.property_id WHERE p.owner_id = p_owner_id AND l.statut = 'active'
+        ORDER BY date DESC
+        LIMIT 10
+      ) act
+    )
+  ) INTO v_result;
+
+  RETURN COALESCE(v_result, '{}'::jsonb);
+END;
+$$;


### PR DESCRIPTION
## Summary
Fixes a bug where fully-signed EDLs (État des Lieux) remained visible as "à signer" on the owner dashboard because the signature check only matched the English role `'owner'`, while live data uses French variants `'proprietaire'` and `'bailleur'`.

## Key Changes

- **Migration**: Updated `owner_dashboard()` RPC function to check for all three owner signer role variants (`'owner'`, `'proprietaire'`, `'bailleur'`) when determining if an EDL is pending owner signature
- **Constants**: Added `EDL_OWNER_SIGNER_ROLES` and `EDL_TENANT_SIGNER_ROLES` to `lib/constants/roles.ts` to centralize role variant definitions and prevent future mismatches
- **Dashboard Data Fetch**: Modified `fetchDashboardDirect()` to:
  - Join `edl_signatures` table to retrieve signer role and signature timestamp
  - Apply the same role-matching logic as the RPC function when counting pending signatures
- **UI Copy**: Updated dashboard alert messaging to be more specific about EDL entry state and the lease activation flow

## Implementation Details

The fix ensures consistency between:
1. The backend RPC function (`owner_dashboard`) which counts pending signatures
2. The frontend data fetch (`fetchDashboardDirect`) which mirrors the same logic
3. Both now accept all three role variants that the database CHECK constraint allows

This prevents the scenario where an EDL signed with a French role variant would still appear as unsigned on the dashboard due to strict English-only matching.

https://claude.ai/code/session_01QhsAksttkgF4XZqeRX58U3