### PR TITLE
Add subscription caching and optimize database queries

### DIFF
--- a/app/api/accounting/settings/route.ts
+++ b/app/api/accounting/settings/route.ts
@@ -34,61 +34,64 @@ async function resolveProfileId(supabase: ReturnType<typeof getServiceClient>, u
   return (profile as { id: string } | null)?.id ?? null;
 }
 
-async function assertEntityOwnership(
-  supabase: ReturnType<typeof getServiceClient>,
-  entityId: string,
-  profileId: string,
-) {
-  const { data } = await (supabase as any)
-    .from("legal_entities")
-    .select("id, owner_profile_id")
-    .eq("id", entityId)
-    .maybeSingle();
-  const row = data as { id: string; owner_profile_id: string } | null;
-  if (!row) {
-    throw new ApiError(404, "Entité introuvable");
-  }
-  if (row.owner_profile_id !== profileId) {
-    throw new ApiError(403, "Accès refusé à cette entité");
-  }
-}
-
 /**
  * GET /api/accounting/settings?entityId=<uuid>
  */
 export async function GET(request: Request) {
+  const t0 = Date.now();
+  const timings: Record<string, number> = {};
   try {
     const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
+    timings.auth = Date.now() - t0;
     if (!user) throw new ApiError(401, "Non authentifié");
 
     const serviceClient = getServiceClient();
+    const tProfile = Date.now();
     const profileId = await resolveProfileId(serviceClient, user.id);
+    timings.profile = Date.now() - tProfile;
     if (!profileId) throw new ApiError(403, "Profil introuvable");
 
+    const tGate = Date.now();
     const gate = await requireAccountingAccess(profileId, "entries");
+    timings.gate = Date.now() - tGate;
     if (gate) return gate;
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get("entityId");
     if (!entityId) throw new ApiError(400, "entityId requis");
 
-    await assertEntityOwnership(serviceClient, entityId, profileId);
-
+    // Fetch ownership + settings in a single round-trip, then enforce
+    // ownership in memory. Previously this was two sequential queries on
+    // the same row.
+    const tEntity = Date.now();
     const { data } = await (serviceClient as any)
       .from("legal_entities")
-      .select("id, accounting_enabled, declaration_mode, regime_fiscal")
+      .select("id, owner_profile_id, accounting_enabled, declaration_mode, regime_fiscal")
       .eq("id", entityId)
-      .single();
+      .maybeSingle();
+    timings.entity = Date.now() - tEntity;
 
     const row = data as {
       id: string;
+      owner_profile_id: string;
       accounting_enabled: boolean | null;
       declaration_mode: string | null;
       regime_fiscal: string | null;
-    };
+    } | null;
+    if (!row) throw new ApiError(404, "Entité introuvable");
+    if (row.owner_profile_id !== profileId) {
+      throw new ApiError(403, "Accès refusé à cette entité");
+    }
+
+    timings.total = Date.now() - t0;
+    if (timings.total > 1000) {
+      console.warn("[perf] GET /api/accounting/settings slow", timings);
+    } else if (process.env.NODE_ENV === "development") {
+      console.log("[perf] GET /api/accounting/settings", timings);
+    }
 
     return NextResponse.json({
       success: true,
@@ -103,6 +106,10 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
+    timings.total = Date.now() - t0;
+    if (timings.total > 1000) {
+      console.warn("[perf] GET /api/accounting/settings slow (error)", timings);
+    }
     return handleApiError(error);
   }
 }
@@ -112,18 +119,25 @@ export async function GET(request: Request) {
  * Body: { entityId, accountingEnabled?, declarationMode? }
  */
 export async function PATCH(request: Request) {
+  const t0 = Date.now();
+  const timings: Record<string, number> = {};
   try {
     const supabase = await createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
+    timings.auth = Date.now() - t0;
     if (!user) throw new ApiError(401, "Non authentifié");
 
     const serviceClient = getServiceClient();
+    const tProfile = Date.now();
     const profileId = await resolveProfileId(serviceClient, user.id);
+    timings.profile = Date.now() - tProfile;
     if (!profileId) throw new ApiError(403, "Profil introuvable");
 
+    const tGate = Date.now();
     const gate = await requireAccountingAccess(profileId, "entries");
+    timings.gate = Date.now() - tGate;
     if (gate) return gate;
 
     const body = await request.json();
@@ -133,7 +147,6 @@ export async function PATCH(request: Request) {
     }
 
     const { entityId, accountingEnabled, declarationMode } = validation.data;
-    await assertEntityOwnership(serviceClient, entityId, profileId);
 
     const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
     if (typeof accountingEnabled === "boolean") {
@@ -148,16 +161,32 @@ export async function PATCH(request: Request) {
       throw new ApiError(400, "Aucun champ à mettre à jour");
     }
 
+    // Fold ownership check into the UPDATE via the owner_profile_id filter.
+    // If no row matches we distinguish 404 vs 403 with a single follow-up
+    // lookup, but only in the unhappy path.
+    const tUpdate = Date.now();
     const { data, error } = await (serviceClient as any)
       .from("legal_entities")
       .update(update)
       .eq("id", entityId)
+      .eq("owner_profile_id", profileId)
       .select("id, accounting_enabled, declaration_mode")
-      .single();
+      .maybeSingle();
+    timings.update = Date.now() - tUpdate;
 
     if (error) {
       console.error("[Accounting Settings] update failed:", error);
       throw new ApiError(500, "Mise à jour impossible");
+    }
+
+    if (!data) {
+      const { data: existing } = await (serviceClient as any)
+        .from("legal_entities")
+        .select("id")
+        .eq("id", entityId)
+        .maybeSingle();
+      if (!existing) throw new ApiError(404, "Entité introuvable");
+      throw new ApiError(403, "Accès refusé à cette entité");
     }
 
     const row = data as {
@@ -165,6 +194,13 @@ export async function PATCH(request: Request) {
       accounting_enabled: boolean;
       declaration_mode: string;
     };
+
+    timings.total = Date.now() - t0;
+    if (timings.total > 1000) {
+      console.warn("[perf] PATCH /api/accounting/settings slow", timings);
+    } else if (process.env.NODE_ENV === "development") {
+      console.log("[perf] PATCH /api/accounting/settings", timings);
+    }
 
     return NextResponse.json({
       success: true,
@@ -178,6 +214,10 @@ export async function PATCH(request: Request) {
       },
     });
   } catch (error) {
+    timings.total = Date.now() - t0;
+    if (timings.total > 1000) {
+      console.warn("[perf] PATCH /api/accounting/settings slow (error)", timings);
+    }
     return handleApiError(error);
   }
 }

--- a/lib/accounting/backfill.ts
+++ b/lib/accounting/backfill.ts
@@ -83,6 +83,41 @@ function mergeInto(target: BackfillStats, source: BackfillStats) {
   }
 }
 
+/**
+ * Bulk-fetch the set of source IDs that already have a matching auto-entry.
+ * Running this once per category replaces N individual idempotency probes
+ * from ensure* helpers — the short-circuit is the common path on re-runs
+ * and saves ~6 round-trips per already-booked item.
+ */
+async function fetchAlreadyBookedReferences(
+  supabase: SupabaseClient,
+  references: string[],
+  sourcePrefix: string,
+): Promise<Set<string>> {
+  if (references.length === 0) return new Set();
+  const CHUNK = 500;
+  const booked = new Set<string>();
+  for (let i = 0; i < references.length; i += CHUNK) {
+    const slice = references.slice(i, i + CHUNK);
+    const { data, error } = await (supabase as any)
+      .from("accounting_entries")
+      .select("reference")
+      .in("reference", slice)
+      .like("source", `${sourcePrefix}%`);
+    if (error) {
+      console.warn(
+        `[backfill] bulk idempotency probe failed for ${sourcePrefix}; falling back to per-item check`,
+        error,
+      );
+      return new Set();
+    }
+    for (const row of (data as Array<{ reference: string | null }> | null) ?? []) {
+      if (row.reference) booked.add(row.reference);
+    }
+  }
+  return booked;
+}
+
 async function backfillRentPayments(
   supabase: SupabaseClient,
   entityId: string,
@@ -120,7 +155,18 @@ async function backfillRentPayments(
     return stats;
   }
 
-  for (const p of (payments as Array<{ id: string }> | null) ?? []) {
+  const rows = (payments as Array<{ id: string }> | null) ?? [];
+  const alreadyBooked = await fetchAlreadyBookedReferences(
+    supabase,
+    rows.map((r) => r.id),
+    "auto:rent_received",
+  );
+  for (const p of rows) {
+    if (alreadyBooked.has(p.id)) {
+      stats.processed++;
+      stats.skipped++;
+      continue;
+    }
     const result = await ensureReceiptAccountingEntry(supabase as any, p.id);
     recordResult(stats, result, { category: "rent", sourceId: p.id });
   }
@@ -161,7 +207,18 @@ async function backfillDepositReceived(
     return stats;
   }
 
-  for (const m of (movements as Array<{ id: string }> | null) ?? []) {
+  const rows = (movements as Array<{ id: string }> | null) ?? [];
+  const alreadyBooked = await fetchAlreadyBookedReferences(
+    supabase,
+    rows.map((r) => r.id),
+    "auto:deposit_received",
+  );
+  for (const m of rows) {
+    if (alreadyBooked.has(m.id)) {
+      stats.processed++;
+      stats.skipped++;
+      continue;
+    }
     const result = await ensureDepositReceivedEntry(supabase as any, m.id);
     recordResult(stats, result, { category: "depositIn", sourceId: m.id });
   }
@@ -199,7 +256,18 @@ async function backfillDepositRefunded(
     return stats;
   }
 
-  for (const r of (refunds as Array<{ id: string }> | null) ?? []) {
+  const rows = (refunds as Array<{ id: string }> | null) ?? [];
+  const alreadyBooked = await fetchAlreadyBookedReferences(
+    supabase,
+    rows.map((row) => row.id),
+    "auto:deposit_returned",
+  );
+  for (const r of rows) {
+    if (alreadyBooked.has(r.id)) {
+      stats.processed++;
+      stats.skipped++;
+      continue;
+    }
     const result = await ensureDepositRefundedEntry(supabase as any, r.id);
     recordResult(stats, result, { category: "depositOut", sourceId: r.id });
   }
@@ -246,7 +314,18 @@ async function backfillSubscriptions(
     return stats;
   }
 
-  for (const inv of (invoices as Array<{ id: string }> | null) ?? []) {
+  const rows = (invoices as Array<{ id: string }> | null) ?? [];
+  const alreadyBooked = await fetchAlreadyBookedReferences(
+    supabase,
+    rows.map((r) => r.id),
+    "auto:subscription_paid",
+  );
+  for (const inv of rows) {
+    if (alreadyBooked.has(inv.id)) {
+      stats.processed++;
+      stats.skipped++;
+      continue;
+    }
     const result = await ensureSubscriptionPaidEntry(supabase as any, inv.id);
     recordResult(stats, result, { category: "subscription", sourceId: inv.id });
   }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -10,11 +10,37 @@ const API_BASE = '/api';
 // Empêcher plusieurs redirections simultanées vers la page de connexion
 let isRedirectingToSignIn = false;
 
+// Marge de sécurité : on considère qu'une session va expirer sous peu et
+// on déclenche un refresh proactif (évite d'envoyer une requête avec un
+// access_token qui va expirer pendant le vol).
+const SESSION_EXPIRY_BUFFER_SEC = 30;
+
 export class ResourceNotFoundError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ResourceNotFoundError";
   }
+}
+
+export class SessionExpiredError extends Error {
+  constructor(message = 'Session expirée. Veuillez vous reconnecter.') {
+    super(message);
+    this.name = 'SessionExpiredError';
+  }
+}
+
+function isRefreshTokenError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { name?: string; code?: string; message?: string };
+  if (e.name === 'AuthApiError' || e.name === 'AuthSessionMissingError') return true;
+  const code = e.code ?? '';
+  if (code === 'refresh_token_not_found' || code === 'invalid_refresh_token') return true;
+  const msg = e.message ?? '';
+  return (
+    msg.includes('Refresh Token Not Found') ||
+    msg.includes('Invalid Refresh Token') ||
+    msg.includes('refresh_token')
+  );
 }
 
 export class ApiClient {
@@ -33,7 +59,7 @@ export class ApiClient {
       }
       window.location.href = '/auth/signin?error=session_expired';
     }
-    throw new Error('Session expirée. Veuillez vous reconnecter.');
+    throw new SessionExpiredError();
   }
 
   private async request<T>(
@@ -45,18 +71,14 @@ export class ApiClient {
 
     // Si une redirection est déjà en cours, ne pas envoyer de requête
     if (isRedirectingToSignIn) {
-      throw new Error('Session expirée. Veuillez vous reconnecter.');
+      throw new SessionExpiredError();
     }
 
     try {
       const { data: { session }, error: sessionError } = await supabase.auth.getSession();
 
-      // Gérer l'erreur de refresh token invalide
-      if (sessionError && (
-        sessionError.message?.includes('refresh_token') ||
-        sessionError.message?.includes('Invalid Refresh Token') ||
-        sessionError.message?.includes('Refresh Token Not Found')
-      )) {
+      // Refresh token invalide / absent → redirection propre
+      if (sessionError && isRefreshTokenError(sessionError)) {
         await this.handleSessionExpired(supabase);
       }
 
@@ -65,12 +87,28 @@ export class ApiClient {
         await this.handleSessionExpired(supabase);
       }
 
+      // Refresh proactif si le token expire dans les prochaines secondes. On
+      // évite ainsi qu'une requête en vol échoue côté serveur avec 401, et on
+      // capture explicitement un refresh_token invalide.
+      let accessToken = session!.access_token;
+      const expiresAt = session!.expires_at ?? 0;
+      const nowSec = Math.floor(Date.now() / 1000);
+      if (expiresAt && expiresAt - nowSec < SESSION_EXPIRY_BUFFER_SEC) {
+        const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession();
+        if (refreshError && isRefreshTokenError(refreshError)) {
+          await this.handleSessionExpired(supabase);
+        }
+        if (refreshed?.session?.access_token) {
+          accessToken = refreshed.session.access_token;
+        }
+      }
+
       const headers = new Headers({
         'Content-Type': 'application/json',
         ...options.headers,
       });
 
-      headers.set('Authorization', `Bearer ${session!.access_token}`);
+      headers.set('Authorization', `Bearer ${accessToken}`);
 
       // Inclure le token CSRF pour les requêtes de mutation (POST, PUT, DELETE, PATCH)
       const method = options.method?.toUpperCase() || 'GET';
@@ -146,6 +184,14 @@ export class ApiClient {
         clearTimeout(timeoutId);
       }
 
+      // Les erreurs de session doivent remonter telles quelles : elles
+      // déclenchent déjà une redirection côté handleSessionExpired et ne
+      // doivent surtout pas être reformulées en timeout.
+      if (error instanceof SessionExpiredError) throw error;
+      if (isRefreshTokenError(error)) {
+        await this.handleSessionExpired(supabase);
+      }
+
       // Gérer les erreurs de timeout/abort
       if ((error as any).name === 'AbortError' || (error as Error).message?.includes('aborted')) {
         const timeoutError = new Error("Le chargement prend trop de temps. Veuillez réessayer.");
@@ -153,7 +199,7 @@ export class ApiClient {
         throw timeoutError;
       }
 
-      // Propager les autres erreurs (y compris les erreurs de session)
+      // Propager les autres erreurs
       throw error;
     }
   }

--- a/lib/middleware/subscription-check.ts
+++ b/lib/middleware/subscription-check.ts
@@ -28,6 +28,69 @@ import {
 
 export type LimitType = "properties" | "leases" | "users" | "documents_gb" | "signatures";
 
+// In-memory TTL cache for the subscription lookup. Bursts of gating calls
+// within the same request (or across concurrent requests from the same
+// user) otherwise re-hit Postgres for the same row. 3s TTL keeps the
+// staleness window acceptable for billing decisions (webhook writes will
+// be visible at the next cache miss).
+type CachedSubscription = {
+  data: any;
+  expiresAt: number;
+};
+const SUBSCRIPTION_CACHE_TTL_MS = 3000;
+const SUBSCRIPTION_CACHE_MAX_ENTRIES = 500;
+const subscriptionCache = new Map<string, CachedSubscription>();
+
+function pruneSubscriptionCache() {
+  if (subscriptionCache.size <= SUBSCRIPTION_CACHE_MAX_ENTRIES) return;
+  const now = Date.now();
+  for (const [key, value] of subscriptionCache) {
+    if (value.expiresAt <= now) subscriptionCache.delete(key);
+  }
+  // If still oversized, drop oldest entries (insertion order preserved by Map)
+  while (subscriptionCache.size > SUBSCRIPTION_CACHE_MAX_ENTRIES) {
+    const oldestKey = subscriptionCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    subscriptionCache.delete(oldestKey);
+  }
+}
+
+async function loadSubscription(ownerId: string): Promise<any> {
+  const now = Date.now();
+  const cached = subscriptionCache.get(ownerId);
+  if (cached && cached.expiresAt > now) {
+    return cached.data;
+  }
+  const { data, error } = await getServiceClient()
+    .from("subscriptions")
+    .select(`
+      *,
+      plan:subscription_plans!plan_id(*)
+    `)
+    .eq("owner_id", ownerId)
+    .maybeSingle();
+  if (error) {
+    // Ne pas cacher les erreurs — laisser l'appelant les gérer, et retenter
+    // au prochain passage.
+    throw error;
+  }
+  subscriptionCache.set(ownerId, {
+    data,
+    expiresAt: now + SUBSCRIPTION_CACHE_TTL_MS,
+  });
+  pruneSubscriptionCache();
+  return data;
+}
+
+/**
+ * Invalide le cache d'une subscription — à appeler après écriture
+ * (création, upgrade, annulation). Pas grave si omis : le cache s'auto-expire
+ * en SUBSCRIPTION_CACHE_TTL_MS.
+ */
+export function invalidateSubscriptionCache(ownerId: string): void {
+  subscriptionCache.delete(ownerId);
+}
+
 export interface LimitCheckResult {
   allowed: boolean;
   current: number;
@@ -55,31 +118,18 @@ export async function withSubscriptionLimit(
   const serviceClient = getServiceClient();
 
   try {
-    // Récupérer la subscription et le plan
-    const { data: subscription, error: subError } = await serviceClient
-      .from("subscriptions")
-      .select(`
-        *,
-        plan:subscription_plans!plan_id(*)
-      `)
-      .eq("owner_id", ownerId)
-      .maybeSingle();
-
-    // DEBUG: log pour tracer le bug "trialing traité comme gratuit"
-    if (subError) {
+    // Récupérer la subscription et le plan (cache TTL court — voir loadSubscription)
+    let subscription: any = null;
+    let subError: { code?: string; message?: string } | null = null;
+    try {
+      subscription = await loadSubscription(ownerId);
+    } catch (e: any) {
+      subError = { code: e?.code, message: e?.message };
       console.error(`[subscription-check] Query error for owner_id=${ownerId}:`, subError.code, subError.message);
     }
+
     if (!subscription && !subError) {
       console.warn(`[subscription-check] No subscription found for owner_id=${ownerId}, falling back to free plan`);
-      // Vérifier si le problème est un mismatch owner_id vs user_id
-      const { data: subByAny, error: debugError } = await serviceClient
-        .from("subscriptions")
-        .select("id, owner_id, plan_slug, status")
-        .limit(1)
-        .maybeSingle();
-      if (subByAny) {
-        console.warn(`[subscription-check] DEBUG: Found subscription ${subByAny.id} with owner_id=${subByAny.owner_id}, plan_slug=${subByAny.plan_slug}, status=${subByAny.status}`);
-      }
     }
 
     if (subError || !subscription) {
@@ -311,22 +361,16 @@ export async function withFeatureAccess(
   ownerId: string,
   feature: FeatureKey
 ): Promise<FeatureCheckResult> {
-  const serviceClient = getServiceClient();
-
   try {
-    // Seuls status + plan_slug (+ jointure slug en fallback) sont lus ici —
-    // éviter `*` réduit le payload et accélère le parse côté PostgREST.
-    const { data: subscription, error } = await serviceClient
-      .from("subscriptions")
-      .select(`
-        status,
-        plan_slug,
-        plan:subscription_plans!plan_id(slug)
-      `)
-      .eq("owner_id", ownerId)
-      .maybeSingle();
+    // Cache TTL partagé avec withSubscriptionLimit — voir loadSubscription
+    let subscription: any = null;
+    try {
+      subscription = await loadSubscription(ownerId);
+    } catch (e: any) {
+      console.error(`[subscription-check] Query error for owner_id=${ownerId}:`, e?.code, e?.message);
+    }
 
-    if (error || !subscription) {
+    if (!subscription) {
       const requiredPlan = getRequiredPlanForFeature(feature);
       return {
         allowed: false,

--- a/lib/middleware/subscription-check.ts
+++ b/lib/middleware/subscription-check.ts
@@ -314,12 +314,14 @@ export async function withFeatureAccess(
   const serviceClient = getServiceClient();
 
   try {
-    // Récupérer la subscription et le plan
+    // Seuls status + plan_slug (+ jointure slug en fallback) sont lus ici —
+    // éviter `*` réduit le payload et accélère le parse côté PostgREST.
     const { data: subscription, error } = await serviceClient
       .from("subscriptions")
       .select(`
-        *,
-        plan:subscription_plans!plan_id(*)
+        status,
+        plan_slug,
+        plan:subscription_plans!plan_id(slug)
       `)
       .eq("owner_id", ownerId)
       .maybeSingle();

--- a/supabase/migrations/20260423120000_drop_duplicate_subscriptions_owner_index.sql
+++ b/supabase/migrations/20260423120000_drop_duplicate_subscriptions_owner_index.sql
@@ -1,0 +1,13 @@
+-- Drop the duplicate index on subscriptions.owner_id.
+--
+-- Two equivalent indexes were created over time:
+--   - idx_subscriptions_owner      (2024-11-29 migration)
+--   - idx_subscriptions_owner_id   (2026-01 migration)
+--
+-- Both are plain btree indexes on (owner_id) with no partial filter and no
+-- differing opclass, so keeping both only costs extra writes on every
+-- INSERT/UPDATE of the subscriptions table without any read benefit.
+-- We keep the older one (`idx_subscriptions_owner`) since it predates the
+-- duplicate.
+
+DROP INDEX IF EXISTS idx_subscriptions_owner_id;


### PR DESCRIPTION
## Summary
This PR introduces an in-memory TTL cache for subscription lookups to reduce redundant database queries, optimizes several API endpoints to batch queries and reduce round-trips, and improves session handling in the API client with proactive token refresh.

## Key Changes

### Subscription Caching (`lib/middleware/subscription-check.ts`)
- Added a 3-second TTL in-memory cache for subscription lookups with a 500-entry limit
- Implemented `loadSubscription()` helper that checks cache before querying the database
- Exported `invalidateSubscriptionCache()` function for manual cache invalidation after writes
- Updated `withSubscriptionLimit()` and `withFeatureAccess()` to use the cached loader
- Removed debug queries that were attempting to diagnose owner_id mismatches

### API Endpoint Optimizations (`app/api/accounting/settings/route.ts`)
- **GET endpoint**: Consolidated ownership check into a single query by fetching `owner_profile_id` alongside settings, then validating in-memory
- **PATCH endpoint**: Folded ownership validation into the UPDATE query via `eq("owner_profile_id", profileId)` filter; only performs a follow-up lookup on failure to distinguish 404 vs 403
- Added performance timing instrumentation to both endpoints with warnings for slow requests (>1s)
- Removed the separate `assertEntityOwnership()` function in favor of inline ownership checks

### Accounting Backfill Optimization (`lib/accounting/backfill.ts`)
- Added `fetchAlreadyBookedReferences()` helper to bulk-fetch already-booked source IDs in chunks of 500
- Updated all four backfill functions (`backfillRentPayments`, `backfillDepositReceived`, `backfillDepositRefunded`, `backfillSubscriptions`) to use bulk idempotency checks instead of per-item probes
- Reduces ~6 round-trips per already-booked item on re-runs

### Session Management (`lib/api-client.ts`)
- Added `SessionExpiredError` class for explicit session expiry handling
- Implemented `isRefreshTokenError()` helper to detect refresh token failures
- Added proactive session refresh when access token is within 30 seconds of expiry, preventing in-flight requests from failing with 401
- Improved error handling to distinguish session errors from timeout errors

### Database Maintenance (`supabase/migrations/20260423120000_drop_duplicate_subscriptions_owner_index.sql`)
- Dropped duplicate `idx_subscriptions_owner_id` index on `subscriptions.owner_id`
- Kept the older `idx_subscriptions_owner` index to avoid unnecessary index churn

## Implementation Details
- The subscription cache uses a `Map` with insertion-order preservation for LRU-style eviction
- Cache pruning removes expired entries first, then drops oldest entries if still oversized
- Errors from subscription queries are not cached, allowing retries on the next request
- Performance timings are logged at development level and warned at production level for slow requests
- Bulk reference lookups gracefully fall back to per-item checks if the bulk query fails

https://claude.ai/code/session_012F5V5bMUyFeG3WwY45fnxn