### PR TITLE
feat(tickets): backlog cleanup — API unification, deposit split, payment email

### DIFF
--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -9,9 +9,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { TicketRow } from "@/lib/supabase/typed-client";
 import { ticketsQuerySchema, validateQueryParams } from "@/lib/validations/params";
 import { withSecurity } from "@/lib/api/with-security";
-import { resolveTicketContext } from "@/lib/tickets/resolve-ticket-context";
-import { resolveSyndicForProperty } from "@/lib/tickets/resolve-syndic";
-import { suggestForTicketCategory } from "@/lib/tickets/charges-classification";
+import { createTicket } from "@/lib/tickets/create-ticket.service";
 
 /**
  * GET /api/tickets - Récupérer les tickets de l'utilisateur
@@ -237,103 +235,36 @@ export const POST = withSecurity(async function POST(request: Request) {
 
     const profileData = profile as { id: string; role: string; email: string | null };
 
-    // Résoudre le contexte du ticket (property_id, lease_id, owner) et vérifier
-    // l'accès. Le helper gère locataire invité par email (cas courant : invitation
-    // non encore "healed") et renvoie des codes d'erreur distincts.
-    const userEmail = profileData.email ?? user.email ?? null;
-    const context = await resolveTicketContext({
+    // Délégation au service partagé (source unique pour la création ticket).
+    const result = await createTicket({
       serviceClient,
-      profileId: profileData.id,
-      role: profileData.role,
-      userEmail,
-      propertyId: validated.property_id ?? null,
-      leaseId: validated.lease_id ?? null,
+      auth: {
+        user_id: user.id,
+        user_email: user.email ?? null,
+        profile_id: profileData.id,
+        profile_email: profileData.email,
+        profile_role: profileData.role,
+      },
+      input: validated,
     });
 
-    if (!context.ok) {
+    if (!result.ok) {
       return NextResponse.json(
-        { error: context.message, code: context.code },
-        { status: context.status }
+        { error: result.message, code: result.code },
+        { status: result.status }
       );
     }
 
-    // Routage parties communes → syndic (si la propriété est rattachée à une
-    // copropriété avec un syndic affecté). Sinon, pas d'effet : on retombe
-    // sur le destinataire propriétaire standard.
-    const isPartiesCommunes = validated.category === "parties_communes";
-    const syndicRouting = isPartiesCommunes
-      ? await resolveSyndicForProperty(serviceClient, context.property_id)
-      : { entity_id: null, syndic_profile_id: null, syndic_user_id: null };
-
-    // Suggestion de classification "charges récupérables" (décret 87-713).
-    // Pose les colonnes à la création ; le propriétaire peut changer
-    // ensuite via l'UI ticket. NULL = ambigu, à décider manuellement.
-    const chargeSuggestion = suggestForTicketCategory(validated.category ?? null);
-
-    // Créer le ticket avec service client
-    const { data: ticket, error: insertError } = await serviceClient
-      .from("tickets")
-      .insert({
-        ...validated,
-        property_id: context.property_id,
-        lease_id: context.lease_id ?? validated.lease_id ?? null,
-        created_by_profile_id: profileData.id,
-        owner_id: context.owner_profile_id,
-        entity_id: syndicRouting.entity_id,
-        assigned_to: syndicRouting.syndic_profile_id,
-        statut: syndicRouting.syndic_profile_id ? "acknowledged" : "open",
-        is_tenant_chargeable: chargeSuggestion.is_tenant_chargeable,
-        charge_category_code: chargeSuggestion.charge_category_code,
-      })
-      .select()
-      .single();
-
-    if (insertError) throw insertError;
-
-    // Destinataire de la notification :
-    //   - parties communes + syndic identifié → le syndic
-    //   - sinon → le propriétaire
-    const recipientUserId =
-      syndicRouting.syndic_user_id ?? context.owner_user_id;
-
-    await serviceClient.from("outbox").insert({
-      event_type: isPartiesCommunes && syndicRouting.syndic_profile_id
-        ? "Ticket.OpenedPartiesCommunes"
-        : "Ticket.Opened",
-      payload: {
-        ticket_id: ticket.id,
-        property_id: context.property_id,
-        lease_id: context.lease_id,
-        entity_id: syndicRouting.entity_id,
-        priority: validated.priorite,
-        title: validated.titre,
-        category: validated.category ?? null,
-        owner_id: context.owner_user_id,
-        syndic_user_id: syndicRouting.syndic_user_id,
-        recipient_user_id: recipientUserId,
-        created_by: profileData.id,
-        creator_role: context.creator_role,
-      },
-    } as any);
-
-    // AI Analysis Trigger (Async but awaited here for serverless environment safety)
-    try {
-        // En background job idéalement, mais ici on l'exécute
-        await maintenanceAiService.analyzeAndEnrichTicket(ticket.id);
-    } catch (aiError) {
+    // AI Analysis (fire-and-forget, non-blocking)
+    void (async () => {
+      try {
+        await maintenanceAiService.analyzeAndEnrichTicket(result.ticket.id);
+      } catch (aiError) {
         console.error("AI Maintenance analysis failed:", aiError);
-    }
+      }
+    })();
 
-    // Journaliser
-    await serviceClient.from("audit_log").insert({
-      user_id: user.id,
-      action: "ticket_created",
-      entity_type: "ticket",
-      entity_id: ticket.id,
-      metadata: { priority: validated.priorite },
-    } as any);
-
-    return NextResponse.json({ ticket });
+    return NextResponse.json({ ticket: result.ticket });
   } catch (error: unknown) {
     return handleApiError(error);
   }

--- a/app/api/v1/tickets/route.ts
+++ b/app/api/v1/tickets/route.ts
@@ -3,6 +3,7 @@ export const runtime = 'nodejs';
 
 import { NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import {
   apiError,
   apiSuccess,
@@ -10,9 +11,9 @@ import {
   requireApiAccess,
   validateBody,
   getPaginationParams,
-  logAudit,
 } from "@/lib/api/middleware";
 import { CreateTicketSchema } from "@/lib/api/schemas";
+import { createTicket } from "@/lib/tickets/create-ticket.service";
 
 /**
  * GET /api/v1/tickets
@@ -116,120 +117,65 @@ export async function GET(request: NextRequest) {
 
 /**
  * POST /api/v1/tickets
- * Create a new ticket
- * Events: Ticket.Opened
+ * Create a new ticket.
+ *
+ * Depuis l'unification d'avril 2026, cette route partage intégralement la
+ * logique métier avec POST /api/tickets via `createTicket()` service :
+ *   - résolution property_id + lease_id par profile_id OU invited_email
+ *   - routage parties communes → syndic
+ *   - suggestion de classification charges récupérables (décret 87-713)
+ *   - outbox Ticket.Opened / Ticket.OpenedPartiesCommunes
+ *   - audit log
+ *
+ * Ce qui reste spécifique à la route v1 :
+ *   - wrapper auth (requireAuth), feature gating api_access (owners Pro+),
+ *     format de réponse apiSuccess/apiError, code 201 à la création.
  */
 export async function POST(request: NextRequest) {
   try {
     const auth = await requireAuth(request);
     if (auth instanceof Response) return auth;
 
-    // Owners and tenants can create tickets
     if (!["owner", "tenant", "admin"].includes(auth.profile.role)) {
       return apiError("Accès non autorisé", 403);
     }
 
-    // SOTA 2026: Gating api_access (Pro+) - only for owners
     if (auth.profile.role === "owner") {
       const apiAccessCheck = await requireApiAccess(auth.profile);
       if (apiAccessCheck) return apiAccessCheck;
     }
 
-    const supabase = await createClient();
     const body = await request.json();
     const { data, error: validationError } = validateBody(CreateTicketSchema, body);
-
     if (validationError) return validationError;
 
-    // Verify access to property
-    const { data: property } = await supabase
-      .from("properties")
-      .select("owner_id")
-      .eq("id", data.property_id)
-      .single();
-
-    if (!property) {
-      return apiError("Propriété non trouvée", 404);
-    }
-
-    // Authorization check
-    if (auth.profile.role === "owner" && property.owner_id !== auth.profile.id) {
-      return apiError("Accès non autorisé à cette propriété", 403);
-    }
-
-    if (auth.profile.role === "tenant") {
-      // Tenant must have an active lease for this property
-      const { data: lease } = await supabase
-        .from("leases")
-        .select("id")
-        .eq("property_id", data.property_id)
-        .eq("statut", "active")
-        .single();
-
-      if (!lease) {
-        return apiError("Aucun bail actif pour cette propriété", 403);
-      }
-
-      const { data: signer } = await supabase
-        .from("lease_signers")
-        .select("id")
-        .eq("lease_id", lease.id)
-        .eq("profile_id", auth.profile.id)
-        .single();
-
-      if (!signer) {
-        return apiError("Vous n'êtes pas locataire de cette propriété", 403);
-      }
-    }
-
-    // Create ticket with SOTA fields
-    const { data: ticket, error } = await supabase
-      .from("tickets")
-      .insert({
+    const result = await createTicket({
+      serviceClient: getServiceClient(),
+      auth: {
+        user_id: auth.user.id,
+        user_email: auth.user.email ?? null,
+        profile_id: auth.profile.id,
+        profile_email: (auth.profile as { email?: string | null }).email ?? null,
+        profile_role: auth.profile.role,
+      },
+      input: {
         property_id: data.property_id,
-        lease_id: data.lease_id || null,
+        lease_id: data.lease_id ?? null,
         titre: data.titre,
         description: data.description,
-        category: data.category || null,
-        priorite: data.priorite || "normal",
-        photos: data.photos || [],
-        created_by_profile_id: auth.profile.id,
-        owner_id: property.owner_id,
-        statut: "open",
-      })
-      .select()
-      .single();
-
-    if (error) {
-      console.error("[POST /tickets] Error:", error);
-      return apiError("Erreur lors de la création", 500);
-    }
-
-    // Emit event
-    await supabase.from("outbox").insert({
-      event_type: "Ticket.Opened",
-      payload: {
-        ticket_id: ticket.id,
-        property_id: data.property_id,
-        created_by: auth.profile.id,
-        priority: data.priorite,
+        category: data.category ?? null,
+        priorite: data.priorite ?? "normal",
+        photos: data.photos ?? [],
       },
     });
 
-    // Audit log
-    await logAudit(
-      supabase,
-      "ticket.created",
-      "tickets",
-      ticket.id,
-      auth.user.id,
-      null,
-      ticket
-    );
+    if (!result.ok) {
+      return apiError(result.message, result.status);
+    }
 
-    return apiSuccess({ ticket }, 201);
+    return apiSuccess({ ticket: result.ticket }, 201);
   } catch (error: unknown) {
-    console.error("[POST /tickets] Error:", error);
+    console.error("[POST /v1/tickets] Error:", error);
     return apiError("Erreur serveur", 500);
   }
 }

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1957,6 +1957,28 @@ async function handleWorkOrderPaymentSucceeded(
     }
   }
 
+  // Résoudre la référence humaine du ticket lié pour l'email
+  let ticketReference: string | null = null;
+  try {
+    const { data: woRow } = await supabase
+      .from("work_orders")
+      .select("ticket_id")
+      .eq("id", workOrderId)
+      .maybeSingle();
+    const ticketId = (woRow as { ticket_id: string | null } | null)?.ticket_id ?? null;
+    if (ticketId) {
+      const { data: tRow } = await supabase
+        .from("tickets")
+        .select("reference")
+        .eq("id", ticketId)
+        .maybeSingle();
+      ticketReference =
+        (tRow as { reference: string | null } | null)?.reference ?? null;
+    }
+  } catch {
+    /* non-blocking — just means the email won't carry the reference */
+  }
+
   // Outbox : notifier le prestataire que les fonds sont transférés
   const payeeProfileId = paymentIntent.metadata?.payee_profile_id;
   if (payeeProfileId) {
@@ -1975,6 +1997,7 @@ async function handleWorkOrderPaymentSucceeded(
           work_order_id: workOrderId,
           payment_type: paymentType,
           amount_cents: paymentIntent.amount,
+          ticket_reference: ticketReference,
           recipient_user_id: payeeUserId,
         },
       });

--- a/features/tickets/components/ticket-detail.tsx
+++ b/features/tickets/components/ticket-detail.tsx
@@ -269,29 +269,63 @@ export function TicketDetailView({ ticketId, userRole, backHref }: TicketDetailV
                 activeWo.statut === "work_completed" ||
                 activeWo.statut === "balance_pending";
               if (!canPay) return null;
-              const paymentType =
+
+              // Phase : acompte pas encore payé → split proposé.
+              //         acompte payé → solde uniquement.
+              const awaitingDeposit = activeWo.statut === "quote_accepted";
+              const awaitingBalance =
                 activeWo.statut === "deposit_paid" ||
-                activeWo.statut === "balance_pending"
-                  ? "balance"
-                  : "full";
+                activeWo.statut === "balance_pending" ||
+                activeWo.statut === "work_completed";
+
               return (
-                <div className="rounded-xl border border-border bg-card p-4 space-y-2">
-                  <p className="text-sm font-semibold text-foreground">
-                    {paymentType === "balance"
-                      ? "Solde à régler"
-                      : "Régler l'intervention"}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Paiement sécurisé par carte. Les fonds sont transférés
-                    directement au prestataire.
-                  </p>
-                  <WorkOrderPayButton
-                    workOrderId={woId}
-                    paymentType={paymentType}
-                    hintLabel={
-                      paymentType === "balance" ? "Payer le solde" : "Payer"
-                    }
-                  />
+                <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">
+                      {awaitingDeposit
+                        ? "Régler l'intervention"
+                        : "Solde à régler"}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Paiement sécurisé par carte. Les fonds sont transférés
+                      directement au prestataire.
+                    </p>
+                  </div>
+
+                  {awaitingDeposit && (
+                    <>
+                      {/* Option par défaut : payer la totalité */}
+                      <WorkOrderPayButton
+                        workOrderId={woId}
+                        paymentType="full"
+                        hintLabel="Payer la totalité"
+                      />
+                      {/* Option alternative : split acompte / solde */}
+                      <div className="pt-2 border-t border-border">
+                        <p className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider mb-2">
+                          ou paiement en deux fois
+                        </p>
+                        <WorkOrderPayButton
+                          workOrderId={woId}
+                          paymentType="deposit"
+                          hintLabel="Verser l'acompte (2/3)"
+                          variant="outline"
+                          size="sm"
+                        />
+                        <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+                          Le solde d'1/3 sera dû à la fin des travaux.
+                        </p>
+                      </div>
+                    </>
+                  )}
+
+                  {awaitingBalance && !awaitingDeposit && (
+                    <WorkOrderPayButton
+                      workOrderId={woId}
+                      paymentType="balance"
+                      hintLabel="Payer le solde (1/3)"
+                    />
+                  )}
                 </div>
               );
             })()}

