### PR TITLE
Replace hardcoded 'system' user with resolved entity owner for accounting entries

### DIFF
--- a/app/api/accounting/backfill/route.ts
+++ b/app/api/accounting/backfill/route.ts
@@ -87,6 +87,7 @@ export async function POST(request: Request) {
     const result = await runEntityBackfill(serviceClient as any, entityId, {
       from: from ?? null,
       dryRun: dryRun ?? false,
+      userId: user.id,
     });
 
     return NextResponse.json({ success: true, data: result });

--- a/app/api/accounting/exercises/[exerciseId]/close/route.ts
+++ b/app/api/accounting/exercises/[exerciseId]/close/route.ts
@@ -83,7 +83,7 @@ export async function POST(
     // Step 2: Compute amortizations
     try {
       const { error: amortErr } = await supabase.functions.invoke("amortization-compute", {
-        body: { entityId, exerciseId, exerciseYear },
+        body: { entityId, exerciseId, exerciseYear, userId: user.id },
       });
       if (!amortErr) amortizationEntries = 1; // Simplified count
     } catch {

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1128,23 +1128,27 @@ export async function POST(request: NextRequest) {
                 if (config?.accountingEnabled) {
                   const exercise = await getOrCreateCurrentExercise(supabase, entityId);
                   if (exercise) {
-                    const tenantName = invoiceForEntity?.tenant
-                      ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
-                      : '';
-                    const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
+                    const { resolveSystemActorForEntity } = await import('@/lib/accounting/system-actor');
+                    const actorUserId = await resolveSystemActorForEntity(supabase, entityId);
+                    if (actorUserId) {
+                      const tenantName = invoiceForEntity?.tenant
+                        ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
+                        : '';
+                      const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
 
-                    const entry = await createAutoEntry(supabase, 'rent_received', {
-                      entityId,
-                      exerciseId: exercise.id,
-                      userId: 'system',
-                      amountCents: paymentIntent.amount, // already in cents from Stripe
-                      label: `Loyer ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
-                      date: new Date().toISOString().split('T')[0],
-                      reference: paymentIntent.id,
-                    });
+                      const entry = await createAutoEntry(supabase, 'rent_received', {
+                        entityId,
+                        exerciseId: exercise.id,
+                        userId: actorUserId,
+                        amountCents: paymentIntent.amount, // already in cents from Stripe
+                        label: `Loyer ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
+                        date: new Date().toISOString().split('T')[0],
+                        reference: paymentIntent.id,
+                      });
 
-                    if (shouldMarkInformational(config)) {
-                      await markEntryInformational(supabase, entry.id);
+                      if (shouldMarkInformational(config)) {
+                        await markEntryInformational(supabase, entry.id);
+                      }
                     }
                   }
                 }
@@ -1237,23 +1241,27 @@ export async function POST(request: NextRequest) {
               if (config?.accountingEnabled) {
                 const exercise = await getOrCreateCurrentExercise(supabase, entityId);
                 if (exercise) {
-                  const tenantName = invoiceForEntity?.tenant
-                    ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
-                    : '';
-                  const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
+                  const { resolveSystemActorForEntity } = await import('@/lib/accounting/system-actor');
+                  const actorUserId = await resolveSystemActorForEntity(supabase, entityId);
+                  if (actorUserId) {
+                    const tenantName = invoiceForEntity?.tenant
+                      ? `${invoiceForEntity.tenant.prenom || ''} ${invoiceForEntity.tenant.nom || ''}`.trim()
+                      : '';
+                    const propertyAddress = invoiceForEntity?.lease?.property?.adresse_complete || '';
 
-                  const entry = await createAutoEntry(supabase, 'sepa_rejected', {
-                    entityId,
-                    exerciseId: exercise.id,
-                    userId: 'system',
-                    amountCents: paymentIntent.amount,
-                    label: `Rejet prelevement ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
-                    date: new Date().toISOString().split('T')[0],
-                    reference: paymentIntent.id,
-                  });
+                    const entry = await createAutoEntry(supabase, 'sepa_rejected', {
+                      entityId,
+                      exerciseId: exercise.id,
+                      userId: actorUserId,
+                      amountCents: paymentIntent.amount,
+                      label: `Rejet prelevement ${tenantName}${tenantName && propertyAddress ? ' - ' : ''}${propertyAddress}`,
+                      date: new Date().toISOString().split('T')[0],
+                      reference: paymentIntent.id,
+                    });
 
-                  if (shouldMarkInformational(config)) {
-                    await markEntryInformational(supabase, entry.id);
+                    if (shouldMarkInformational(config)) {
+                      await markEntryInformational(supabase, entry.id);
+                    }
                   }
                 }
               }

--- a/features/providers/services/work-orders-extended.service.ts
+++ b/features/providers/services/work-orders-extended.service.ts
@@ -419,7 +419,6 @@ async function postWorkOrderAutoEntry(
     date: string;
     label: string;
     reference?: string;
-    userId: string;
     persistEntryIdOnWorkOrder?: boolean;
   },
 ): Promise<void> {
@@ -437,6 +436,7 @@ async function postWorkOrderAutoEntry(
     const { getOrCreateCurrentExercise } = await import('@/lib/accounting/auto-exercise');
     const { getEntityAccountingConfig, shouldMarkInformational, markEntryInformational } =
       await import('@/lib/accounting/entity-config');
+    const { resolveSystemActorForEntity } = await import('@/lib/accounting/system-actor');
 
     const config = await getEntityAccountingConfig(supabase, entityId);
     if (!config || !config.accountingEnabled) {
@@ -453,10 +453,20 @@ async function postWorkOrderAutoEntry(
       return;
     }
 
+    // accounting_entries.created_by is UUID NOT NULL REFERENCES auth.users(id).
+    // work_orders.owner_id is a profiles.id, not an auth.users.id, so we always
+    // resolve the entity owner's auth user id to avoid both UUID-syntax errors
+    // and FK violations.
+    const actorUserId = await resolveSystemActorForEntity(supabase, entityId);
+    if (!actorUserId) {
+      console.warn('[work-orders] Skipping auto-entry: no actor resolvable for entity', entityId);
+      return;
+    }
+
     const entry = await createAutoEntry(supabase, params.event, {
       entityId,
       exerciseId: exercise.id,
-      userId: params.userId,
+      userId: actorUserId,
       amountCents: params.amountCents,
       label: params.label,
       date: params.date,
@@ -514,7 +524,6 @@ export async function submitInvoice(
     date: new Date().toISOString().split('T')[0],
     label: `Facture prestataire - ${updatedWo.title ?? 'Work order'}`,
     reference: workOrderId,
-    userId: updatedWo.owner_id ?? 'system',
     persistEntryIdOnWorkOrder: true,
   });
 
@@ -555,7 +564,6 @@ export async function markAsPaid(
       date: new Date().toISOString().split('T')[0],
       label: `Paiement prestataire - ${updatedWo.title ?? 'Work order'}`,
       reference: workOrderId,
-      userId: updatedWo.owner_id ?? 'system',
     });
   }
 

--- a/lib/accounting/backfill.ts
+++ b/lib/accounting/backfill.ts
@@ -38,6 +38,12 @@ export interface BackfillOptions {
   from?: string | null;
   dryRun?: boolean;
   verbose?: boolean;
+  /**
+   * `auth.users.id` of the operator triggering the backfill — stamped onto
+   * every generated accounting entry as `created_by`. When omitted, each
+   * ensure* helper falls back to the entity owner's auth user id.
+   */
+  userId?: string;
 }
 
 const ERROR_MESSAGES_CAP = 20;
@@ -122,6 +128,7 @@ async function backfillRentPayments(
   supabase: SupabaseClient,
   entityId: string,
   from: string | null,
+  userId: string | undefined,
 ): Promise<BackfillStats> {
   const stats = newStats();
 
@@ -167,7 +174,7 @@ async function backfillRentPayments(
       stats.skipped++;
       continue;
     }
-    const result = await ensureReceiptAccountingEntry(supabase as any, p.id);
+    const result = await ensureReceiptAccountingEntry(supabase as any, p.id, { userId });
     recordResult(stats, result, { category: "rent", sourceId: p.id });
   }
   return stats;
@@ -177,6 +184,7 @@ async function backfillDepositReceived(
   supabase: SupabaseClient,
   entityId: string,
   from: string | null,
+  userId: string | undefined,
 ): Promise<BackfillStats> {
   const stats = newStats();
 
@@ -219,7 +227,7 @@ async function backfillDepositReceived(
       stats.skipped++;
       continue;
     }
-    const result = await ensureDepositReceivedEntry(supabase as any, m.id);
+    const result = await ensureDepositReceivedEntry(supabase as any, m.id, { userId });
     recordResult(stats, result, { category: "depositIn", sourceId: m.id });
   }
   return stats;
@@ -229,6 +237,7 @@ async function backfillDepositRefunded(
   supabase: SupabaseClient,
   entityId: string,
   from: string | null,
+  userId: string | undefined,
 ): Promise<BackfillStats> {
   const stats = newStats();
 
@@ -268,7 +277,7 @@ async function backfillDepositRefunded(
       stats.skipped++;
       continue;
     }
-    const result = await ensureDepositRefundedEntry(supabase as any, r.id);
+    const result = await ensureDepositRefundedEntry(supabase as any, r.id, { userId });
     recordResult(stats, result, { category: "depositOut", sourceId: r.id });
   }
   return stats;
@@ -278,6 +287,7 @@ async function backfillSubscriptions(
   supabase: SupabaseClient,
   entityId: string,
   from: string | null,
+  userId: string | undefined,
 ): Promise<BackfillStats> {
   const stats = newStats();
 
@@ -326,7 +336,7 @@ async function backfillSubscriptions(
       stats.skipped++;
       continue;
     }
-    const result = await ensureSubscriptionPaidEntry(supabase as any, inv.id);
+    const result = await ensureSubscriptionPaidEntry(supabase as any, inv.id, { userId });
     recordResult(stats, result, { category: "subscription", sourceId: inv.id });
   }
   return stats;
@@ -345,10 +355,11 @@ export async function runEntityBackfill(
     return runDryRun(supabase, entityId, from);
   }
 
-  const rent = await backfillRentPayments(supabase, entityId, from);
-  const depositIn = await backfillDepositReceived(supabase, entityId, from);
-  const depositOut = await backfillDepositRefunded(supabase, entityId, from);
-  const subscription = await backfillSubscriptions(supabase, entityId, from);
+  const userId = options.userId;
+  const rent = await backfillRentPayments(supabase, entityId, from, userId);
+  const depositIn = await backfillDepositReceived(supabase, entityId, from, userId);
+  const depositOut = await backfillDepositRefunded(supabase, entityId, from, userId);
+  const subscription = await backfillSubscriptions(supabase, entityId, from, userId);
 
   const totals = newStats();
   mergeInto(totals, rent);

--- a/lib/accounting/deposit-entry.ts
+++ b/lib/accounting/deposit-entry.ts
@@ -31,6 +31,7 @@ import {
   markEntryInformational,
   shouldMarkInformational,
 } from "@/lib/accounting/entity-config";
+import { resolveSystemActorForEntity } from "@/lib/accounting/system-actor";
 
 export type EnsureDepositSkipReason =
   | "already_exists"
@@ -189,10 +190,16 @@ export async function ensureDepositReceivedEntry(
       propertyAddress ? ` - ${propertyAddress}` : ""
     }`;
 
+    const actorUserId =
+      options.userId ?? (await resolveSystemActorForEntity(supabase, entityId));
+    if (!actorUserId) {
+      return { created: false, skippedReason: "error", error: "actor_unresolved" };
+    }
+
     const entry = await createAutoEntry(supabase, "deposit_received", {
       entityId,
       exerciseId: exercise.id,
-      userId: options.userId ?? "system",
+      userId: actorUserId,
       amountCents,
       label,
       date: entryDate,
@@ -300,10 +307,16 @@ export async function ensureDepositRefundedEntry(
     const primaryCents = refundCents > 0 ? refundCents : retainedCents;
     const secondaryCents = refundCents > 0 ? retainedCents : 0;
 
+    const actorUserId =
+      options.userId ?? (await resolveSystemActorForEntity(supabase, entityId));
+    if (!actorUserId) {
+      return { created: false, skippedReason: "error", error: "actor_unresolved" };
+    }
+
     const entry = await createAutoEntry(supabase, "deposit_returned", {
       entityId,
       exerciseId: exercise.id,
-      userId: options.userId ?? "system",
+      userId: actorUserId,
       amountCents: primaryCents,
       secondaryAmountCents: secondaryCents,
       label,

--- a/lib/accounting/receipt-entry.ts
+++ b/lib/accounting/receipt-entry.ts
@@ -23,6 +23,7 @@ import {
   markEntryInformational,
   shouldMarkInformational,
 } from "@/lib/accounting/entity-config";
+import { resolveSystemActorForEntity } from "@/lib/accounting/system-actor";
 
 export interface EnsureReceiptAccountingEntryResult {
   created: boolean;
@@ -164,10 +165,16 @@ export async function ensureReceiptAccountingEntry(
       propertyAddress ? ` - ${propertyAddress}` : ""
     }`.trim();
 
+    const actorUserId =
+      options.userId ?? (await resolveSystemActorForEntity(supabase, entityId));
+    if (!actorUserId) {
+      return { created: false, skippedReason: "error", error: "actor_unresolved" };
+    }
+
     const entry = await createAutoEntry(supabase, "rent_received", {
       entityId,
       exerciseId: exercise.id,
-      userId: options.userId ?? "system",
+      userId: actorUserId,
       amountCents,
       label,
       date: entryDate,

--- a/lib/accounting/subscription-entry.ts
+++ b/lib/accounting/subscription-entry.ts
@@ -27,6 +27,7 @@ import {
   markEntryInformational,
   shouldMarkInformational,
 } from "@/lib/accounting/entity-config";
+import { resolveSystemActorForEntity } from "@/lib/accounting/system-actor";
 
 export type EnsureSubscriptionSkipReason =
   | "already_exists"
@@ -160,10 +161,16 @@ export async function ensureSubscriptionPaidEntry(
       invoiceRow.paid_at?.split("T")[0] ??
       new Date().toISOString().split("T")[0];
 
+    const actorUserId =
+      options.userId ?? (await resolveSystemActorForEntity(supabase, entityId));
+    if (!actorUserId) {
+      return { created: false, skippedReason: "error", error: "actor_unresolved" };
+    }
+
     const entry = await createAutoEntry(supabase, "subscription_paid", {
       entityId,
       exerciseId: exercise.id,
-      userId: options.userId ?? "system",
+      userId: actorUserId,
       amountCents,
       label: "Abonnement Talok",
       date: entryDate,

--- a/lib/accounting/system-actor.ts
+++ b/lib/accounting/system-actor.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve a real `auth.users.id` UUID to use as the actor (`created_by`)
+ * when an automatic accounting entry is posted from a background context
+ * (Stripe webhook, cron, backfill without an explicit user).
+ *
+ * `accounting_entries.created_by` is `UUID NOT NULL REFERENCES auth.users(id)`,
+ * so passing a placeholder string like "system" causes
+ * `invalid input syntax for type uuid` and the insert is rejected.
+ *
+ * The owner of the legal entity is the right semantic actor: the entry is
+ * being booked into their books on their behalf.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function resolveSystemActorForEntity(
+  supabase: SupabaseClient,
+  entityId: string,
+): Promise<string | null> {
+  const { data: entity } = await (supabase as any)
+    .from("legal_entities")
+    .select("owner_profile_id")
+    .eq("id", entityId)
+    .maybeSingle();
+
+  const ownerProfileId = (entity as { owner_profile_id?: string } | null)?.owner_profile_id;
+  if (!ownerProfileId) return null;
+
+  const { data: profile } = await (supabase as any)
+    .from("profiles")
+    .select("user_id")
+    .eq("id", ownerProfileId)
+    .maybeSingle();
+
+  return (profile as { user_id?: string } | null)?.user_id ?? null;
+}

--- a/supabase/functions/amortization-compute/index.ts
+++ b/supabase/functions/amortization-compute/index.ts
@@ -35,7 +35,7 @@ serve(async (req: Request) => {
   }
 
   try {
-    const { entityId, exerciseId, exerciseYear } = await req.json();
+    const { entityId, exerciseId, exerciseYear, userId } = await req.json();
 
     if (!entityId || !exerciseId || !exerciseYear) {
       return new Response(
@@ -49,6 +49,33 @@ serve(async (req: Request) => {
       Deno.env.get("SUPABASE_URL")!,
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
+
+    // accounting_entries.created_by is UUID NOT NULL REFERENCES auth.users(id).
+    // Use the explicit caller userId, otherwise fall back to the entity owner's
+    // auth.users.id resolved via legal_entities.owner_profile_id -> profiles.user_id.
+    let actorUserId: string | null = userId ?? null;
+    if (!actorUserId) {
+      const { data: entity } = await supabase
+        .from("legal_entities")
+        .select("owner_profile_id")
+        .eq("id", entityId)
+        .maybeSingle();
+      const ownerProfileId = (entity as { owner_profile_id?: string } | null)?.owner_profile_id;
+      if (ownerProfileId) {
+        const { data: profile } = await supabase
+          .from("profiles")
+          .select("user_id")
+          .eq("id", ownerProfileId)
+          .maybeSingle();
+        actorUserId = (profile as { user_id?: string } | null)?.user_id ?? null;
+      }
+    }
+    if (!actorUserId) {
+      return new Response(
+        JSON.stringify({ error: "actor_unresolved" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
 
     // Fetch all active amortization schedules for entity
     const { data: schedules, error: schedError } = await supabase
@@ -180,7 +207,7 @@ serve(async (req: Request) => {
           label: `Dotation amortissement ${schedule.component} ${exerciseYear}`,
           source: "auto:amortization",
           is_validated: true,
-          created_by: "system",
+          created_by: actorUserId,
         })
         .select("id")
         .single();


### PR DESCRIPTION
## Summary
This PR replaces hardcoded `'system'` string placeholders with actual `auth.users.id` UUIDs when creating automatic accounting entries. The `accounting_entries.created_by` column has a `UUID NOT NULL` constraint with a foreign key to `auth.users(id)`, so passing the string `'system'` causes database errors. The solution resolves the entity owner's auth user ID to use as the actor for all system-generated entries.

## Key Changes

- **New utility module** (`lib/accounting/system-actor.ts`): Introduced `resolveSystemActorForEntity()` function that resolves a real `auth.users.id` by traversing `legal_entities.owner_profile_id` → `profiles.user_id`

- **Stripe webhook handler** (`app/api/webhooks/stripe/route.ts`): 
  - Updated rent received and SEPA rejection entry creation to resolve and use the entity owner's user ID instead of hardcoded `'system'`
  - Added null checks to skip entry creation if actor cannot be resolved

- **Backfill system** (`lib/accounting/backfill.ts`):
  - Added optional `userId` parameter to `BackfillOptions` interface
  - Threaded `userId` through all backfill helper functions (`backfillRentPayments`, `backfillDepositReceived`, `backfillDepositRefunded`, `backfillSubscriptions`)
  - Updated API endpoint to pass authenticated user's ID to backfill operation

- **Entry creation helpers** (`lib/accounting/receipt-entry.ts`, `lib/accounting/deposit-entry.ts`, `lib/accounting/subscription-entry.ts`):
  - Updated to resolve system actor when `userId` option is not provided
  - Added error handling for unresolvable actors

- **Work orders service** (`features/providers/services/work-orders-extended.service.ts`):
  - Removed `userId` parameter from `postWorkOrderAutoEntry()` call sites
  - Always resolve entity owner's auth user ID instead of using `work_orders.owner_id` (which is a `profiles.id`, not an `auth.users.id`)

- **Amortization compute function** (`supabase/functions/amortization-compute/index.ts`):
  - Added `userId` parameter to function signature
  - Implemented actor resolution logic with fallback to entity owner
  - Updated amortization entry creation to use resolved actor instead of `'system'`

- **Exercise close endpoint** (`app/api/accounting/exercises/[exerciseId]/close/route.ts`):
  - Passes authenticated user's ID to amortization compute function

## Implementation Details

The solution maintains backward compatibility by:
- Making `userId` optional in all backfill/entry creation functions
- Falling back to entity owner resolution when explicit `userId` is not provided
- Returning appropriate error states when actor cannot be resolved
- Preserving all existing entry creation logic and labels

https://claude.ai/code/session_01AfyG4jwJrtv5zmrvGYNSBn