### PR TITLE
Fix properties usage calculation in smart paywall

### DIFF
--- a/components/subscription/smart-paywall.tsx
+++ b/components/subscription/smart-paywall.tsx
@@ -465,7 +465,7 @@ export function UpgradeTrigger({ className, variant = "prominent" }: UpgradeTrig
     return null;
   }
 
-  const propertiesUsed = (usage as any)?.properties_count || 0;
+  const propertiesUsed = usage?.properties?.used ?? 0;
   const propertiesLimit = PLANS[currentPlan].limits.max_properties;
   const usagePercentage = propertiesLimit > 0 ? (propertiesUsed / propertiesLimit) * 100 : 0;
 


### PR DESCRIPTION
## Summary
Updated the properties usage calculation in the `UpgradeTrigger` component to use the correct data structure from the usage object.

## Key Changes
- Changed `usage?.properties_count` to `usage?.properties?.used` to access the correct nested property
- Replaced unsafe type casting `(usage as any)` with proper optional chaining and nullish coalescing
- Maintains the same fallback behavior (defaults to 0 when data is unavailable)

## Implementation Details
The usage object structure has been corrected to reflect the actual API response format where properties usage is nested under `properties.used` rather than a top-level `properties_count` field. This ensures accurate usage percentage calculations for the paywall display.

https://claude.ai/code/session_01KvcT2c28rknwAAcTdb6CNA