### PR TITLE
feat(work-orders): Sprint E — TVA auto-fill + facture PDF

### DIFF
--- a/app/api/admin/work-order-disputes/[id]/route.ts
+++ b/app/api/admin/work-order-disputes/[id]/route.ts
@@ -1,0 +1,96 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import {
+  refundDisputedPayment,
+  releaseDisputedPayment,
+  DisputeError,
+} from "@/lib/work-orders/dispute";
+
+/**
+ * PATCH /api/admin/work-order-disputes/[id]
+ *
+ * Admin résout un litige.
+ *   action='refund' (full ou partiel) — Stripe Refund au proprio
+ *   action='release' — libération vers prestataire (le proprio est débouté)
+ */
+
+const schema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("refund"),
+    refund_amount_cents: z.number().int().positive().optional(), // si absent, full
+    notes: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("release"),
+    notes: z.string().optional(),
+  }),
+]);
+
+export const PATCH = withSecurity(
+  async function PATCH(
+    request: Request,
+    context: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const serviceClient = getServiceClient();
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      const profileRow = profile as { id: string; role: string } | null;
+      if (!profileRow || profileRow.role !== "admin") {
+        throw new ApiError(403, "Réservé aux admins");
+      }
+
+      const { id: disputeId } = await context.params;
+      const body = await request.json().catch(() => ({}));
+      const input = schema.parse(body);
+
+      if (input.action === "refund") {
+        const result = await refundDisputedPayment(serviceClient, disputeId, {
+          refundAmountCents: input.refund_amount_cents,
+          resolvedByProfileId: profileRow.id,
+          notes: input.notes,
+        });
+        return NextResponse.json({
+          success: true,
+          stripe_refund_id: result.stripeRefundId,
+          refund_amount_cents: result.refundAmountCents,
+        });
+      } else {
+        const result = await releaseDisputedPayment(
+          serviceClient,
+          disputeId,
+          profileRow.id,
+          input.notes,
+        );
+        return NextResponse.json({ success: true, payment_id: result.paymentId });
+      }
+    } catch (error) {
+      if (error instanceof DisputeError) {
+        return NextResponse.json(
+          { error: error.message, code: error.code },
+          { status: 400 },
+        );
+      }
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "PATCH /api/admin/work-order-disputes/[id]",
+    csrf: true,
+  },
+);

