### PR TITLE
fix(rls): phase 2 — 8 high-impact lease routes (pay, terminate, deposit, summary, invoices, signatures)

### DIFF
--- a/app/api/leases/[id]/deposit/refunds/route.ts
+++ b/app/api/leases/[id]/deposit/refunds/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -41,15 +42,17 @@ export async function POST(
       );
     }
 
-    // Vérifier que l'utilisateur est propriétaire du bail
-    const { data: lease } = await supabase
+    // Service-role + check métier owner/admin (cf. docs/audits/rls-cascade-audit.md).
+    const serviceClient = getServiceClient();
+
+    const { data: lease } = await serviceClient
       .from("leases")
       .select(`
         id,
-        property:properties!inner(owner_id)
+        property:properties(owner_id)
       `)
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!lease) {
       return NextResponse.json(
@@ -58,15 +61,18 @@ export async function POST(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    const leaseData = lease as any;
-    const profileData = profile as any;
-    if (leaseData.property.owner_id !== profileData?.id) {
+    const leaseData = lease as { property?: { owner_id?: string } | null };
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = leaseData.property?.owner_id === profileData?.id;
+
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }
@@ -74,13 +80,13 @@ export async function POST(
     }
 
     // Vérifier le solde disponible
-    const { data: balance } = await supabase
+    const { data: balance } = await serviceClient
       .from("deposit_balance")
       .select("balance")
-      .eq("lease_id", id as any)
+      .eq("lease_id", id)
       .maybeSingle();
 
-    const balanceData = balance as any;
+    const balanceData = balance as { balance?: number } | null;
     const availableBalance = balanceData?.balance || 0;
 
     if (amount > availableBalance) {
@@ -92,11 +98,11 @@ export async function POST(
 
     // Vérifier que l'EDL de sortie est signé (pour restitution totale)
     if (!is_partial) {
-      const { data: edl } = await supabase
+      const { data: edl } = await serviceClient
         .from("edl")
         .select("id, signed_at")
-        .eq("lease_id", id as any)
-        .eq("type", "sortie" as any)
+        .eq("lease_id", id)
+        .eq("type", "sortie")
         .is("signed_at", null)
         .maybeSingle();
 

--- a/app/api/leases/[id]/deposit/route.ts
+++ b/app/api/leases/[id]/deposit/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -34,15 +35,18 @@ export async function POST(
       );
     }
 
-    // Vérifier que l'utilisateur est propriétaire du bail
-    const { data: lease } = await supabase
+    // Service-role pour la lecture (RLS cascade leases→properties).
+    // Sécurité garantie par le check owner_id ci-dessous.
+    const serviceClient = getServiceClient();
+
+    const { data: lease } = await serviceClient
       .from("leases")
       .select(`
         id,
-        property:properties!inner(owner_id)
+        property:properties(owner_id)
       `)
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!lease) {
       return NextResponse.json(
@@ -51,15 +55,18 @@ export async function POST(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    const leaseData = lease as any;
-    const profileData = profile as any;
-    if (leaseData.property.owner_id !== profileData?.id) {
+    const leaseData = lease as { property?: { owner_id?: string } | null };
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = leaseData.property?.owner_id === profileData?.id;
+
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }
@@ -67,11 +74,11 @@ export async function POST(
     }
 
     // Vérifier le montant du dépôt dans le bail
-    const { data: leaseDetails } = await supabase
+    const { data: leaseDetails } = await serviceClient
       .from("leases")
       .select("depot_de_garantie")
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     // Créer le mouvement d'encaissement
     const { data: movement, error } = await supabase
@@ -159,32 +166,42 @@ export async function GET(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Vérifier l'accès au bail
-    const { data: roommate } = await supabase
-      .from("roommates")
-      .select("id")
-      .eq("lease_id", id as any)
-      .eq("user_id", user.id as any)
-      .maybeSingle();
+    // Service-role + check métier explicite (locataire actif via roommates,
+    // propriétaire via property, ou admin).
+    const serviceClient = getServiceClient();
 
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+    const [{ data: roommate }, { data: profile }, { data: lease }] = await Promise.all([
+      serviceClient
+        .from("roommates")
+        .select("id")
+        .eq("lease_id", id)
+        .eq("user_id", user.id)
+        .is("left_on", null)
+        .maybeSingle(),
+      serviceClient
+        .from("profiles")
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle(),
+      serviceClient
+        .from("leases")
+        .select(`
+          id,
+          property:properties(owner_id)
+        `)
+        .eq("id", id)
+        .maybeSingle(),
+    ]);
 
-    const { data: lease } = await supabase
-      .from("leases")
-      .select(`
-        id,
-        property:properties!inner(owner_id)
-      `)
-      .eq("id", id as any)
-      .single();
+    if (!lease) {
+      return NextResponse.json({ error: "Bail non trouvé" }, { status: 404 });
+    }
 
-    const leaseData = lease as any;
-    const profileData = profile as any;
-    const hasAccess = roommate || leaseData?.property?.owner_id === profileData?.id;
+    const leaseData = lease as { property?: { owner_id?: string } | null };
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = leaseData.property?.owner_id === profileData?.id;
+    const hasAccess = !!roommate || isOwner || isAdmin;
 
     if (!hasAccess) {
       return NextResponse.json(
@@ -193,20 +210,18 @@ export async function GET(
       );
     }
 
-    // Récupérer les mouvements
-    const { data: movements, error } = await supabase
+    const { data: movements, error } = await serviceClient
       .from("deposit_movements")
       .select("*")
-      .eq("lease_id", id as any)
+      .eq("lease_id", id)
       .order("created_at", { ascending: false });
 
     if (error) throw error;
 
-    // Récupérer le solde
-    const { data: balance } = await supabase
+    const { data: balance } = await serviceClient
       .from("deposit_balance")
       .select("*")
-      .eq("lease_id", id as any)
+      .eq("lease_id", id)
       .maybeSingle();
 
     return NextResponse.json({

--- a/app/api/leases/[id]/pay/route.ts
+++ b/app/api/leases/[id]/pay/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { getRateLimiterByUser, rateLimitPresets } from "@/lib/middleware/rate-limit";
 import { isLegacyTenantPaymentRouteEnabled } from "@/lib/payments/tenant-payment-flow";
@@ -71,14 +72,18 @@ export async function POST(
       );
     }
 
-    // Vérifier que l'utilisateur est bien locataire de ce bail
-    const { data: roommate } = await supabase
+    // Service-role: la RLS sur roommates retournait null pour des locataires
+    // pourtant légitimes (cascade via lease_signers). Le check métier ci-dessous
+    // garantit qu'on n'accepte le paiement que pour un roommate actif sur ce bail.
+    const serviceClient = getServiceClient();
+
+    const { data: roommate } = await serviceClient
       .from("roommates")
       .select("id")
-      .eq("lease_id", id as any)
-      .eq("user_id", user.id as any)
+      .eq("lease_id", id)
+      .eq("user_id", user.id)
       .is("left_on", null)
-      .single();
+      .maybeSingle();
 
     if (!roommate) {
       return NextResponse.json(
@@ -87,15 +92,14 @@ export async function POST(
       );
     }
 
-    // Récupérer la part de paiement
-    const { data: paymentShare, error: shareError } = await supabase
+    const { data: paymentShare } = await serviceClient
       .from("payment_shares")
       .select("*")
-      .eq("id", paymentShareId as any)
-      .eq("roommate_id", (roommate as any).id as any)
-      .single();
+      .eq("id", paymentShareId)
+      .eq("roommate_id", (roommate as { id: string }).id)
+      .maybeSingle();
 
-    if (shareError || !paymentShare) {
+    if (!paymentShare) {
       return NextResponse.json(
         { error: "Part de paiement non trouvée" },
         { status: 404 }

--- a/app/api/leases/[id]/rent-invoices/route.ts
+++ b/app/api/leases/[id]/rent-invoices/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -34,18 +35,21 @@ export async function POST(
       );
     }
 
-    // Vérifier que l'utilisateur est propriétaire
-    const { data: lease } = await supabase
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: lease } = await serviceClient
       .from("leases")
       .select(`
         id,
         statut,
         loyer,
         charges_forfaitaires,
-        property:properties!inner(owner_id)
+        property:properties(owner_id)
       `)
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!lease) {
       return NextResponse.json(
@@ -54,7 +58,12 @@ export async function POST(
       );
     }
 
-    const leaseData = lease as any;
+    const leaseData = lease as {
+      statut?: string;
+      loyer?: number;
+      charges_forfaitaires?: number;
+      property?: { owner_id?: string } | null;
+    };
     if (leaseData.statut !== "active") {
       return NextResponse.json(
         { error: "Le bail doit être actif" },
@@ -62,14 +71,17 @@ export async function POST(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    const profileData = profile as any;
-    if (leaseData.property.owner_id !== profileData?.id) {
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = leaseData.property?.owner_id === profileData?.id;
+
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }
@@ -77,10 +89,10 @@ export async function POST(
     }
 
     // Vérifier si une facture existe déjà pour ce mois
-    const { data: existing } = await supabase
+    const { data: existing } = await serviceClient
       .from("invoices")
       .select("id")
-      .eq("lease_id", id as any)
+      .eq("lease_id", id)
       .eq("periode", month)
       .maybeSingle();
 
@@ -127,10 +139,14 @@ export async function POST(
       );
     }
 
-    const montant_loyer = parsedLoyerOverride ?? leaseData.loyer;
+    const montant_loyer = parsedLoyerOverride ?? leaseData.loyer ?? 0;
     const montant_charges = parsedChargesOverride ?? leaseData.charges_forfaitaires ?? 0;
     const montant_total = montant_loyer + montant_charges;
     const dueDate = `${month}-05`;
+
+    if (!profileData) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+    }
 
     // Créer la facture
     const { data: invoice, error: invoiceError } = await supabase

--- a/app/api/leases/[id]/summary/route.ts
+++ b/app/api/leases/[id]/summary/route.ts
@@ -1,16 +1,20 @@
 export const dynamic = "force-dynamic";
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
  * GET /api/leases/[id]/summary - Fiche synthèse d'un bail
  *
- * @version 2026-01-22 - Fix: Next.js 15 params Promise pattern
+ * Service-role + check métier explicite (cf. docs/audits/rls-cascade-audit.md) :
+ * accès accordé aux signataires du bail, au propriétaire de la propriété
+ * et aux admins. Avant ce fix, la cascade RLS sur properties/units/profiles
+ * pouvait blanker la jointure et renvoyer 404 à un signataire légitime.
  */
 export async function GET(
-  request: Request,
+  _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
@@ -24,8 +28,9 @@ export async function GET(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Récupérer le bail avec les détails
-    const { data: lease, error: leaseError } = await supabase
+    const serviceClient = getServiceClient();
+
+    const { data: lease } = await serviceClient
       .from("leases")
       .select(
         `
@@ -38,34 +43,42 @@ export async function GET(
         )
       `
       )
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
-    if (leaseError || !lease) {
+    if (!lease) {
       return NextResponse.json(
         { error: "Bail non trouvé" },
         { status: 404 }
       );
     }
 
-    const leaseData = lease as any;
+    const leaseData = lease as Record<string, unknown> & {
+      type_bail?: string;
+      property?: { owner_id?: string } | null;
+      signers?: Array<{ profile?: { user_id?: string } | null }> | null;
+    };
 
-    // Vérifier que l'utilisateur est signataire
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = leaseData.property?.owner_id === profileData?.id;
     const isSigner = leaseData.signers?.some(
-      (s: any) => s.profile?.user_id === user.id
-    );
+      (s) => s.profile?.user_id === user.id
+    ) ?? false;
 
-    if (!isSigner) {
-      return NextResponse.json(
-        { error: "Non autorisé" },
-        { status: 403 }
-      );
+    if (!isAdmin && !isOwner && !isSigner) {
+      return NextResponse.json({ error: "Non autorisé" }, { status: 403 });
     }
 
-    // Récupérer les colocataires si colocation
     let roommates = null;
     if (leaseData.type_bail === "colocation") {
-      const { data: roommatesData } = await supabase
+      const { data: roommatesData } = await serviceClient
         .from("roommates")
         .select(
           `
@@ -73,33 +86,32 @@ export async function GET(
           profile:profiles(prenom, nom, avatar_url)
         `
         )
-        .eq("lease_id", id as any)
+        .eq("lease_id", id)
         .is("left_on", null);
 
       roommates = roommatesData;
     }
 
-    // Récupérer le dernier paiement
-    const { data: lastPayment } = await supabase
+    const { data: lastPayment } = await serviceClient
       .from("payment_shares")
       .select("*")
-        .eq("lease_id", id as any)
-        .order("month", { ascending: false })
+      .eq("lease_id", id)
+      .order("month", { ascending: false })
       .limit(1)
-      .single();
+      .maybeSingle();
 
     return NextResponse.json({
       lease: {
-        id: leaseData.id,
+        id: (leaseData as Record<string, unknown>).id,
         type_bail: leaseData.type_bail,
-        loyer: leaseData.loyer,
-        charges_forfaitaires: leaseData.charges_forfaitaires,
-        depot_de_garantie: leaseData.depot_de_garantie,
-        date_debut: leaseData.date_debut,
-        date_fin: leaseData.date_fin,
-        statut: leaseData.statut,
+        loyer: (leaseData as Record<string, unknown>).loyer,
+        charges_forfaitaires: (leaseData as Record<string, unknown>).charges_forfaitaires,
+        depot_de_garantie: (leaseData as Record<string, unknown>).depot_de_garantie,
+        date_debut: (leaseData as Record<string, unknown>).date_debut,
+        date_fin: (leaseData as Record<string, unknown>).date_fin,
+        statut: (leaseData as Record<string, unknown>).statut,
         property: leaseData.property,
-        unit: leaseData.unit,
+        unit: (leaseData as Record<string, unknown>).unit,
         signers: leaseData.signers,
         roommates,
         last_payment: lastPayment,
@@ -112,4 +124,3 @@ export async function GET(
     );
   }
 }
-

--- a/app/api/leases/[id]/terminate/route.ts
+++ b/app/api/leases/[id]/terminate/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 
@@ -25,16 +26,20 @@ export async function POST(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Récupérer le bail
-    const { data: lease } = await supabase
+    // Service-role pour la lecture : la cascade RLS leases → properties
+    // pouvait masquer un bail au propriétaire légitime. Sécurité garantie
+    // par le check owner_id ci-dessous.
+    const serviceClient = getServiceClient();
+
+    const { data: lease } = await serviceClient
       .from("leases")
       .select(`
         id,
         statut,
-        property:properties!inner(owner_id)
+        property:properties(owner_id)
       `)
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!lease) {
       return NextResponse.json(
@@ -43,14 +48,14 @@ export async function POST(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
       .select("id, role")
-      .eq("user_id", user.id as any)
-      .single();
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    const leaseData = lease as any;
-    const profileData = profile as any;
+    const leaseData = lease as { statut?: string; property?: { owner_id?: string } | null };
+    const profileData = profile as { id: string; role: string } | null;
     const isAdmin = profileData?.role === "admin";
     const isOwner = leaseData.property?.owner_id === profileData?.id;
 

--- a/app/api/v1/leases/[lid]/rent-invoices/route.ts
+++ b/app/api/v1/leases/[lid]/rent-invoices/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import {
   apiError,
   apiSuccess,
@@ -34,9 +34,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const roleCheck = requireRole(auth.profile, ["owner", "admin"]);
     if (roleCheck) return roleCheck;
 
-    const supabase = await createClient();
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
 
-    // Check idempotency
     const idempotencyKey = request.headers.get("Idempotency-Key");
     if (idempotencyKey) {
       const cached = await checkIdempotency(supabase, idempotencyKey, "invoice");
@@ -48,46 +49,41 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Get lease with property
-    const { data: lease, error: leaseError } = await supabase
+    const { data: lease } = await supabase
       .from("leases")
       .select(`
         *,
-        properties!inner(owner_id),
+        properties(owner_id),
         lease_signers(profile_id, role)
       `)
       .eq("id", lid)
-      .single();
+      .maybeSingle();
 
-    if (leaseError || !lease) {
+    if (!lease) {
       return apiError("Bail non trouvé", 404);
     }
 
-    // Verify ownership
-    if (auth.profile.role === "owner" && lease.properties.owner_id !== auth.profile.id) {
+    if (auth.profile.role === "owner" && lease.properties?.owner_id !== auth.profile.id) {
       return apiError("Accès non autorisé", 403);
     }
 
-    // Check lease is active
     if (lease.statut !== "active") {
       return apiError("Le bail doit être actif pour émettre une facture", 400);
     }
 
     const body = await request.json();
 
-    // Use lease values if not provided
     const periode = body.periode || new Date().toISOString().slice(0, 7);
     const montantLoyer = body.montant_loyer ?? lease.loyer;
     const montantCharges = body.montant_charges ?? lease.charges_forfaitaires;
     const montantTotal = montantLoyer + montantCharges;
 
-    // Check for existing invoice for this period
     const { data: existingInvoice } = await supabase
       .from("invoices")
       .select("id")
       .eq("lease_id", lid)
       .eq("periode", periode)
-      .single();
+      .maybeSingle();
 
     if (existingInvoice) {
       return apiError("Une facture existe déjà pour cette période", 409, "DUPLICATE_INVOICE");

--- a/app/api/v1/leases/[lid]/signature-sessions/route.ts
+++ b/app/api/v1/leases/[lid]/signature-sessions/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import {
   apiError,
   apiSuccess,
@@ -29,14 +29,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const roleCheck = requireRole(auth.profile, ["owner", "admin"]);
     if (roleCheck) return roleCheck;
 
-    const supabase = await createClient();
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
 
-    // Get lease with property and signers
-    const { data: lease, error: leaseError } = await supabase
+    const { data: lease } = await supabase
       .from("leases")
       .select(`
         *,
-        properties!inner(owner_id, adresse_complete),
+        properties(owner_id, adresse_complete),
         lease_signers(
           id,
           profile_id,
@@ -46,14 +47,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         )
       `)
       .eq("id", lid)
-      .single();
+      .maybeSingle();
 
-    if (leaseError || !lease) {
+    if (!lease) {
       return apiError("Bail non trouvé", 404);
     }
 
-    // Verify ownership
-    if (auth.profile.role === "owner" && lease.properties.owner_id !== auth.profile.id) {
+    if (auth.profile.role === "owner" && lease.properties?.owner_id !== auth.profile.id) {
       return apiError("Accès non autorisé", 403);
     }
 


### PR DESCRIPTION
## Summary
Phase 2 of the [RLS cascade audit](docs/audits/rls-cascade-audit.md). Closes the 8 highest-impact leases routes — every one of them blocks a real tenant or owner action when the silent 404 fires.

| Route | Was breaking |
|---|---|
| `/api/leases/[id]/pay` | Tenant rejected from paying their own lease |
| `/api/leases/[id]/terminate` | Owner couldn't terminate the lease |
| `/api/leases/[id]/deposit` | Owner blocked recording deposit; tenant blocked viewing |
| `/api/leases/[id]/deposit/refunds` | Owner blocked refunding deposit |
| `/api/leases/[id]/summary` | Legitimate signers got 404 on their own lease |
| `/api/leases/[id]/rent-invoices` | Owner couldn't issue monthly invoices |
| `/api/v1/leases/[lid]/rent-invoices` | Same on the public API |
| `/api/v1/leases/[lid]/signature-sessions` | Owner couldn't send leases for signature |

## Recipe (same as PR #499 / #504)
Service-role read, drop `!inner`, `.maybeSingle()`, then explicit owner/tenant/signer/admin check.

## Side fixes picked up
- `summary` now lets owners and admins read (was tenant-only — owners legitimately need this on /owner/leases/[id])
- `rent-invoices` guards `profileData == null` before using `profileData.id`
- `deposit` GET runs (roommate, profile, lease) in parallel via Promise.all

## Still queued (phase 2-bis)
The 10 remaining lease routes from the audit: cancel, autopay, edl, generate-receipt, receipts, punctuality, meter-consumption, visale/verify, the non-v1 signature-sessions, and v1 leases listing.

## Test plan
- [ ] `npx tsc --noEmit` — no new errors specific to modified files
- [ ] Smoke `/owner/leases/[id]/summary` as owner (200), as random user (403)
- [ ] Smoke `POST /api/leases/[id]/rent-invoices` as owner of the property (200), as another owner (403)

https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH)_