### PR TITLE
Fix RLS infinite recursion on documents ↔ profiles queries

### DIFF
--- a/lib/hooks/use-documents.ts
+++ b/lib/hooks/use-documents.ts
@@ -149,9 +149,11 @@ export function useDocuments(filters?: {
           if (!viewError && viewData) {
             allDocs = viewData as DocumentRow[];
             usedView = true;
+          } else if (viewError) {
+            console.warn("[useDocuments] v_tenant_accessible_documents failed, falling back:", viewError);
           }
-        } catch {
-          // View doesn't exist yet, fall through to legacy logic
+        } catch (e) {
+          console.warn("[useDocuments] v_tenant_accessible_documents threw, falling back:", e);
         }
 
         if (!usedView) {
@@ -256,9 +258,11 @@ export function useDocuments(filters?: {
           if (!viewError && viewData) {
             allDocs = viewData as DocumentRow[];
             usedView = true;
+          } else if (viewError) {
+            console.warn("[useDocuments] v_owner_accessible_documents failed, falling back:", viewError);
           }
-        } catch {
-          // View doesn't exist yet, fall through to legacy logic
+        } catch (e) {
+          console.warn("[useDocuments] v_owner_accessible_documents threw, falling back:", e);
         }
 
         if (!usedView) {
@@ -392,6 +396,7 @@ export function useDocuments(filters?: {
       return [];
     },
     enabled: !!profile,
+    retry: 1,
   });
 }
 

--- a/lib/hooks/use-ged-alerts.ts
+++ b/lib/hooks/use-ged-alerts.ts
@@ -59,7 +59,15 @@ export function useGedAlertsSummary() {
         )
         .order("valid_until", { ascending: true });
 
-      if (error) throw error;
+      if (error) {
+        console.error("[useGedAlertsSummary] documents query failed:", {
+          message: error.message,
+          code: error.code,
+          details: error.details,
+          hint: error.hint,
+        });
+        throw error;
+      }
 
       const now = new Date();
       now.setHours(0, 0, 0, 0);
@@ -113,6 +121,7 @@ export function useGedAlertsSummary() {
     enabled: !!profile && profile.role === "owner",
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
+    retry: 1,
   });
 }
 

--- a/lib/hooks/use-ged-documents.ts
+++ b/lib/hooks/use-ged-documents.ts
@@ -146,7 +146,15 @@ export function useGedDocuments(filters?: GedDocumentFilters) {
       }
 
       const { data, error } = await query;
-      if (error) throw error;
+      if (error) {
+        console.error("[useGedDocuments] documents query failed:", {
+          message: error.message,
+          code: error.code,
+          details: error.details,
+          hint: error.hint,
+        });
+        throw error;
+      }
 
       // Enrichir les documents avec les infos du référentiel
       const docs = (data || []).map((doc: Record<string, unknown>) => enrichDocument(doc));
@@ -175,6 +183,7 @@ export function useGedDocuments(filters?: GedDocumentFilters) {
     enabled: !!profile,
     staleTime: 2 * 60 * 1000,
     gcTime: 5 * 60 * 1000,
+    retry: 1,
   });
 }
 