--- a/app/api/cron/release-escrow/route.ts
+++ b/app/api/cron/release-escrow/route.ts
@@ -1,0 +1,126 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import {
+  releaseEscrowToProvider,
+  EscrowReleaseError,
+} from "@/lib/work-orders/release-escrow";
+
+/**
+ * GET /api/cron/release-escrow — libération automatique des soldes WO
+ *
+ * Quotidien (cron Netlify ou GitHub Actions). Pour chaque paiement
+ * work_order_payments avec :
+ *   - escrow_status = 'held'
+ *   - dispute_deadline IS NOT NULL AND dispute_deadline <= NOW()
+ *   - status = 'succeeded'
+ * on libère les fonds vers le compte Connect du prestataire (Stripe Transfer).
+ *
+ * Sécurité : Header Authorization: Bearer <CRON_SECRET>
+ *
+ * Idempotence : releaseEscrowToProvider() utilise une idempotencyKey Stripe
+ * et un UPDATE WHERE escrow_status='held', donc tout double appel est safe.
+ */
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+
+  const supabase = getServiceClient();
+  const startedAt = Date.now();
+
+  try {
+    // Sélection des paiements à libérer
+    const { data: candidates, error } = await (supabase as any)
+      .from("work_order_payments")
+      .select("id, work_order_id, payment_type, dispute_deadline")
+      .eq("escrow_status", "held")
+      .eq("status", "succeeded")
+      .not("dispute_deadline", "is", null)
+      .lte("dispute_deadline", new Date().toISOString())
+      .limit(100);
+
+    if (error) {
+      console.error("[cron/release-escrow] query error:", error);
+      return NextResponse.json(
+        { error: "Failed to query held payments", details: error.message },
+        { status: 500 },
+      );
+    }
+
+    const payments = (candidates || []) as Array<{
+      id: string;
+      work_order_id: string;
+      payment_type: string;
+      dispute_deadline: string;
+    }>;
+
+    if (payments.length === 0) {
+      return NextResponse.json({
+        released: 0,
+        errors: 0,
+        duration_ms: Date.now() - startedAt,
+      });
+    }
+
+    let releasedCount = 0;
+    const errors: Array<{ payment_id: string; error: string }> = [];
+
+    for (const p of payments) {
+      try {
+        await releaseEscrowToProvider(supabase, {
+          paymentId: p.id,
+          reason: "balance_release_on_deadline",
+        });
+        releasedCount++;
+
+        // Avancer le statut WO vers 'paid' si tout le reste est libéré
+        const { data: stillHeld } = await (supabase as any)
+          .from("work_order_payments")
+          .select("id")
+          .eq("work_order_id", p.work_order_id)
+          .eq("escrow_status", "held")
+          .limit(1);
+
+        if (!stillHeld || stillHeld.length === 0) {
+          await supabase
+            .from("work_orders")
+            .update({ statut: "paid", paid_at: new Date().toISOString() })
+            .eq("id", p.work_order_id);
+        }
+      } catch (err) {
+        const message =
+          err instanceof EscrowReleaseError
+            ? `${err.code}: ${err.message}`
+            : err instanceof Error
+              ? err.message
+              : "Unknown error";
+        errors.push({ payment_id: p.id, error: message });
+        console.error(
+          `[cron/release-escrow] Failed to release ${p.id}:`,
+          message,
+        );
+      }
+    }
+
+    return NextResponse.json({
+      released: releasedCount,
+      errors: errors.length,
+      error_details: errors,
+      duration_ms: Date.now() - startedAt,
+    });
+  } catch (err) {
+    console.error("[cron/release-escrow] fatal:", err);
+    return NextResponse.json(
+      {
+        error: "Cron fatal error",
+        details: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/stripe/connect/route.ts
+++ b/app/api/stripe/connect/route.ts
@@ -112,10 +112,13 @@ async function getAuthenticatedOwnerProfile() {
     .eq("user_id", user.id)
     .single();
 
-  if (!profile || !["owner", "syndic"].includes(profile.role)) {
+  if (!profile || !["owner", "syndic", "provider"].includes(profile.role)) {
     return {
       error: NextResponse.json(
-        { error: "Seuls les propriétaires et syndics peuvent avoir un compte Connect" },
+        {
+          error:
+            "Seuls les propriétaires, syndics et prestataires peuvent avoir un compte Connect",
+        },
         { status: 403 }
       ),
     };

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1931,6 +1931,115 @@ export async function POST(request: NextRequest) {
             }
           }
         }
+
+        // Cas work_order_payment : un dispute Stripe (chargeback bancaire)
+        // sur la charge d'un paiement WO. On bloque la libération + crée
+        // une ligne work_order_disputes pour audit + notif.
+        if (chargeId) {
+          const { data: woPayment } = await supabase
+            .from("work_order_payments")
+            .select("id, work_order_id, payer_profile_id, escrow_status")
+            .eq("stripe_charge_id", chargeId)
+            .maybeSingle();
+
+          if (woPayment) {
+            const wp = woPayment as {
+              id: string;
+              work_order_id: string;
+              payer_profile_id: string;
+              escrow_status: string;
+            };
+
+            // Bloquer la libération si encore possible
+            if (["held", "released"].includes(wp.escrow_status)) {
+              await supabase
+                .from("work_order_payments")
+                .update({ escrow_status: "disputed" })
+                .eq("id", wp.id);
+            }
+
+            // Insérer un litige (idempotent via stripe_dispute_id ?
+            // Pas de colonne dédiée, on utilise idempotency par
+            // upsert sur (work_order_payment_id + reason='unauthorized'
+            // + status='open') pour éviter doublon en cas de re-livraison
+            // du webhook — best effort.
+            const { data: existing } = await supabase
+              .from("work_order_disputes")
+              .select("id")
+              .eq("work_order_payment_id", wp.id)
+              .eq("status", "open")
+              .maybeSingle();
+
+            if (!existing) {
+              await supabase.from("work_order_disputes").insert({
+                work_order_payment_id: wp.id,
+                work_order_id: wp.work_order_id,
+                raised_by_profile_id: wp.payer_profile_id,
+                reason: "unauthorized",
+                description:
+                  `Chargeback bancaire Stripe — motif: ${dispute.reason || "non spécifié"}. ` +
+                  `Dispute ID: ${dispute.id}.`,
+                status: "open",
+              });
+            }
+
+            // Notifier l'admin via outbox
+            await supabase.from("outbox").insert({
+              event_type: "WorkOrder.StripeChargeback",
+              payload: {
+                work_order_payment_id: wp.id,
+                work_order_id: wp.work_order_id,
+                stripe_dispute_id: dispute.id,
+                reason: dispute.reason,
+                amount_cents: dispute.amount,
+              },
+            });
+          }
+        }
+        break;
+      }
+
+      // ===============================================
+      // CHARGE REFUNDED (manuel ou via dispute)
+      // ===============================================
+      case "charge.refunded": {
+        const charge = event.data.object as Stripe.Charge;
+
+        // Détecter si la charge appartient à un work_order_payment
+        const { data: woPayment } = await supabase
+          .from("work_order_payments")
+          .select("id, work_order_id, gross_amount, escrow_status")
+          .eq("stripe_charge_id", charge.id)
+          .maybeSingle();
+
+        if (woPayment) {
+          const wp = woPayment as {
+            id: string;
+            work_order_id: string;
+            gross_amount: number | string;
+            escrow_status: string;
+          };
+
+          const refundedCents = charge.amount_refunded ?? 0;
+          const grossCents = Math.round(Number(wp.gross_amount) * 100);
+          const isFullRefund = refundedCents >= grossCents;
+
+          await supabase
+            .from("work_order_payments")
+            .update({
+              status: isFullRefund ? "refunded" : "succeeded",
+              escrow_status: isFullRefund ? "refunded" : wp.escrow_status,
+            })
+            .eq("id", wp.id);
+
+          // Si plein refund → revert le statut WO si tout est refundé
+          if (isFullRefund) {
+            await supabase
+              .from("work_orders")
+              .update({ statut: "cancelled" })
+              .eq("id", wp.work_order_id);
+          }
+        }
         break;
       }
 

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1691,7 +1691,25 @@ export async function POST(request: NextRequest) {
       case "transfer.created": {
         const transfer = event.data.object as Stripe.Transfer;
 
-        // Enregistrer le transfert en base
+        // Cas 1 : libération d'escrow work_order_payment.
+        // releaseEscrowToProvider() a déjà fait l'UPDATE synchrone, le
+        // webhook sert ici de filet de sécurité (idempotent).
+        if (transfer.metadata?.type === "work_order_escrow_release") {
+          const wopPaymentId = transfer.metadata?.payment_id;
+          if (wopPaymentId) {
+            await supabase
+              .from("work_order_payments")
+              .update({
+                stripe_transfer_id: transfer.id,
+                escrow_status: "released",
+                escrow_released_at: new Date().toISOString(),
+              })
+              .eq("id", wopPaymentId)
+              .neq("escrow_status", "released");
+          }
+        }
+
+        // Cas 2 (legacy) : transfert flux rent — enregistrer dans stripe_transfers
         const { data: connectAccount } = await supabase
           .from("stripe_connect_accounts")
           .select("id")
@@ -1747,17 +1765,49 @@ export async function POST(request: NextRequest) {
       }
 
       // ===============================================
-      // STRIPE CONNECT - TRANSFERT ÉCHOUÉ
+      // STRIPE CONNECT - TRANSFERT ÉCHOUÉ / REVERSED
       // ===============================================
-      case "transfer.failed" as any: {
+      case "transfer.failed" as any:
+      case "transfer.reversed" as any: {
         const transfer = (event as any).data.object as Stripe.Transfer;
 
-        // Mettre à jour le statut du transfert
+        // Cas 1 : libération escrow work_order qui a échoué — on revient
+        // à escrow_status='held' pour retry et on clear le stripe_transfer_id.
+        if (transfer.metadata?.type === "work_order_escrow_release") {
+          const wopPaymentId = transfer.metadata?.payment_id;
+          if (wopPaymentId) {
+            await supabase
+              .from("work_order_payments")
+              .update({
+                escrow_status: "held",
+                escrow_released_at: null,
+                stripe_transfer_id: null,
+                escrow_release_reason: `transfer_failed: ${event.type}`,
+              })
+              .eq("id", wopPaymentId);
+
+            // Outbox : alerter pour intervention humaine
+            await supabase.from("outbox").insert({
+              event_type: "WorkOrder.EscrowReleaseFailed",
+              payload: {
+                payment_id: wopPaymentId,
+                work_order_id: transfer.metadata?.work_order_id ?? null,
+                stripe_transfer_id: transfer.id,
+                stripe_event: event.type,
+              },
+            });
+          }
+        }
+
+        // Cas 2 (legacy) : transferts rent
         await supabase
           .from("stripe_transfers")
           .update({
-            status: "failed",
-            failure_reason: "Transfer failed",
+            status: event.type === "transfer.reversed" ? "reversed" : "failed",
+            failure_reason:
+              event.type === "transfer.reversed"
+                ? "Transfer reversed"
+                : "Transfer failed",
           })
           .eq("stripe_transfer_id", transfer.id);
 

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1669,15 +1669,41 @@ export async function POST(request: NextRequest) {
             .eq("id", connectAccount.id as string);
 
           if (!updateError) {
-
-            // Notifier le propriétaire si l'onboarding est terminé
+            // Notifier le titulaire du compte si l'onboarding est terminé.
+            // Le message + lien dépendent du rôle (owner / syndic / provider).
             if (account.charges_enabled && account.payouts_enabled && connectAccount.profile_id) {
+              const { data: ownerProfile } = await supabase
+                .from("profiles")
+                .select("role")
+                .eq("id", connectAccount.profile_id)
+                .maybeSingle();
+              const role = (ownerProfile as { role: string } | null)?.role;
+
+              const notif =
+                role === "provider"
+                  ? {
+                      message:
+                        "Votre compte Stripe est actif. Vous recevrez vos paiements d'intervention directement.",
+                      link: "/provider/settings/payouts",
+                    }
+                  : role === "syndic"
+                    ? {
+                        message:
+                          "Votre compte Stripe est actif. Vous pourrez encaisser les charges de copropriété.",
+                        link: "/syndic/settings/payouts",
+                      }
+                    : {
+                        message:
+                          "Votre compte Stripe est actif. Vous recevrez les loyers directement.",
+                        link: "/owner/money?tab=banque",
+                      };
+
               await supabase.rpc("create_notification", {
                 p_recipient_id: connectAccount.profile_id,
                 p_type: "success",
                 p_title: "Compte de paiement activé !",
-                p_message: "Votre compte Stripe est maintenant actif. Vous recevrez les loyers directement.",
-                p_link: "/owner/money?tab=banque",
+                p_message: notif.message,
+                p_link: notif.link,
               });
             }
           }

--- a/app/api/work-orders/[id]/dispute/route.ts
+++ b/app/api/work-orders/[id]/dispute/route.ts
@@ -1,0 +1,153 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import { raiseDispute, withdrawDispute, DisputeError } from "@/lib/work-orders/dispute";
+
+/**
+ * POST /api/work-orders/[id]/dispute — owner conteste un paiement
+ * DELETE /api/work-orders/[id]/dispute?dispute_id=xxx — owner retire sa contestation
+ */
+
+const raiseSchema = z.object({
+  payment_id: z.string().uuid(),
+  reason: z.enum([
+    "work_not_done",
+    "work_incomplete",
+    "quality_issue",
+    "wrong_amount",
+    "unauthorized",
+    "other",
+  ]),
+  description: z.string().min(20).max(2000),
+  evidence_urls: z.array(z.string().url()).max(10).optional(),
+});
+
+export const POST = withSecurity(
+  async function POST(
+    request: Request,
+    context: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: workOrderId } = await context.params;
+      const body = await request.json().catch(() => ({}));
+      const input = raiseSchema.parse(body);
+
+      const serviceClient = getServiceClient();
+
+      // Vérif owner
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const profileRow = profile as { id: string; role: string };
+
+      const { data: wo } = await serviceClient
+        .from("work_orders")
+        .select("id, property_id")
+        .eq("id", workOrderId)
+        .maybeSingle();
+      if (!wo) throw new ApiError(404, "Intervention introuvable");
+
+      if (profileRow.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", (wo as { property_id: string }).property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileRow.id) {
+          throw new ApiError(403, "Seul le propriétaire peut contester ce paiement");
+        }
+      }
+
+      // Vérif que le payment_id appartient bien à ce WO
+      const { data: payment } = await serviceClient
+        .from("work_order_payments")
+        .select("id, work_order_id")
+        .eq("id", input.payment_id)
+        .maybeSingle();
+      if (!payment || (payment as { work_order_id: string }).work_order_id !== workOrderId) {
+        throw new ApiError(400, "Le paiement n'appartient pas à cette intervention");
+      }
+
+      const result = await raiseDispute(serviceClient, {
+        workOrderPaymentId: input.payment_id,
+        raisedByProfileId: profileRow.id,
+        reason: input.reason,
+        description: input.description,
+        evidenceUrls: input.evidence_urls,
+      });
+
+      return NextResponse.json({ dispute_id: result.disputeId }, { status: 201 });
+    } catch (error) {
+      if (error instanceof DisputeError) {
+        return NextResponse.json(
+          { error: error.message, code: error.code },
+          { status: 400 },
+        );
+      }
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "POST /api/work-orders/[id]/dispute",
+    csrf: true,
+  },
+);
+
+export const DELETE = withSecurity(
+  async function DELETE(
+    request: Request,
+    _context: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const url = new URL(request.url);
+      const disputeId = url.searchParams.get("dispute_id");
+      if (!disputeId) throw new ApiError(400, "dispute_id requis");
+
+      const serviceClient = getServiceClient();
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+
+      await withdrawDispute(
+        serviceClient,
+        disputeId,
+        (profile as { id: string }).id,
+      );
+
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      if (error instanceof DisputeError) {
+        return NextResponse.json(
+          { error: error.message, code: error.code },
+          { status: 400 },
+        );
+      }
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "DELETE /api/work-orders/[id]/dispute",
+    csrf: true,
+  },
+);

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -1,0 +1,209 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { generateWorkOrderInvoicePdf } from "@/lib/pdf/work-order-invoice-pdf";
+import { resolveWorkOrderTVA } from "@/lib/work-orders/tva-travaux";
+
+/**
+ * GET /api/work-orders/[id]/invoice-pdf
+ *
+ * Génère et retourne la facture PDF d'une intervention. Lecture pour
+ * propriétaire (concerné) et prestataire (émetteur).
+ */
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError) throw new ApiError(authError.status || 401, authError.message);
+    if (!user) throw new ApiError(401, "Non authentifié");
+
+    const { id: workOrderId } = await context.params;
+    const serviceClient = getServiceClient();
+
+    // 1. Profil + role
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) throw new ApiError(404, "Profil non trouvé");
+    const profileRow = profile as { id: string; role: string };
+
+    // 2. Charger work order + relations nécessaires
+    const { data: wo } = await serviceClient
+      .from("work_orders")
+      .select(
+        "id, property_id, provider_id, accepted_quote_id, completed_at, title, description",
+      )
+      .eq("id", workOrderId)
+      .maybeSingle();
+    if (!wo) throw new ApiError(404, "Intervention introuvable");
+    const workOrder = wo as {
+      id: string;
+      property_id: string;
+      provider_id: string | null;
+      accepted_quote_id: string | null;
+      completed_at: string | null;
+      title: string | null;
+      description: string | null;
+    };
+
+    // 3. Vérifier accès (owner du bien OU le prestataire OU admin)
+    const { data: property } = await serviceClient
+      .from("properties")
+      .select("id, owner_id, adresse_complete, ville, code_postal, annee_construction")
+      .eq("id", workOrder.property_id)
+      .maybeSingle();
+    const propertyRow = property as {
+      id: string;
+      owner_id: string;
+      adresse_complete: string;
+      ville: string;
+      code_postal: string;
+      annee_construction: number | null;
+    } | null;
+    if (!propertyRow) throw new ApiError(404, "Bien introuvable");
+
+    const isOwner = propertyRow.owner_id === profileRow.id;
+    const isProvider = workOrder.provider_id === profileRow.id;
+    const isAdmin = profileRow.role === "admin";
+    if (!isOwner && !isProvider && !isAdmin) {
+      throw new ApiError(403, "Non autorisé");
+    }
+
+    // 4. Charger devis accepté + lignes
+    if (!workOrder.accepted_quote_id) {
+      throw new ApiError(409, "Pas de devis accepté pour cette intervention");
+    }
+    const { data: quote } = await serviceClient
+      .from("provider_quotes")
+      .select(
+        "id, reference, total_amount, tax_rate, terms_and_conditions, valid_until, created_at",
+      )
+      .eq("id", workOrder.accepted_quote_id)
+      .maybeSingle();
+    if (!quote) throw new ApiError(404, "Devis introuvable");
+
+    const { data: items } = await serviceClient
+      .from("provider_quote_items")
+      .select("description, quantity, unit, unit_price, tax_rate, sort_order")
+      .eq("quote_id", workOrder.accepted_quote_id)
+      .order("sort_order", { ascending: true });
+
+    const quoteRow = quote as {
+      id: string;
+      reference: string | null;
+      total_amount: number | string;
+      tax_rate: number | string | null;
+      terms_and_conditions: string | null;
+      valid_until: string | null;
+      created_at: string;
+    };
+
+    // 5. Charger prestataire (companies / profiles)
+    const { data: providerProfile } = await serviceClient
+      .from("profiles")
+      .select("id, prenom, nom, email, telephone")
+      .eq("id", workOrder.provider_id ?? "")
+      .maybeSingle();
+    const { data: providerEntity } = await serviceClient
+      .from("provider_profiles")
+      .select(
+        "company_name, siret, vat_number, address, city, postal_code, vat_exempt",
+      )
+      .eq("profile_id", workOrder.provider_id ?? "")
+      .maybeSingle();
+    const provP = providerProfile as
+      | { prenom: string | null; nom: string | null; email: string | null; telephone: string | null }
+      | null;
+    const provE = providerEntity as
+      | {
+          company_name: string | null;
+          siret: string | null;
+          vat_number: string | null;
+          address: string | null;
+          city: string | null;
+          postal_code: string | null;
+          vat_exempt: boolean | null;
+        }
+      | null;
+
+    // 6. Charger client (owner)
+    const { data: ownerProfile } = await serviceClient
+      .from("profiles")
+      .select("prenom, nom, email")
+      .eq("id", propertyRow.owner_id)
+      .maybeSingle();
+    const ownerRow = ownerProfile as
+      | { prenom: string | null; nom: string | null; email: string | null }
+      | null;
+
+    // 7. Référence légale TVA pour le footer
+    const tva = resolveWorkOrderTVA({
+      codePostal: propertyRow.code_postal,
+      propertyBuildYear: propertyRow.annee_construction,
+      workType: "entretien",
+      isCommercial: false,
+    });
+
+    const invoiceNumber = `${quoteRow.reference || `WO-${workOrder.id.slice(0, 8).toUpperCase()}`}`;
+    const invoiceDate = workOrder.completed_at?.split("T")[0] || new Date().toISOString().split("T")[0];
+
+    const itemsList = (items || []).map((it: any) => ({
+      description: it.description,
+      quantity: Number(it.quantity),
+      unit: it.unit,
+      unitPriceCents: Math.round(Number(it.unit_price) * 100),
+      taxRate: Number(it.tax_rate) / (Number(it.tax_rate) > 1 ? 100 : 1), // si 20 → 0.20, si 0.20 → 0.20
+    }));
+
+    const pdfBuffer = await generateWorkOrderInvoicePdf({
+      invoiceNumber,
+      invoiceDate,
+      provider: {
+        companyName:
+          provE?.company_name ||
+          [provP?.prenom, provP?.nom].filter(Boolean).join(" ") ||
+          "Prestataire",
+        contactName: [provP?.prenom, provP?.nom].filter(Boolean).join(" ") || null,
+        address: provE?.address ?? null,
+        city: provE?.city ?? null,
+        postalCode: provE?.postal_code ?? null,
+        siret: provE?.siret ?? null,
+        vatNumber: provE?.vat_number ?? null,
+        email: provP?.email ?? null,
+        phone: provP?.telephone ?? null,
+        isVatExempt: Boolean(provE?.vat_exempt),
+      },
+      client: {
+        name: [ownerRow?.prenom, ownerRow?.nom].filter(Boolean).join(" ") || "Client",
+      },
+      property: {
+        address: propertyRow.adresse_complete,
+        city: propertyRow.ville,
+        postalCode: propertyRow.code_postal,
+      },
+      items: itemsList,
+      tvaReference: tva.reference,
+      notes: quoteRow.terms_and_conditions,
+    });
+
+    return new NextResponse(new Uint8Array(pdfBuffer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `inline; filename="facture-${invoiceNumber}.pdf"`,
+        "Cache-Control": "private, max-age=60",
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/work-orders/[id]/release-transfer/route.ts
+++ b/app/api/work-orders/[id]/release-transfer/route.ts
@@ -1,0 +1,176 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { withSecurity } from "@/lib/api/with-security";
+import {
+  releaseEscrowToProvider,
+  findHeldPayments,
+  EscrowReleaseError,
+} from "@/lib/work-orders/release-escrow";
+
+/**
+ * POST /api/work-orders/[id]/release-transfer
+ *
+ * Libère un (ou plusieurs) paiements escrow vers le compte Connect du
+ * prestataire, en créant un Stripe Transfer.
+ *
+ * Cas d'usage :
+ *   - Propriétaire valide explicitement après les travaux (raccourcit le
+ *     délai de contestation 7j)
+ *   - Admin support libère manuellement après résolution d'un litige
+ *   - Cron auto (réservé au cron via header autorisé, voir /api/cron/release-escrow)
+ *
+ * Body (optionnel) :
+ *   - payment_type: 'deposit' | 'balance' | 'full' — filtre quel paiement libérer.
+ *     Si absent, libère TOUS les paiements en escrow_status='held' du WO.
+ *
+ * Permissions :
+ *   - Owner du WO (via property_id)
+ *   - Admin
+ */
+const bodySchema = z.object({
+  payment_type: z.enum(["deposit", "balance", "full"]).optional(),
+});
+
+export const POST = withSecurity(
+  async function POST(
+    request: Request,
+    context: { params: Promise<{ id: string }> },
+  ) {
+    try {
+      const { user, error: authError } = await getAuthenticatedUser(request);
+      if (authError) throw new ApiError(authError.status || 401, authError.message);
+      if (!user) throw new ApiError(401, "Non authentifié");
+
+      const { id: workOrderId } = await context.params;
+      const body = await request.json().catch(() => ({}));
+      const { payment_type } = bodySchema.parse(body);
+
+      const serviceClient = getServiceClient();
+
+      // 1. Profil + check permissions
+      const { data: profile } = await serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profile) throw new ApiError(404, "Profil non trouvé");
+      const profileRow = profile as { id: string; role: string };
+
+      // 2. Work order + check owner
+      const { data: wo } = await serviceClient
+        .from("work_orders")
+        .select("id, property_id, statut")
+        .eq("id", workOrderId)
+        .maybeSingle();
+      if (!wo) throw new ApiError(404, "Intervention introuvable");
+      const workOrder = wo as { id: string; property_id: string; statut: string | null };
+
+      if (profileRow.role !== "admin") {
+        const { data: property } = await serviceClient
+          .from("properties")
+          .select("owner_id")
+          .eq("id", workOrder.property_id)
+          .maybeSingle();
+        const ownerId = (property as { owner_id: string } | null)?.owner_id;
+        if (ownerId !== profileRow.id) {
+          throw new ApiError(403, "Seul le propriétaire peut libérer ces fonds");
+        }
+      }
+
+      // 3. Déterminer la raison de libération selon le statut WO
+      // - 'fully_paid' + balance/full → validation explicite (raccourci 7j)
+      // - 'in_progress' + deposit → libération acompte au démarrage
+      // - sinon → manuelle
+      const reason =
+        payment_type === "deposit"
+          ? "deposit_release_on_start"
+          : payment_type === "balance" || payment_type === "full"
+            ? "balance_release_on_validation"
+            : workOrder.statut === "in_progress"
+              ? "deposit_release_on_start"
+              : "balance_release_on_validation";
+
+      // 4. Charger les paiements à libérer
+      const heldPayments = await findHeldPayments(
+        serviceClient,
+        workOrderId,
+        payment_type,
+      );
+
+      if (heldPayments.length === 0) {
+        return NextResponse.json({
+          released: [],
+          message: "Aucun paiement en escrow à libérer",
+        });
+      }
+
+      // 5. Libérer chaque paiement (séquentiel pour éviter les race conditions
+      // côté Stripe Transfer idempotency)
+      const released: Array<{
+        payment_id: string;
+        payment_type: string;
+        transfer_id: string;
+        net_amount_cents: number;
+      }> = [];
+      const errors: Array<{ payment_id: string; error: string }> = [];
+
+      for (const heldPayment of heldPayments) {
+        try {
+          const result = await releaseEscrowToProvider(serviceClient, {
+            paymentId: heldPayment.id,
+            reason,
+            releasedByProfileId: profileRow.id,
+          });
+          released.push({
+            payment_id: result.paymentId,
+            payment_type: heldPayment.payment_type,
+            transfer_id: result.transferId,
+            net_amount_cents: result.netAmountCents,
+          });
+        } catch (err) {
+          if (err instanceof EscrowReleaseError) {
+            errors.push({ payment_id: heldPayment.id, error: err.message });
+          } else {
+            errors.push({
+              payment_id: heldPayment.id,
+              error: err instanceof Error ? err.message : "Erreur inconnue",
+            });
+          }
+        }
+      }
+
+      // 6. Si tous les paiements sont libérés et que c'était un solde/full,
+      // avancer le statut WO vers 'paid' (les fonds sont bien chez le presta).
+      if (released.length > 0 && errors.length === 0) {
+        const releasedTypes = new Set(released.map((r) => r.payment_type));
+        if (releasedTypes.has("balance") || releasedTypes.has("full")) {
+          await serviceClient
+            .from("work_orders")
+            .update({ statut: "paid", paid_at: new Date().toISOString() })
+            .eq("id", workOrderId);
+        }
+      }
+
+      const status = errors.length > 0 ? 207 : 200; // 207 Multi-Status si partiel
+      return NextResponse.json(
+        {
+          released,
+          errors,
+        },
+        { status },
+      );
+    } catch (error) {
+      return handleApiError(error);
+    }
+  },
+  {
+    routeName: "POST /api/work-orders/[id]/release-transfer",
+    csrf: true,
+  },
+);

--- a/app/api/work-orders/[id]/suggested-tva/route.ts
+++ b/app/api/work-orders/[id]/suggested-tva/route.ts
@@ -1,0 +1,98 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import {
+  resolveWorkOrderTVA,
+  type WorkType,
+} from "@/lib/work-orders/tva-travaux";
+
+/**
+ * GET /api/work-orders/[id]/suggested-tva?work_type=entretien&commercial=false
+ *
+ * Calcule le taux de TVA recommandé pour le devis selon :
+ *  - Code postal du bien associé (DROM vs métropole)
+ *  - Année de construction (règle 2 ans)
+ *  - Type de travaux
+ *  - Caractère commercial
+ *
+ * Utilisé par l'UI prestataire pour pré-remplir tax_rate à la création
+ * d'un provider_quote, modifiable par le prestataire.
+ */
+const querySchema = z.object({
+  work_type: z
+    .enum([
+      "entretien",
+      "amelioration",
+      "renovation_energetique",
+      "construction",
+      "autre",
+    ])
+    .default("entretien"),
+  commercial: z.coerce.boolean().default(false),
+});
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError) throw new ApiError(authError.status || 401, authError.message);
+    if (!user) throw new ApiError(401, "Non authentifié");
+
+    const { id: workOrderId } = await context.params;
+    const url = new URL(request.url);
+    const { work_type, commercial } = querySchema.parse({
+      work_type: url.searchParams.get("work_type") ?? undefined,
+      commercial: url.searchParams.get("commercial") ?? undefined,
+    });
+
+    const serviceClient = getServiceClient();
+
+    const { data: wo } = await serviceClient
+      .from("work_orders")
+      .select("id, property_id")
+      .eq("id", workOrderId)
+      .maybeSingle();
+
+    if (!wo) throw new ApiError(404, "Intervention introuvable");
+
+    const propertyId = (wo as { property_id: string }).property_id;
+    const { data: property } = await serviceClient
+      .from("properties")
+      .select("code_postal, annee_construction")
+      .eq("id", propertyId)
+      .maybeSingle();
+
+    const prop = property as {
+      code_postal: string | null;
+      annee_construction: number | null;
+    } | null;
+
+    const tva = resolveWorkOrderTVA({
+      codePostal: prop?.code_postal ?? null,
+      propertyBuildYear: prop?.annee_construction ?? null,
+      workType: work_type as WorkType,
+      isCommercial: commercial,
+    });
+
+    return NextResponse.json({
+      rate: tva.rate,
+      rate_percent: Math.round(tva.rate * 10000) / 100, // 10.0, 8.5, 5.5...
+      formatted: tva.formatted,
+      regime: tva.regime,
+      reference: tva.reference,
+      property: {
+        code_postal: prop?.code_postal,
+        annee_construction: prop?.annee_construction,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/owner/work-orders/[id]/page.tsx
+++ b/app/owner/work-orders/[id]/page.tsx
@@ -265,6 +265,19 @@ export default function WorkOrderDetailPage() {
                     Marquer comme paye
                   </Button>
                 )}
+                {/* Validation explicite : libère le solde en escrow sans
+                    attendre les 7 jours de délai de contestation */}
+                {(status === 'completed' || status === 'invoiced') && (
+                  <Button
+                    variant="outline"
+                    onClick={() => performAction('release-transfer', {})}
+                    disabled={actionLoading}
+                    title="Confirme la fin des travaux et libère immédiatement les fonds vers le prestataire (sans attendre le délai de 7 jours)."
+                  >
+                    <CreditCard className="h-4 w-4 mr-2" />
+                    Valider et libérer les fonds
+                  </Button>
+                )}
                 {!['paid', 'cancelled'].includes(status) && (
                   <Button
                     variant="outline"

--- a/app/provider/settings/page.tsx
+++ b/app/provider/settings/page.tsx
@@ -2,6 +2,7 @@
 // @ts-nocheck
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { useProfileQuery } from "@/lib/hooks/use-profile-query";
@@ -298,6 +299,30 @@ export default function ProviderSettingsPage() {
                     )}
                   </div>
                 </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+
+          {/* Compte de paiement (Stripe Connect) */}
+          <motion.div variants={itemVariants}>
+            <Card className="bg-card/80 backdrop-blur-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <CreditCard className="h-5 w-5 text-emerald-500" />
+                  Compte de paiement
+                </CardTitle>
+                <CardDescription>
+                  Configurez votre compte bancaire pour recevoir vos paiements
+                  d'intervention
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button asChild variant="outline" className="w-full sm:w-auto">
+                  <Link href="/provider/settings/payouts">
+                    <CreditCard className="h-4 w-4 mr-2" />
+                    Gérer mon compte de paiement
+                  </Link>
+                </Button>
               </CardContent>
             </Card>
           </motion.div>

--- a/app/provider/settings/payouts/page.tsx
+++ b/app/provider/settings/payouts/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  AlertTriangle,
+  Loader2,
+  ExternalLink,
+  Banknote,
+  Shield,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+
+interface ConnectAccountResponse {
+  has_account: boolean;
+  account: null | {
+    id: string;
+    stripe_account_id: string;
+    charges_enabled: boolean;
+    payouts_enabled: boolean;
+    details_submitted: boolean;
+    onboarding_completed: boolean;
+    requirements_currently_due: string[];
+    requirements_past_due: string[];
+    requirements_disabled_reason: string | null;
+    bank_account_last4: string | null;
+    bank_account_bank_name: string | null;
+  };
+}
+
+export default function ProviderPayoutsPage() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<ConnectAccountResponse | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAccount = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await fetch("/api/stripe/connect");
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Erreur lors du chargement");
+      }
+      const json: ConnectAccountResponse = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAccount();
+  }, [fetchAccount]);
+
+  const startOnboarding = async () => {
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/stripe/connect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Erreur lors de l'onboarding");
+      }
+      const body = await res.json();
+      const url: string | undefined = body.onboarding_url || body.url;
+      if (!url) {
+        throw new Error("URL d'onboarding manquante");
+      }
+      window.location.href = url;
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Erreur inconnue",
+        variant: "destructive",
+      });
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-3xl py-6 space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  const account = data?.account ?? null;
+  const isComplete = Boolean(
+    account?.charges_enabled && account?.payouts_enabled
+  );
+  const hasRequirements =
+    (account?.requirements_currently_due?.length ?? 0) > 0 ||
+    (account?.requirements_past_due?.length ?? 0) > 0;
+
+  return (
+    <div className="container mx-auto max-w-3xl py-6 space-y-6">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/provider/settings">
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            Paramètres
+          </Link>
+        </Button>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+          <Banknote className="h-6 w-6 text-primary" />
+          Compte de paiement
+        </h1>
+        <p className="text-muted-foreground mt-1">
+          Configurez votre compte bancaire pour recevoir vos paiements
+          d'intervention via Stripe.
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Statut du compte */}
+      {!account ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Shield className="h-5 w-5 text-muted-foreground" />
+              Aucun compte configuré
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Pour recevoir vos paiements quand un propriétaire vous règle une
+              intervention, vous devez créer un compte Stripe et fournir vos
+              informations bancaires (KYC). Cela prend 5 à 10 minutes.
+            </p>
+            <ul className="text-sm space-y-2 list-disc list-inside text-muted-foreground">
+              <li>Vérification d'identité (CNI ou passeport)</li>
+              <li>RIB ou IBAN pour recevoir les virements</li>
+              <li>Informations entreprise (SIRET) si vous êtes en société</li>
+            </ul>
+            <Button
+              onClick={startOnboarding}
+              disabled={submitting}
+              className="w-full sm:w-auto"
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <ExternalLink className="h-4 w-4 mr-2" />
+              )}
+              Démarrer l'onboarding
+            </Button>
+          </CardContent>
+        </Card>
+      ) : isComplete ? (
+        <Card className="border-emerald-200 bg-emerald-50/40 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-emerald-800 dark:text-emerald-200">
+              <CheckCircle2 className="h-5 w-5" />
+              Compte actif
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-emerald-800/80 dark:text-emerald-200/80">
+              Votre compte Stripe est configuré. Vous recevrez automatiquement
+              les paiements d'intervention sur votre compte bancaire après
+              chaque libération de fonds.
+            </p>
+            {account.bank_account_last4 && (
+              <div className="text-sm text-foreground/80 bg-background/60 rounded-md p-3 border">
+                Compte bancaire :{" "}
+                <span className="font-medium">
+                  {account.bank_account_bank_name || "Banque"} ••••{" "}
+                  {account.bank_account_last4}
+                </span>
+              </div>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startOnboarding}
+              disabled={submitting}
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <ExternalLink className="h-4 w-4 mr-2" />
+              )}
+              Mettre à jour mes informations
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="border-amber-200 bg-amber-50/40 dark:border-amber-900/40 dark:bg-amber-950/20">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-amber-800 dark:text-amber-200">
+              <AlertTriangle className="h-5 w-5" />
+              Onboarding incomplet
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-amber-800/80 dark:text-amber-200/80">
+              Votre compte Stripe a été créé mais l'onboarding n'est pas
+              terminé. Tant que ce n'est pas fait, vous ne pouvez pas recevoir
+              de paiements.
+            </p>
+
+            {account.requirements_disabled_reason && (
+              <div className="text-sm bg-background/60 rounded-md p-3 border border-amber-300/50">
+                <strong>Raison du blocage :</strong>{" "}
+                {account.requirements_disabled_reason}
+              </div>
+            )}
+
+            {hasRequirements && (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+                  Informations à fournir :
+                </p>
+                <ul className="text-xs space-y-1 list-disc list-inside text-amber-800/70 dark:text-amber-200/70">
+                  {(account.requirements_past_due ?? []).map((r) => (
+                    <li key={r} className="text-red-700 dark:text-red-300">
+                      <strong>En retard :</strong> {r}
+                    </li>
+                  ))}
+                  {(account.requirements_currently_due ?? []).map((r) => (
+                    <li key={r}>{r}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <Button onClick={startOnboarding} disabled={submitting}>
+              {submitting ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <ExternalLink className="h-4 w-4 mr-2" />
+              )}
+              Reprendre l'onboarding
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Info commission */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Frais et commission</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground space-y-2">
+          <p>
+            Sur chaque paiement d'intervention reçu via Talok, les frais
+            suivants sont déduits :
+          </p>
+          <ul className="space-y-1 list-disc list-inside">
+            <li>
+              <strong>Frais Stripe</strong> : 1.4% + 0.25 € (incompressibles)
+            </li>
+            <li>
+              <strong>Commission Talok</strong> : 1.0% + 0.50 €
+            </li>
+          </ul>
+          <p className="text-xs">
+            Les paiements sont versés sur votre compte bancaire sous 2 à 7 jours
+            ouvrés après la libération des fonds (au démarrage des travaux pour
+            l'acompte, après validation pour le solde).
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/features/providers/services/work-orders-extended.service.ts
+++ b/features/providers/services/work-orders-extended.service.ts
@@ -357,6 +357,13 @@ export async function startIntervention(
     .single();
 
   if (error) throw error;
+
+  // Escrow : libère automatiquement l'acompte vers le compte Connect du
+  // prestataire au démarrage des travaux. Fire-and-forget — un échec
+  // (compte Connect KO, charge_id manquant…) ne doit pas bloquer la
+  // transition de statut.
+  void releaseDepositOnStart(supabase, workOrderId);
+
   return data as WorkOrderExtended;
 }
 
@@ -384,7 +391,69 @@ export async function completeIntervention(
     .single();
 
   if (error) throw error;
+
+  // Escrow : à la complétion, on pose la dispute_deadline = now + 7j sur
+  // tous les paiements 'balance'/'full' encore en escrow_status='held'.
+  // Le cron /api/cron/release-escrow libérera ces fonds après la deadline
+  // si le proprio ne valide pas explicitement avant.
+  void setDisputeDeadlineOnComplete(supabase, workOrderId);
+
   return data as WorkOrderExtended;
+}
+
+/**
+ * Libère l'acompte (escrow) vers le compte Connect du prestataire au
+ * démarrage de l'intervention. Fire-and-forget : log mais ne throw pas.
+ */
+async function releaseDepositOnStart(
+  supabase: SupabaseClient,
+  workOrderId: string
+): Promise<void> {
+  try {
+    const { findHeldPayments, releaseEscrowToProvider } = await import(
+      '@/lib/work-orders/release-escrow'
+    );
+    const heldDeposits = await findHeldPayments(supabase, workOrderId, 'deposit');
+    for (const payment of heldDeposits) {
+      try {
+        await releaseEscrowToProvider(supabase, {
+          paymentId: payment.id,
+          reason: 'deposit_release_on_start',
+        });
+      } catch (err) {
+        console.error(
+          `[startIntervention] Escrow deposit release failed for payment ${payment.id}:`,
+          err
+        );
+      }
+    }
+  } catch (err) {
+    console.error('[startIntervention] releaseDepositOnStart fatal:', err);
+  }
+}
+
+/**
+ * Pose dispute_deadline = NOW() + 7 jours sur les paiements balance/full
+ * en escrow held. Idempotent : si déjà posée, ne touche pas.
+ */
+async function setDisputeDeadlineOnComplete(
+  supabase: SupabaseClient,
+  workOrderId: string
+): Promise<void> {
+  try {
+    const deadline = new Date();
+    deadline.setDate(deadline.getDate() + 7);
+
+    await (supabase as SupabaseClient)
+      .from('work_order_payments')
+      .update({ dispute_deadline: deadline.toISOString() })
+      .eq('work_order_id', workOrderId)
+      .eq('escrow_status', 'held')
+      .in('payment_type', ['balance', 'full'])
+      .is('dispute_deadline', null);
+  } catch (err) {
+    console.error('[completeIntervention] setDisputeDeadlineOnComplete failed:', err);
+  }
 }
 
 /**

--- a/features/work-orders/components/dispute-payment-button.tsx
+++ b/features/work-orders/components/dispute-payment-button.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, Loader2, ShieldAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+
+const REASONS = [
+  { value: "work_not_done", label: "Travaux non réalisés" },
+  { value: "work_incomplete", label: "Travaux partiellement réalisés" },
+  { value: "quality_issue", label: "Problème de qualité" },
+  { value: "wrong_amount", label: "Montant incorrect" },
+  { value: "unauthorized", label: "Paiement non autorisé" },
+  { value: "other", label: "Autre" },
+] as const;
+
+interface Props {
+  workOrderId: string;
+  paymentId: string;
+  onDisputed?: () => void;
+  size?: "sm" | "default";
+  variant?: "destructive" | "outline";
+}
+
+/**
+ * Bouton "Contester ce paiement" pour le proprio. Ouvre un modal qui collecte
+ * motif + description (>=20 chars) puis poste sur
+ * /api/work-orders/[id]/dispute. Bloque la libération automatique des fonds.
+ */
+export function DisputePaymentButton({
+  workOrderId,
+  paymentId,
+  onDisputed,
+  size = "default",
+  variant = "outline",
+}: Props) {
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState<string>("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (!reason || description.trim().length < 20) {
+      toast({
+        title: "Champs incomplets",
+        description: "Sélectionnez un motif et décrivez le problème (20 caractères min)",
+        variant: "destructive",
+      });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/work-orders/${workOrderId}/dispute`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          payment_id: paymentId,
+          reason,
+          description: description.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Erreur lors de la contestation");
+      }
+      toast({
+        title: "Contestation enregistrée",
+        description:
+          "Le paiement est bloqué. Notre équipe vous contactera sous 48h pour examiner votre demande.",
+      });
+      setOpen(false);
+      setReason("");
+      setDescription("");
+      onDisputed?.();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Erreur inconnue",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant={variant}
+        size={size}
+        onClick={() => setOpen(true)}
+        className="text-amber-700 border-amber-300 hover:bg-amber-50 dark:text-amber-300 dark:border-amber-800 dark:hover:bg-amber-950/30"
+      >
+        <ShieldAlert className="h-4 w-4 mr-2" />
+        Contester ce paiement
+      </Button>
+
+      <Dialog open={open} onOpenChange={(o) => !submitting && setOpen(o)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-600" />
+              Contester le paiement
+            </DialogTitle>
+            <DialogDescription>
+              Cette contestation bloque la libération des fonds vers le
+              prestataire. Notre équipe examinera votre dossier et tranchera
+              sous 48 à 72 heures (libération, remboursement total ou partiel).
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="dispute-reason">Motif</Label>
+              <Select value={reason} onValueChange={setReason}>
+                <SelectTrigger id="dispute-reason">
+                  <SelectValue placeholder="Sélectionner un motif" />
+                </SelectTrigger>
+                <SelectContent>
+                  {REASONS.map((r) => (
+                    <SelectItem key={r.value} value={r.value}>
+                      {r.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="dispute-description">
+                Description détaillée
+                <span className="text-muted-foreground text-xs ml-1">
+                  (20 caractères minimum)
+                </span>
+              </Label>
+              <Textarea
+                id="dispute-description"
+                rows={5}
+                placeholder="Décrivez précisément le problème : ce qui était prévu vs ce qui a été fait, dates, échanges avec le prestataire…"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                {description.trim().length}/2000 caractères
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={submitting}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={submit}
+              disabled={
+                submitting || !reason || description.trim().length < 20
+              }
+              variant="destructive"
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <ShieldAlert className="h-4 w-4 mr-2" />
+              )}
+              Confirmer la contestation
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/lib/pdf/work-order-invoice-pdf.ts
+++ b/lib/pdf/work-order-invoice-pdf.ts
@@ -1,0 +1,273 @@
+/**
+ * Génère une facture PDF pour un work order avec ventilation TVA conforme.
+ *
+ * Format : A4, mentions légales obligatoires (n° SIRET prestataire, mention
+ * TVA art. 279-0 bis CGI / art. 296 CGI selon localisation, etc.).
+ *
+ * Cette facture est émise par le PRESTATAIRE au PROPRIETAIRE (pas par Talok).
+ * Talok facture sa commission séparément, mensuellement, au prestataire.
+ */
+
+import { renderHtmlToPdf } from "./html-to-pdf";
+
+export interface WorkOrderInvoiceData {
+  /** Numéro de facture (généré par le prestataire ou Talok) */
+  invoiceNumber: string;
+  /** Date d'émission au format YYYY-MM-DD */
+  invoiceDate: string;
+  /** Date d'échéance (optionnel) */
+  dueDate?: string | null;
+
+  /** Prestataire (émetteur) */
+  provider: {
+    companyName: string;
+    contactName?: string | null;
+    address?: string | null;
+    city?: string | null;
+    postalCode?: string | null;
+    siret?: string | null;
+    vatNumber?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    /** Si en franchise en base TVA, on n'affiche pas la TVA */
+    isVatExempt?: boolean;
+  };
+
+  /** Propriétaire (destinataire) */
+  client: {
+    name: string;
+    address?: string | null;
+    city?: string | null;
+    postalCode?: string | null;
+  };
+
+  /** Bien concerné par les travaux */
+  property: {
+    address: string;
+    city: string;
+    postalCode: string;
+  };
+
+  /** Lignes de devis / facture */
+  items: Array<{
+    description: string;
+    quantity: number;
+    unit: string;
+    unitPriceCents: number;
+    taxRate: number; // 0.10, 0.20, etc.
+  }>;
+
+  /** Régime TVA appliqué (référence légale) */
+  tvaReference: string;
+
+  /** Notes / conditions */
+  notes?: string | null;
+}
+
+const fmt = (cents: number) =>
+  new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+  }).format(cents / 100);
+
+const fmtDate = (iso: string | null | undefined): string => {
+  if (!iso) return "—";
+  try {
+    return new Intl.DateTimeFormat("fr-FR", {
+      day: "2-digit",
+      month: "long",
+      year: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+};
+
+const fmtPct = (rate: number) => {
+  const v = rate * 100;
+  return v % 1 === 0 ? `${v.toFixed(0)} %` : `${v.toFixed(1).replace(".", ",")} %`;
+};
+
+const escapeHtml = (s: string | null | undefined): string => {
+  if (!s) return "";
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+};
+
+function buildHtml(data: WorkOrderInvoiceData): string {
+  // Calculs ventilation
+  const linesWithTotals = data.items.map((it) => {
+    const lineHTCents = Math.round(it.quantity * it.unitPriceCents);
+    const lineTVACents = data.provider.isVatExempt
+      ? 0
+      : Math.round(lineHTCents * it.taxRate);
+    return {
+      ...it,
+      lineHTCents,
+      lineTVACents,
+      lineTTCCents: lineHTCents + lineTVACents,
+    };
+  });
+
+  const totalHT = linesWithTotals.reduce((s, l) => s + l.lineHTCents, 0);
+  const totalTVA = linesWithTotals.reduce((s, l) => s + l.lineTVACents, 0);
+  const totalTTC = totalHT + totalTVA;
+
+  // Ventilation par taux (utile si plusieurs taux dans la même facture)
+  const tvaByRate = new Map<number, { ht: number; tva: number }>();
+  linesWithTotals.forEach((l) => {
+    const cur = tvaByRate.get(l.taxRate) ?? { ht: 0, tva: 0 };
+    tvaByRate.set(l.taxRate, {
+      ht: cur.ht + l.lineHTCents,
+      tva: cur.tva + l.lineTVACents,
+    });
+  });
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Facture ${escapeHtml(data.invoiceNumber)}</title>
+  <style>
+    @page { size: A4; margin: 1.5cm; }
+    * { box-sizing: border-box; }
+    body { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; color: #0f172a; font-size: 11pt; line-height: 1.4; margin: 0; padding: 0; }
+    h1 { font-size: 24pt; margin: 0 0 4pt; color: #1d4ed8; }
+    h2 { font-size: 12pt; margin: 0 0 6pt; color: #475569; text-transform: uppercase; letter-spacing: 0.5pt; }
+    .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 24pt; }
+    .header-right { text-align: right; }
+    .meta { color: #64748b; font-size: 10pt; }
+    .parties { display: flex; gap: 16pt; margin-bottom: 24pt; }
+    .party { flex: 1; padding: 12pt; background: #f8fafc; border-radius: 6pt; border: 1pt solid #e2e8f0; }
+    .property-banner { padding: 10pt 12pt; background: #eff6ff; border-left: 3pt solid #2563eb; border-radius: 4pt; margin-bottom: 18pt; font-size: 10pt; color: #1e3a8a; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 16pt; }
+    th, td { padding: 8pt 6pt; text-align: left; border-bottom: 0.5pt solid #cbd5e1; }
+    th { background: #1e3a8a; color: #fff; font-weight: 600; font-size: 9pt; text-transform: uppercase; letter-spacing: 0.3pt; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    .totals { margin-top: 12pt; margin-left: auto; width: 50%; }
+    .totals tr td { border: none; padding: 4pt 0; }
+    .totals .label { color: #64748b; }
+    .totals .ttc { font-size: 14pt; font-weight: 700; padding-top: 8pt; border-top: 1pt solid #1e3a8a; }
+    .footer { margin-top: 32pt; padding-top: 12pt; border-top: 0.5pt solid #cbd5e1; font-size: 9pt; color: #64748b; }
+    .footer p { margin: 2pt 0; }
+    .legal { margin-top: 16pt; font-size: 8.5pt; color: #94a3b8; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1>FACTURE</h1>
+      <div class="meta">N° ${escapeHtml(data.invoiceNumber)}</div>
+      <div class="meta">Émise le ${fmtDate(data.invoiceDate)}</div>
+      ${data.dueDate ? `<div class="meta">Échéance : ${fmtDate(data.dueDate)}</div>` : ""}
+    </div>
+    <div class="header-right">
+      <strong>${escapeHtml(data.provider.companyName)}</strong><br />
+      ${data.provider.address ? `${escapeHtml(data.provider.address)}<br />` : ""}
+      ${data.provider.postalCode ? `${escapeHtml(data.provider.postalCode)} ${escapeHtml(data.provider.city ?? "")}<br />` : ""}
+      ${data.provider.siret ? `<span class="meta">SIRET : ${escapeHtml(data.provider.siret)}</span><br />` : ""}
+      ${data.provider.vatNumber ? `<span class="meta">TVA : ${escapeHtml(data.provider.vatNumber)}</span>` : ""}
+    </div>
+  </div>
+
+  <div class="parties">
+    <div class="party">
+      <h2>Émetteur</h2>
+      <strong>${escapeHtml(data.provider.companyName)}</strong><br />
+      ${data.provider.contactName ? `${escapeHtml(data.provider.contactName)}<br />` : ""}
+      ${data.provider.email ? `${escapeHtml(data.provider.email)}<br />` : ""}
+      ${data.provider.phone ? escapeHtml(data.provider.phone) : ""}
+    </div>
+    <div class="party">
+      <h2>Destinataire</h2>
+      <strong>${escapeHtml(data.client.name)}</strong><br />
+      ${data.client.address ? `${escapeHtml(data.client.address)}<br />` : ""}
+      ${data.client.postalCode ? `${escapeHtml(data.client.postalCode)} ${escapeHtml(data.client.city ?? "")}` : ""}
+    </div>
+  </div>
+
+  <div class="property-banner">
+    <strong>Lieu d'intervention :</strong>
+    ${escapeHtml(data.property.address)}, ${escapeHtml(data.property.postalCode)} ${escapeHtml(data.property.city)}
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Description</th>
+        <th class="num">Qté</th>
+        <th>Unité</th>
+        <th class="num">PU HT</th>
+        <th class="num">TVA</th>
+        <th class="num">Total HT</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${linesWithTotals
+        .map(
+          (l) => `
+      <tr>
+        <td>${escapeHtml(l.description)}</td>
+        <td class="num">${l.quantity}</td>
+        <td>${escapeHtml(l.unit)}</td>
+        <td class="num">${fmt(l.unitPriceCents)}</td>
+        <td class="num">${data.provider.isVatExempt ? "—" : fmtPct(l.taxRate)}</td>
+        <td class="num">${fmt(l.lineHTCents)}</td>
+      </tr>`,
+        )
+        .join("")}
+    </tbody>
+  </table>
+
+  <table class="totals">
+    <tr>
+      <td class="label">Total HT</td>
+      <td class="num">${fmt(totalHT)}</td>
+    </tr>
+    ${
+      data.provider.isVatExempt
+        ? `<tr>
+            <td class="label" colspan="2" style="font-style: italic; color: #64748b; padding-top: 8pt;">
+              TVA non applicable, art. 293 B du CGI
+            </td>
+          </tr>`
+        : Array.from(tvaByRate.entries())
+            .map(
+              ([rate, t]) => `
+    <tr>
+      <td class="label">TVA ${fmtPct(rate)} sur ${fmt(t.ht)}</td>
+      <td class="num">${fmt(t.tva)}</td>
+    </tr>`,
+            )
+            .join("")
+    }
+    <tr>
+      <td class="ttc">Total TTC</td>
+      <td class="ttc num">${fmt(totalTTC)}</td>
+    </tr>
+  </table>
+
+  ${data.notes ? `<div class="footer"><p><strong>Conditions :</strong> ${escapeHtml(data.notes)}</p></div>` : ""}
+
+  <div class="legal">
+    <p>${escapeHtml(data.tvaReference)}</p>
+    <p>En cas de retard de paiement, application d'une indemnité forfaitaire de 40 € pour frais de recouvrement (art. L.441-10 Code de commerce).</p>
+    <p>Tout règlement s'effectue via la plateforme Talok (paiement par carte) ou par virement bancaire.</p>
+  </div>
+</body>
+</html>`;
+}
+
+export async function generateWorkOrderInvoicePdf(
+  data: WorkOrderInvoiceData,
+): Promise<Buffer> {
+  const html = buildHtml(data);
+  return await renderHtmlToPdf(html, {
+    format: "A4",
+    margin: { top: "1.5cm", right: "1.5cm", bottom: "1.5cm", left: "1.5cm" },
+  });
+}

--- a/lib/work-orders/dispute.ts
+++ b/lib/work-orders/dispute.ts
@@ -1,0 +1,360 @@
+/**
+ * Service de gestion des litiges sur les paiements work orders.
+ *
+ * Flux :
+ *   1. Owner conteste un paiement en escrow_status='held' (ou 'released' si
+ *      vraiment problème post-libération, dans la limite de la fenêtre de
+ *      remboursement Stripe).
+ *   2. work_order_payments.escrow_status passe à 'disputed' → cron de
+ *      libération auto bloqué.
+ *   3. Admin Talok examine + tranche :
+ *        - Libère vers le prestataire (resolved_release)
+ *        - Rembourse vers le proprio (resolved_refund) → Stripe Refund
+ *        - Mix (resolved_partial)
+ *   4. Le owner peut retirer sa contestation (withdrawn) à tout moment.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { stripe } from "@/lib/stripe";
+
+export type DisputeReason =
+  | "work_not_done"
+  | "work_incomplete"
+  | "quality_issue"
+  | "wrong_amount"
+  | "unauthorized"
+  | "other";
+
+export interface RaiseDisputeInput {
+  workOrderPaymentId: string;
+  raisedByProfileId: string;
+  reason: DisputeReason;
+  description: string;
+  evidenceUrls?: string[];
+}
+
+export class DisputeError extends Error {
+  constructor(
+    public readonly code:
+      | "PAYMENT_NOT_FOUND"
+      | "INVALID_STATE"
+      | "ALREADY_DISPUTED"
+      | "STRIPE_ERROR"
+      | "NOT_FOUND",
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "DisputeError";
+  }
+}
+
+/**
+ * Crée un litige et bloque la libération automatique du paiement.
+ */
+export async function raiseDispute(
+  supabase: SupabaseClient,
+  input: RaiseDisputeInput,
+): Promise<{ disputeId: string }> {
+  const { workOrderPaymentId, raisedByProfileId, reason, description, evidenceUrls = [] } = input;
+
+  // 1. Charger le paiement
+  const { data: payment } = await supabase
+    .from("work_order_payments")
+    .select("id, work_order_id, escrow_status, status")
+    .eq("id", workOrderPaymentId)
+    .maybeSingle();
+
+  if (!payment) {
+    throw new DisputeError(
+      "PAYMENT_NOT_FOUND",
+      `Paiement ${workOrderPaymentId} introuvable`,
+    );
+  }
+
+  const p = payment as {
+    id: string;
+    work_order_id: string;
+    escrow_status: string;
+    status: string;
+  };
+
+  if (p.escrow_status === "disputed") {
+    throw new DisputeError(
+      "ALREADY_DISPUTED",
+      "Ce paiement est déjà en litige",
+    );
+  }
+
+  if (!["held", "released"].includes(p.escrow_status)) {
+    throw new DisputeError(
+      "INVALID_STATE",
+      `Impossible de contester un paiement en escrow_status='${p.escrow_status}'`,
+    );
+  }
+
+  // 2. Créer la ligne dispute
+  const { data: dispute, error: dErr } = await supabase
+    .from("work_order_disputes")
+    .insert({
+      work_order_payment_id: workOrderPaymentId,
+      work_order_id: p.work_order_id,
+      raised_by_profile_id: raisedByProfileId,
+      reason,
+      description,
+      evidence_urls: evidenceUrls,
+      status: "open",
+    })
+    .select("id")
+    .single();
+
+  if (dErr || !dispute) {
+    throw new DisputeError(
+      "STRIPE_ERROR",
+      `Erreur création dispute: ${dErr?.message ?? "unknown"}`,
+      dErr,
+    );
+  }
+
+  // 3. Bloquer le paiement (escrow_status='disputed') si encore en escrow.
+  //    Si déjà 'released', on garde le status pour audit mais le dispute
+  //    nécessitera un Refund Stripe (admin tranche).
+  if (p.escrow_status === "held") {
+    await supabase
+      .from("work_order_payments")
+      .update({ escrow_status: "disputed" })
+      .eq("id", workOrderPaymentId)
+      .eq("escrow_status", "held");
+  }
+
+  return { disputeId: (dispute as { id: string }).id };
+}
+
+/**
+ * L'owner retire sa contestation. Si le paiement était bloqué en
+ * 'disputed', il revient à 'held' et reprend son cycle normal.
+ */
+export async function withdrawDispute(
+  supabase: SupabaseClient,
+  disputeId: string,
+  profileId: string,
+): Promise<void> {
+  const { data: dispute } = await supabase
+    .from("work_order_disputes")
+    .select("id, work_order_payment_id, status, raised_by_profile_id")
+    .eq("id", disputeId)
+    .maybeSingle();
+
+  if (!dispute) {
+    throw new DisputeError("NOT_FOUND", `Litige ${disputeId} introuvable`);
+  }
+
+  const d = dispute as {
+    id: string;
+    work_order_payment_id: string;
+    status: string;
+    raised_by_profile_id: string;
+  };
+
+  if (d.raised_by_profile_id !== profileId) {
+    throw new DisputeError(
+      "INVALID_STATE",
+      "Seul le contestataire peut retirer la contestation",
+    );
+  }
+
+  if (d.status !== "open") {
+    throw new DisputeError(
+      "INVALID_STATE",
+      `Litige déjà résolu (status=${d.status})`,
+    );
+  }
+
+  await supabase
+    .from("work_order_disputes")
+    .update({
+      status: "withdrawn",
+      resolved_at: new Date().toISOString(),
+      resolved_by_profile_id: profileId,
+    })
+    .eq("id", disputeId);
+
+  // Débloquer le paiement si encore en disputed
+  await supabase
+    .from("work_order_payments")
+    .update({ escrow_status: "held" })
+    .eq("id", d.work_order_payment_id)
+    .eq("escrow_status", "disputed");
+}
+
+/**
+ * Admin résout un litige par remboursement (full ou partiel).
+ * Crée un Stripe Refund sur la charge associée au paiement.
+ */
+export async function refundDisputedPayment(
+  supabase: SupabaseClient,
+  disputeId: string,
+  options: {
+    refundAmountCents?: number; // si absent, full refund
+    resolvedByProfileId: string;
+    notes?: string;
+  },
+): Promise<{ stripeRefundId: string; refundAmountCents: number }> {
+  const { refundAmountCents, resolvedByProfileId, notes } = options;
+
+  // 1. Charger dispute + payment
+  const { data: row } = await (supabase as any)
+    .from("work_order_disputes")
+    .select(
+      "id, work_order_payment_id, status, work_order_payments!inner(id, gross_amount, stripe_charge_id, stripe_payment_intent_id)",
+    )
+    .eq("id", disputeId)
+    .maybeSingle();
+
+  if (!row) throw new DisputeError("NOT_FOUND", `Litige ${disputeId} introuvable`);
+  const r = row as {
+    id: string;
+    work_order_payment_id: string;
+    status: string;
+    work_order_payments: {
+      id: string;
+      gross_amount: number | string;
+      stripe_charge_id: string | null;
+      stripe_payment_intent_id: string | null;
+    };
+  };
+
+  if (r.status !== "open") {
+    throw new DisputeError(
+      "INVALID_STATE",
+      `Litige déjà résolu (status=${r.status})`,
+    );
+  }
+
+  const grossCents = Math.round(Number(r.work_order_payments.gross_amount) * 100);
+  const amountCents = refundAmountCents ?? grossCents;
+  if (amountCents <= 0 || amountCents > grossCents) {
+    throw new DisputeError(
+      "INVALID_STATE",
+      `Montant de remboursement invalide (${amountCents} cents pour gross=${grossCents})`,
+    );
+  }
+
+  // 2. Créer le Refund Stripe (priorité charge_id, fallback payment_intent)
+  const refundParams: any = {
+    amount: amountCents,
+    metadata: {
+      type: "work_order_dispute_refund",
+      dispute_id: r.id,
+      payment_id: r.work_order_payment_id,
+    },
+    reason: "requested_by_customer",
+  };
+  if (r.work_order_payments.stripe_charge_id) {
+    refundParams.charge = r.work_order_payments.stripe_charge_id;
+  } else if (r.work_order_payments.stripe_payment_intent_id) {
+    refundParams.payment_intent = r.work_order_payments.stripe_payment_intent_id;
+  } else {
+    throw new DisputeError(
+      "INVALID_STATE",
+      "Aucune charge ni PaymentIntent Stripe associé — refund impossible",
+    );
+  }
+
+  let refund;
+  try {
+    refund = await stripe.refunds.create(refundParams, {
+      idempotencyKey: `wo-dispute-refund-${r.id}`,
+    });
+  } catch (err) {
+    throw new DisputeError(
+      "STRIPE_ERROR",
+      err instanceof Error ? err.message : "Erreur Stripe",
+      err,
+    );
+  }
+
+  // 3. Mettre à jour la dispute
+  const isPartial = amountCents < grossCents;
+  await supabase
+    .from("work_order_disputes")
+    .update({
+      status: isPartial ? "resolved_partial" : "resolved_refund",
+      resolved_at: new Date().toISOString(),
+      resolved_by_profile_id: resolvedByProfileId,
+      resolution_notes: notes ?? null,
+      stripe_refund_id: refund.id,
+      refund_amount: amountCents / 100,
+    })
+    .eq("id", r.id);
+
+  // 4. Mettre à jour le paiement
+  await supabase
+    .from("work_order_payments")
+    .update({
+      escrow_status: isPartial ? "released" : "refunded",
+      status: isPartial ? "succeeded" : "refunded",
+    })
+    .eq("id", r.work_order_payment_id);
+
+  return { stripeRefundId: refund.id, refundAmountCents: amountCents };
+}
+
+/**
+ * Admin tranche en faveur du prestataire : libération normale via le service
+ * release-escrow, et clôture du litige.
+ */
+export async function releaseDisputedPayment(
+  supabase: SupabaseClient,
+  disputeId: string,
+  resolvedByProfileId: string,
+  notes?: string,
+): Promise<{ paymentId: string }> {
+  const { data: dispute } = await supabase
+    .from("work_order_disputes")
+    .select("id, work_order_payment_id, status")
+    .eq("id", disputeId)
+    .maybeSingle();
+
+  if (!dispute) throw new DisputeError("NOT_FOUND", `Litige ${disputeId} introuvable`);
+  const d = dispute as {
+    id: string;
+    work_order_payment_id: string;
+    status: string;
+  };
+
+  if (d.status !== "open") {
+    throw new DisputeError(
+      "INVALID_STATE",
+      `Litige déjà résolu (status=${d.status})`,
+    );
+  }
+
+  // 1. Débloquer le paiement (disputed -> held) avant la libération
+  await supabase
+    .from("work_order_payments")
+    .update({ escrow_status: "held" })
+    .eq("id", d.work_order_payment_id)
+    .eq("escrow_status", "disputed");
+
+  // 2. Libérer
+  const { releaseEscrowToProvider } = await import("./release-escrow");
+  await releaseEscrowToProvider(supabase, {
+    paymentId: d.work_order_payment_id,
+    reason: "manual_admin_release",
+    releasedByProfileId: resolvedByProfileId,
+  });
+
+  // 3. Clôturer la dispute
+  await supabase
+    .from("work_order_disputes")
+    .update({
+      status: "resolved_release",
+      resolved_at: new Date().toISOString(),
+      resolved_by_profile_id: resolvedByProfileId,
+      resolution_notes: notes ?? null,
+    })
+    .eq("id", d.id);
+
+  return { paymentId: d.work_order_payment_id };
+}

--- a/lib/work-orders/release-escrow.ts
+++ b/lib/work-orders/release-escrow.ts
@@ -1,0 +1,238 @@
+/**
+ * Service de libération escrow pour les paiements de work orders.
+ *
+ * Mode ESCROW (Separate charges and transfers) :
+ *   1. Le proprio a payé via Checkout Session — la charge est sur le compte
+ *      plateforme Talok (work_order_payments.escrow_status='held').
+ *   2. À un moment contrôlé (démarrage des travaux pour l'acompte, validation
+ *      ou délai 7j pour le solde), on appelle releaseEscrowToProvider() qui :
+ *        - crée un Stripe Transfer vers le compte Connect du prestataire
+ *        - le montant transféré = net_amount (déjà calculé = gross - fees)
+ *        - les fees Stripe + plateforme restent sur le compte Talok
+ *      Cette commission Talok sera consolidée mensuellement par un cron
+ *      (Sprint à venir) qui crée une facture au prestataire.
+ *
+ * Concurrency / idempotence :
+ *   - Un Transfer Stripe est idempotent via idempotencyKey (work_order_payment_id)
+ *   - Le UPDATE RLS sur work_order_payments avec WHERE escrow_status='held'
+ *     empêche une double libération
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { stripe } from "@/lib/stripe";
+
+export type ReleaseReason =
+  | "deposit_release_on_start" // libération acompte au démarrage des travaux
+  | "balance_release_on_validation" // libération solde validation explicite proprio
+  | "balance_release_on_deadline" // libération solde après délai 7j
+  | "manual_admin_release"; // libération manuelle par admin
+
+export interface ReleaseEscrowOptions {
+  paymentId: string;
+  reason: ReleaseReason;
+  /** Profil qui déclenche la libération (NULL si cron auto). */
+  releasedByProfileId?: string | null;
+}
+
+export interface ReleaseEscrowResult {
+  paymentId: string;
+  transferId: string;
+  netAmountCents: number;
+  destinationAccount: string;
+}
+
+export class EscrowReleaseError extends Error {
+  constructor(
+    public readonly code:
+      | "PAYMENT_NOT_FOUND"
+      | "NOT_HELD"
+      | "NO_CONNECT_ACCOUNT"
+      | "NO_CHARGE_ID"
+      | "STRIPE_ERROR"
+      | "ZERO_AMOUNT",
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "EscrowReleaseError";
+  }
+}
+
+/**
+ * Libère un paiement escrow vers le compte Connect du prestataire.
+ * Idempotent côté Stripe via idempotencyKey = paymentId.
+ */
+export async function releaseEscrowToProvider(
+  supabase: SupabaseClient,
+  options: ReleaseEscrowOptions,
+): Promise<ReleaseEscrowResult> {
+  const { paymentId, reason, releasedByProfileId = null } = options;
+
+  // 1. Charger le paiement + work order + provider
+  const { data: payment, error: pErr } = await supabase
+    .from("work_order_payments")
+    .select(
+      "id, work_order_id, payee_profile_id, net_amount, gross_amount, escrow_status, stripe_charge_id, stripe_transfer_id, stripe_payment_intent_id",
+    )
+    .eq("id", paymentId)
+    .maybeSingle();
+
+  if (pErr || !payment) {
+    throw new EscrowReleaseError(
+      "PAYMENT_NOT_FOUND",
+      `Paiement ${paymentId} introuvable`,
+      pErr,
+    );
+  }
+
+  const p = payment as {
+    id: string;
+    work_order_id: string;
+    payee_profile_id: string;
+    net_amount: number | string;
+    gross_amount: number | string;
+    escrow_status: string;
+    stripe_charge_id: string | null;
+    stripe_transfer_id: string | null;
+    stripe_payment_intent_id: string | null;
+  };
+
+  // 2. Garde-fou : déjà libéré ?
+  if (p.stripe_transfer_id) {
+    return {
+      paymentId: p.id,
+      transferId: p.stripe_transfer_id,
+      netAmountCents: Math.round(Number(p.net_amount) * 100),
+      destinationAccount: "<already-released>",
+    };
+  }
+
+  if (p.escrow_status !== "held") {
+    throw new EscrowReleaseError(
+      "NOT_HELD",
+      `Paiement ${paymentId} en escrow_status='${p.escrow_status}', attendu 'held'`,
+    );
+  }
+
+  if (!p.stripe_charge_id) {
+    throw new EscrowReleaseError(
+      "NO_CHARGE_ID",
+      `Paiement ${paymentId} sans stripe_charge_id — impossible de transférer`,
+    );
+  }
+
+  // 3. Compte Connect du prestataire
+  const { data: connect } = await supabase
+    .from("stripe_connect_accounts")
+    .select("stripe_account_id, charges_enabled, payouts_enabled")
+    .eq("profile_id", p.payee_profile_id)
+    .is("entity_id", null)
+    .maybeSingle();
+
+  const c = connect as {
+    stripe_account_id: string | null;
+    charges_enabled: boolean | null;
+    payouts_enabled: boolean | null;
+  } | null;
+
+  if (!c?.stripe_account_id) {
+    throw new EscrowReleaseError(
+      "NO_CONNECT_ACCOUNT",
+      `Prestataire ${p.payee_profile_id} sans compte Stripe Connect`,
+    );
+  }
+  if (!c.payouts_enabled) {
+    throw new EscrowReleaseError(
+      "NO_CONNECT_ACCOUNT",
+      `Compte Connect du prestataire ${p.payee_profile_id} : payouts désactivés`,
+    );
+  }
+
+  // 4. Montant net en centimes (gross - tous les frais)
+  const netAmountCents = Math.round(Number(p.net_amount) * 100);
+  if (netAmountCents <= 0) {
+    throw new EscrowReleaseError(
+      "ZERO_AMOUNT",
+      `net_amount=${p.net_amount} pour le paiement ${paymentId}`,
+    );
+  }
+
+  // 5. Créer le Transfer Stripe (idempotent par paymentId)
+  let transfer;
+  try {
+    transfer = await stripe.transfers.create(
+      {
+        amount: netAmountCents,
+        currency: "eur",
+        destination: c.stripe_account_id,
+        // source_transaction lie ce transfer à la charge originale, ce qui
+        // permet à Stripe de débloquer le transfer même si la balance Talok
+        // est insuffisante (les fonds viennent directement de la charge).
+        source_transaction: p.stripe_charge_id,
+        metadata: {
+          type: "work_order_escrow_release",
+          work_order_id: p.work_order_id,
+          payment_id: p.id,
+          release_reason: reason,
+        },
+        description: `WO ${p.work_order_id} — escrow release (${reason})`,
+      },
+      {
+        idempotencyKey: `wo-escrow-release-${p.id}`,
+      },
+    );
+  } catch (err: unknown) {
+    throw new EscrowReleaseError(
+      "STRIPE_ERROR",
+      err instanceof Error ? err.message : "Erreur Stripe inconnue",
+      err,
+    );
+  }
+
+  // 6. Update work_order_payments — l'index partiel WHERE escrow_status='held'
+  // garantit qu'on ne peut pas marquer 'released' deux fois.
+  const nowIso = new Date().toISOString();
+  await supabase
+    .from("work_order_payments")
+    .update({
+      escrow_status: "released",
+      escrow_released_at: nowIso,
+      escrow_release_reason: reason,
+      stripe_transfer_id: transfer.id,
+      released_by_profile_id: releasedByProfileId,
+      paid_at: nowIso,
+    })
+    .eq("id", p.id)
+    .eq("escrow_status", "held");
+
+  return {
+    paymentId: p.id,
+    transferId: transfer.id,
+    netAmountCents,
+    destinationAccount: c.stripe_account_id,
+  };
+}
+
+/**
+ * Trouve les paiements à libérer pour un work_order donné.
+ * @param paymentType - Filtrer par type ('deposit' / 'balance' / 'full')
+ */
+export async function findHeldPayments(
+  supabase: SupabaseClient,
+  workOrderId: string,
+  paymentType?: "deposit" | "balance" | "full",
+): Promise<Array<{ id: string; payment_type: string }>> {
+  let query = (supabase as any)
+    .from("work_order_payments")
+    .select("id, payment_type")
+    .eq("work_order_id", workOrderId)
+    .eq("escrow_status", "held")
+    .eq("status", "succeeded");
+
+  if (paymentType) {
+    query = query.eq("payment_type", paymentType);
+  }
+
+  const { data } = await query;
+  return (data || []) as Array<{ id: string; payment_type: string }>;
+}

--- a/lib/work-orders/tva-travaux.ts
+++ b/lib/work-orders/tva-travaux.ts
@@ -1,0 +1,170 @@
+/**
+ * Taux de TVA applicables aux travaux dans un logement.
+ *
+ * Différent de la TVA SaaS (lib/billing/tva.ts) :
+ *   - Travaux logement habitation > 2 ans : 10% (art. 279-0 bis CGI)
+ *   - Rénovation énergétique avec attestation : 5.5% (art. 278-0 bis A CGI)
+ *   - Travaux logement < 2 ans ou local commercial : 20% (taux normal)
+ *   - DROM : 8.5% Antilles + Réunion, 2.1% Guyane, 0% Mayotte
+ *
+ * Source : https://bofip.impots.gouv.fr/bofip/2099-PGP.html
+ */
+
+import { getDepartementCodeFromCP } from "@/lib/helpers/address-utils";
+
+export type WorkType =
+  | "entretien" // Entretien courant — taux réduit
+  | "amelioration" // Amélioration / pose équipement — taux réduit
+  | "renovation_energetique" // Rénovation énergétique avec attestation — super réduit
+  | "construction" // Construction neuve / surélévation — taux normal
+  | "autre"; // Cas non clair — taux normal
+
+export type TVATravauxResult = {
+  /** Taux décimal (ex: 0.10 pour 10%) */
+  rate: number;
+  /** Taux affichable ("10 %", "8,5 %"…) */
+  formatted: string;
+  /** Code interne du régime appliqué */
+  regime:
+    | "metropole_normal" // 20%
+    | "metropole_reduit" // 10%
+    | "metropole_super_reduit" // 5.5%
+    | "drom_antilles_reunion" // 8.5%
+    | "drom_guyane" // 2.1%
+    | "drom_mayotte"; // 0%
+  /** Référence légale */
+  reference: string;
+};
+
+interface ResolveTVAParams {
+  /** Code postal du bien (utilisé pour DROM) */
+  codePostal: string | null | undefined;
+  /** Année de construction du logement (pour règle des 2 ans) */
+  propertyBuildYear: number | null | undefined;
+  /** Type de travaux */
+  workType: WorkType;
+  /** S'il s'agit d'un local commercial, on force le taux normal métropole */
+  isCommercial?: boolean;
+  /** Override manuel du taux (par le prestataire) — bypass tout */
+  overrideRate?: number | null;
+}
+
+const PCT = (rate: number) => {
+  const v = rate * 100;
+  const formatted =
+    v % 1 === 0 ? v.toFixed(0) : v.toFixed(1).replace(".", ",");
+  return `${formatted} %`;
+};
+
+/**
+ * Résout le taux de TVA applicable pour des travaux selon :
+ * - localisation du bien (métropole vs DROM)
+ * - âge du logement (2 ans = règle clé)
+ * - type de travaux
+ */
+export function resolveWorkOrderTVA(params: ResolveTVAParams): TVATravauxResult {
+  const {
+    codePostal,
+    propertyBuildYear,
+    workType,
+    isCommercial = false,
+    overrideRate,
+  } = params;
+
+  // Override manuel par le prestataire
+  if (overrideRate !== null && overrideRate !== undefined) {
+    return {
+      rate: overrideRate,
+      formatted: PCT(overrideRate),
+      regime: "metropole_normal", // n'a pas de sens technique mais respecte le type
+      reference: "Taux saisi par le prestataire",
+    };
+  }
+
+  // 1. DROM : règle territoriale prioritaire (art. 296 et 296 ter CGI)
+  const dept = getDepartementCodeFromCP(codePostal);
+  if (dept === "976") {
+    return {
+      rate: 0,
+      formatted: PCT(0),
+      regime: "drom_mayotte",
+      reference: "Pas de TVA à Mayotte (art. 1er-1° bis CGI)",
+    };
+  }
+  if (dept === "973") {
+    return {
+      rate: 0.021,
+      formatted: PCT(0.021),
+      regime: "drom_guyane",
+      reference: "TVA 2,1 % Guyane (art. 296 CGI)",
+    };
+  }
+  if (dept && ["971", "972", "974"].includes(dept)) {
+    return {
+      rate: 0.085,
+      formatted: PCT(0.085),
+      regime: "drom_antilles_reunion",
+      reference: "TVA 8,5 % Antilles/Réunion (art. 296 CGI)",
+    };
+  }
+
+  // 2. Métropole : taux normal pour locaux non-habitation, neufs, ou
+  //    travaux non éligibles
+  if (isCommercial || workType === "construction" || workType === "autre") {
+    return {
+      rate: 0.20,
+      formatted: PCT(0.20),
+      regime: "metropole_normal",
+      reference: "TVA 20 % (art. 278 CGI)",
+    };
+  }
+
+  // 3. Règle des 2 ans : si logement < 2 ans, taux normal
+  const currentYear = new Date().getFullYear();
+  const ageYears = propertyBuildYear
+    ? currentYear - propertyBuildYear
+    : null;
+  if (ageYears !== null && ageYears < 2) {
+    return {
+      rate: 0.20,
+      formatted: PCT(0.20),
+      regime: "metropole_normal",
+      reference: "Logement < 2 ans : TVA 20 % (art. 279-0 bis CGI a contrario)",
+    };
+  }
+
+  // 4. Rénovation énergétique : taux super réduit avec attestation
+  if (workType === "renovation_energetique") {
+    return {
+      rate: 0.055,
+      formatted: PCT(0.055),
+      regime: "metropole_super_reduit",
+      reference:
+        "TVA 5,5 % rénovation énergétique (art. 278-0 bis A CGI), sous attestation",
+    };
+  }
+
+  // 5. Entretien / amélioration logement > 2 ans : taux réduit 10%
+  return {
+    rate: 0.10,
+    formatted: PCT(0.10),
+    regime: "metropole_reduit",
+    reference: "TVA 10 % travaux logement > 2 ans (art. 279-0 bis CGI)",
+  };
+}
+
+/**
+ * Calcule la ventilation HT / TVA / TTC depuis un montant TTC + un taux.
+ * Utile pour générer la facture PDF quand le devis stocke seulement le TTC.
+ */
+export function splitFromTTC(
+  ttcCents: number,
+  rate: number,
+): { htCents: number; tvaCents: number; ttcCents: number } {
+  const htCents = Math.round(ttcCents / (1 + rate));
+  return {
+    htCents,
+    tvaCents: ttcCents - htCents,
+    ttcCents,
+  };
+}

--- a/supabase/migrations/20260426130000_work_orders_dispute_deadline.sql
+++ b/supabase/migrations/20260426130000_work_orders_dispute_deadline.sql
@@ -1,0 +1,43 @@
+-- =====================================================
+-- Migration : Délai de contestation 7j avant libération du solde
+-- Date : 2026-04-26
+--
+-- Contexte :
+--   Sprint B du flux escrow. Quand le proprio paie le solde (70%) après que
+--   les travaux sont marqués 'completed', les fonds restent en escrow le
+--   temps d'un délai de contestation de 7 jours. Passé ce délai sans dispute,
+--   un cron quotidien libère automatiquement les fonds vers le compte
+--   Connect du prestataire (Stripe Transfer).
+--
+-- Changements :
+--   1. Ajout work_order_payments.dispute_deadline TIMESTAMPTZ — date après
+--      laquelle le cron peut libérer automatiquement les fonds.
+--   2. Ajout work_order_payments.released_by_profile_id UUID — qui a
+--      déclenché la libération (proprio si validation explicite, NULL si
+--      cron auto, prestataire jamais).
+--   3. Index partiel pour accélérer le cron (escrow_status='held' AND
+--      dispute_deadline IS NOT NULL).
+-- =====================================================
+
+BEGIN;
+
+-- 1. Colonnes
+ALTER TABLE public.work_order_payments
+  ADD COLUMN IF NOT EXISTS dispute_deadline TIMESTAMPTZ;
+
+ALTER TABLE public.work_order_payments
+  ADD COLUMN IF NOT EXISTS released_by_profile_id UUID
+    REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.work_order_payments.dispute_deadline IS
+  'Date limite de contestation. Si escrow_status=''held'' et NOW() > dispute_deadline, le cron libère les fonds vers le compte Connect du prestataire. NULL = libération immédiate possible (acompte au démarrage).';
+
+COMMENT ON COLUMN public.work_order_payments.released_by_profile_id IS
+  'Profil qui a déclenché la libération (proprio si validation explicite). NULL = libération automatique par cron après dispute_deadline.';
+
+-- 2. Index pour le cron de libération automatique
+CREATE INDEX IF NOT EXISTS idx_wo_payments_pending_release
+  ON public.work_order_payments (dispute_deadline)
+  WHERE escrow_status = 'held' AND dispute_deadline IS NOT NULL;
+
+COMMIT;

--- a/supabase/migrations/20260426140000_work_orders_disputes.sql
+++ b/supabase/migrations/20260426140000_work_orders_disputes.sql
@@ -1,0 +1,118 @@
+-- =====================================================
+-- Migration : Litiges work orders (Sprint D)
+-- Date : 2026-04-26
+--
+-- Permet à un propriétaire de contester un paiement WO en escrow_status='held'
+-- avant la libération automatique. Pendant la contestation, le cron de
+-- libération est bloqué (escrow_status='disputed' au lieu de 'held').
+-- L'admin support peut résoudre le litige (libérer ou rembourser).
+-- =====================================================
+
+BEGIN;
+
+-- 1. Table des litiges
+CREATE TABLE IF NOT EXISTS public.work_order_disputes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Le paiement contesté
+  work_order_payment_id UUID NOT NULL
+    REFERENCES public.work_order_payments(id) ON DELETE CASCADE,
+  work_order_id UUID NOT NULL
+    REFERENCES public.work_orders(id) ON DELETE CASCADE,
+
+  -- Qui conteste (propriétaire normalement)
+  raised_by_profile_id UUID NOT NULL
+    REFERENCES public.profiles(id) ON DELETE SET NULL,
+
+  -- Détails de la contestation
+  reason TEXT NOT NULL CHECK (reason IN (
+    'work_not_done',           -- Travaux non réalisés
+    'work_incomplete',         -- Travaux partiellement réalisés
+    'quality_issue',           -- Problème de qualité
+    'wrong_amount',            -- Montant incorrect
+    'unauthorized',            -- Paiement non autorisé
+    'other'                    -- Autre
+  )),
+  description TEXT NOT NULL,
+  evidence_urls TEXT[] DEFAULT '{}',
+
+  -- Résolution
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN (
+    'open',                    -- En cours d'examen
+    'resolved_release',        -- Libéré au prestataire (admin tranche)
+    'resolved_refund',         -- Remboursé au propriétaire (admin tranche)
+    'resolved_partial',        -- Remboursement partiel + libération partielle
+    'withdrawn'                -- Retiré par le propriétaire
+  )),
+  resolution_notes TEXT,
+  resolved_at TIMESTAMPTZ,
+  resolved_by_profile_id UUID
+    REFERENCES public.profiles(id) ON DELETE SET NULL,
+
+  -- Stripe (si remboursement effectué)
+  stripe_refund_id TEXT,
+  refund_amount DECIMAL(10,2),
+
+  -- Dates
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wo_disputes_payment
+  ON public.work_order_disputes(work_order_payment_id);
+CREATE INDEX IF NOT EXISTS idx_wo_disputes_work_order
+  ON public.work_order_disputes(work_order_id);
+CREATE INDEX IF NOT EXISTS idx_wo_disputes_status
+  ON public.work_order_disputes(status)
+  WHERE status = 'open';
+
+-- 2. Trigger updated_at
+CREATE OR REPLACE FUNCTION public.tg_work_order_disputes_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_wo_disputes_updated_at ON public.work_order_disputes;
+CREATE TRIGGER trg_wo_disputes_updated_at
+  BEFORE UPDATE ON public.work_order_disputes
+  FOR EACH ROW EXECUTE FUNCTION public.tg_work_order_disputes_updated_at();
+
+-- 3. RLS : owner voit ses litiges, admin voit tout
+ALTER TABLE public.work_order_disputes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Owners read their disputes" ON public.work_order_disputes;
+CREATE POLICY "Owners read their disputes" ON public.work_order_disputes
+  FOR SELECT
+  USING (
+    raised_by_profile_id IN (
+      SELECT id FROM public.profiles WHERE user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Owners create their disputes" ON public.work_order_disputes;
+CREATE POLICY "Owners create their disputes" ON public.work_order_disputes
+  FOR INSERT
+  WITH CHECK (
+    raised_by_profile_id IN (
+      SELECT id FROM public.profiles WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Admin updates disputes" ON public.work_order_disputes;
+CREATE POLICY "Admin updates disputes" ON public.work_order_disputes
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## Sprint E — TVA auto-fill + facture PDF

Dernier sprint du flux escrow work orders. Permet :
- Au prestataire : récupérer le taux de TVA recommandé selon la localisation du bien + son âge + le type de travaux, modifiable
- Aux deux parties : télécharger une facture PDF conforme avec ventilation HT/TVA/TTC + mentions légales

## Architecture TVA travaux

Différent de la TVA SaaS (`lib/billing/tva.ts`). Règles spécifiques aux travaux :

| Cas | Taux | Référence |
|-----|------|-----------|
| Logement habitation > 2 ans, métropole | **10 %** | art. 279-0 bis CGI |
| Rénovation énergétique avec attestation | **5,5 %** | art. 278-0 bis A CGI |
| Logement < 2 ans / local commercial | **20 %** | art. 278 CGI |
| Antilles + Réunion (CP 971/972/974) | **8,5 %** | art. 296 CGI |
| Guyane (CP 973) | **2,1 %** | art. 296 CGI |
| Mayotte (CP 976) | **0 %** | art. 1er-1° bis CGI |

Helper `resolveWorkOrderTVA({codePostal, propertyBuildYear, workType, isCommercial, overrideRate})` → `{rate, formatted, regime, reference}`.

## Changements

### `lib/work-orders/tva-travaux.ts` (nouveau)
Logique territoriale + ancienneté + type travaux. Helper `splitFromTTC()` pour ventilation HT/TVA/TTC.

### `GET /api/work-orders/[id]/suggested-tva` (nouveau)
Query `?work_type=entretien&commercial=false` → renvoie le taux suggéré. Charge automatiquement `code_postal` + `annee_construction` du bien.

### `lib/pdf/work-order-invoice-pdf.ts` (nouveau)
Générateur HTML→PDF (via `renderHtmlToPdf` existant) :
- En-tête prestataire (raison sociale, SIRET, n° TVA, adresse)
- Bandeau "Lieu d'intervention" (adresse du bien)
- Tableau lignes (qté, unité, PU HT, TVA, total HT)
- Totaux ventilés par taux
- Mention `TVA non applicable, art. 293 B du CGI` si `vat_exempt`
- Référence légale TVA en footer
- Mention indemnité 40 € art. L.441-10 Code de commerce

### `GET /api/work-orders/[id]/invoice-pdf` (nouveau)
Retourne le PDF inline. Accès owner / prestataire / admin.

## Hors scope (à traiter ultérieurement si besoin)

- UI provider pour appeler `/suggested-tva` avant création quote (tooltip/champ pré-rempli) — la route API est prête, intégration UI dans un sprint séparé
- Cron mensuel de facturation commission Talok aux prestataires (déjà tracé dans `work_order_payments.platform_fee + stripe_fee`, reste à agréger)
- Bouton "Télécharger facture" dans l'UI WO detail

## Test plan

- [ ] `GET /api/work-orders/[id]/suggested-tva?work_type=entretien` retourne 0.10 + ref "art. 279-0 bis CGI" pour bien métropole > 2 ans
- [ ] `?work_type=renovation_energetique` → 0.055 + art. 278-0 bis A
- [ ] Bien Martinique (CP 97200) → 0.085 + art. 296 CGI peu importe `work_type`
- [ ] Bien construit cette année → 0.20 + "logement < 2 ans"
- [ ] `GET /api/work-orders/[id]/invoice-pdf` retourne un PDF Content-Type `application/pdf`
- [ ] PDF contient : en-tête prestataire avec SIRET, bandeau lieu intervention, lignes avec PU HT, totaux par taux, mention légale TVA, délai L.441-10
- [ ] Si provider `vat_exempt=true` : bloc "TVA non applicable" remplace les lignes TVA
- [ ] Owner + provider + admin peuvent télécharger ; locataire 403

## ✅ Fin du chantier escrow WO

Avec ce PR + les Sprints A/B/C/D, le flux complet est opérationnel :
1. **Onboarding prestataire** Connect Express avec UI dédiée (Sprint C)
2. **Acompte 30%** payé via Stripe Checkout, escrow sur compte plateforme (Sprint A)
3. **Libération acompte** automatique au démarrage des travaux (Sprint B)
4. **Solde 70%** payé après facturation, escrow + délai contestation 7j (Sprint A+B)
5. **Libération solde** : validation owner, cron auto, ou contestation (Sprints B+D)
6. **Litiges + remboursements** Stripe Refund full/partiel (Sprint D)
7. **TVA + facture PDF** conforme (Sprint E)

https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J)_