### PR TITLE
docs(tickets): clarify the dual /api/tickets vs /api/v1/tickets surface

### DIFF
--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -1,3 +1,22 @@
+/**
+ * /api/tickets/** — Famille **API interne UI**.
+ *
+ * Routes consommées par l'application Talok elle-même (UI propriétaire,
+ * locataire, prestataire, syndic) via `features/tickets/services/tickets.service.ts`
+ * et l'app router pages.
+ *
+ * Caractéristiques :
+ * - **Aucun feature gating de plan** : accessibles à tous les owners (gratuit → enterprise),
+ *   parce qu'on ne peut pas refuser à un owner Free de gérer ses propres tickets.
+ * - Auth cookie (Supabase session) requise.
+ * - Lecture/écriture via `getServiceClient()` (service-role) après vérification métier
+ *   explicite (creator / owner / assignee / admin) — voir commit 7518520 (PR #499).
+ *
+ * Pour exposer ces opérations en **API publique** (clients externes), utiliser
+ * la famille `/api/v1/tickets/**` qui ajoute `requireApiAccess` (Pro+ requis).
+ *
+ * Ne pas fusionner les deux familles tant que ce gating est intentionnel.
+ */
 export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 

--- a/app/api/v1/tickets/route.ts
+++ b/app/api/v1/tickets/route.ts
@@ -1,3 +1,22 @@
+/**
+ * /api/v1/tickets/** — Famille **API publique versionnée**.
+ *
+ * Surface destinée aux **clients externes** (intégrations tiers, scripts,
+ * webhooks Pro+). Activée par le forfait `api_access` :
+ * pro / enterprise_s / enterprise_m / enterprise_l / enterprise_xl.
+ *
+ * Caractéristiques :
+ * - Feature gating `requireApiAccess` sur les opérations de listing/création
+ *   (voir GET et POST ci-dessous) — un owner Free obtiendra 403 API_ACCESS_REQUIRED.
+ * - Les routes d'action (`[id]/assign`, `[id]/resolve`, `[id]/close`, etc.) ne
+ *   gatent pas, pour ne pas casser les workflows en cours quand un plan expire.
+ * - Format de réponse normalisé (`apiSuccess` / `apiError`).
+ * - Lecture via `createServiceRoleClient()` + check métier explicite
+ *   (creator / owner / assignee / admin) — voir commit 71907d5 (PR #499).
+ *
+ * Pour les appels **internes UI**, utiliser la famille `/api/tickets/**`
+ * (sans gating) via `features/tickets/services/tickets.service.ts`.
+ */
 export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 

--- a/features/tickets/services/tickets.service.ts
+++ b/features/tickets/services/tickets.service.ts
@@ -1,3 +1,18 @@
+/**
+ * `ticketsService` — Client typé pour la famille `/api/tickets/**`
+ * (API **interne UI**, sans feature gating de plan).
+ *
+ * Utilisé par l'application Talok elle-même : pages owner/tenant/provider/syndic,
+ * hooks React (`useTickets`), composants (`ticket-form`, `ticket-card`).
+ *
+ * **Ne pas migrer ces appels vers `/api/v1/tickets/**`** : la famille v1 ajoute
+ * un gating `requireApiAccess` qui retournerait 403 pour les owners en plan
+ * Free / Starter / Confort. Voir le commentaire d'en-tête dans
+ * `app/api/tickets/route.ts` pour la justification.
+ *
+ * Pour exposer ces opérations à des intégrations tiers (API publique), utiliser
+ * directement la famille v1 — elle existe pour cet usage.
+ */
 import { apiClient } from "@/lib/api-client";
 import type { Ticket, TicketStatus, TicketPriority, TicketCategory, TicketComment } from "@/lib/types";
 


### PR DESCRIPTION
## Summary
- Add a header doc on `/api/tickets/route.ts` explaining it's the **internal UI surface** (no plan gating)
- Add a header doc on `/api/v1/tickets/route.ts` explaining it's the **public API** (Pro+ gated via `requireApiAccess`)
- Add a header doc on `features/tickets/services/tickets.service.ts` warning not to migrate its calls to v1 (would silently 403 free-tier owners)

## Why
While auditing the tickets module (PR #499) I almost migrated `ticketsService` to call `/api/v1/tickets/...` to remove the duplication. That would have broken the dashboard for every owner on Free / Starter / Confort plans because the v1 routes gate listing/creation behind Pro+ (`requireApiAccess`). The split is intentional and load-bearing — the comments now make that clear so a future contributor (or Claude session) doesn't fall in the same trap.

## Test plan
- [ ] Pure documentation, no runtime change
- [ ] Type-check passes (no code touched)

https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH)_