### PR TITLE
fix(rls): phase 3 — 9 routes in the properties module

### DIFF
--- a/app/api/agency/properties/route.ts
+++ b/app/api/agency/properties/route.ts
@@ -8,22 +8,27 @@ export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 
 export async function GET(request: NextRequest) {
   try {
-    const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const authClient = await createClient();
+    const { data: { user }, error: authError } = await authClient.auth.getUser();
 
     if (authError || !user) {
       return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
     }
 
-    // Récupérer le profil
+    // Service-role + check explicite agency/admin (mandats + biens lus
+    // directement, sécurité = filtre métier sur agency_profile_id).
+    // Voir docs/audits/rls-cascade-audit.md.
+    const supabase = getServiceClient();
+
     const { data: profile } = await supabase
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile) {
       return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });

--- a/app/api/owner/properties/route.ts
+++ b/app/api/owner/properties/route.ts
@@ -29,13 +29,13 @@ export async function GET(request: Request) {
     // Service role pour bypass RLS (évite récursion et 403)
     const { supabaseAdmin } = await import("@/app/api/_lib/supabase");
     const adminClient = supabaseAdmin();
-    const { data: profile, error: profileError } = await adminClient
+    const { data: profile } = await adminClient
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
-    if (profileError || !profile) {
+    if (!profile) {
       throw new ApiError(404, "Profil non trouvé");
     }
 

--- a/app/api/properties/[id]/invitations/[iid]/route.ts
+++ b/app/api/properties/[id]/invitations/[iid]/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -23,12 +24,15 @@ export async function DELETE(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Vérifier que l'utilisateur est propriétaire
-    const { data: property } = await supabase
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: property } = await serviceClient
       .from("properties")
       .select("id, owner_id")
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!property) {
       return NextResponse.json(
@@ -37,28 +41,29 @@ export async function DELETE(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    const propertyData = property as any;
-    const profileData = profile as any;
-    if (propertyData.owner_id !== profileData?.id) {
+    const propertyData = property as { owner_id?: string };
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = propertyData.owner_id === profileData?.id;
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }
       );
     }
 
-    // Récupérer le code
-    const { data: accessCode } = await supabase
+    const { data: accessCode } = await serviceClient
       .from("unit_access_codes")
       .select("*")
-      .eq("id", iid as any)
-      .eq("property_id", id as any)
-      .single();
+      .eq("id", iid)
+      .eq("property_id", id)
+      .maybeSingle();
 
     if (!accessCode) {
       return NextResponse.json(

--- a/app/api/properties/[id]/invitations/route.ts
+++ b/app/api/properties/[id]/invitations/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { generateCode } from "@/lib/helpers/code-generator";
 import { applyRateLimit } from "@/lib/middleware/rate-limit";
@@ -34,12 +35,15 @@ export async function POST(
     const body = await request.json();
     const { unit_id, role = "locataire_principal" } = body;
 
-    // Vérifier que l'utilisateur est propriétaire
-    const { data: property } = await supabase
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: property } = await serviceClient
       .from("properties")
       .select("id, owner_id")
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!property) {
       return NextResponse.json(
@@ -48,22 +52,24 @@ export async function POST(
       );
     }
 
-    const { data: profile, error: profileError } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    // SOTA 2026: Vérifier que le profil existe AVANT de comparer
-    if (profileError || !profile) {
+    if (!profile) {
       return NextResponse.json(
         { error: "Profil non trouvé" },
         { status: 404 }
       );
     }
 
-    const propertyData = property as any;
-    if (propertyData.owner_id !== profile.id) {
+    const propertyData = property as { owner_id?: string };
+    const profileData = profile as { id: string; role: string };
+    const isAdmin = profileData.role === "admin";
+    const isOwner = propertyData.owner_id === profileData.id;
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }
@@ -158,12 +164,15 @@ export async function GET(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Vérifier que l'utilisateur est propriétaire
-    const { data: property } = await supabase
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: property } = await serviceClient
       .from("properties")
       .select("id, owner_id")
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!property) {
       return NextResponse.json(
@@ -172,22 +181,24 @@ export async function GET(
       );
     }
 
-    const { data: profile, error: profileError } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    // SOTA 2026: Vérifier que le profil existe AVANT de comparer
-    if (profileError || !profile) {
+    if (!profile) {
       return NextResponse.json(
         { error: "Profil non trouvé" },
         { status: 404 }
       );
     }
 
-    const propertyData = property as any;
-    if (propertyData.owner_id !== profile.id) {
+    const propertyData = property as { owner_id?: string };
+    const profileData = profile as { id: string; role: string };
+    const isAdmin = profileData.role === "admin";
+    const isOwner = propertyData.owner_id === profileData.id;
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }

--- a/app/api/properties/[id]/meters/[meterId]/route.ts
+++ b/app/api/properties/[id]/meters/[meterId]/route.ts
@@ -24,20 +24,60 @@ export async function GET(
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Récupérer le compteur
-    const { data: meter, error } = await supabase
+    // Service-role + check explicite owner/tenant/admin (le GET n'avait
+    // aucun contrôle d'accès métier — voir docs/audits/rls-cascade-audit.md).
+    const serviceClient = createServiceRoleClient();
+
+    const { data: property } = await serviceClient
+      .from("properties")
+      .select("id, owner_id")
+      .eq("id", propertyId)
+      .maybeSingle();
+
+    if (!property) {
+      return NextResponse.json({ error: "Logement non trouvé" }, { status: 404 });
+    }
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    const propertyData = property as { owner_id?: string };
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = propertyData.owner_id === profileData?.id;
+
+    // Locataire actif sur le bien (via roommates de leases actifs)
+    let isTenant = false;
+    if (!isAdmin && !isOwner) {
+      const { data: roommate } = await serviceClient
+        .from("roommates")
+        .select("id, leases!inner(property_id, statut)")
+        .eq("user_id", user.id)
+        .is("left_on", null)
+        .maybeSingle();
+      const r = roommate as { leases?: { property_id?: string; statut?: string } | null } | null;
+      isTenant = r?.leases?.property_id === propertyId && r?.leases?.statut === "active";
+    }
+
+    if (!isAdmin && !isOwner && !isTenant) {
+      return NextResponse.json({ error: "Accès non autorisé" }, { status: 403 });
+    }
+
+    const { data: meter } = await serviceClient
       .from("meters")
       .select("*")
       .eq("id", meterId)
       .eq("property_id", propertyId)
-      .single();
+      .maybeSingle();
 
-    if (error || !meter) {
+    if (!meter) {
       return NextResponse.json({ error: "Compteur non trouvé" }, { status: 404 });
     }
 
-    // Récupérer les 10 derniers relevés
-    const { data: readings } = await supabase
+    const { data: readings } = await serviceClient
       .from("meter_readings")
       .select("*")
       .eq("meter_id", meterId)
@@ -85,7 +125,7 @@ export async function PATCH(
       .from("properties")
       .select("id, owner_id")
       .eq("id", propertyId)
-      .single();
+      .maybeSingle();
 
     if (!property) {
       return NextResponse.json({ error: "Logement non trouvé" }, { status: 404 });
@@ -95,7 +135,7 @@ export async function PATCH(
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     const propertyData = property as any;
     const profileData = profile as any;
@@ -113,7 +153,7 @@ export async function PATCH(
       .select("id")
       .eq("id", meterId)
       .eq("property_id", propertyId)
-      .single();
+      .maybeSingle();
 
     if (!existingMeter) {
       return NextResponse.json({ error: "Compteur non trouvé" }, { status: 404 });
@@ -198,7 +238,7 @@ export async function DELETE(
       .from("properties")
       .select("id, owner_id")
       .eq("id", propertyId)
-      .single();
+      .maybeSingle();
 
     if (!property) {
       return NextResponse.json({ error: "Logement non trouvé" }, { status: 404 });
@@ -208,7 +248,7 @@ export async function DELETE(
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     const propertyData = property as any;
     const profileData = profile as any;
@@ -226,7 +266,7 @@ export async function DELETE(
       .select("id, type, serial_number")
       .eq("id", meterId)
       .eq("property_id", propertyId)
-      .single();
+      .maybeSingle();
 
     if (!meter) {
       return NextResponse.json({ error: "Compteur non trouvé" }, { status: 404 });

--- a/app/api/properties/[id]/units/route.ts
+++ b/app/api/properties/[id]/units/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -40,12 +41,14 @@ export async function POST(
       );
     }
 
-    // Vérifier que l'utilisateur est propriétaire
-    const { data: property } = await supabase
+    // Service-role + check explicite owner/admin (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: property } = await serviceClient
       .from("properties")
       .select("id, owner_id")
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!property) {
       return NextResponse.json(
@@ -54,15 +57,17 @@ export async function POST(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    const propertyData = property as any;
-    const profileData = profile as any;
-    if (propertyData.owner_id !== profileData?.id) {
+    const propertyData = property as { owner_id?: string };
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = propertyData.owner_id === profileData?.id;
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }

--- a/app/api/properties/diagnostic/route.ts
+++ b/app/api/properties/diagnostic/route.ts
@@ -6,9 +6,15 @@ import { createClient } from "@/lib/supabase/server";
 
 /**
  * GET /api/properties/diagnostic - Diagnostic complet de l'endpoint /api/properties
- * 
+ *
  * Cet endpoint teste chaque étape isolément et retourne un rapport détaillé
  * pour identifier précisément où l'erreur se produit.
+ *
+ * NOTE (audit RLS) : cette route utilise volontairement le client RLS-aware
+ * (`createClient()` + `.single()`) parce que son but est exactement de
+ * détecter les blocages RLS silencieux. Ne PAS migrer vers `getServiceClient()`
+ * — ça la rendrait incapable de remonter le bug qu'elle est conçue à
+ * diagnostiquer. Voir docs/audits/rls-cascade-audit.md.
  */
 export async function GET(request: Request) {
   const diagnostic: any = {

--- a/app/api/properties/init/route.ts
+++ b/app/api/properties/init/route.ts
@@ -62,13 +62,13 @@ export async function POST(request: Request) {
 
     // 2. Récupérer le profil propriétaire via service role (évite la récursion RLS 42P17 sur profiles)
     const serviceClient = createServiceRoleClient();
-    const { data: profile, error: profileError } = await serviceClient
+    const { data: profile } = await serviceClient
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
-    if (profileError || !profile || profile.role !== "owner") {
+    if (!profile || profile.role !== "owner") {
       return NextResponse.json({ error: "Profil propriétaire requis" }, { status: 403 });
     }
 

--- a/app/api/v1/properties/[pid]/route.ts
+++ b/app/api/v1/properties/[pid]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import {
   apiError,
   apiSuccess,
@@ -27,9 +27,12 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const auth = await requireAuth(request);
     if (auth instanceof Response) return auth;
 
-    const supabase = await createClient();
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md). La cascade lease_signers→profiles
+    // pouvait blanker la propriété au propriétaire légitime.
+    const supabase = getServiceClient();
 
-    const { data: property, error } = await supabase
+    const { data: property } = await supabase
       .from("properties")
       .select(`
         *,
@@ -43,9 +46,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         meters(*)
       `)
       .eq("id", pid)
-      .single();
+      .maybeSingle();
 
-    if (error || !property) {
+    if (!property) {
       return apiError("Propriété non trouvée", 404, "NOT_FOUND");
     }
 
@@ -74,16 +77,15 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const roleCheck = requireRole(auth.profile, ["owner", "admin"]);
     if (roleCheck) return roleCheck;
 
-    const supabase = await createClient();
+    const supabase = getServiceClient();
 
-    // Verify ownership
-    const { data: existing, error: fetchError } = await supabase
+    const { data: existing } = await supabase
       .from("properties")
       .select("*")
       .eq("id", pid)
-      .single();
+      .maybeSingle();
 
-    if (fetchError || !existing) {
+    if (!existing) {
       return apiError("Propriété non trouvée", 404, "NOT_FOUND");
     }
 
@@ -96,7 +98,6 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     if (validationError) return validationError;
 
-    // Update
     const { data: property, error } = await supabase
       .from("properties")
       .update(data)
@@ -140,16 +141,15 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     const roleCheck = requireRole(auth.profile, ["owner", "admin"]);
     if (roleCheck) return roleCheck;
 
-    const supabase = await createClient();
+    const supabase = getServiceClient();
 
-    // Verify ownership
-    const { data: existing, error: fetchError } = await supabase
+    const { data: existing } = await supabase
       .from("properties")
       .select("owner_id, unique_code")
       .eq("id", pid)
-      .single();
+      .maybeSingle();
 
-    if (fetchError || !existing) {
+    if (!existing) {
       return apiError("Propriété non trouvée", 404, "NOT_FOUND");
     }
 

--- a/app/api/v1/properties/route.ts
+++ b/app/api/v1/properties/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import {
   apiError,
   apiSuccess,
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
     const apiAccessCheck = await requireApiAccess(auth.profile);
     if (apiAccessCheck) return apiAccessCheck;
 
-    const supabase = await createClient();
+    const supabase = getServiceClient();
     const { searchParams } = new URL(request.url);
     const { page, limit, offset } = getPaginationParams(searchParams);
 
@@ -104,7 +104,7 @@ export async function POST(request: NextRequest) {
     const apiAccessCheck = await requireApiAccess(auth.profile);
     if (apiAccessCheck) return apiAccessCheck;
 
-    const supabase = await createClient();
+    const supabase = getServiceClient();
 
     // Check idempotency
     const idempotencyKey = request.headers.get("Idempotency-Key");


### PR DESCRIPTION
## Summary
Phase 3 of the [RLS cascade audit](docs/audits/rls-cascade-audit.md). Closes the 9 actionable property routes (the 10th, `/api/properties/diagnostic`, is intentionally left vulnerable — its purpose is to detect RLS blocks).

| Route | Was breaking |
|---|---|
| `/api/v1/properties/[pid]` (GET/PATCH/DELETE) | Owner couldn't read own property when any embed hit recursive RLS |
| `/api/v1/properties` (GET/POST) | Same cascade on `units`/`leases` count embeds |
| `/api/owner/properties` | `.single()` 500 on missing profile row |
| `/api/properties/[id]/units` | Owner couldn't activate cohousing |
| `/api/properties/[id]/meters/[meterId]` | **GET had no business check** — added owner/tenant/admin matrix |
| `/api/properties/[id]/invitations` | Owner couldn't create/list invitation codes |
| `/api/properties/[id]/invitations/[iid]` | Owner couldn't revoke their own invitation |
| `/api/properties/init` | `.single()` 500 on missing profile |
| `/api/agency/properties` | Agency couldn't list managed properties |

## Side fix
The `/meters/[meterId]` GET now also accepts the active tenant of the property (via `roommates → leases.statut = active`), not just owner/admin — tenants legitimately consult meters during EDL and charge regularization.

## Diagnostic route
Added a header comment to `/api/properties/diagnostic` explaining it's deliberately on the RLS-aware client to detect blocks — a future audit pass won't accidentally "fix" the bug it's designed to find.

## Test plan
- [ ] `npx tsc --noEmit` — 114 errors before/after on the slice (all pre-existing import/implicit-any), no regression
- [ ] Smoke `GET /api/v1/properties/[pid]` as owner of a property with active leases (200), as another owner (403)
- [ ] Smoke `GET /api/properties/[id]/meters/[meterId]` as owner (200), as active tenant (200), as random user (403)

## Status of the audit after this PR
| Phase | Module | Routes closed | Total in audit |
|---|---|---|---|
| 1 | work_orders + payments critical | 3 | 3 |
| 2 | leases | 8 | 18 |
| 3 | properties | 9 | 10 |
| **Total** | | **20** | **58** |

Remaining: 38 routes (10 leases, 9 documents, 6 work_orders, 1 inspection, 11 misc).

https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH)_