### PR TITLE
Add owner role support and entry ownership scoping

### DIFF
--- a/app/api/accounting/entries/[id]/reverse/route.ts
+++ b/app/api/accounting/entries/[id]/reverse/route.ts
@@ -13,6 +13,7 @@ import { handleApiError, ApiError } from "@/lib/helpers/api-error";
 import { z } from "zod";
 import { requireAccountingAccess } from '@/lib/accounting/feature-gates';
 import { reverseEntry } from '@/lib/accounting/engine';
+import { isEntryOwnedByProfile } from '@/lib/accounting/entry-access';
 
 export const dynamic = "force-dynamic";
 
@@ -45,8 +46,8 @@ export async function POST(request: Request, context: Context) {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "admin") {
-      throw new ApiError(403, "Seuls les administrateurs peuvent extourner des écritures");
+    if (!profile || (profile.role !== "admin" && profile.role !== "owner")) {
+      throw new ApiError(403, "Non autorisé");
     }
 
     // Feature gate: check subscription plan
@@ -71,6 +72,13 @@ export async function POST(request: Request, context: Context) {
 
     if (fetchError || !original) {
       throw new ApiError(404, "Écriture non trouvée");
+    }
+
+    if (profile.role !== "admin") {
+      const ok = await isEntryOwnedByProfile(supabase, original, profile.id);
+      if (!ok) {
+        throw new ApiError(404, "Écriture non trouvée");
+      }
     }
 
     // ---------- New double-entry mode (entry has entity_id) ----------

--- a/app/api/accounting/entries/[id]/route.ts
+++ b/app/api/accounting/entries/[id]/route.ts
@@ -10,6 +10,7 @@ import { createClient } from "@/lib/supabase/server";
 import { handleApiError, ApiError } from "@/lib/helpers/api-error";
 import { z } from "zod";
 import { requireAccountingAccess } from '@/lib/accounting/feature-gates';
+import { isEntryOwnedByProfile } from '@/lib/accounting/entry-access';
 
 export const dynamic = "force-dynamic";
 
@@ -52,23 +53,27 @@ export async function GET(request: Request, context: Context) {
     const featureGate = await requireAccountingAccess(profile.id, 'entries');
     if (featureGate) return featureGate;
 
-    let query = supabase
+    const { data: entry, error } = await supabase
       .from("accounting_entries")
       .select(`
         *,
         invoice:invoices(id, periode, montant_total, statut),
         payment:payments(id, montant, statut, date_paiement)
       `)
-      .eq("id", id);
-
-    if (profile.role !== "admin") {
-      query = query.eq("owner_id", profile.id);
-    }
-
-    const { data: entry, error } = await query.single();
+      .eq("id", id)
+      .single();
 
     if (error || !entry) {
       throw new ApiError(404, "Écriture non trouvée");
+    }
+
+    // Ownership scoping for non-admin. Engine-posted entries carry entity_id
+    // (owner_id is NULL), legacy flat entries carry owner_id directly.
+    if (profile.role !== "admin") {
+      const ok = await isEntryOwnedByProfile(supabase, entry, profile.id);
+      if (!ok) {
+        throw new ApiError(404, "Écriture non trouvée");
+      }
     }
 
     return NextResponse.json({ success: true, data: entry });
@@ -97,8 +102,8 @@ export async function PUT(request: Request, context: Context) {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "admin") {
-      throw new ApiError(403, "Seuls les administrateurs peuvent modifier les écritures");
+    if (!profile || (profile.role !== "admin" && profile.role !== "owner")) {
+      throw new ApiError(403, "Non autorisé");
     }
 
     // Feature gate: check subscription plan
@@ -108,7 +113,7 @@ export async function PUT(request: Request, context: Context) {
     // Vérifier que l'écriture existe et n'est pas validée
     const { data: existing } = await supabase
       .from("accounting_entries")
-      .select("id, valid_date")
+      .select("id, valid_date, is_validated, entity_id, owner_id")
       .eq("id", id)
       .single();
 
@@ -116,7 +121,14 @@ export async function PUT(request: Request, context: Context) {
       throw new ApiError(404, "Écriture non trouvée");
     }
 
-    if (existing.valid_date) {
+    if (profile.role !== "admin") {
+      const ok = await isEntryOwnedByProfile(supabase, existing, profile.id);
+      if (!ok) {
+        throw new ApiError(404, "Écriture non trouvée");
+      }
+    }
+
+    if (existing.valid_date || existing.is_validated) {
       throw new ApiError(400, "Impossible de modifier une écriture validée");
     }
 
@@ -165,8 +177,8 @@ export async function DELETE(request: Request, context: Context) {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "admin") {
-      throw new ApiError(403, "Seuls les administrateurs peuvent supprimer les écritures");
+    if (!profile || (profile.role !== "admin" && profile.role !== "owner")) {
+      throw new ApiError(403, "Non autorisé");
     }
 
     // Feature gate: check subscription plan
@@ -176,7 +188,7 @@ export async function DELETE(request: Request, context: Context) {
     // Vérifier que l'écriture existe et n'est pas validée
     const { data: existing } = await supabase
       .from("accounting_entries")
-      .select("id, valid_date, ecriture_num")
+      .select("id, valid_date, is_validated, ecriture_num, entity_id, owner_id")
       .eq("id", id)
       .single();
 
@@ -184,7 +196,14 @@ export async function DELETE(request: Request, context: Context) {
       throw new ApiError(404, "Écriture non trouvée");
     }
 
-    if (existing.valid_date) {
+    if (profile.role !== "admin") {
+      const ok = await isEntryOwnedByProfile(supabase, existing, profile.id);
+      if (!ok) {
+        throw new ApiError(404, "Écriture non trouvée");
+      }
+    }
+
+    if (existing.valid_date || existing.is_validated) {
       throw new ApiError(400, "Impossible de supprimer une écriture validée. Utilisez une écriture d'extourne.");
     }
 

--- a/app/api/accounting/entries/route.ts
+++ b/app/api/accounting/entries/route.ts
@@ -265,8 +265,8 @@ export async function POST(request: Request) {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "admin") {
-      throw new ApiError(403, "Seuls les administrateurs peuvent créer des écritures");
+    if (!profile || (profile.role !== "admin" && profile.role !== "owner")) {
+      throw new ApiError(403, "Non autorisé");
     }
 
     // Feature gate: check subscription plan
@@ -284,6 +284,18 @@ export async function POST(request: Request) {
       }
 
       const data = validation.data;
+
+      if (profile.role !== "admin") {
+        const { data: entity } = await supabase
+          .from("legal_entities")
+          .select("id")
+          .eq("id", data.entity_id)
+          .eq("owner_profile_id", profile.id)
+          .maybeSingle();
+        if (!entity) {
+          throw new ApiError(403, "Accès refusé à cette entité");
+        }
+      }
 
       const entry = await createEntry(supabase, {
         entityId: data.entity_id,
@@ -309,6 +321,9 @@ export async function POST(request: Request) {
 
     const data = validation.data;
     const today = new Date().toISOString().split("T")[0];
+
+    // For non-admins, force owner_id = self so they cannot post to someone else.
+    const ownerId = profile.role === "admin" ? data.owner_id : profile.id;
 
     // Générer le numéro d'écriture
     const year = (data.ecriture_date || today).substring(0, 4);
@@ -343,7 +358,7 @@ export async function POST(request: Request) {
         ecriture_lib: data.ecriture_lib,
         debit: data.debit,
         credit: data.credit,
-        owner_id: data.owner_id,
+        owner_id: ownerId,
         property_id: data.property_id,
         invoice_id: data.invoice_id,
         payment_id: data.payment_id,

--- a/app/api/accounting/entries/validate/route.ts
+++ b/app/api/accounting/entries/validate/route.ts
@@ -39,8 +39,8 @@ export async function POST(request: Request) {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "admin") {
-      throw new ApiError(403, "Seuls les administrateurs peuvent valider les écritures");
+    if (!profile || (profile.role !== "admin" && profile.role !== "owner")) {
+      throw new ApiError(403, "Non autorisé");
     }
 
     // Feature gate: check subscription plan
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
     // Fetch all entries to determine which mode to use
     const { data: entries, error: fetchError } = await supabase
       .from("accounting_entries")
-      .select("id, ecriture_num, entry_number, valid_date, is_validated, journal_code, debit, credit, entity_id")
+      .select("id, ecriture_num, entry_number, valid_date, is_validated, journal_code, debit, credit, entity_id, owner_id")
       .in("id", entry_ids);
 
     if (fetchError) {
@@ -69,6 +69,31 @@ export async function POST(request: Request) {
 
     if (!entries || entries.length !== entry_ids.length) {
       throw new ApiError(400, "Certaines écritures n'existent pas");
+    }
+
+    // Ownership scoping for non-admin. Engine-posted entries have owner_id=NULL
+    // and scope via entity_id → legal_entities.owner_profile_id, while legacy
+    // flat entries scope via owner_id directly.
+    if (profile.role !== "admin") {
+      const entityIds = Array.from(
+        new Set(entries.map(e => e.entity_id).filter(Boolean) as string[]),
+      );
+      let ownedEntityIds = new Set<string>();
+      if (entityIds.length > 0) {
+        const { data: owned } = await supabase
+          .from("legal_entities")
+          .select("id")
+          .in("id", entityIds)
+          .eq("owner_profile_id", profile.id);
+        ownedEntityIds = new Set((owned ?? []).map(e => e.id as string));
+      }
+      const unauthorized = entries.filter(e => {
+        if (e.entity_id) return !ownedEntityIds.has(e.entity_id as string);
+        return e.owner_id !== profile.id;
+      });
+      if (unauthorized.length > 0) {
+        throw new ApiError(403, "Accès refusé à certaines écritures");
+      }
     }
 
     // Separate entries into double-entry (have entity_id) and legacy

--- a/lib/accounting/entry-access.ts
+++ b/lib/accounting/entry-access.ts
@@ -1,0 +1,23 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+interface EntryOwnership {
+  entity_id?: string | null;
+  owner_id?: string | null;
+}
+
+export async function isEntryOwnedByProfile(
+  supabase: SupabaseClient,
+  entry: EntryOwnership,
+  profileId: string,
+): Promise<boolean> {
+  if (entry.entity_id) {
+    const { data } = await supabase
+      .from('legal_entities')
+      .select('id')
+      .eq('id', entry.entity_id)
+      .eq('owner_profile_id', profileId)
+      .maybeSingle();
+    return !!data;
+  }
+  return entry.owner_id === profileId;
+}


### PR DESCRIPTION
## Summary
This PR extends accounting entry access control to support an "owner" role alongside the existing "admin" role, and implements proper ownership scoping for non-admin users. It introduces a new helper function to centralize ownership validation logic for entries that can be owned either directly (via `owner_id`) or through a legal entity (via `entity_id`).

## Key Changes

- **New ownership helper**: Created `lib/accounting/entry-access.ts` with `isEntryOwnedByProfile()` function that validates entry ownership by checking either direct `owner_id` or entity ownership via `legal_entities.owner_profile_id`

- **Role expansion**: Updated authorization checks across all accounting entry endpoints to allow both "admin" and "owner" roles:
  - GET `/entries/[id]` - retrieve entry
  - PUT `/entries/[id]` - update entry
  - DELETE `/entries/[id]` - delete entry
  - POST `/entries` - create entry
  - POST `/entries/validate` - validate entries
  - POST `/entries/[id]/reverse` - reverse entry

- **Ownership scoping for non-admins**:
  - GET: Added post-fetch ownership validation to prevent unauthorized access
  - PUT/DELETE: Added ownership checks before allowing modifications
  - POST (create): Added entity ownership validation for non-admins; forces `owner_id` to current profile to prevent posting to other owners
  - POST (validate): Added comprehensive ownership scoping that checks both entity-based and direct ownership across multiple entries
  - POST (reverse): Added ownership validation before allowing reversal

- **Validation improvements**: Updated `is_validated` field checks alongside existing `valid_date` checks to properly detect validated entries

- **Query optimization**: Refactored GET endpoint to fetch entry first, then validate ownership separately, improving code clarity

## Implementation Details

The ownership model supports two entry types:
- **Engine-posted entries**: Have `entity_id` set and `owner_id` NULL; ownership determined via `legal_entities.owner_profile_id`
- **Legacy flat entries**: Have `owner_id` set directly; ownership determined by direct comparison

Non-admin users are prevented from:
- Accessing entries they don't own
- Modifying/deleting validated entries
- Creating entries for entities they don't own
- Validating entries they don't own
- Reversing entries they don't own

https://claude.ai/code/session_011jTeRRZrdkzfibAvv9Qpq4