### PR TITLE
fix(onboarding): route phone OTP through Talok identity API

### DIFF
--- a/app/onboarding/phone/page.tsx
+++ b/app/onboarding/phone/page.tsx
@@ -14,7 +14,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/use-toast";
 import { Phone, ArrowRight, RefreshCw } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
 
 export default function OnboardingPhonePage() {
   const router = useRouter();
@@ -31,9 +30,15 @@ export default function OnboardingPhonePage() {
     if (!phone.trim()) return;
     setLoading(true);
     try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOtp({ phone });
-      if (error) throw error;
+      const res = await fetch("/api/identity/send-otp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || "Impossible d'envoyer le code.");
+      }
       setStep("verify");
       toast({
         title: "Code envoyé",
@@ -57,29 +62,14 @@ export default function OnboardingPhonePage() {
     if (!code.trim()) return;
     setLoading(true);
     try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.verifyOtp({
-        phone,
-        token: code,
-        type: "sms",
+      const res = await fetch("/api/identity/verify-otp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
       });
-      if (error) throw error;
-
-      // Mettre à jour le profil
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (user) {
-        await supabase
-          .from("profiles")
-          .update({
-            telephone: phone,
-            phone_verified: true,
-            phone_verified_at: new Date().toISOString(),
-            identity_status: "phone_verified",
-            onboarding_step: "phone_done",
-          })
-          .eq("user_id", user.id);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || "Le code saisi est incorrect.");
       }
 
       toast({


### PR DESCRIPTION
The phone verification page was calling supabase.auth.signInWithOtp
directly, bypassing the Talok OTP pipeline (Twilio Verify with FR
translations, rate limit, DROM-COM support, anti-duplicate phone
guard). When Supabase Phone Auth was misconfigured, the raw English
Twilio error (including the SID identifier) leaked to end users.

Switch to /api/identity/send-otp and /api/identity/verify-otp so the
flow uses Twilio Verify Service via Talok's own credentials, gets
translated user-facing errors, and benefits from the existing rate
limiter. The redundant client-side profile update is dropped because
verify-otp already writes phone_verified, phone_verified_at,
identity_status and onboarding_step server-side.

https://claude.ai/code/session_01JZDt3Q3wX3myMvteUeh8eg