### PR TITLE
feat(work-orders): Sprint B — libération escrow + cron 7j + webhooks transfer

### DIFF
--- a/app/api/cron/release-escrow/route.ts
+++ b/app/api/cron/release-escrow/route.ts
@@ -1,0 +1,126 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import {
+  releaseEscrowToProvider,
+  EscrowReleaseError,
+} from "@/lib/work-orders/release-escrow";
+
+/**
+ * GET /api/cron/release-escrow — libération automatique des soldes WO
+ *
+ * Quotidien (cron Netlify ou GitHub Actions). Pour chaque paiement
+ * work_order_payments avec :
+ *   - escrow_status = 'held'
+ *   - dispute_deadline IS NOT NULL AND dispute_deadline <= NOW()
+ *   - status = 'succeeded'
+ * on libère les fonds vers le compte Connect du prestataire (Stripe Transfer).
+ *
+ * Sécurité : Header Authorization: Bearer <CRON_SECRET>
+ *
+ * Idempotence : releaseEscrowToProvider() utilise une idempotencyKey Stripe
+ * et un UPDATE WHERE escrow_status='held', donc tout double appel est safe.
+ */
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+
+  const supabase = getServiceClient();
+  const startedAt = Date.now();
+
+  try {
+    // Sélection des paiements à libérer
+    const { data: candidates, error } = await (supabase as any)
+      .from("work_order_payments")
+      .select("id, work_order_id, payment_type, dispute_deadline")
+      .eq("escrow_status", "held")
+      .eq("status", "succeeded")
+      .not("dispute_deadline", "is", null)
+      .lte("dispute_deadline", new Date().toISOString())
+      .limit(100);
+
+    if (error) {
+      console.error("[cron/release-escrow] query error:", error);
+      return NextResponse.json(
+        { error: "Failed to query held payments", details: error.message },
+        { status: 500 },
+      );
+    }
+
+    const payments = (candidates || []) as Array<{
+      id: string;
+      work_order_id: string;
+      payment_type: string;
+      dispute_deadline: string;
+    }>;
+
+    if (payments.length === 0) {
+      return NextResponse.json({
+        released: 0,
+        errors: 0,
+        duration_ms: Date.now() - startedAt,
+      });
+    }
+
+    let releasedCount = 0;
+    const errors: Array<{ payment_id: string; error: string }> = [];
+
+    for (const p of payments) {
+      try {
+        await releaseEscrowToProvider(supabase, {
+          paymentId: p.id,
+          reason: "balance_release_on_deadline",
+        });
+        releasedCount++;
+
+        // Avancer le statut WO vers 'paid' si tout le reste est libéré
+        const { data: stillHeld } = await (supabase as any)
+          .from("work_order_payments")
+          .select("id")
+          .eq("work_order_id", p.work_order_id)
+          .eq("escrow_status", "held")
+          .limit(1);
+
+        if (!stillHeld || stillHeld.length === 0) {
+          await supabase
+            .from("work_orders")
+            .update({ statut: "paid", paid_at: new Date().toISOString() })
+            .eq("id", p.work_order_id);
+        }
+      } catch (err) {
+        const message =
+          err instanceof EscrowReleaseError
+            ? `${err.code}: ${err.message}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        errors.push({ payment_id: p.id, error: message });
+        console.error(
+          `[cron/release-escrow] Failed to release ${p.id}:`,
+          message,
+        );
+      }
+    }
+
+    return NextResponse.json({
+      released: releasedCount,
+      errors: errors.length,
+      error_details: errors,
+      duration_ms: Date.now() - startedAt,
+    });
+  } catch (err) {
+    console.error("[cron/release-escrow] fatal:", err);
+    return NextResponse.json(
+      {
+        error: "Cron fatal error",
+        details: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1691,7 +1691,25 @@ export async function POST(request: NextRequest) {
       case "transfer.created": {
         const transfer = event.data.object as Stripe.Transfer;
 
-        // Enregistrer le transfert en base
+        // Cas 1 : libération d'escrow work_order_payment.
+        // releaseEscrowToProvider() a déjà fait l'UPDATE synchrone, le
+        // webhook sert ici de filet de sécurité (idempotent).
+        if (transfer.metadata?.type === "work_order_escrow_release") {
+          const wopPaymentId = transfer.metadata?.payment_id;
+          if (wopPaymentId) {
+            await supabase
+              .from("work_order_payments")
+              .update({
+                stripe_transfer_id: transfer.id,
+                escrow_status: "released",
+                escrow_released_at: new Date().toISOString(),
+              })
+              .eq("id", wopPaymentId)
+              .neq("escrow_status", "released");
+          }
+        }
+
+        // Cas 2 (legacy) : transfert flux rent — enregistrer dans stripe_transfers
         const { data: connectAccount } = await supabase
           .from("stripe_connect_accounts")
           .select("id")
@@ -1747,17 +1765,49 @@ export async function POST(request: NextRequest) {
       }
 
       // ===============================================
-      // STRIPE CONNECT - TRANSFERT ÉCHOUÉ
+      // STRIPE CONNECT - TRANSFERT ÉCHOUÉ / REVERSED
       // ===============================================
-      case "transfer.failed" as any: {
+      case "transfer.failed" as any:
+      case "transfer.reversed" as any: {
         const transfer = (event as any).data.object as Stripe.Transfer;
 
-        // Mettre à jour le statut du transfert
+        // Cas 1 : libération escrow work_order qui a échoué — on revient
+        // à escrow_status='held' pour retry et on clear le stripe_transfer_id.
+        if (transfer.metadata?.type === "work_order_escrow_release") {
+          const wopPaymentId = transfer.metadata?.payment_id;
+          if (wopPaymentId) {
+            await supabase
+              .from("work_order_payments")
+              .update({
+                escrow_status: "held",
+                escrow_released_at: null,
+                stripe_transfer_id: null,
+                escrow_release_reason: `transfer_failed: ${event.type}`,
+              })
+              .eq("id", wopPaymentId);
+
+            // Outbox : alerter pour intervention humaine
+            await supabase.from("outbox").insert({
+              event_type: "WorkOrder.EscrowReleaseFailed",
+              payload: {
+                payment_id: wopPaymentId,
+                work_order_id: transfer.metadata?.work_order_id ?? null,
+                stripe_transfer_id: transfer.id,
+                stripe_event: event.type,
+              },
+            });
+          }
+        }
+
+        // Cas 2 (legacy) : transferts rent
         await supabase
           .from("stripe_transfers")
           .update({
-            status: "failed",
-            failure_reason: "Transfer failed",
+            status: event.type === "transfer.reversed" ? "reversed" : "failed",
+            failure_reason:
+              event.type === "transfer.reversed"
+                ? "Transfer reversed"
+                : "Transfer failed",
           })
           .eq("stripe_transfer_id", transfer.id);
 

--- a/app/api/work-orders/[id]/release-transfer/route.ts
+++ b/app/api/work-orders/[id]/release-transfer/route.ts
@@ -1,0 +1,176 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import {
+  releaseEscrowToProvider,
+  findHeldPayments,
+  EscrowReleaseError,
+} from "@/lib/work-orders/release-escrow";
+
+/**
+ * POST /api/work-orders/[id]/release-transfer
+ *
+ * Libère un (ou plusieurs) paiements escrow vers le compte Connect du
+ * prestataire, en créant un Stripe Transfer.
+ *
+ * Cas d'usage :
+ *   - Propriétaire valide explicitement après les travaux (raccourcit le
+ *     délai de contestation 7j)
+ *   - Admin support libère manuellement après résolution d'un litige
+ *   - Cron auto (réservé au cron via header autorisé, voir /api/cron/release-escrow)
+ *
+ * Body (optionnel) :
+ *   - payment_type: 'deposit' | 'balance' | 'full' — filtre quel paiement libérer.
+ *     Si absent, libère TOUS les paiements en escrow_status='held' du WO.
+ *
+ * Permissions :
+ *   - Owner du WO (via property_id)
+ *   - Admin
+ */
+const bodySchema = z.object({
+  payment_type: z.enum(["deposit", "balance", "full"]).optional(),
+});
+
+export const POST = withSecurity(
+  async function POST(
+    request: Request,
+    context: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: workOrderId } = await context.params;
+      const body = await request.json().catch(() => ({}));
+      const { payment_type } = bodySchema.parse(body);
+
+      const serviceClient = getServiceClient();
+
+      // 1. Profil + check permissions
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const profileRow = profile as { id: string; role: string };
+
+      // 2. Work order + check owner
+      const { data: wo } = await serviceClient
+        .from("work_orders")
+        .select("id, property_id, statut")
+        .eq("id", workOrderId)
+        .maybeSingle();
+      if (!wo) throw new ApiError(404, "Intervention introuvable");
+      const workOrder = wo as { id: string; property_id: string; statut: string | null };
+
+      if (profileRow.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", workOrder.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileRow.id) {
+          throw new ApiError(403, "Seul le propriétaire peut libérer ces fonds");
+        }
+      }
+
+      // 3. Déterminer la raison de libération selon le statut WO
+      // - 'fully_paid' + balance/full → validation explicite (raccourci 7j)
+      // - 'in_progress' + deposit → libération acompte au démarrage
+      // - sinon → manuelle
+      const reason =
+        payment_type === "deposit"
+          ? "deposit_release_on_start"
+          : payment_type === "balance" || payment_type === "full"
+            ? "balance_release_on_validation"
+            : workOrder.statut === "in_progress"
+              ? "deposit_release_on_start"
+              : "balance_release_on_validation";
+
+      // 4. Charger les paiements à libérer
+      const heldPayments = await findHeldPayments(
+        serviceClient,
+        workOrderId,
+        payment_type,
+      );
+
+      if (heldPayments.length === 0) {
+        return NextResponse.json({
+          released: [],
+          message: "Aucun paiement en escrow à libérer",
+        });
+      }
+
+      // 5. Libérer chaque paiement (séquentiel pour éviter les race conditions
+      // côté Stripe Transfer idempotency)
+      const released: Array<{
+        payment_id: string;
+        payment_type: string;
+        transfer_id: string;
+        net_amount_cents: number;
+      }> = [];
+      const errors: Array<{ payment_id: string; error: string }> = [];
+
+      for (const heldPayment of heldPayments) {
+        try {
+          const result = await releaseEscrowToProvider(serviceClient, {
+            paymentId: heldPayment.id,
+            reason,
+            releasedByProfileId: profileRow.id,
+          });
+          released.push({
+            payment_id: result.paymentId,
+            payment_type: heldPayment.payment_type,
+            transfer_id: result.transferId,
+            net_amount_cents: result.netAmountCents,
+          });
+        } catch (err) {
+          if (err instanceof EscrowReleaseError) {
+            errors.push({ payment_id: heldPayment.id, error: err.message });
+          } else {
+            errors.push({
+              payment_id: heldPayment.id,
+              error: err instanceof Error ? err.message : "Erreur inconnue",
+            });
+          }
+        }
+      }
+
+      // 6. Si tous les paiements sont libérés et que c'était un solde/full,
+      // avancer le statut WO vers 'paid' (les fonds sont bien chez le presta).
+      if (released.length > 0 && errors.length === 0) {
+        const releasedTypes = new Set(released.map((r) => r.payment_type));
+        if (releasedTypes.has("balance") || releasedTypes.has("full")) {
+          await serviceClient
+            .from("work_orders")
+            .update({ statut: "paid", paid_at: new Date().toISOString() })
+            .eq("id", workOrderId);
+        }
+      }
+
+      const status = errors.length > 0 ? 207 : 200; // 207 Multi-Status si partiel
+      return NextResponse.json(
+        {
+          released,
+          errors,
+        },
+        { status },
+      );
+    } catch (error) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "POST /api/work-orders/[id]/release-transfer",
+    csrf: true,
+  },
+);

--- a/app/owner/work-orders/[id]/page.tsx
+++ b/app/owner/work-orders/[id]/page.tsx
@@ -265,6 +265,19 @@ export default function WorkOrderDetailPage() {
                     Marquer comme paye
                   </Button>
                 )}
+                {/* Validation explicite : libère le solde en escrow sans
+                    attendre les 7 jours de délai de contestation */}
+                {(status === 'completed' || status === 'invoiced') && (
+                  <Button
+                    variant="outline"
+                    onClick={() => performAction('release-transfer', {})}
+                    disabled={actionLoading}
+                    title="Confirme la fin des travaux et libère immédiatement les fonds vers le prestataire (sans attendre le délai de 7 jours)."
+                  >
+                    <CreditCard className="h-4 w-4 mr-2" />
+                    Valider et libérer les fonds
+                  </Button>
+                )}
                 {!['paid', 'cancelled'].includes(status) && (
                   <Button
                     variant="outline"

--- a/features/providers/services/work-orders-extended.service.ts
+++ b/features/providers/services/work-orders-extended.service.ts
@@ -357,6 +357,13 @@ export async function startIntervention(
     .single();
 
   if (error) throw error;
+
+  // Escrow : libère automatiquement l'acompte vers le compte Connect du
+  // prestataire au démarrage des travaux. Fire-and-forget — un échec
+  // (compte Connect KO, charge_id manquant…) ne doit pas bloquer la
+  // transition de statut.
+  void releaseDepositOnStart(supabase, workOrderId);
+
   return data as WorkOrderExtended;
 }
 
@@ -384,7 +391,69 @@ export async function completeIntervention(
     .single();
 
   if (error) throw error;
+
+  // Escrow : à la complétion, on pose la dispute_deadline = now + 7j sur
+  // tous les paiements 'balance'/'full' encore en escrow_status='held'.
+  // Le cron /api/cron/release-escrow libérera ces fonds après la deadline
+  // si le proprio ne valide pas explicitement avant.
+  void setDisputeDeadlineOnComplete(supabase, workOrderId);
+
   return data as WorkOrderExtended;
+}
+
+/**
+ * Libère l'acompte (escrow) vers le compte Connect du prestataire au
+ * démarrage de l'intervention. Fire-and-forget : log mais ne throw pas.
+ */
+async function releaseDepositOnStart(
+  supabase: SupabaseClient,
+  workOrderId: string
+): Promise<void> {
+  try {
+    const { findHeldPayments, releaseEscrowToProvider } = await import(
+      '@/lib/work-orders/release-escrow'
+    );
+    const heldDeposits = await findHeldPayments(supabase, workOrderId, 'deposit');
+    for (const payment of heldDeposits) {
+      try {
+        await releaseEscrowToProvider(supabase, {
+          paymentId: payment.id,
+          reason: 'deposit_release_on_start',
+        });
+      } catch (err) {
+        console.error(
+          `[startIntervention] Escrow deposit release failed for payment ${payment.id}:`,
+          err
+        );
+      }
+    }
+  } catch (err) {
+    console.error('[startIntervention] releaseDepositOnStart fatal:', err);
+  }
+}
+
+/**
+ * Pose dispute_deadline = NOW() + 7 jours sur les paiements balance/full
+ * en escrow held. Idempotent : si déjà posée, ne touche pas.
+ */
+async function setDisputeDeadlineOnComplete(
+  supabase: SupabaseClient,
+  workOrderId: string
+): Promise<void> {
+  try {
+    const deadline = new Date();
+    deadline.setDate(deadline.getDate() + 7);
+
+    await (supabase as SupabaseClient)
+      .from('work_order_payments')
+      .update({ dispute_deadline: deadline.toISOString() })
+      .eq('work_order_id', workOrderId)
+      .eq('escrow_status', 'held')
+      .in('payment_type', ['balance', 'full'])
+      .is('dispute_deadline', null);
+  } catch (err) {
+    console.error('[completeIntervention] setDisputeDeadlineOnComplete failed:', err);
+  }
 }
 
 /**

--- a/lib/work-orders/release-escrow.ts
+++ b/lib/work-orders/release-escrow.ts
@@ -1,0 +1,238 @@
+/**
+ * Service de libération escrow pour les paiements de work orders.
+ *
+ * Mode ESCROW (Separate charges and transfers) :
+ *   1. Le proprio a payé via Checkout Session — la charge est sur le compte
+ *      plateforme Talok (work_order_payments.escrow_status='held').
+ *   2. À un moment contrôlé (démarrage des travaux pour l'acompte, validation
+ *      ou délai 7j pour le solde), on appelle releaseEscrowToProvider() qui :
+ *        - crée un Stripe Transfer vers le compte Connect du prestataire
+ *        - le montant transféré = net_amount (déjà calculé = gross - fees)
+ *        - les fees Stripe + plateforme restent sur le compte Talok
+ *      Cette commission Talok sera consolidée mensuellement par un cron
+ *      (Sprint à venir) qui crée une facture au prestataire.
+ *
+ * Concurrency / idempotence :
+ *   - Un Transfer Stripe est idempotent via idempotencyKey (work_order_payment_id)
+ *   - Le UPDATE RLS sur work_order_payments avec WHERE escrow_status='held'
+ *     empêche une double libération
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { stripe } from "@/lib/stripe";
+
+export type ReleaseReason =
+  | "deposit_release_on_start" // libération acompte au démarrage des travaux
+  | "balance_release_on_validation" // libération solde validation explicite proprio
+  | "balance_release_on_deadline" // libération solde après délai 7j
+  | "manual_admin_release"; // libération manuelle par admin
+
+export interface ReleaseEscrowOptions {
+  paymentId: string;
+  reason: ReleaseReason;
+  /** Profil qui déclenche la libération (NULL si cron auto). */
+  releasedByProfileId?: string | null;
+}
+
+export interface ReleaseEscrowResult {
+  paymentId: string;
+  transferId: string;
+  netAmountCents: number;
+  destinationAccount: string;
+}
+
+export class EscrowReleaseError extends Error {
+  constructor(
+    public readonly code:
+      | "PAYMENT_NOT_FOUND"
+      | "NOT_HELD"
+      | "NO_CONNECT_ACCOUNT"
+      | "NO_CHARGE_ID"
+      | "STRIPE_ERROR"
+      | "ZERO_AMOUNT",
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "EscrowReleaseError";
+  }
+}
+
+/**
+ * Libère un paiement escrow vers le compte Connect du prestataire.
+ * Idempotent côté Stripe via idempotencyKey = paymentId.
+ */
+export async function releaseEscrowToProvider(
+  supabase: SupabaseClient,
+  options: ReleaseEscrowOptions,
+): Promise<ReleaseEscrowResult> {
+  const { paymentId, reason, releasedByProfileId = null } = options;
+
+  // 1. Charger le paiement + work order + provider
+  const { data: payment, error: pErr } = await supabase
+    .from("work_order_payments")
+    .select(
+      "id, work_order_id, payee_profile_id, net_amount, gross_amount, escrow_status, stripe_charge_id, stripe_transfer_id, stripe_payment_intent_id",
+    )
+    .eq("id", paymentId)
+    .maybeSingle();
+
+  if (pErr || !payment) {
+    throw new EscrowReleaseError(
+      "PAYMENT_NOT_FOUND",
+      `Paiement ${paymentId} introuvable`,
+      pErr,
+    );
+  }
+
+  const p = payment as {
+    id: string;
+    work_order_id: string;
+    payee_profile_id: string;
+    net_amount: number | string;
+    gross_amount: number | string;
+    escrow_status: string;
+    stripe_charge_id: string | null;
+    stripe_transfer_id: string | null;
+    stripe_payment_intent_id: string | null;
+  };
+
+  // 2. Garde-fou : déjà libéré ?
+  if (p.stripe_transfer_id) {
+    return {
+      paymentId: p.id,
+      transferId: p.stripe_transfer_id,
+      netAmountCents: Math.round(Number(p.net_amount) * 100),
+      destinationAccount: "<already-released>",
+    };
+  }
+
+  if (p.escrow_status !== "held") {
+    throw new EscrowReleaseError(
+      "NOT_HELD",
+      `Paiement ${paymentId} en escrow_status='${p.escrow_status}', attendu 'held'`,
+    );
+  }
+
+  if (!p.stripe_charge_id) {
+    throw new EscrowReleaseError(
+      "NO_CHARGE_ID",
+      `Paiement ${paymentId} sans stripe_charge_id — impossible de transférer`,
+    );
+  }
+
+  // 3. Compte Connect du prestataire
+  const { data: connect } = await supabase
+    .from("stripe_connect_accounts")
+    .select("stripe_account_id, charges_enabled, payouts_enabled")
+    .eq("profile_id", p.payee_profile_id)
+    .is("entity_id", null)
+    .maybeSingle();
+
+  const c = connect as {
+    stripe_account_id: string | null;
+    charges_enabled: boolean | null;
+    payouts_enabled: boolean | null;
+  } | null;
+
+  if (!c?.stripe_account_id) {
+    throw new EscrowReleaseError(
+      "NO_CONNECT_ACCOUNT",
+      `Prestataire ${p.payee_profile_id} sans compte Stripe Connect`,
+    );
+  }
+  if (!c.payouts_enabled) {
+    throw new EscrowReleaseError(
+      "NO_CONNECT_ACCOUNT",
+      `Compte Connect du prestataire ${p.payee_profile_id} : payouts désactivés`,
+    );
+  }
+
+  // 4. Montant net en centimes (gross - tous les frais)
+  const netAmountCents = Math.round(Number(p.net_amount) * 100);
+  if (netAmountCents <= 0) {
+    throw new EscrowReleaseError(
+      "ZERO_AMOUNT",
+      `net_amount=${p.net_amount} pour le paiement ${paymentId}`,
+    );
+  }
+
+  // 5. Créer le Transfer Stripe (idempotent par paymentId)
+  let transfer;
+  try {
+    transfer = await stripe.transfers.create(
+      {
+        amount: netAmountCents,
+        currency: "eur",
+        destination: c.stripe_account_id,
+        // source_transaction lie ce transfer à la charge originale, ce qui
+        // permet à Stripe de débloquer le transfer même si la balance Talok
+        // est insuffisante (les fonds viennent directement de la charge).
+        source_transaction: p.stripe_charge_id,
+        metadata: {
+          type: "work_order_escrow_release",
+          work_order_id: p.work_order_id,
+          payment_id: p.id,
+          release_reason: reason,
+        },
+        description: `WO ${p.work_order_id} — escrow release (${reason})`,
+      },
+      {
+        idempotencyKey: `wo-escrow-release-${p.id}`,
+      },
+    );
+  } catch (err: unknown) {
+    throw new EscrowReleaseError(
+      "STRIPE_ERROR",
+      err instanceof Error ? err.message : "Erreur Stripe inconnue",
+      err,
+    );
+  }
+
+  // 6. Update work_order_payments — l'index partiel WHERE escrow_status='held'
+  // garantit qu'on ne peut pas marquer 'released' deux fois.
+  const nowIso = new Date().toISOString();
+  await supabase
+    .from("work_order_payments")
+    .update({
+      escrow_status: "released",
+      escrow_released_at: nowIso,
+      escrow_release_reason: reason,
+      stripe_transfer_id: transfer.id,
+      released_by_profile_id: releasedByProfileId,
+      paid_at: nowIso,
+    })
+    .eq("id", p.id)
+    .eq("escrow_status", "held");
+
+  return {
+    paymentId: p.id,
+    transferId: transfer.id,
+    netAmountCents,
+    destinationAccount: c.stripe_account_id,
+  };
+}
+
+/**
+ * Trouve les paiements à libérer pour un work_order donné.
+ * @param paymentType - Filtrer par type ('deposit' / 'balance' / 'full')
+ */
+export async function findHeldPayments(
+  supabase: SupabaseClient,
+  workOrderId: string,
+  paymentType?: "deposit" | "balance" | "full",
+): Promise<Array<{ id: string; payment_type: string }>> {
+  let query = (supabase as any)
+    .from("work_order_payments")
+    .select("id, payment_type")
+    .eq("work_order_id", workOrderId)
+    .eq("escrow_status", "held")
+    .eq("status", "succeeded");
+
+  if (paymentType) {
+    query = query.eq("payment_type", paymentType);
+  }
+
+  const { data } = await query;
+  return (data || []) as Array<{ id: string; payment_type: string }>;
+}

--- a/supabase/migrations/20260426130000_work_orders_dispute_deadline.sql
+++ b/supabase/migrations/20260426130000_work_orders_dispute_deadline.sql
@@ -1,0 +1,43 @@
+-- =====================================================
+-- Migration : Délai de contestation 7j avant libération du solde
+-- Date : 2026-04-26
+--
+-- Contexte :
+--   Sprint B du flux escrow. Quand le proprio paie le solde (70%) après que
+--   les travaux sont marqués 'completed', les fonds restent en escrow le
+--   temps d'un délai de contestation de 7 jours. Passé ce délai sans dispute,
+--   un cron quotidien libère automatiquement les fonds vers le compte
+--   Connect du prestataire (Stripe Transfer).
+--
+-- Changements :
+--   1. Ajout work_order_payments.dispute_deadline TIMESTAMPTZ — date après
+--      laquelle le cron peut libérer automatiquement les fonds.
+--   2. Ajout work_order_payments.released_by_profile_id UUID — qui a
+--      déclenché la libération (proprio si validation explicite, NULL si
+--      cron auto, prestataire jamais).
+--   3. Index partiel pour accélérer le cron (escrow_status='held' AND
+--      dispute_deadline IS NOT NULL).
+-- =====================================================
+
+BEGIN;
+
+-- 1. Colonnes
+ALTER TABLE public.work_order_payments
+  ADD COLUMN IF NOT EXISTS dispute_deadline TIMESTAMPTZ;
+
+ALTER TABLE public.work_order_payments
+  ADD COLUMN IF NOT EXISTS released_by_profile_id UUID
+    REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.work_order_payments.dispute_deadline IS
+  'Date limite de contestation. Si escrow_status=''held'' et NOW() > dispute_deadline, le cron libère les fonds vers le compte Connect du prestataire. NULL = libération immédiate possible (acompte au démarrage).';
+
+COMMENT ON COLUMN public.work_order_payments.released_by_profile_id IS
+  'Profil qui a déclenché la libération (proprio si validation explicite). NULL = libération automatique par cron après dispute_deadline.';
+
+-- 2. Index pour le cron de libération automatique
+CREATE INDEX IF NOT EXISTS idx_wo_payments_pending_release
+  ON public.work_order_payments (dispute_deadline)
+  WHERE escrow_status = 'held' AND dispute_deadline IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Sprint B — Libération escrow vers prestataires

**Critique** : sans cette PR, après le Sprint A les fonds des paiements WO restent bloqués indéfiniment sur le compte plateforme Talok. Cette PR ferme la boucle.

## Architecture

```
Acompte payé          → escrow_status='held'         (Sprint A)
   ↓
start_work appelé     → Transfer Stripe automatique  (Sprint B)
                        net_amount → compte Connect
                        escrow_status='released'
   ↓
Travaux completed     → dispute_deadline = NOW() + 7j (Sprint B)
   ↓
   ├─ Owner valide explicitement   → /release-transfer immédiat
   ├─ 7j passent sans contestation → cron /release-escrow auto-libère
   └─ Owner conteste (Sprint D)    → escrow_status='disputed', bloqué
```

## Changements

### Service `lib/work-orders/release-escrow.ts` (nouveau)
- `releaseEscrowToProvider()` : crée un Stripe Transfer avec `source_transaction = stripe_charge_id` (lie au charge originale, débloque même si balance Talok insuffisante), idempotencyKey = paymentId
- `findHeldPayments()` : helper pour lister les paiements à libérer

### Route `POST /api/work-orders/[id]/release-transfer` (nouvelle)
- Owner ou admin
- Body optionnel `{payment_type}` pour filtrer
- Avance le statut WO à `paid` si tout est libéré
- 207 Multi-Status si libération partielle

### Cron `GET /api/cron/release-escrow` (nouveau)
- Auth `Bearer CRON_SECRET`
- Scanne les paiements `escrow_status='held'` avec `dispute_deadline <= NOW()`
- Libère via le service, max 100 par run
- À configurer côté Netlify scheduled functions / GitHub Actions

### Auto-release dans le service WO
- `startIntervention()` → libère l'acompte (fire-and-forget)
- `completeIntervention()` → pose `dispute_deadline = NOW() + 7j` sur le solde

### Webhooks `transfer.*` étendus
- `transfer.created` : filet de sécurité idempotent pour `metadata.type='work_order_escrow_release'`
- `transfer.failed` / `transfer.reversed` : reverte `escrow_status='held'` + clear `stripe_transfer_id` + outbox `WorkOrder.EscrowReleaseFailed`

### Migration `20260426130000_work_orders_dispute_deadline.sql`
- `work_order_payments.dispute_deadline TIMESTAMPTZ`
- `work_order_payments.released_by_profile_id` (FK profiles)
- Index partiel `WHERE escrow_status = 'held' AND dispute_deadline IS NOT NULL`

### UI
Bouton **"Valider et libérer les fonds"** sur le détail WO owner quand status ∈ {`completed`, `invoiced`}, court-circuite le délai 7j.

## Hors scope

- Sprint C : UI prestataire `/provider/settings/payouts` + webhook `account.updated`
- Sprint D : refund + dispute UI + webhooks `charge.refunded` / `charge.dispute.created`
- Sprint E : TVA auto-fill + facture PDF

## Test plan

- [ ] Migration appliquée : `SELECT dispute_deadline FROM work_order_payments LIMIT 1` OK
- [ ] Acompte payé Stripe → `start_work` → Stripe Transfer créé, `escrow_status='released'`, `stripe_transfer_id` renseigné
- [ ] `completeIntervention` → `dispute_deadline = today + 7j` sur le solde balance/full
- [ ] `POST /api/work-orders/[id]/release-transfer` libère manuellement (owner)
- [ ] Cron `/api/cron/release-escrow` (avec UPDATE manuel pour avancer `dispute_deadline`) libère les past-deadline
- [ ] Webhook simulé `transfer.failed` → `escrow_status` revient à `'held'` + outbox `WorkOrder.EscrowReleaseFailed`
- [ ] Bouton UI "Valider et libérer" appelle bien la route
- [ ] Statut WO passe à `paid` après libération du solde

## ⚠️ À configurer après merge

- **Cron scheduled** : ajouter `/api/cron/release-escrow` au `netlify.toml` ou aux GitHub Actions, fréquence quotidienne minimum
- **`CRON_SECRET`** doit être set dans les env vars Netlify

https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J)_