### PR TITLE
fix(rls): close 3 critical paths from the cascade audit (work_orders + payments)

### DIFF
--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -2,6 +2,7 @@ export const runtime = "nodejs";
 export const dynamic = 'force-dynamic';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { z } from "zod";
@@ -65,8 +66,25 @@ export async function POST(request: Request) {
 
     const { invoiceId } = parseResult.data;
 
-    // Récupérer les détails de la facture et du bien
-    const { data: invoice, error: invoiceError } = await supabase
+    // Service-role pour la lecture : la RLS sur leases/properties cascadait
+    // silencieusement et faisait apparaître les factures du locataire comme
+    // "non trouvées" alors qu'il en était bien le tenant_id légitime.
+    // La sécurité est garantie par le check explicite tenant_id ci-dessous.
+    // Voir docs/audits/rls-cascade-audit.md.
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+    }
+    const profileData = profile as { id: string; role: string };
+
+    const { data: invoice } = await serviceClient
       .from("invoices")
       .select(`
         *,
@@ -79,14 +97,24 @@ export async function POST(request: Request) {
         )
       `)
       .eq("id", invoiceId)
-      .eq("tenant_id", (await supabase.from("profiles").select("id").eq("user_id", user.id).single()).data?.id as string)
-      .single();
+      .maybeSingle();
 
-    if (invoiceError || !invoice) {
-      return NextResponse.json({ error: "Facture non trouvée ou accès refusé" }, { status: 404 });
+    if (!invoice) {
+      return NextResponse.json({ error: "Facture non trouvée" }, { status: 404 });
     }
 
-    if (invoice.statut === "paid") {
+    const invoiceData = invoice as Record<string, unknown> & {
+      tenant_id?: string | null;
+      statut?: string | null;
+    };
+
+    const isAdmin = profileData.role === "admin";
+    const isTenant = invoiceData.tenant_id === profileData.id;
+    if (!isAdmin && !isTenant) {
+      return NextResponse.json({ error: "Accès non autorisé" }, { status: 403 });
+    }
+
+    if (invoiceData.statut === "paid") {
       return NextResponse.json({ error: "Cette facture est déjà payée" }, { status: 400 });
     }
 

--- a/app/api/v1/invoices/[iid]/payments/route.ts
+++ b/app/api/v1/invoices/[iid]/payments/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import {
   apiError,
   apiSuccess,
@@ -46,7 +46,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const auth = await requireAuth(request);
     if (auth instanceof Response) return auth;
 
-    const supabase = await createClient();
+    // Service-role pour la lecture : la cascade RLS invoices → leases →
+    // properties faisait disparaître les factures du locataire légitime
+    // (jointures !inner). Sécurité garantie par le check tenant_id /
+    // owner / admin ci-dessous. Voir docs/audits/rls-cascade-audit.md.
+    const supabase = getServiceClient();
 
     // Require idempotency key for payment operations
     const idempotencyKey = request.headers.get("Idempotency-Key");
@@ -63,25 +67,32 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       });
     }
 
-    // Get invoice
-    const { data: invoice, error: invoiceError } = await supabase
+    // Get invoice (no !inner: keep the row even if RLS would have stripped
+    // a child; the business check below validates access).
+    const { data: invoice } = await supabase
       .from("invoices")
       .select(`
         *,
-        leases!inner(
+        leases(
           id,
-          properties!inner(adresse_complete)
+          properties(adresse_complete, owner_id)
         )
       `)
       .eq("id", iid)
-      .single();
+      .maybeSingle();
 
