### PR TITLE
feat(work-orders): Sprint A — switch paiements en mode ESCROW (30/70)

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1898,12 +1898,16 @@ export async function POST(request: NextRequest) {
 // ============================================================================
 // Work Order payment — handler dédié
 // ============================================================================
-// Déclenché quand un paiement Stripe (Connect) d'une intervention aboutit.
-// Le montant net est déjà routé vers le compte du prestataire par Stripe
-// (transfer_data.destination + application_fee). Ici on met à jour la
-// ligne work_order_payments, on fait avancer le work_order, et — si la
-// classification marque l'intervention comme récupérable — on injecte
-// automatiquement l'écriture dans charge_entries.
+// Déclenché quand un paiement Stripe Connect d'une intervention aboutit.
+//
+// Mode ESCROW (Separate charges and transfers) : la charge est encaissée sur
+// le compte plateforme Talok et y reste jusqu'à libération explicite. Ce
+// handler ne fait DONC PAS de Transfer vers le compte Connect du prestataire :
+// il se contente de marquer le paiement 'succeeded' / escrow 'held' et
+// d'avancer le statut WO. La libération (Transfer + déduction commission)
+// est gérée par la route /api/work-orders/[id]/release-transfer (Sprint B)
+// et le cron de libération automatique 7j après 'completed'.
+// ============================================================================
 
 async function handleWorkOrderPaymentSucceeded(
   supabase: any,
@@ -1926,18 +1930,22 @@ async function handleWorkOrderPaymentSucceeded(
     .eq("stripe_payment_intent_id", paymentIntent.id)
     .maybeSingle();
 
-  const transferId =
+  const chargeId =
     typeof paymentIntent.latest_charge === "string"
       ? paymentIntent.latest_charge
-      : (paymentIntent.latest_charge as any)?.transfer || null;
+      : (paymentIntent.latest_charge as any)?.id || null;
 
+  // Escrow held : fonds sur compte Talok, en attente de libération vers
+  // le compte Connect du prestataire (Sprint B).
+  const nowIso = new Date().toISOString();
   if (existing) {
     await supabase
       .from("work_order_payments")
       .update({
         status: "succeeded",
-        escrow_status: "released",
-        stripe_transfer_id: transferId,
+        escrow_status: "held",
+        stripe_charge_id: chargeId,
+        escrow_held_at: nowIso,
       })
       .eq("id", (existing as { id: string }).id);
   } else {
@@ -1947,9 +1955,10 @@ async function handleWorkOrderPaymentSucceeded(
       .from("work_order_payments")
       .update({
         status: "succeeded",
-        escrow_status: "released",
+        escrow_status: "held",
         stripe_payment_intent_id: paymentIntent.id,
-        stripe_transfer_id: transferId,
+        stripe_charge_id: chargeId,
+        escrow_held_at: nowIso,
       })
       .eq("work_order_id", workOrderId)
       .eq("payment_type", paymentType)
@@ -1959,6 +1968,9 @@ async function handleWorkOrderPaymentSucceeded(
   // Avancer le statut du work_order :
   //   'deposit' → deposit_paid
   //   'balance' ou 'full' → fully_paid
+  // Note : 'fully_paid' signifie ici "le proprio a tout payé", pas "les
+  // fonds sont arrivés chez le prestataire". Le transfer effectif dépend
+  // de la libération escrow (Sprint B).
   const nextStatut =
     paymentType === "deposit" ? "deposit_paid" : "fully_paid";
   await supabase
@@ -1967,9 +1979,9 @@ async function handleWorkOrderPaymentSucceeded(
     .eq("id", workOrderId);
 
   // Injection automatique dans charge_entries si is_tenant_chargeable=true
-  // (idempotent côté helper — safe à appeler même si le WO n'est pas
-  // complètement payé, il ne fera rien tant qu'aucun paiement n'est
-  // succeeded avec montant > 0).
+  // (idempotent côté helper). On le déclenche dès que le proprio a tout payé,
+  // même si l'escrow n'est pas encore libéré côté prestataire — la dépense
+  // est bien engagée pour le proprio.
   if (nextStatut === "fully_paid") {
     try {
       const { injectChargeEntryForWorkOrder } = await import(
@@ -2006,7 +2018,9 @@ async function handleWorkOrderPaymentSucceeded(
     /* non-blocking — just means the email won't carry the reference */
   }
 
-  // Outbox : notifier le prestataire que les fonds sont transférés
+  // Outbox : notifier le prestataire que le paiement est confirmé (mais
+  // les fonds sont encore en escrow, ils seront transférés au démarrage
+  // des travaux ou après le délai de contestation 7j).
   const payeeProfileId = paymentIntent.metadata?.payee_profile_id;
   if (payeeProfileId) {
     const { data: payeeProfile } = await supabase
@@ -2024,6 +2038,7 @@ async function handleWorkOrderPaymentSucceeded(
           work_order_id: workOrderId,
           payment_type: paymentType,
           amount_cents: paymentIntent.amount,
+          escrow_status: "held",
           ticket_reference: ticketReference,
           recipient_user_id: payeeUserId,
         },

--- a/app/api/work-orders/[id]/checkout-session/route.ts
+++ b/app/api/work-orders/[id]/checkout-session/route.ts
@@ -7,29 +7,73 @@ import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
 import { getServiceClient } from "@/lib/supabase/service-client";
 import { handleApiError, ApiError } from "@/lib/helpers/api-error";
 import { withSecurity } from "@/lib/api/with-security";
-import { stripe, formatAmountForStripe } from "@/lib/stripe";
+import { stripe } from "@/lib/stripe";
 
 /**
  * POST /api/work-orders/[id]/checkout-session
  *
- * Crée une Stripe Checkout Session pour payer l'intervention au prestataire.
- * Le propriétaire paie par CB (ou moyen configuré) via la page Stripe hébergée,
- * puis est redirigé vers success_url. Les side-effects (marquer le paiement
- * succeeded, avancer le work_order, injecter en charge récupérable) sont
- * déclenchés par le webhook Stripe (checkout.session.completed).
+ * Crée une Stripe Checkout Session pour qu'un propriétaire paie l'intervention
+ * d'un prestataire.
  *
- * Architecture : Stripe Connect — le montant net va sur le compte Connect
- * du prestataire, les frais plateforme restent sur le compte plateforme.
+ * Architecture : ESCROW via Separate charges and transfers (Stripe Connect).
+ *   1. Le proprio paie -> charge sur le compte plateforme Talok (PAS de
+ *      transfer_data.destination, donc PAS de routage immédiat).
+ *   2. Les fonds sont retenus sur le compte Talok (escrow_status = 'held').
+ *   3. La libération vers le compte Connect du prestataire (Transfer Stripe
+ *      avec déduction de la commission) est faite plus tard, à des moments
+ *      contrôlés par la plateforme :
+ *        - Acompte (30%) libéré quand le prestataire démarre l'intervention
+ *          (statut 'in_progress')
+ *        - Solde (70%) libéré après le délai de contestation 7j ou validation
+ *          explicite par le proprio.
+ *
+ * Cette logique de libération sera implémentée dans le Sprint B (route
+ * /release-transfer + cron de libération automatique).
  */
 const bodySchema = z.object({
   /** Par défaut 'full' — on paye la totalité en un coup. */
   payment_type: z.enum(["deposit", "balance", "full"]).default("full"),
-  /** Montant surchargé si fourni (cents). Sinon auto : basé sur quote ou split 2/3-1/3. */
+  /** Montant surchargé si fourni (cents). Sinon auto : basé sur quote ou split deposit/balance. */
   amount_cents: z.number().int().positive().optional(),
 });
 
-const PLATFORM_FEE_PCT = 0.01; // 1% — aligné payment_fee_config default
-const PLATFORM_FEE_FIXED_CENTS = 50; // 0,50 €
+interface FeeConfig {
+  stripe_percent: number;
+  stripe_fixed: number;
+  platform_percent: number;
+  platform_fixed: number;
+  deposit_percent: number;
+}
+
+const FEE_CONFIG_FALLBACK: FeeConfig = {
+  stripe_percent: 0.014,
+  stripe_fixed: 0.25,
+  platform_percent: 0.01,
+  platform_fixed: 0.5,
+  deposit_percent: 30,
+};
+
+async function loadFeeConfig(serviceClient: any): Promise<FeeConfig> {
+  const { data } = await serviceClient
+    .from("payment_fee_config")
+    .select(
+      "stripe_percent, stripe_fixed, platform_percent, platform_fixed, deposit_percent"
+    )
+    .eq("config_key", "default")
+    .eq("is_active", true)
+    .maybeSingle();
+
+  if (!data) return FEE_CONFIG_FALLBACK;
+
+  const row = data as Record<string, string | number | null>;
+  return {
+    stripe_percent: Number(row.stripe_percent ?? FEE_CONFIG_FALLBACK.stripe_percent),
+    stripe_fixed: Number(row.stripe_fixed ?? FEE_CONFIG_FALLBACK.stripe_fixed),
+    platform_percent: Number(row.platform_percent ?? FEE_CONFIG_FALLBACK.platform_percent),
+    platform_fixed: Number(row.platform_fixed ?? FEE_CONFIG_FALLBACK.platform_fixed),
+    deposit_percent: Number(row.deposit_percent ?? FEE_CONFIG_FALLBACK.deposit_percent),
+  };
+}
 
 export const POST = withSecurity(
   async function POST(
@@ -66,7 +110,7 @@ export const POST = withSecurity(
         nom: string | null;
       };
 
-      // 2. Work order + vérif accès + résolution provider Stripe Connect
+      // 2. Work order + vérif accès
       const { data: wo } = await serviceClient
         .from("work_orders")
         .select(
@@ -101,30 +145,43 @@ export const POST = withSecurity(
         throw new ApiError(409, "Aucun prestataire n'est assigné à cette intervention");
       }
 
-      // 3. Compte Stripe Connect du prestataire
-      const { data: payoutAccount } = await serviceClient
-        .from("provider_payout_accounts")
-        .select("stripe_account_id, stripe_account_status")
+      // 3. Vérifier que le prestataire a un compte Connect actif.
+      //    Note: en mode escrow on ne passe PAS transfer_data au Checkout
+      //    (charge sur compte Talok), mais il faut quand même que le compte
+      //    Connect soit prêt pour la future libération (Sprint B).
+      const { data: connectAccount } = await serviceClient
+        .from("stripe_connect_accounts")
+        .select("stripe_account_id, charges_enabled, payouts_enabled")
         .eq("profile_id", workOrder.provider_id)
+        .is("entity_id", null)
         .maybeSingle();
-      const payout = payoutAccount as
-        | { stripe_account_id: string; stripe_account_status: string }
+      const connect = connectAccount as
+        | {
+            stripe_account_id: string;
+            charges_enabled: boolean;
+            payouts_enabled: boolean;
+          }
         | null;
-      if (!payout?.stripe_account_id) {
+      if (!connect?.stripe_account_id) {
         throw new ApiError(
           409,
           "Le prestataire n'a pas encore configuré son compte de paiement"
         );
       }
-      if (payout.stripe_account_status !== "enabled") {
+      if (!connect.charges_enabled || !connect.payouts_enabled) {
         throw new ApiError(
           409,
-          "Le compte de paiement du prestataire n'est pas encore actif"
+          "Le compte de paiement du prestataire n'est pas encore actif (KYC en cours)"
         );
       }
 
-      // 4. Montant : soit surchargé, soit résolu depuis le devis accepté
+      // 4. Charger la config des frais
+      const feeConfig = await loadFeeConfig(serviceClient);
+      const depositRatio = feeConfig.deposit_percent / 100;
+
+      // 5. Montant : soit surchargé, soit résolu depuis le devis accepté
       let grossCents = amount_cents ?? 0;
+      let percentageOfTotal: number | null = null;
       if (grossCents === 0 && workOrder.accepted_quote_id) {
         const { data: quote } = await serviceClient
           .from("provider_quotes")
@@ -137,13 +194,23 @@ export const POST = withSecurity(
         if (quoteTotal > 0) {
           const fullCents = Math.round(quoteTotal * 100);
           if (payment_type === "deposit") {
-            grossCents = Math.round(fullCents * (2 / 3));
+            grossCents = Math.round(fullCents * depositRatio);
+            percentageOfTotal = feeConfig.deposit_percent;
           } else if (payment_type === "balance") {
-            grossCents = fullCents - Math.round(fullCents * (2 / 3));
+            grossCents = fullCents - Math.round(fullCents * depositRatio);
+            percentageOfTotal = 100 - feeConfig.deposit_percent;
           } else {
             grossCents = fullCents;
+            percentageOfTotal = 100;
           }
         }
+      } else if (grossCents > 0) {
+        percentageOfTotal =
+          payment_type === "deposit"
+            ? feeConfig.deposit_percent
+            : payment_type === "balance"
+              ? 100 - feeConfig.deposit_percent
+              : 100;
       }
       if (grossCents <= 0) {
         throw new ApiError(
@@ -152,18 +219,31 @@ export const POST = withSecurity(
         );
       }
 
-      // 5. Frais plateforme (à retenir sur le transfer vers le provider)
-      const applicationFeeCents =
-        Math.round(grossCents * PLATFORM_FEE_PCT) + PLATFORM_FEE_FIXED_CENTS;
+      // 6. Calcul des frais (à appliquer au moment du Transfer en Sprint B,
+      //    on les enregistre dès maintenant pour traçabilité).
+      //    Stripe : 1.4% + 0,25 € (incompressible, prélevé par Stripe sur
+      //              la charge plateforme à l'encaissement).
+      //    Plateforme : 1.0% + 0,50 € (commission Talok, déduite du transfer).
+      const stripeFeeCents =
+        Math.round(grossCents * feeConfig.stripe_percent) +
+        Math.round(feeConfig.stripe_fixed * 100);
+      const platformFeeCents =
+        Math.round(grossCents * feeConfig.platform_percent) +
+        Math.round(feeConfig.platform_fixed * 100);
+      const totalFeesCents = stripeFeeCents + platformFeeCents;
+      const netToProviderCents = grossCents - totalFeesCents;
 
-      // 6. URLs de retour
-      const appUrl =
-        process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
+      // 7. URLs de retour
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
       const successUrl = `${appUrl}/owner/tickets?wo_paid=${workOrder.id}`;
       const cancelUrl = `${appUrl}/owner/tickets?wo_cancel=${workOrder.id}`;
 
-      // 7. Création de la Checkout Session — Stripe Connect (destination charge)
+      // 8. Création de la Checkout Session — ESCROW MODE
+      //    Pas de transfer_data.destination -> charge encaissée sur le compte
+      //    plateforme Talok et y reste jusqu'à la libération manuelle/cron.
       const customerEmail = payerProfile.email ?? user.email ?? undefined;
+      const depositLabel = `Acompte (${feeConfig.deposit_percent.toFixed(0)}%)`;
+      const balanceLabel = `Solde (${(100 - feeConfig.deposit_percent).toFixed(0)}%)`;
       const session = await stripe.checkout.sessions.create({
         mode: "payment",
         payment_method_types: ["card"],
@@ -177,9 +257,9 @@ export const POST = withSecurity(
                 name: `Intervention : ${workOrder.title || "Prestation"}`,
                 description:
                   payment_type === "deposit"
-                    ? "Acompte (2/3)"
+                    ? depositLabel
                     : payment_type === "balance"
-                      ? "Solde (1/3)"
+                      ? balanceLabel
                       : "Paiement intégral",
               },
             },
@@ -187,10 +267,7 @@ export const POST = withSecurity(
           },
         ],
         payment_intent_data: {
-          application_fee_amount: applicationFeeCents,
-          transfer_data: {
-            destination: payout.stripe_account_id,
-          },
+          // Pas d'application_fee_amount ni transfer_data : escrow.
           metadata: {
             type: "work_order_payment",
             work_order_id: workOrder.id,
@@ -209,23 +286,26 @@ export const POST = withSecurity(
         cancel_url: cancelUrl,
       });
 
-      // 8. Insertion work_order_payments en 'pending' pour traçabilité
-      //    Le webhook passera status='succeeded' à réception.
+      // 9. Insertion work_order_payments en 'pending' pour traçabilité.
+      //    Le webhook passera status='succeeded' + escrow_status='held' à
+      //    réception (pas 'released' : la libération est différée).
       await serviceClient.from("work_order_payments").insert({
         work_order_id: workOrder.id,
         payment_type,
         payer_profile_id: payerProfile.id,
         payee_profile_id: workOrder.provider_id,
         gross_amount: formatAmountFromCents(grossCents),
-        platform_fee: formatAmountFromCents(applicationFeeCents),
-        stripe_fee: 0,
-        total_fees: formatAmountFromCents(applicationFeeCents),
-        net_amount: formatAmountFromCents(grossCents - applicationFeeCents),
+        percentage_of_total: percentageOfTotal,
+        stripe_fee: formatAmountFromCents(stripeFeeCents),
+        platform_fee: formatAmountFromCents(platformFeeCents),
+        total_fees: formatAmountFromCents(totalFeesCents),
+        net_amount: formatAmountFromCents(netToProviderCents),
         status: "pending",
         escrow_status: "pending",
         stripe_payment_intent_id: session.payment_intent as string | null,
         metadata: {
           checkout_session_id: session.id,
+          fee_config_snapshot: feeConfig,
         },
       } as any);
 

--- a/supabase/migrations/20260426120000_work_orders_escrow_30_70.sql
+++ b/supabase/migrations/20260426120000_work_orders_escrow_30_70.sql
@@ -1,0 +1,42 @@
+-- =====================================================
+-- Migration : Switch work_orders payments to ESCROW mode (30/70 split)
+-- Date : 2026-04-26
+--
+-- Contexte :
+--   La spec Talok (PR Stripe Connect WO) acte le passage en escrow via
+--   "Separate charges and transfers" Stripe Connect, avec un acompte 30%
+--   au lieu de 66.67% (modèle plus adapté aux interventions domestiques :
+--   moins de risque pour le proprio, plus pratique pour les petites
+--   interventions).
+--
+-- Changements :
+--   1. payment_fee_config.deposit_percent : 66.67 → 30.00 (default + ligne 'default')
+--   2. work_order_payments.percentage_of_total : commentaire mis à jour
+--      (pas de contrainte CHECK sur cette colonne, juste sémantique)
+--
+-- Backward compatibility :
+--   Aucun WO en cours n'utilisait le flux Stripe (PR Sprint A change le
+--   calcul côté code). Les WO historiques avec percentage_of_total=66.67
+--   restent inchangés (data préservée).
+-- =====================================================
+
+BEGIN;
+
+-- 1. Mettre à jour la valeur par défaut de deposit_percent
+ALTER TABLE public.payment_fee_config
+  ALTER COLUMN deposit_percent SET DEFAULT 30.00;
+
+-- 2. Mettre à jour la ligne 'default' existante pour appliquer le nouveau %
+--    aux nouveaux paiements créés après cette migration.
+UPDATE public.payment_fee_config
+   SET deposit_percent = 30.00,
+       updated_at = NOW()
+ WHERE config_key = 'default'
+   AND deposit_percent = 66.67;
+
+-- 3. Mettre à jour le commentaire sur percentage_of_total pour refléter
+--    le nouveau split.
+COMMENT ON COLUMN public.work_order_payments.percentage_of_total IS
+  'Pourcentage du total que représente ce paiement (30 pour acompte, 70 pour solde, 100 pour full).';
+
+COMMIT;


### PR DESCRIPTION
## Sprint A — Switch des paiements WO en mode ESCROW (30/70)

Première étape de l'alignement du flux de paiement des work orders avec la spec actée (escrow Stripe Connect). Les sprints suivants (B/C/D/E) viendront en PRs séparées.

## Spec rappelée

- **Acompte 30%** à la planification, **solde 70%** à la fin
- **Escrow** via "Separate charges and transfers" : charge sur compte plateforme Talok, libération différée vers compte Connect du prestataire
- **Connect Express** pour le KYC prestataire
- **Commission** 1% plateforme + 1.4% Stripe (déduite au transfer, pas au checkout)
- **Délai de contestation 7j** avant libération solde

## Changements

### 1. `app/api/work-orders/[id]/checkout-session/route.ts` — refacto majeure

**Mode ESCROW activé** : suppression de `transfer_data.destination` et `application_fee_amount` du `PaymentIntent`. Les fonds restent sur le compte plateforme Talok au lieu d'être routés vers le prestataire. La libération sera faite par la route `/release-transfer` du Sprint B.

**Split 30/70** au lieu de 66.67/33.33, lu depuis `payment_fee_config.deposit_percent`.

**Frais dynamiques** : Stripe 1.4% + 0.25€ et plateforme 1% + 0.50€ lus depuis `payment_fee_config` (avec fallback hardcodé). Snapshot persisté dans `work_order_payments.metadata.fee_config_snapshot`.

**Fix bug du gate** : passait par `provider_payout_accounts` (table obsolète) → utilise désormais `stripe_connect_accounts` avec `entity_id IS NULL` pour le compte personnel + check `charges_enabled` + `payouts_enabled`.

`percentage_of_total` calculé et persisté (30, 70 ou 100).

### 2. `app/api/webhooks/stripe/route.ts` — `handleWorkOrderPaymentSucceeded`

À réception : `escrow_status = 'held'` (au lieu de `'released'`). Les fonds sont confirmés sur Talok, **pas encore chez le prestataire**. Ajout `escrow_held_at = NOW()` et `stripe_charge_id` (le `stripe_transfer_id` reste NULL — il sera posé par la route `/release-transfer`).

Outbox prestataire mise à jour pour indiquer que les fonds sont en escrow (transfert différé).

Statut work_order toujours avancé (`deposit_paid` / `fully_paid`) car côté propriétaire le paiement est bien effectué.

### 3. Migration `20260426120000_work_orders_escrow_30_70.sql`

`payment_fee_config.deposit_percent` : 66.67 → 30.00 (default de colonne + UPDATE de la ligne `'default'`).

## Hors scope (sprints suivants)

- **Sprint B** : route `/release-transfer` + cron de libération 7j + webhooks `transfer.*`
- **Sprint C** : page UI prestataire `/provider/settings/payouts` + webhook `account.updated`
- **Sprint D** : refund + dispute UI propriétaire + webhooks `charge.refunded` / `charge.dispute.created`
- **Sprint E** : TVA auto-fill par localisation/age/type + facture PDF avec ventilation

## Risques connus

⚠️ **Régression fonctionnelle critique pour les paiements WO en cours de cycle** : tout paiement initié AVANT cette PR avec l'ancien mode (transfer_data immédiat) est inchangé côté Stripe, mais aucun nouveau paiement ne créera de transfer automatique. **Tant que le Sprint B n'est pas mergé, les fonds resteront sur le compte plateforme et le prestataire ne sera pas payé.** Si du trafic réel existe, attendre Sprint B avant de merger ce PR.

⚠️ **Données historiques** : les WO avec `percentage_of_total = 66.67` restent inchangés (data préservée), mais la sémantique évolue.

## Test plan

- [ ] Migration appliquée : `SELECT deposit_percent FROM payment_fee_config WHERE config_key='default';` retourne `30.00`
- [ ] POST `/api/work-orders/[id]/checkout-session` avec `payment_type: 'deposit'` génère une session avec montant = 30% du devis
- [ ] La Checkout Session ne contient PAS `transfer_data.destination`
- [ ] Après paiement test, `work_order_payments.escrow_status = 'held'` (pas `'released'`)
- [ ] `escrow_held_at` est renseigné
- [ ] `stripe_charge_id` est renseigné, `stripe_transfer_id` reste NULL
- [ ] Le statut WO passe à `deposit_paid` (pour deposit) ou `fully_paid` (pour balance/full)
- [ ] Prestataire sans compte Connect actif reçoit erreur 409 claire
- [ ] Si `payment_fee_config` row absente : fallback hardcodé fonctionne

https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J)_