### PR TITLE
feat(cron): planifier release-escrow quotidien via pg_cron

### DIFF
--- a/supabase/migrations/20260426150000_schedule_release_escrow_cron.sql
+++ b/supabase/migrations/20260426150000_schedule_release_escrow_cron.sql
@@ -1,0 +1,32 @@
+-- ============================================
+-- Migration : Schedule cron release-escrow (Sprint B work orders)
+-- Date : 2026-04-26
+--
+-- Active la libération automatique des paiements work_order_payments en
+-- escrow_status='held' dont le dispute_deadline est passé. Sans ce cron,
+-- les soldes restent bloqués indéfiniment côté plateforme Talok.
+--
+-- Pattern : Supabase pg_cron + pg_net, identique aux autres crons Talok
+-- (cf. 20260304100000_activate_pg_cron_schedules.sql).
+--
+-- Prérequis dashboard Supabase :
+--   ALTER DATABASE postgres SET app.settings.app_url = 'https://...';
+--   ALTER DATABASE postgres SET app.settings.cron_secret = '...';
+-- (déjà configuré pour les autres crons Talok)
+-- ============================================
+
+-- Idempotent : retirer l'ancien job s'il existe déjà
+SELECT cron.unschedule(jobname)
+FROM cron.job
+WHERE jobname = 'release-escrow';
+
+-- Quotidien à 3h00 UTC (heure creuse, après les éventuels paiements
+-- nocturnes). Scanne les paiements WO en escrow held avec
+-- dispute_deadline <= NOW() et déclenche les Stripe Transfers.
+SELECT cron.schedule('release-escrow', '0 3 * * *',
+  $$SELECT net.http_post(
+    url := current_setting('app.settings.app_url') || '/api/cron/release-escrow',
+    headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.settings.cron_secret')),
+    body := '{}'::jsonb
+  )$$
+);


### PR DESCRIPTION
## Cron release-escrow quotidien

Active la libération automatique des paiements `work_order_payments` en `escrow_status='held'` dont le `dispute_deadline` est passé. Sans ce cron, les soldes restent bloqués **indéfiniment** côté plateforme Talok après le délai de contestation 7j.

## Changement

Migration `20260426150000_schedule_release_escrow_cron.sql` :
- Pattern Supabase `pg_cron` + `pg_net` identique aux autres crons Talok (cf. `20260304100000_activate_pg_cron_schedules.sql`)
- Idempotent (`cron.unschedule` avant `cron.schedule`)
- **Quotidien à 3h00 UTC** (heure creuse)
- Auth `Bearer current_setting('app.settings.cron_secret')`

## Prérequis dashboard Supabase

Déjà configuré pour les autres crons (rien à faire) :
- `ALTER DATABASE postgres SET app.settings.app_url = '...'`
- `ALTER DATABASE postgres SET app.settings.cron_secret = '...'`

## Test plan

- [ ] Migration appliquée : `SELECT * FROM cron.job WHERE jobname='release-escrow'` retourne 1 ligne, schedule='0 3 * * *'
- [ ] Vérif déclenchement : `SELECT * FROM cron.job_run_details WHERE jobid IN (SELECT jobid FROM cron.job WHERE jobname='release-escrow') ORDER BY start_time DESC LIMIT 5` après 3h UTC
- [ ] Test manuel : `curl -H "Authorization: Bearer $CRON_SECRET" https://app.talok.fr/api/cron/release-escrow` retourne `{released: N, errors: 0}`

https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQdEvPzHWfX5YWeBcdiu9J)_