-    if (invoiceError || !invoice) {
+    if (!invoice) {
       return apiError("Facture non trouvée", 404);
     }
 
-    // Check authorization (tenant can pay their own, owner can see)
-    if (auth.profile.role === "tenant" && invoice.tenant_id !== auth.profile.id) {
+    // Explicit business check: tenant of the invoice, owner of the
+    // underlying property, or admin.
+    const isAdmin = auth.profile.role === "admin";
+    const isTenant = invoice.tenant_id === auth.profile.id;
+    const isOwner =
+      invoice.leases?.properties?.owner_id === auth.profile.id;
+
+    if (!isAdmin && !isTenant && !isOwner) {
       return apiError("Accès non autorisé", 403);
     }
 

--- a/app/api/work-orders/[id]/route.ts
+++ b/app/api/work-orders/[id]/route.ts
@@ -1,109 +1,188 @@
 export const dynamic = "force-dynamic";
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
-import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
-import { getTypedSupabaseClient } from "@/lib/helpers/supabase-client";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { workOrderSchema } from "@/lib/validations";
 
 /**
- * @version 2026-01-22 - Fix: Next.js 15 params Promise pattern
+ * Charge le work_order + le contexte d'accès (ticket, property owner) en
+ * service-role, puis applique le check métier explicite.
+ *
+ * Le check RLS de Supabase ne suffit pas : tant qu'on appelle ces routes
+ * sans cookie utilisateur valide ou avec une RLS récursive, la table
+ * répondrait `null` sur le SELECT et l'ancien code retournait simplement
+ * 500 ou — pire — laissait passer toute row visible côté RLS sans
+ * vérifier que l'appelant en est vraiment provider/owner/admin.
+ *
+ * Pattern aligné avec PR #499 (tickets) et `docs/audits/rls-cascade-audit.md`.
  */
-export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+async function authorize(workOrderId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: NextResponse.json({ error: "Non authentifié" }, { status: 401 }) };
+
+  const serviceClient = getServiceClient();
+
+  const { data: profile } = await serviceClient
+    .from("profiles")
+    .select("id, role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!profile) {
+    return { error: NextResponse.json({ error: "Profil non trouvé" }, { status: 404 }) };
+  }
+  const profileData = profile as { id: string; role: string };
+
+  const { data: workOrder } = await serviceClient
+    .from("work_orders")
+    .select(
+      `
+        *,
+        ticket:tickets(
+          id,
+          owner_id,
+          created_by_profile_id,
+          assigned_to,
+          property:properties(owner_id)
+        )
+      `,
+    )
+    .eq("id", workOrderId)
+    .maybeSingle();
+
+  if (!workOrder) {
+    return { error: NextResponse.json({ error: "Work order non trouvé" }, { status: 404 }) };
+  }
+  const wo = workOrder as Record<string, unknown> & {
+    provider_id?: string | null;
+    ticket?: {
+      owner_id?: string | null;
+      created_by_profile_id?: string | null;
+      assigned_to?: string | null;
+      property?: { owner_id?: string | null } | null;
+    } | null;
+  };
+
+  const isAdmin = profileData.role === "admin";
+  const isProvider = wo.provider_id === profileData.id;
+  const isOwner =
+    wo.ticket?.property?.owner_id === profileData.id ||
+    wo.ticket?.owner_id === profileData.id;
+  const isCreator = wo.ticket?.created_by_profile_id === profileData.id;
+
+  return {
+    serviceClient,
+    user,
+    profile: profileData,
+    workOrder: wo,
+    isAdmin,
+    isProvider,
+    isOwner,
+    isCreator,
+  };
+}
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
-    const supabaseClient = getTypedSupabaseClient(supabase);
-    const {
-      data: { user },
-    } = await supabaseClient.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    const ctx = await authorize(id);
+    if ("error" in ctx) return ctx.error;
+
+    if (!ctx.isAdmin && !ctx.isProvider && !ctx.isOwner && !ctx.isCreator) {
+      return NextResponse.json({ error: "Accès non autorisé" }, { status: 403 });
     }
 
-    const { data: workOrder, error } = await supabaseClient
-      .from("work_orders")
-      .select("*")
-      .eq("id", id as any)
-      .single();
-
-    if (error) throw error;
-    return NextResponse.json({ workOrder });
+    return NextResponse.json({ workOrder: ctx.workOrder });
   } catch (error: unknown) {
-    return NextResponse.json({ error: error instanceof Error ? (error as Error).message : "Erreur serveur" }, { status: 500 });
+    console.error("[GET /work-orders/:id] Error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 },
+    );
   }
 }
 
 export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
-    const supabaseClient = getTypedSupabaseClient(supabase);
-    const {
-      data: { user },
-    } = await supabaseClient.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    const ctx = await authorize(id);
+    if ("error" in ctx) return ctx.error;
+
+    if (!ctx.isAdmin && !ctx.isProvider && !ctx.isOwner) {
+      return NextResponse.json({ error: "Accès non autorisé" }, { status: 403 });
     }
 
     const body = await request.json();
     const validated = workOrderSchema.partial().parse(body);
 
-    const { data: workOrder, error } = await supabaseClient
+    const { data: workOrder, error } = await ctx.serviceClient
       .from("work_orders")
-      .update(validated as any)
-      .eq("id", id as any)
+      .update(validated as Record<string, unknown>)
+      .eq("id", id)
       .select()
       .single();
 
     if (error) throw error;
 