--- a/supabase/migrations/20260423140000_fix_documents_profiles_rls_recursion.sql
+++ b/supabase/migrations/20260423140000_fix_documents_profiles_rls_recursion.sql
@@ -1,0 +1,240 @@
+-- =====================================================
+-- Migration: Fix 42P17 infinite recursion on documents <-> profiles RLS
+-- Date: 2026-04-23
+--
+-- CONTEXT:
+--   HTTP 500 returned by PostgREST when the client hooks useDocuments,
+--   useGedDocuments, useGedAlertsSummary query `documents` or
+--   `v_owner_accessible_documents` from /owner/documents. The server-side
+--   fetcher (app/owner/_data/fetchDocuments.ts) works around it by using
+--   the service role and avoiding joins, but the workaround was never
+--   ported to the RLS layer.
+--
+-- ROOT CAUSE — Cycle chain (diagnosed via pg_policies audit 2026-04-23):
+--
+--   (1) Client SELECT on documents
+--   (2) documents policy "Tenants can read visible lease documents" evaluates:
+--         EXISTS (SELECT 1 FROM lease_signers ls JOIN profiles p
+--                 ON p.id = ls.profile_id
+--                 WHERE ls.lease_id = documents.lease_id ...)
+--         EXISTS (SELECT 1 FROM properties p
+--                 WHERE p.id = documents.property_id AND p.owner_id = user_profile_id())
+--   (3) The JOIN on profiles triggers profiles RLS policies, including:
+--         "profiles_owner_read_tenants" (from 20260107150000)
+--           USING EXISTS (
+--             SELECT 1 FROM lease_signers ls
+--             JOIN leases l ON l.id = ls.lease_id
+--             JOIN properties p ON p.id = l.property_id
+--             WHERE ls.profile_id = profiles.id
+--               AND p.owner_id = get_my_profile_id()
+--           )
+--   (4) The SELECT on leases and properties triggers their RLS, which can
+--       circle back to documents (via other cross-table policies) or at
+--       minimum form a cycle detectable by PostgreSQL at plan time.
+--   (5) Postgres raises ERROR 42P17 "infinite recursion detected in policy"
+--       → Supabase returns HTTP 500.
+--
+-- Note: Using get_my_profile_id() / user_profile_id() (both SECURITY DEFINER)
+--   avoids recursion on the `profiles` table itself but NOT on the joined
+--   tables in the USING sub-SELECT. The planner sees the full cross-table
+--   dependency graph and refuses to plan.
+--
+-- FIX — same pattern used by 20260410213940, 20260415140000, 20260418130000:
+--   extract each inline EXISTS sub-SELECT into a SECURITY DEFINER helper.
+--   The helper runs with definer privileges, which bypasses RLS on the
+--   joined tables, breaking the cycle at the language level.
+--
+-- SEMANTICS PRESERVED:
+--   - Tenants still read docs where tenant_id = me AND visible_tenant != false
+--   - Tenants on a lease still read docs of that lease (visible_tenant = true)
+--   - Owners still read docs owned by them or attached to their properties
+--   - Admins still read all
+--   - Owners still read tenant profiles tied to their active leases
+--
+--   Only the *plan shape* changes (helpers instead of inline EXISTS).
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION + DROP POLICY IF EXISTS.
+-- =====================================================
+
+BEGIN;
+
+-- =====================================================
+-- 1. SECURITY DEFINER helpers
+-- =====================================================
+
+-- Helper: is the current auth user the owner of this property?
+CREATE OR REPLACE FUNCTION public.is_owner_of_property(p_property_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.properties
+    WHERE id = p_property_id
+      AND owner_id = public.user_profile_id()
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_owner_of_property(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_owner_of_property(uuid)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.is_owner_of_property(uuid) IS
+  'Returns true if the current authenticated user is the owner of the given '
+  'property. SECURITY DEFINER to bypass RLS on properties and avoid the '
+  'documents <-> properties <-> leases cycle in RLS policies.';
+
+
+-- Helper: is the current auth user a tenant signer on this lease?
+CREATE OR REPLACE FUNCTION public.is_tenant_signer_of_lease(p_lease_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.lease_signers
+    WHERE lease_id = p_lease_id
+      AND profile_id = public.user_profile_id()
+      AND role IN ('locataire_principal', 'locataire', 'colocataire')
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_tenant_signer_of_lease(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_tenant_signer_of_lease(uuid)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.is_tenant_signer_of_lease(uuid) IS
+  'Returns true if the current authenticated user is a tenant / principal / '
+  'colocataire signer on the given lease. SECURITY DEFINER to bypass RLS on '
+  'lease_signers and avoid recursion through profiles RLS.';
+
+
+-- Helper: is the given profile a tenant signer on any lease of a property I own?
+CREATE OR REPLACE FUNCTION public.is_tenant_of_my_property(p_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.lease_signers ls
+    JOIN public.leases l ON l.id = ls.lease_id
+    JOIN public.properties p ON p.id = l.property_id
+    WHERE ls.profile_id = p_profile_id
+      AND p.owner_id = public.user_profile_id()
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_tenant_of_my_property(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_tenant_of_my_property(uuid)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.is_tenant_of_my_property(uuid) IS
+  'Returns true if the given profile is a signer on any lease attached to a '
+  'property owned by the current authenticated user. SECURITY DEFINER to '
+  'bypass RLS on lease_signers / leases / properties and break the cycle '
+  'that made profiles_owner_read_tenants recurse into documents RLS.';
+
+
+-- =====================================================
+-- 2. Rewrite documents SELECT policy using helpers
+-- =====================================================
+
+DROP POLICY IF EXISTS "Tenants can read visible lease documents" ON public.documents;
+
+CREATE POLICY "Tenants can read visible lease documents"
+  ON public.documents FOR SELECT
+  USING (
+    -- Tenant direct match: respect visible_tenant
+    (tenant_id = public.user_profile_id() AND visible_tenant IS NOT FALSE)
+    -- Tenant via lease signer (SECURITY DEFINER helper, no cycle)
+    OR (
+      visible_tenant = true
+      AND lease_id IS NOT NULL
+      AND public.is_tenant_signer_of_lease(lease_id)
+    )
+    -- Owner direct match
+    OR owner_id = public.user_profile_id()
+    -- Owner via property (SECURITY DEFINER helper, no cycle)
+    OR (
+      property_id IS NOT NULL
+      AND public.is_owner_of_property(property_id)
+    )
+    -- Admin
+    OR public.user_role() = 'admin'
+  );
+
+COMMENT ON POLICY "Tenants can read visible lease documents" ON public.documents IS
+  'SOTA 2026-04-23: unified SELECT policy covering tenants (direct + lease '
+  'signer), owners (direct + property), and admin. Uses SECURITY DEFINER '
+  'helpers (is_tenant_signer_of_lease, is_owner_of_property) instead of '
+  'inline EXISTS to avoid the 42P17 recursion via profiles_owner_read_tenants.';
+
+
+-- =====================================================
+-- 3. Rewrite profiles_owner_read_tenants using helper
+-- =====================================================
+
+DROP POLICY IF EXISTS profiles_owner_read_tenants ON public.profiles;
+
+CREATE POLICY profiles_owner_read_tenants
+  ON public.profiles FOR SELECT
+  TO authenticated
+  USING (public.is_tenant_of_my_property(profiles.id));
+
+COMMENT ON POLICY profiles_owner_read_tenants ON public.profiles IS
+  'SOTA 2026-04-23: owners can read profiles of tenants attached to their '
+  'properties. Uses is_tenant_of_my_property() SECURITY DEFINER helper '
+  'instead of inline EXISTS on lease_signers/leases/properties — prevents '
+  'the cycle that caused 42P17 when documents RLS joined profiles.';
+
+
+-- =====================================================
+-- 4. Sanity check: no inline cross-table EXISTS left on documents/profiles
+--    (skip helper-based policies from our rewrite)
+-- =====================================================
+DO $$
+DECLARE
+  v_count INT;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename IN ('documents', 'profiles')
+    AND (
+      qual ILIKE '%JOIN profiles%'
+      OR qual ILIKE '%JOIN lease_signers%'
+      OR qual ILIKE '%JOIN leases%'
+      OR qual ILIKE '%FROM leases%'
+    )
+    -- Exclude helper-based policies (safe)
+    AND qual NOT ILIKE '%is_tenant_signer_of_lease%'
+    AND qual NOT ILIKE '%is_owner_of_property%'
+    AND qual NOT ILIKE '%is_tenant_of_my_property%'
+    AND qual NOT ILIKE '%tenant_accessible_%'
+    AND qual NOT ILIKE '%is_unit_accessible_%';
+
+  IF v_count > 0 THEN
+    RAISE WARNING
+      'Still % RLS policies on documents/profiles with inline cross-table '
+      'EXISTS — potential residual recursion. Audit pg_policies and port '
+      'them to SECURITY DEFINER helpers.', v_count;
+  ELSE
+    RAISE NOTICE 'OK: no inline cross-table EXISTS left on documents/profiles policies';
+  END IF;
+END $$;
+
+
+-- =====================================================
+-- 5. Reload PostgREST schema cache
+-- =====================================================
+NOTIFY pgrst, 'reload schema';
+NOTIFY pgrst, 'reload config';
+
+COMMIT;


### PR DESCRIPTION
## Summary
Fixes HTTP 500 errors (PostgreSQL error 42P17) caused by infinite recursion in RLS policies when querying documents or accessible document views. The root cause was a cycle between documents and profiles RLS policies that the query planner could not resolve.

## Root Cause
The documents RLS policy joined on profiles to check lease signers, which triggered the profiles RLS policy `profiles_owner_read_tenants`. That policy then joined on lease_signers → leases → properties, creating a circular dependency that PostgreSQL detected at plan time and rejected with error 42P17.

## Key Changes

**Database Migration (20260423140000)**
- Created three SECURITY DEFINER helper functions to break the RLS cycle:
  - `is_owner_of_property(uuid)` — checks property ownership without triggering properties RLS
  - `is_tenant_signer_of_lease(uuid)` — checks lease signer status without triggering lease_signers/leases RLS
  - `is_tenant_of_my_property(uuid)` — checks if a profile is a tenant of the owner's properties
- Rewrote the documents SELECT policy to use `is_tenant_signer_of_lease()` and `is_owner_of_property()` instead of inline EXISTS subqueries
- Rewrote the profiles `profiles_owner_read_tenants` policy to use `is_tenant_of_my_property()` instead of inline EXISTS
- Added sanity check to detect any remaining inline cross-table EXISTS in documents/profiles policies
- Notified PostgREST to reload schema cache

**Client-side improvements**
- Enhanced error logging in `useDocuments`, `useGedDocuments`, and `useGedAlertsSummary` hooks to capture and log query failures with full error details
- Added `retry: 1` configuration to all three hooks to allow a single retry on transient failures
- Improved fallback behavior with explicit console warnings when accessible document views fail

## Semantics Preserved
- Tenants still read documents where `tenant_id = me` and `visible_tenant ≠ false`
- Tenants on a lease still read documents of that lease (when `visible_tenant = true`)
- Owners still read documents owned by them or attached to their properties
- Admins still read all documents
- Owners still read tenant profiles tied to their active leases

Only the query plan shape changes (SECURITY DEFINER helpers instead of inline EXISTS), not the authorization logic.

https://claude.ai/code/session_013JCT1FAiNnvYTWdi6HWuam