### PR TITLE
Relax NOT NULL constraints on legacy accounting_entries columns

### DIFF
--- a/supabase/migrations/20260423130000_accounting_entries_relax_legacy_not_null.sql
+++ b/supabase/migrations/20260423130000_accounting_entries_relax_legacy_not_null.sql
@@ -1,0 +1,44 @@
+-- =====================================================
+-- MIGRATION: Relax legacy NOT NULL on accounting_entries
+-- Date: 2026-04-23
+--
+-- The initial migration 20260110000001_accounting_tables.sql created the
+-- agency-style accounting_entries schema, where each row was one side of a
+-- booking and carried its own compte/piece/ecriture_lib/ecriture_num inline.
+--
+-- The current double-entry engine (lib/accounting/engine.ts) and its auto
+-- bridges (receipt-entry, deposit-entry, subscription-entry) treat
+-- accounting_entries as the header row and push the account-level detail into
+-- accounting_entry_lines. They populate the new columns introduced by
+-- 20260407120000_accounting_reconcile_schemas.sql (entry_number, entry_date,
+-- label, ...) and leave the legacy columns unset.
+--
+-- That reconcile migration added the new columns but never relaxed the
+-- original NOT NULL constraints, so every engine-driven INSERT fails with:
+--   null value in column "ecriture_num" of relation "accounting_entries"
+--   violates not-null constraint
+--
+-- Reproduction: the "Lancer l'import historique" button in
+-- /owner/accounting/settings (POST /api/accounting/backfill) calls the
+-- ensure* helpers for rent payments, deposits received, deposit refunds and
+-- Talok subscription invoices; all of them fail with this error.
+--
+-- This migration drops NOT NULL on the legacy-only columns so both code paths
+-- can coexist. Legacy rows keep their values; engine-driven rows leave them
+-- NULL and expose their detail via accounting_entry_lines.
+-- =====================================================
+
+ALTER TABLE public.accounting_entries
+  ALTER COLUMN ecriture_num  DROP NOT NULL,
+  ALTER COLUMN ecriture_date DROP NOT NULL,
+  ALTER COLUMN compte_num    DROP NOT NULL,
+  ALTER COLUMN compte_lib    DROP NOT NULL,
+  ALTER COLUMN piece_ref     DROP NOT NULL,
+  ALTER COLUMN piece_date    DROP NOT NULL,
+  ALTER COLUMN ecriture_lib  DROP NOT NULL;
+
+COMMENT ON COLUMN public.accounting_entries.ecriture_num IS
+  'Legacy agency-style entry identifier. Nullable since 2026-04-23: the '
+  'double-entry engine uses entry_number and stores line detail in '
+  'accounting_entry_lines. Populated only for rows created by the legacy '
+  'agency bookkeeping path.';


### PR DESCRIPTION
## Summary
This migration relaxes NOT NULL constraints on legacy columns in the `accounting_entries` table to support the coexistence of two accounting code paths: the original agency-style bookkeeping and the new double-entry engine.

## Changes
- Dropped NOT NULL constraints from 7 legacy columns in `accounting_entries`:
  - `ecriture_num`
  - `ecriture_date`
  - `compte_num`
  - `compte_lib`
  - `piece_ref`
  - `piece_date`
  - `ecriture_lib`

- Updated the `ecriture_num` column comment to document that it's now nullable and explain the dual code path behavior

## Context
The double-entry accounting engine (`lib/accounting/engine.ts`) and its auto-bridge helpers treat `accounting_entries` as a header row and store account-level details in `accounting_entry_lines`. These engine-driven inserts populate the new columns introduced in migration `20260407120000_accounting_reconcile_schemas.sql` but leave the legacy columns unset.

The previous reconcile migration added new columns but failed to relax the original NOT NULL constraints, causing all engine-driven inserts to fail with constraint violations. This migration resolves that issue while preserving backward compatibility with the legacy agency-style bookkeeping path.

## Impact
- Fixes the "Lancer l'import historique" backfill operation in `/owner/accounting/settings`
- Enables the accounting backfill API endpoint (`POST /api/accounting/backfill`) to successfully process rent payments, deposits, refunds, and subscription invoices
- Legacy rows retain their values; engine-driven rows leave legacy columns NULL and expose detail via `accounting_entry_lines`

https://claude.ai/code/session_01VUcpMeqfUkgiJHzjTH481t