### PR TITLE
fix(onboarding): repair phone OTP, defer phone gate, wire welcome email

### DIFF
--- a/app/agency/layout.tsx
+++ b/app/agency/layout.tsx
@@ -11,6 +11,7 @@ import { headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { getServerProfile } from "@/lib/helpers/auth-helper";
 import { checkIdentityGate } from "@/lib/helpers/identity-gate";
+import { PhoneVerificationBanner } from "@/components/identity/PhoneVerificationBanner";
 import { ErrorBoundary } from "@/components/error-boundary";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
 import { OfflineIndicator } from "@/components/ui/offline-indicator";
@@ -82,6 +83,7 @@ export default async function AgencyLayout({
   return (
     <ErrorBoundary>
       <CsrfTokenInjector />
+      <PhoneVerificationBanner identityStatus={profile.identity_status} pathname={pathname} />
       <OnboardingWrapper
         role={tourRole}
         profileId={profile.id}

--- a/app/api/identity/skip-phone/route.ts
+++ b/app/api/identity/skip-phone/route.ts
@@ -1,0 +1,59 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthenticatedUser } from '@/lib/helpers/auth-helper';
+import { createServiceRoleClient } from '@/lib/supabase/service-client';
+
+/**
+ * POST /api/identity/skip-phone
+ * Marque le profil comme `phone_skipped` pour autoriser l'accès au
+ * dashboard sans vérification SMS. Les actions sensibles (signature
+ * de bail, paiements) restent gardées par les niveaux d'identité
+ * supérieurs (document_uploaded, identity_verified).
+ */
+export async function POST(req: NextRequest) {
+  const { user, error } = await getAuthenticatedUser(req);
+  if (error || !user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
+  }
+
+  const serviceClient = createServiceRoleClient();
+
+  const { data: profile, error: profileError } = await serviceClient
+    .from('profiles')
+    .select('id, identity_status')
+    .eq('user_id', user.id)
+    .single();
+
+  if (profileError || !profile) {
+    return NextResponse.json({ error: 'Profil introuvable' }, { status: 404 });
+  }
+
+  // Idempotence : ne pas régresser un statut déjà supérieur.
+  if (
+    profile.identity_status === 'phone_verified' ||
+    profile.identity_status === 'document_uploaded' ||
+    profile.identity_status === 'identity_review' ||
+    profile.identity_status === 'identity_verified'
+  ) {
+    return NextResponse.json({ success: true, alreadyVerified: true });
+  }
+
+  const { error: updateError } = await (serviceClient as any)
+    .from('profiles')
+    .update({
+      identity_status: 'phone_skipped',
+      onboarding_step: 'phone_pending',
+    })
+    .eq('id', profile.id);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: 'Impossible de différer la vérification.' },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -14,11 +14,14 @@ import {
   getPasswordResetCookieOptions,
   validatePasswordResetRequestForCallback,
 } from "@/lib/auth/password-recovery.service";
+import { sendWelcomeEmail } from "@/lib/services/email-service";
 
 interface ProfilePartial {
   id?: string;
   role?: string;
   onboarding_completed_at?: string | null;
+  prenom?: string | null;
+  nom?: string | null;
 }
 
 function isValidRole(role: string | undefined | null): role is PublicRole {
@@ -27,6 +30,23 @@ function isValidRole(role: string | undefined | null): role is PublicRole {
 
 function isSafeRelativePath(path: string | null | undefined): path is string {
   return !!path && path.startsWith("/") && !path.startsWith("//");
+}
+
+function fireWelcomeEmail(params: {
+  userEmail: string | null | undefined;
+  prenom: string | null | undefined;
+  role: PublicRole;
+}): void {
+  if (!params.userEmail) return;
+  const userName = (params.prenom || params.userEmail.split("@")[0] || "").trim();
+  // Idempotent côté Resend grâce à idempotencyKey: welcome/<email>.
+  sendWelcomeEmail({
+    userEmail: params.userEmail,
+    userName,
+    role: params.role,
+  }).catch((err) => {
+    console.error("[auth/callback] sendWelcomeEmail failed:", err);
+  });
 }
 
 export async function GET(request: Request) {
@@ -91,7 +111,7 @@ export async function GET(request: Request) {
     if (data.user && data.user.email_confirmed_at) {
       const { data: profile } = await supabase
         .from("profiles")
-        .select("id, role, onboarding_completed_at")
+        .select("id, role, onboarding_completed_at, prenom, nom")
         .eq("user_id", data.user.id)
         .maybeSingle();
 
@@ -115,6 +135,12 @@ export async function GET(request: Request) {
       if (!role) {
         return NextResponse.redirect(new URL("/signup/role", origin));
       }
+
+      fireWelcomeEmail({
+        userEmail: data.user.email,
+        prenom: profileData?.prenom ?? (data.user.user_metadata?.prenom as string | undefined),
+        role,
+      });
 
       if (profileData?.onboarding_completed_at) {
         return NextResponse.redirect(new URL(getRoleDashboardUrl(role), origin));
@@ -180,7 +206,7 @@ export async function GET(request: Request) {
       // Récupérer le profil pour obtenir le rôle et le statut d'onboarding
       const { data: profile } = await supabase
         .from("profiles")
-        .select("id, role, onboarding_completed_at")
+        .select("id, role, onboarding_completed_at, prenom, nom")
         .eq("user_id", data.user.id)
         .maybeSingle();
 
@@ -206,6 +232,12 @@ export async function GET(request: Request) {
       if (!role) {
         return NextResponse.redirect(new URL("/signup/role", origin));
       }
+
+      fireWelcomeEmail({
+        userEmail: data.user.email,
+        prenom: profileData?.prenom ?? (data.user.user_metadata?.prenom as string | undefined),
+        role,
+      });
 
       // Onboarding terminé → dashboard (ou redirect explicite)
       if (profileData?.onboarding_completed_at) {

--- a/app/auth/verify-email/page.tsx
+++ b/app/auth/verify-email/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-// @ts-nocheck
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -70,11 +69,12 @@ export default function VerifyEmailPage() {
       // Essayer d'envoyer l'email via le service
       try {
         await authService.resendConfirmationEmail(email);
-      } catch (serviceError: any) {
+      } catch (serviceError: unknown) {
+        const message = serviceError instanceof Error ? serviceError.message : "";
         // Si erreur de session, essayer directement avec Supabase
         if (
-          serviceError.message?.includes("session") ||
-          serviceError.message?.includes("Auth session missing")
+          message.includes("session") ||
+          message.includes("Auth session missing")
         ) {
           const supabase = (await import("@/lib/supabase/client")).createClient();
           const { getAuthCallbackUrl } = await import("@/lib/utils/redirect-url");
@@ -123,12 +123,13 @@ export default function VerifyEmailPage() {
           router.push("/dashboard");
           return;
         }
-      } catch (sessionError: any) {
+      } catch (sessionError: unknown) {
         // Pas de session active, c'est normal après la création du compte
         // L'utilisateur doit cliquer sur le lien dans l'email pour créer la session
+        const message = sessionError instanceof Error ? sessionError.message : "";
         if (
-          !sessionError.message?.includes("session") &&
-          !sessionError.message?.includes("Auth session missing")
+          !message.includes("session") &&
+          !message.includes("Auth session missing")
         ) {
           throw sessionError;
         }

--- a/app/guarantor/layout.tsx
+++ b/app/guarantor/layout.tsx
@@ -9,6 +9,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getServerProfile } from "@/lib/helpers/auth-helper";
 import { getRoleDashboardUrl } from "@/lib/helpers/role-redirects";
 import { checkIdentityGate } from "@/lib/helpers/identity-gate";
+import { PhoneVerificationBanner } from "@/components/identity/PhoneVerificationBanner";
 import { getSecondaryRoleManifest } from "@/lib/navigation/secondary-role-manifest";
 import { ErrorBoundary } from "@/components/error-boundary";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
@@ -61,6 +62,7 @@ export default async function GuarantorLayout({ children }: { children: ReactNod
   return (
     <ErrorBoundary>
       <CsrfTokenInjector />
+      <PhoneVerificationBanner identityStatus={profile.identity_status} pathname={pathname} />
       <OnboardingWrapper
         role="guarantor"
         profileId={profile.id}

--- a/app/onboarding/phone/page.tsx
+++ b/app/onboarding/phone/page.tsx
@@ -58,6 +58,34 @@ export default function OnboardingPhonePage() {
     }
   };
 
+  const handleSkip = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/identity/skip-phone", { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || "Impossible de différer la vérification.");
+      }
+      toast({
+        title: "Vérification différée",
+        description:
+          "Vous pourrez vérifier votre téléphone plus tard. Certaines actions (signature de bail, paiements) resteront indisponibles.",
+      });
+      router.push(from);
+    } catch (error: unknown) {
+      toast({
+        title: "Erreur",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Impossible de différer la vérification.",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleVerifyCode = async () => {
     if (!code.trim()) return;
     setLoading(true);
@@ -130,6 +158,14 @@ export default function OnboardingPhonePage() {
               )}
               Envoyer le code
             </Button>
+            <button
+              type="button"
+              onClick={handleSkip}
+              disabled={loading}
+              className="text-sm text-muted-foreground hover:text-foreground text-center block w-full disabled:opacity-50"
+            >
+              Vérifier plus tard
+            </button>
           </>
         ) : (
           <>

--- a/app/owner/layout.tsx
+++ b/app/owner/layout.tsx
@@ -14,6 +14,7 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { EntityProvider } from "@/providers/EntityProvider";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
 import { checkIdentityGate } from "@/lib/helpers/identity-gate";
+import { PhoneVerificationBanner } from "@/components/identity/PhoneVerificationBanner";
 
 /**
  * Layout Owner - Server Component
@@ -148,6 +149,7 @@ export default async function OwnerLayout({
     <ErrorBoundary>
       {/* Injection du token CSRF pour les mutations sécurisées */}
       <CsrfTokenInjector />
+      <PhoneVerificationBanner identityStatus={profile.identity_status} pathname={pathname} />
       <OwnerDataProvider
         properties={properties}
         dashboard={dashboard}

--- a/app/provider/layout.tsx
+++ b/app/provider/layout.tsx
@@ -7,6 +7,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getServerProfile } from "@/lib/helpers/auth-helper";
 import { getRoleDashboardUrl } from "@/lib/helpers/role-redirects";
 import { checkIdentityGate } from "@/lib/helpers/identity-gate";
+import { PhoneVerificationBanner } from "@/components/identity/PhoneVerificationBanner";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
 import { NotificationCenter } from "@/components/notifications/notification-center";
 import { ProviderBottomNav } from "@/components/layout/provider-bottom-nav";
@@ -61,6 +62,7 @@ export default async function VendorLayout({
   return (
     <ErrorBoundary>
       <CsrfTokenInjector />
+      <PhoneVerificationBanner identityStatus={profile.identity_status} pathname={pathname} />
       <OnboardingWrapper
         role="provider"
         profileId={profile.id}

--- a/app/syndic/layout.tsx
+++ b/app/syndic/layout.tsx
@@ -12,6 +12,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getServerProfile } from "@/lib/helpers/auth-helper";
 import { getRoleDashboardUrl } from "@/lib/helpers/role-redirects";
 import { checkIdentityGate } from "@/lib/helpers/identity-gate";
+import { PhoneVerificationBanner } from "@/components/identity/PhoneVerificationBanner";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { OfflineIndicator } from "@/components/ui/offline-indicator";
@@ -91,6 +92,7 @@ export default async function SyndicLayout({
   return (
     <ErrorBoundary>
       <CsrfTokenInjector />
+      <PhoneVerificationBanner identityStatus={profile.identity_status} pathname={pathname} />
       <SyndicOnboardingWrapper profileId={profile.id} userName={userName}>
       <div className="min-h-screen bg-gradient-to-br from-slate-50 via-cyan-50/30 to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/30">
         {/* Offline indicator - visible when device loses connectivity */}

--- a/app/tenant/layout.tsx
+++ b/app/tenant/layout.tsx
@@ -13,6 +13,7 @@ import { TenantAppLayout } from "@/components/layout/tenant-app-layout";
 import { ErrorBoundary } from "@/components/error-boundary";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
 import { checkIdentityGate } from "@/lib/helpers/identity-gate";
+import { PhoneVerificationBanner } from "@/components/identity/PhoneVerificationBanner";
 
 /**
  * Auto-link les lease_signers orphelins pour un locataire existant.
@@ -116,6 +117,7 @@ export default async function TenantLayout({
   return (
     <ErrorBoundary>
       <CsrfTokenInjector />
+      <PhoneVerificationBanner identityStatus={profile.identity_status} pathname={pathname} />
       <TenantDataProvider dashboard={dashboardData} profile={profile} error={dataError}>
         <TenantAppLayout profile={profile}>{children}</TenantAppLayout>
       </TenantDataProvider>

--- a/components/identity/PhoneVerificationBanner.tsx
+++ b/components/identity/PhoneVerificationBanner.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { Phone } from "lucide-react";
+
+interface PhoneVerificationBannerProps {
+  identityStatus: string | null | undefined;
+  pathname?: string;
+}
+
+/**
+ * Bannière persistante affichée aux utilisateurs ayant différé la
+ * vérification téléphone (`identity_status === 'phone_skipped'`).
+ * Renvoie null pour tout autre statut.
+ */
+export function PhoneVerificationBanner({
+  identityStatus,
+  pathname,
+}: PhoneVerificationBannerProps) {
+  if (identityStatus !== "phone_skipped") return null;
+
+  const target = pathname
+    ? `/onboarding/phone?from=${encodeURIComponent(pathname)}`
+    : "/onboarding/phone";
+
+  return (
+    <div className="border-b border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-100">
+      <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <Phone className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden />
+          <p className="text-sm">
+            <span className="font-medium">Téléphone non vérifié.</span>{" "}
+            La signature de baux et les paiements sont indisponibles tant que votre numéro n&apos;est pas confirmé.
+          </p>
+        </div>
+        <Link
+          href={target}
+          className="inline-flex items-center rounded-md bg-amber-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+        >
+          Vérifier maintenant
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/onboarding/step-indicator.tsx
+++ b/components/onboarding/step-indicator.tsx
@@ -308,6 +308,8 @@ export const ONBOARDING_STEPS = {
     { id: "finance", label: "Finances", description: "Coordonnées bancaires" },
     { id: "property", label: "Bien", description: "Votre premier logement" },
     { id: "review", label: "Validation", description: "Vérification finale" },
+    { id: "invite", label: "Invitations", description: "Invitez vos locataires", optional: true },
+    { id: "automation", label: "Automatisation", description: "Activez les automatisations", optional: true },
   ],
   tenant: [
     { id: "context", label: "Contexte", description: "Type de location" },
@@ -342,6 +344,6 @@ export const ONBOARDING_STEPS = {
     { id: "team", label: "Équipe", description: "Vos collaborateurs" },
     { id: "review", label: "Validation", description: "Vérification finale" },
   ],
-} as Record<string, Array<{ id: string; label: string; description: string }>>;
+} as Record<string, Array<{ id: string; label: string; description: string; optional?: boolean }>>;
 
 export default StepIndicator;

--- a/lib/helpers/identity-gate.ts
+++ b/lib/helpers/identity-gate.ts
@@ -13,6 +13,7 @@ import { redirect } from "next/navigation";
 
 type IdentityStatus =
   | "unverified"
+  | "phone_skipped"
   | "phone_verified"
   | "document_uploaded"
   | "identity_review"
@@ -48,6 +49,7 @@ const ROUTE_GATES: RouteGate[] = [
 
 const STATUS_ORDER: IdentityStatus[] = [
   "unverified",
+  "phone_skipped",
   "phone_verified",
   "document_uploaded",
   "identity_review",
@@ -58,6 +60,9 @@ const STATUS_ORDER: IdentityStatus[] = [
 function meetsRequirement(current: IdentityStatus, required: RequiredLevel): boolean {
   if (current === "identity_rejected") return false;
   if (current === "identity_review" && required !== "identity_verified") return true;
+  // phone_skipped débloque uniquement les pages dashboard standard ;
+  // les actions sensibles (document_uploaded, identity_verified) restent gardées.
+  if (current === "phone_skipped") return required === "phone_verified";
   return STATUS_ORDER.indexOf(current) >= STATUS_ORDER.indexOf(required);
 }
 
@@ -65,6 +70,8 @@ function getRedirectPath(status: IdentityStatus, role?: string): string {
   // La page /onboarding/phone est mutualisée pour tous les rôles.
   // Elle lit le rôle du profil et propose le parcours approprié.
   if (status === "unverified") return "/onboarding/phone";
+  // phone_skipped accédant à une route qui exige plus → reprend la vérification.
+  if (status === "phone_skipped") return "/onboarding/phone";
   if (status === "phone_verified") {
     // Rediriger vers l'onboarding spécifique du rôle plutôt que /onboarding/profile
     if (role && ["owner", "tenant", "provider", "guarantor", "agency", "syndic"].includes(role)) {

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -193,7 +193,7 @@ export type ProfileRow = {
   login_count?: number
   onboarding_completed_at?: string | null
   onboarding_skipped_at?: string | null
-  identity_status?: 'unverified' | 'phone_verified' | 'document_uploaded' | 'identity_review' | 'identity_verified' | 'identity_rejected'
+  identity_status?: 'unverified' | 'phone_skipped' | 'phone_verified' | 'document_uploaded' | 'identity_review' | 'identity_verified' | 'identity_rejected'
   onboarding_step?: 'account_created' | 'phone_pending' | 'phone_done' | 'profile_pending' | 'profile_done' | 'document_pending' | 'document_done' | 'complete'
   identity_verified_at?: string | null
   phone_verified?: boolean

--- a/supabase/migrations/20260425120000_add_phone_skipped_status.sql
+++ b/supabase/migrations/20260425120000_add_phone_skipped_status.sql
@@ -1,0 +1,7 @@
+-- Migration: Ajout du statut 'phone_skipped' à identity_status_enum
+-- Permet à un utilisateur de différer la vérification téléphone tout en
+-- accédant aux pages standard du dashboard. Les actions sensibles
+-- (signature de bail, paiements, etc.) restent gardées par les niveaux
+-- supérieurs (document_uploaded, identity_verified).
+
+ALTER TYPE identity_status_enum ADD VALUE IF NOT EXISTS 'phone_skipped' BEFORE 'phone_verified';


### PR DESCRIPTION
## Contexte

Audit complet du flux d'inscription qui a remonté plusieurs problèmes en cascade. Trois commits regroupent les fixes ; deux actions hors-code restent à effectuer pour activer le tout en prod.

## Commits

| SHA | Sujet |
|-----|-------|
| `5729322` | OTP phone routé via les routes Talok (Twilio Verify) au lieu de `supabase.auth.signInWithOtp` direct |
| `aab569e` | Bouton "Vérifier plus tard" + bannière persistante + gate `phone_skipped` + migration SQL |
| `351c0d4` | Welcome email branché au callback + `ONBOARDING_STEPS.owner` complété + `@ts-nocheck` retiré |

## Changements détaillés

### 1. Phone OTP — fuite SID Twilio supprimée
- `app/onboarding/phone/page.tsx` n'appelle plus `supabase.auth.signInWithOtp({ phone })` (qui exposait l'erreur Twilio brute en anglais avec le SID), mais POSTe sur `/api/identity/send-otp` et `/api/identity/verify-otp`.
- Bénéfices : messages d'erreur traduits FR via `lib/sms/errors.ts`, rate-limit Talok, support DROM-COM, anti-doublons sur le numéro, plus aucune fuite d'identifiants Twilio côté client.

### 2. "Vérifier plus tard" — débloque l'accès quand SMS indisponible
- Nouveau statut `phone_skipped` dans `identity_status_enum` (migration `20260425120000_add_phone_skipped_status.sql`).
- `lib/helpers/identity-gate.ts` : `phone_skipped` satisfait le niveau `phone_verified` (accès dashboard) mais reste insuffisant pour `document_uploaded` et `identity_verified` (signature bail, paiements gardés).
- Nouvelle route `POST /api/identity/skip-phone`, idempotente (ne dégrade pas un profil déjà `phone_verified+`).
- Nouveau composant `components/identity/PhoneVerificationBanner.tsx` (Server Component) injecté dans les **6 layouts** (owner, tenant, provider, guarantor, syndic, agency). Bannière jaune avec CTA "Vérifier maintenant" tant que le profil reste `phone_skipped`.

### 3. Welcome email enfin envoyé
- `app/auth/callback/route.ts` appelle `sendWelcomeEmail({ userEmail, userName, role })` après confirmation, sur les **deux** branches (token_hash verifyOtp + PKCE exchangeCodeForSession).
- Idempotency Resend (`welcome/<email>`) garantit un seul envoi même si le callback est rejoué.
- Échec silencieux (`.catch` + `console.error`) : un email raté ne bloque jamais le redirect.

### 4. Progress bar owner cohérente
- `ONBOARDING_STEPS.owner` ne listait que 4 steps alors que `/owner/onboarding/` contient aussi `invite/` et `automation/`. Ajout des deux avec `optional: true`.

### 5. Type-safety verify-email
- `// @ts-nocheck` retiré de `app/auth/verify-email/page.tsx`.
- Catch handlers `serviceError`/`sessionError` passent de `any` à `unknown` avec narrow `instanceof Error`.

## Migrations DB

```sql
-- À exécuter en prod AVANT le merge (Supabase Dashboard → SQL Editor)
-- Ne PAS wrapper dans BEGIN/COMMIT, Postgres refuse ALTER TYPE en transaction.
ALTER TYPE identity_status_enum ADD VALUE 'phone_skipped' BEFORE 'phone_verified';
```

## Actions hors-code à effectuer

| # | Action | Où |
|---|--------|-----|
| A | Exécuter la migration ci-dessus | Supabase Dashboard → SQL Editor |
| B | Configurer `TWILIO_VERIFY_SERVICE_SID` (format `VA…`) | Netlify → Site settings → Environment variables |
| C | Confirmer `RESEND_API_KEY` et `NEXT_PUBLIC_APP_URL` | Netlify → Site settings → Environment variables |
| D | Coller le HTML brandé de `emailTemplates.emailConfirmation()` dans le template "Confirm signup" | Supabase Dashboard → Auth → Email Templates |
| E | Upgrade Twilio depuis trial OU activer la géo France dans Verify Service | Twilio Console |

## Test plan

- [ ] Migration SQL exécutée en prod et vérifiée via `SELECT unnest(enum_range(NULL::identity_status_enum));`
- [ ] Inscription owner end-to-end : signup → email Talok brandé reçu → clic lien → /signup/plan
- [ ] Inscription tenant : email reçu → clic → /tenant/onboarding/context
- [ ] Inscription pour les 6 rôles aboutit sur la bonne première étape d'onboarding
- [ ] `/onboarding/phone` : numéro DROM-COM → SMS reçu (post upgrade Twilio) → code valide → dashboard
- [ ] `/onboarding/phone` : bouton "Vérifier plus tard" → accès dashboard avec bannière jaune visible
- [ ] User `phone_skipped` essayant d'accéder à signature bail → redirigé vers `/onboarding/phone`
- [ ] Progress bar owner affiche bien 6 steps (4 obligatoires + 2 optionnels)
- [ ] Aucune fuite de SID Twilio dans l'UI sur erreur SMS
- [ ] Welcome email reçu une seule fois même si callback rejoué

## Risques & rollback

- **Migration enum** : non-réversible facilement (Postgres ne permet pas `DROP VALUE`). En cas de bug critique, code peut être revert sans toucher à l'enum (le statut `phone_skipped` resterait inutilisé en DB sans impact).
- **Identity gate** : changement central. Si bug, revert du commit `aab569e` suffit, pas besoin de toucher la DB.
- **Welcome email** : fire-and-forget, n'impacte jamais le flux user. Revert du commit `351c0d4` si besoin.

https://claude.ai/code/session_01JZDt3Q3wX3myMvteUeh8eg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZDt3Q3wX3myMvteUeh8eg)_