--- a/lib/tickets/create-ticket.service.ts
+++ b/lib/tickets/create-ticket.service.ts
@@ -1,0 +1,181 @@
+/**
+ * Service partagé de création de ticket.
+ *
+ * Source unique pour la logique métier "créer un ticket" appelée par :
+ *   - POST /api/tickets   (route historique, tenant-side)
+ *   - POST /api/v1/tickets (API v1, owner-side avec feature gating)
+ *
+ * Avant l'extraction, les deux routes divergeaient :
+ *   - /api/tickets avait le helper resolveTicketContext (invited_email, etc.)
+ *   - /api/v1/tickets avait un check lease_signers simpliste qui renvoyait
+ *     un 403 dès qu'un locataire était invité par email.
+ * Maintenant les deux partagent exactement les mêmes garanties.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { resolveTicketContext } from "./resolve-ticket-context";
+import { resolveSyndicForProperty } from "./resolve-syndic";
+import { suggestForTicketCategory } from "./charges-classification";
+
+export interface CreateTicketInput {
+  property_id?: string | null;
+  lease_id?: string | null;
+  titre: string;
+  description: string;
+  category?: string | null;
+  priorite: string;
+  photos?: string[];
+}
+
+export interface CreateTicketAuth {
+  user_id: string;       // auth.users.id
+  user_email: string | null;
+  profile_id: string;
+  profile_email: string | null;
+  profile_role: string;
+}
+
+export type CreateTicketResult =
+  | {
+      ok: true;
+      ticket: {
+        id: string;
+        reference: string | null;
+        property_id: string | null;
+        lease_id: string | null;
+        statut: string;
+        is_tenant_chargeable: boolean | null;
+        charge_category_code: string | null;
+      };
+    }
+  | {
+      ok: false;
+      code: string;
+      status: number;
+      message: string;
+    };
+
+/**
+ * Crée un ticket et déclenche les side-effects (outbox, audit log, AI).
+ * La fonction ne fait jamais throw : toutes les erreurs attendues sont
+ * retournées dans un discriminated union.
+ */
+export async function createTicket(args: {
+  serviceClient: SupabaseClient<any>;
+  auth: CreateTicketAuth;
+  input: CreateTicketInput;
+}): Promise<CreateTicketResult> {
+  const { serviceClient, auth, input } = args;
+
+  // 1. Résolution contexte (property_id, lease_id, owner) + RBAC
+  const userEmail = auth.profile_email ?? auth.user_email ?? null;
+  const context = await resolveTicketContext({
+    serviceClient,
+    profileId: auth.profile_id,
+    role: auth.profile_role,
+    userEmail,
+    propertyId: input.property_id ?? null,
+    leaseId: input.lease_id ?? null,
+  });
+
+  if (!context.ok) {
+    return {
+      ok: false,
+      code: context.code,
+      status: context.status,
+      message: context.message,
+    };
+  }
+
+  // 2. Routage parties communes → syndic
+  const isPartiesCommunes = input.category === "parties_communes";
+  const syndicRouting = isPartiesCommunes
+    ? await resolveSyndicForProperty(serviceClient, context.property_id)
+    : { entity_id: null, syndic_profile_id: null, syndic_user_id: null };
+
+  // 3. Classification charges récupérables (décret 87-713)
+  const chargeSuggestion = suggestForTicketCategory(input.category ?? null);
+
+  // 4. Insertion ticket
+  const { data: ticket, error: insertError } = await serviceClient
+    .from("tickets")
+    .insert({
+      titre: input.titre,
+      description: input.description,
+      category: input.category ?? null,
+      priorite: input.priorite,
+      photos: input.photos ?? [],
+      property_id: context.property_id,
+      lease_id: context.lease_id ?? input.lease_id ?? null,
+      created_by_profile_id: auth.profile_id,
+      owner_id: context.owner_profile_id,
+      entity_id: syndicRouting.entity_id,
+      assigned_to: syndicRouting.syndic_profile_id,
+      statut: syndicRouting.syndic_profile_id ? "acknowledged" : "open",
+      is_tenant_chargeable: chargeSuggestion.is_tenant_chargeable,
+      charge_category_code: chargeSuggestion.charge_category_code,
+    })
+    .select(
+      "id, reference, property_id, lease_id, statut, is_tenant_chargeable, charge_category_code"
+    )
+    .single();
+
+  if (insertError) {
+    return {
+      ok: false,
+      code: "INSERT_FAILED",
+      status: 500,
+      message: insertError.message || "Erreur lors de la création du ticket",
+    };
+  }
+
+  const ticketRow = ticket as {
+    id: string;
+    reference: string | null;
+    property_id: string | null;
+    lease_id: string | null;
+    statut: string;
+    is_tenant_chargeable: boolean | null;
+    charge_category_code: string | null;
+  };
+
+  // 5. Outbox event (parties communes → syndic, sinon → owner)
+  const recipientUserId = syndicRouting.syndic_user_id ?? context.owner_user_id;
+
+  await serviceClient.from("outbox").insert({
+    event_type:
+      isPartiesCommunes && syndicRouting.syndic_profile_id
+        ? "Ticket.OpenedPartiesCommunes"
+        : "Ticket.Opened",
+    payload: {
+      ticket_id: ticketRow.id,
+      ticket_reference: ticketRow.reference,
+      property_id: context.property_id,
+      lease_id: context.lease_id,
+      entity_id: syndicRouting.entity_id,
+      priority: input.priorite,
+      title: input.titre,
+      category: input.category ?? null,
+      owner_id: context.owner_user_id,
+      syndic_user_id: syndicRouting.syndic_user_id,
+      recipient_user_id: recipientUserId,
+      created_by: auth.profile_id,
+      creator_role: context.creator_role,
+    },
+  } as any);
+
+  // 6. Audit log (best-effort, n'échoue pas le flow si l'insert échoue)
+  try {
+    await serviceClient.from("audit_log").insert({
+      user_id: auth.user_id,
+      action: "ticket_created",
+      entity_type: "ticket",
+      entity_id: ticketRow.id,
+      metadata: { priority: input.priorite, category: input.category ?? null },
+    } as any);
+  } catch {
+    /* non-blocking */
+  }
+
+  return { ok: true, ticket: ticketRow };
+}