-    // Si l'ordre de travail est terminé, mettre à jour le ticket
-    const validatedData = validated as any;
+    const validatedData = validated as { statut?: string };
     if (validatedData.statut === "done") {
-      const workOrderData = workOrder as any;
-      await supabaseClient
+      const updatedWo = workOrder as { id: string; ticket_id: string };
+      await ctx.serviceClient
         .from("tickets")
-        .update({ statut: "resolved" } as any)
-        .eq("id", workOrderData.ticket_id as any);
+        .update({ statut: "resolved" })
+        .eq("id", updatedWo.ticket_id);
 
-      // Émettre un événement
-      await supabaseClient.from("outbox").insert({
+      await ctx.serviceClient.from("outbox").insert({
         event_type: "Ticket.Done",
         payload: {
-          ticket_id: workOrderData.ticket_id,
-          work_order_id: workOrderData.id,
+          ticket_id: updatedWo.ticket_id,
+          work_order_id: updatedWo.id,
         },
-      } as any);
+      });
     }
 
     return NextResponse.json({ workOrder });
   } catch (error: unknown) {
-    if ((error as any).name === "ZodError") {
-      return NextResponse.json({ error: "Données invalides", details: (error as any).errors }, { status: 400 });
+    if ((error as { name?: string }).name === "ZodError") {
+      return NextResponse.json(
+        { error: "Données invalides", details: (error as { errors?: unknown }).errors },
+        { status: 400 },
+      );
     }
-    return NextResponse.json({ error: error instanceof Error ? (error as Error).message : "Erreur serveur" }, { status: 500 });
+    console.error("[PUT /work-orders/:id] Error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 },
+    );
   }
 }
 
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
-    const supabaseClient = getTypedSupabaseClient(supabase);
-    const {
-      data: { user },
-    } = await supabaseClient.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    const ctx = await authorize(id);
+    if ("error" in ctx) return ctx.error;
+
+    // Suppression : owner ou admin uniquement (pas le provider, qui a juste
+    // accepté/refusé/exécuté la mission).
+    if (!ctx.isAdmin && !ctx.isOwner) {
+      return NextResponse.json({ error: "Accès non autorisé" }, { status: 403 });
     }
 
-    const { error } = await supabaseClient.from("work_orders").delete().eq("id", id as any);
-
+    const { error } = await ctx.serviceClient.from("work_orders").delete().eq("id", id);
     if (error) throw error;
+
     return NextResponse.json({ success: true });
   } catch (error: unknown) {
-    return NextResponse.json({ error: error instanceof Error ? (error as Error).message : "Erreur serveur" }, { status: 500 });
+    console.error("[DELETE /work-orders/:id] Error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 },
+    );
   }
 }
-


### PR DESCRIPTION
## Summary
Phase 1 of the [RLS cascade audit](docs/audits/rls-cascade-audit.md) (merged in PR #501): close the three most dangerous routes.

| Route | Problem | Fix |
|---|---|---|
| `app/api/work-orders/[id]/route.ts` | **Zero business check** on GET/PUT/DELETE — relied on RLS only | Single `authorize()` helper, service-role read, explicit provider/owner/creator/admin matrix; DELETE restricted to owner/admin |
| `app/api/payments/checkout/route.ts` | RLS cascade `invoices → leases → properties` + inline nested `.single()` on profiles → tenants got "facture non trouvée" on legitimate invoices | Service-role read, explicit tenant_id/admin check |
| `app/api/v1/invoices/[iid]/payments/route.ts` | `leases!inner(properties!inner(...))` cascade dropped invoices when any RLS sub-tree blanked | Drop `!inner`, service-role, explicit tenant/owner/admin check |

## Why now
- The work_orders fix is a **security bug**, not just a bug — the GET handler returned any work_order to any authenticated caller as long as RLS happened to allow it.
- Both payment routes are on the Stripe path. Even with their `isLegacyTenantPaymentRouteEnabled()` gate currently off, the bug would resurface the moment the flag flips back on (and the same code shape is used in the canonical `create-intent` flow, which is the next thing to audit).

## Test plan
- [ ] `npx tsc --noEmit` — same error count as main (17), no regression introduced
- [ ] Smoke-test `GET /api/work-orders/[id]` as: provider assigned (200), other provider (403), owner of property (200), random tenant (403), admin (200)
- [ ] Once `isLegacyTenantPaymentRouteEnabled` is on in a preview env, smoke `POST /api/payments/checkout` for a tenant on their own invoice (200) and on someone else's (403)

## What's next
Phase 2 of the audit covers the leases module (18 routes, all the tenant-facing pay/terminate/deposit operations). That's the next PR.

https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH)_