### PR TITLE
Support debit/credit aggregation from accounting entry lines

### DIFF
--- a/app/api/accounting/entries/route.ts
+++ b/app/api/accounting/entries/route.ts
@@ -147,26 +147,68 @@ export async function GET(request: Request) {
       throw new ApiError(500, "Erreur lors de la récupération des écritures");
     }
 
-    // Calculer les totaux
-    const totals = (entries || []).reduce<{ debit: number; credit: number }>(
-      (acc, e) => ({
-        debit: acc.debit + ((e.debit as number) || 0),
-        credit: acc.credit + ((e.credit as number) || 0),
-      }),
-      { debit: 0, credit: 0 }
-    );
+    // Engine-driven entries store debit/credit=0 at the header and the real
+    // amounts in accounting_entry_lines, while legacy rows keep amounts inline.
+    // Batch-fetch lines for the page and aggregate so each row carries a
+    // total_debit_cents / total_credit_cents the client can read uniformly
+    // (see EntryRow.getEntryDebitCents).
+    const entryRows = (entries ?? []) as Array<{
+      id: string;
+      debit?: number | null;
+      credit?: number | null;
+      total_debit_cents?: number;
+      total_credit_cents?: number;
+    }>;
+    const entryIds = entryRows.map((e) => e.id);
+    const lineSums = new Map<string, { debit: number; credit: number }>();
+    if (entryIds.length > 0) {
+      const { data: lines, error: linesError } = await serviceClient
+        .from("accounting_entry_lines")
+        .select("entry_id, debit_cents, credit_cents")
+        .in("entry_id", entryIds);
+      if (linesError) {
+        console.error("[Entries API] Erreur lignes:", linesError);
+      } else {
+        for (const line of (lines ?? []) as Array<{
+          entry_id: string;
+          debit_cents: number | null;
+          credit_cents: number | null;
+        }>) {
+          const sums = lineSums.get(line.entry_id) ?? { debit: 0, credit: 0 };
+          sums.debit += line.debit_cents ?? 0;
+          sums.credit += line.credit_cents ?? 0;
+          lineSums.set(line.entry_id, sums);
+        }
+      }
+    }
+
+    let totalDebitCents = 0;
+    let totalCreditCents = 0;
+    for (const row of entryRows) {
+      const sums = lineSums.get(row.id);
+      const debitCents = sums
+        ? sums.debit
+        : Math.round(((row.debit as number) ?? 0) * 100);
+      const creditCents = sums
+        ? sums.credit
+        : Math.round(((row.credit as number) ?? 0) * 100);
+      row.total_debit_cents = debitCents;
+      row.total_credit_cents = creditCents;
+      totalDebitCents += debitCents;
+      totalCreditCents += creditCents;
+    }
 
     return NextResponse.json({
       success: true,
-      data: entries || [],
+      data: entryRows,
       meta: {
         total: count || 0,
         limit,
         offset,
         totals: {
-          debit: Math.round(totals.debit * 100) / 100,
-          credit: Math.round(totals.credit * 100) / 100,
-          balance: Math.round((totals.debit - totals.credit) * 100) / 100,
+          debit: totalDebitCents / 100,
+          credit: totalCreditCents / 100,
+          balance: (totalDebitCents - totalCreditCents) / 100,
         },
       },
     });

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -162,7 +162,8 @@ export async function createEntry(
 
   const entryNumber = entryNumberData as string;
 
-  // Insert entry
+  // Mirror header fields into the legacy agency columns so the insert works even
+  // when 20260423130000_accounting_entries_relax_legacy_not_null hasn't run yet.
   const { data: entry, error: entryError } = await supabase
     .from('accounting_entries')
     .insert({
@@ -175,6 +176,13 @@ export async function createEntry(
       source: params.source ?? null,
       reference: params.reference ?? null,
       created_by: params.userId,
+      ecriture_num: entryNumber,
+      ecriture_date: params.entryDate,
+      ecriture_lib: params.label,
+      piece_ref: params.reference ?? entryNumber,
+      piece_date: params.entryDate,
+      compte_num: '',
+      compte_lib: '',
     })
     .select()
     .single();


### PR DESCRIPTION
## Summary
This PR updates the accounting entries API and engine to properly handle debit/credit amounts stored in the `accounting_entry_lines` table for engine-driven entries, while maintaining backward compatibility with legacy entries that store amounts inline.

## Key Changes

**API Route (`app/api/accounting/entries/route.ts`)**
- Batch-fetch `accounting_entry_lines` for all entries on the current page
- Aggregate debit/credit amounts from lines and store them as `total_debit_cents` and `total_credit_cents` on each entry row
- Fall back to inline debit/credit values for legacy entries that don't have associated lines
- Update total calculations to work with cent-based values for consistency
- Ensure clients can read amounts uniformly via the new `total_debit_cents` and `total_credit_cents` fields

**Engine (`lib/accounting/engine.ts`)**
- Mirror header fields into legacy agency columns (`ecriture_num`, `ecriture_date`, `ecriture_lib`, `piece_ref`, `piece_date`, `compte_num`, `compte_lib`) when creating entries
- This ensures the insert works even before the migration that relaxes legacy NOT NULL constraints is applied
- Add clarifying comment explaining the dual-write approach for backward compatibility

## Implementation Details
- The API now maintains a `Map` of entry IDs to aggregated line sums for efficient lookup
- Amounts are consistently handled in cents internally and converted to decimal format in the response
- The solution supports a gradual migration path where new entries use the lines table while old entries continue to work with inline amounts

https://claude.ai/code/session_01Dbk1b5NbUqut4R9KPgqwZ3