--- a/supabase/functions/_shared/email-templates.ts
+++ b/supabase/functions/_shared/email-templates.ts
@@ -706,3 +706,56 @@ export function ticketPartiesCommunesToSyndic(params: {
     ${ctaButton("Traiter le signalement", `${APP_URL()}/copro/tickets`, "#6366f1")}
   `);
 }
+
+/**
+ * Email au prestataire : paiement reçu sur le compte Stripe Connect.
+ * Déclenché depuis le webhook Stripe lorsque le PaymentIntent réussit,
+ * donc les fonds sont déjà transférés au moment où cet email part.
+ */
+export function workOrderPaymentReceived(params: {
+  providerName: string;
+  amountEuros: string;
+  paymentType: "deposit" | "balance" | "full";
+  workOrderId: string;
+  ticketReference: string | null;
+}): string {
+  const typeLabel =
+    params.paymentType === "deposit"
+      ? "l'acompte"
+      : params.paymentType === "balance"
+        ? "le solde"
+        : "le paiement";
+
+  const refLine = params.ticketReference
+    ? `<p style="margin: 0 0 8px; color: #64748b; font-size: 13px;">Référence&nbsp;: <span style="font-family: monospace; color: #1e293b;">${params.ticketReference}</span></p>`
+    : "";
+
+  return baseWrapper(`
+    <div style="background: #ecfdf5; border-left: 4px solid #10b981; padding: 16px; border-radius: 8px; margin: 0 0 24px;">
+      <p style="margin: 0; color: #065f46; font-weight: 600; font-size: 15px;">
+        💶 Paiement reçu
+      </p>
+    </div>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Bonjour ${params.providerName},
+    </p>
+    <p style="color: #475569; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      ${typeLabel.charAt(0).toUpperCase() + typeLabel.slice(1)} de votre
+      intervention a été versé sur votre compte.
+    </p>
+
+    <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; padding: 20px; margin: 20px 0; text-align: center;">
+      ${refLine}
+      <p style="margin: 0; color: #1e293b; font-size: 32px; font-weight: 700;">
+        ${params.amountEuros}&nbsp;€
+      </p>
+    </div>
+
+    <p style="color: #64748b; font-size: 14px; line-height: 1.6; margin: 0 0 24px;">
+      Les fonds sont disponibles sur votre compte Stripe. Le détail de la
+      commission plateforme est visible dans votre espace.
+    </p>
+
+    ${ctaButton("Voir l'intervention", `${APP_URL()}/provider/tickets`, "#10b981")}
+  `);
+}

--- a/supabase/functions/process-outbox/index.ts
+++ b/supabase/functions/process-outbox/index.ts
@@ -19,6 +19,7 @@ import {
   tenantServiceRejected as tenantServiceRejectedTemplate,
   workOrderAssignedToProvider as workOrderAssignedToProviderTemplate,
   ticketPartiesCommunesToSyndic as ticketPartiesCommunesToSyndicTemplate,
+  workOrderPaymentReceived as workOrderPaymentReceivedTemplate,
 } from "../_shared/email-templates.ts";
 import { normalizePhoneE164, maskPhone } from "../_shared/phone.ts";
 
@@ -580,6 +581,23 @@ async function processEvent(supabase: any, event: any) {
           );
         } catch {
           /* non-blocking */
+        }
+
+        const recipientInfo = await resolveEmailRecipient(supabase, recipient);
+        if (recipientInfo) {
+          const html = workOrderPaymentReceivedTemplate({
+            providerName: recipientInfo.name,
+            amountEuros,
+            paymentType: paymentType as "deposit" | "balance" | "full",
+            workOrderId: payload.work_order_id,
+            ticketReference: payload.ticket_reference ?? null,
+          });
+          await sendOutboxEmail({
+            to: recipientInfo.email,
+            subject: `Paiement de ${amountEuros} € reçu`,
+            html,
+            tags: [{ name: "type", value: "work_order_payment_received" }],
+          });
         }
       }
       break;


### PR DESCRIPTION
## Contexte

Suite de la PR #466 — les 4 items de backlog explicitement laissés pour plus tard sont livrés ici.

## Ce qui est livré

### 1. Unification API `/api/tickets` ↔ `/api/v1/tickets`

Les deux routes partageaient 90% de leur logique mais avec des checks RBAC différents — la v1 faisait un plain lease_signers qui renvoyait 403 sur tout locataire invité par email (même bug qu'on avait corrigé sur `/api/tickets` dans la PR précédente, sauf qu'il restait côté v1).

Extraction dans `lib/tickets/create-ticket.service.ts` (fonction pure, pas de concerns HTTP). Les deux routes deviennent de simples wrappers :

- `POST /api/tickets` : wrapper tenant-side (ticketSchema, withSecurity)
- `POST /api/v1/tickets` : wrapper owner-side (requireAuth, requireApiAccess, apiSuccess, 201)

Le service garantit pour les deux :
- `resolveTicketContext` (profile_id OU invited_email)
- `resolveSyndicForProperty` pour le routage parties communes
- `suggestForTicketCategory` pour la classification charges (décret 87-713)
- Outbox `Ticket.Opened` / `Ticket.OpenedPartiesCommunes`
- audit_log

### 2. UI split deposit / balance

Sur `/owner/tickets/[id]`, la sidebar paiement propose désormais deux chemins quand le work_order vient d'accepter un devis :

- **Payer la totalité** (bouton primaire indigo)
- **Verser l'acompte (2/3)** (bouton secondaire outline)

Une fois l'acompte versé, la carte bascule automatiquement en "Payer le solde (1/3)". Le backend (`work_order_payments`, webhook Stripe) acceptait déjà les 3 `payment_type` — c'est juste la face UI qui manquait.

### 3. Email `WorkOrder.PaymentReceived`

Nouveau template `workOrderPaymentReceived()` dans `supabase/functions/_shared/email-templates.ts` :
- Accent Stripe green (#10b981)
- Affichage montant en gros + référence `TKT-YYYY-NNNN`
- Wording adapté selon `payment_type` (acompte / solde / paiement)

Le worker `process-outbox` appelle désormais `sendOutboxEmail()` dans le case `WorkOrder.PaymentReceived` (la notif in-app + SMS restent inchangées). Le webhook Stripe enrichit le payload outbox avec `ticket_reference` pour que l'email porte la référence humaine.

### 4. Diagnostic Stripe Connect providers

Pas de code — lance cette requête en staging/prod pour voir combien de providers sont prêts à recevoir des paiements :

```sql
SELECT
  p.status,
  COUNT(*) AS providers,
  COUNT(ppa.stripe_account_id) FILTER (WHERE ppa.stripe_account_status = 'enabled') AS stripe_ready
FROM providers p
LEFT JOIN provider_payout_accounts ppa ON ppa.profile_id = p.profile_id
GROUP BY p.status;
```

Les providers qui ne sont pas `stripe_ready` verront un message clair "Le compte de paiement du prestataire n'est pas encore actif" quand l'owner tentera de les payer (déjà en place depuis PR #466).

## Bonus

`maintenanceAiService.analyzeAndEnrichTicket()` est maintenant fire-and-forget dans `POST /api/tickets` au lieu de bloquer la réponse HTTP. Gain de latence visible côté UI (l'utilisateur n'attend plus l'analyse IA pour voir son ticket créé).

## Déploiement

Pas de migration SQL. Deux actions côté infra :

```bash
supabase functions deploy process-outbox    # pour le template email
```

Redéploiement Next.js auto via merge `main` (Netlify).

## Tests à faire en staging

- [ ] Créer un ticket via `/api/v1/tickets` depuis un compte tenant invité par email — doit passer (avant : 403)
- [ ] Ticket créé via `/api/tickets` et via `/api/v1/tickets` produisent le même résultat (même `reference`, même `is_tenant_chargeable`, même entity_id pour parties_communes)
- [ ] Sur un work_order `quote_accepted`, voir les 2 boutons "Payer la totalité" + "Verser l'acompte (2/3)"
- [ ] Payer l'acompte → carte bascule en "Payer le solde"
- [ ] Après paiement Stripe test, vérifier que le prestataire reçoit l'email "Paiement de X € reçu" avec la bonne référence


---
_Generated by [Claude Code](https://claude.ai/code/session_011LAabAkZzbcb1YoYmNcE1e)_