### PR TITLE
fix(rls): phase 5 — 5 work_orders state-machine routes

### DIFF
--- a/app/api/work-orders/[id]/accept/route.ts
+++ b/app/api/work-orders/[id]/accept/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextRequest, NextResponse } from "next/server";
 import { sendTicketUpdateNotification } from "@/lib/services/email-service";
 
@@ -16,21 +17,24 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Récupérer le profil et vérifier le rôle
+    // Service-role + check métier provider assigné
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
+
     const { data: profile } = await supabase
       .from("profiles")
       .select("id, role, prenom, nom")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile || profile.role !== "provider") {
       return NextResponse.json(
@@ -39,15 +43,14 @@ export async function POST(
       );
     }
 
-    // Récupérer l'ordre de travail
-    const { data: workOrder, error: woError } = await supabase
+    const { data: workOrder } = await supabase
       .from("work_orders")
       .select(`
         *,
-        ticket:tickets!inner(
+        ticket:tickets(
           id,
           titre,
-          property:properties!inner(
+          property:properties(
             owner_id,
             adresse_complete
           )
@@ -55,9 +58,9 @@ export async function POST(
       `)
       .eq("id", id)
       .eq("provider_id", profile.id)
-      .single();
+      .maybeSingle();
 
-    if (woError || !workOrder) {
+    if (!workOrder) {
       return NextResponse.json(
         { error: "Ordre de travail non trouvé ou non assigné à vous" },
         { status: 404 }

--- a/app/api/work-orders/[id]/complete/route.ts
+++ b/app/api/work-orders/[id]/complete/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextRequest, NextResponse } from "next/server";
 import { sendTicketUpdateNotification } from "@/lib/services/email-service";
 
@@ -16,21 +17,24 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Récupérer le profil et vérifier le rôle
+    // Service-role + check provider assigné
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
+
     const { data: profile } = await supabase
       .from("profiles")
       .select("id, role, prenom, nom")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile || profile.role !== "provider") {
       return NextResponse.json(
@@ -39,16 +43,15 @@ export async function POST(
       );
     }
 
-    // Récupérer l'ordre de travail
-    const { data: workOrder, error: woError } = await supabase
+    const { data: workOrder } = await supabase
       .from("work_orders")
       .select(`
         *,
-        ticket:tickets!inner(
+        ticket:tickets(
           id,
           titre,
           created_by_profile_id,
-          property:properties!inner(
+          property:properties(
             owner_id,
             adresse_complete
           )
@@ -56,9 +59,9 @@ export async function POST(
       `)
       .eq("id", id)
       .eq("provider_id", profile.id)
-      .single();
+      .maybeSingle();
 
-    if (woError || !workOrder) {
+    if (!workOrder) {
       return NextResponse.json(
         { error: "Ordre de travail non trouvé ou non assigné à vous" },
         { status: 404 }

--- a/app/api/work-orders/[id]/flow/route.ts
+++ b/app/api/work-orders/[id]/flow/route.ts
@@ -18,6 +18,7 @@ export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getServiceClient } from '@/lib/supabase/service-client';
 import { z } from 'zod';
 
 interface RouteParams {
@@ -59,15 +60,19 @@ const ACTION_STATUS_MAP: Record<string, { from: string[]; to: string }> = {
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
       error: authError,
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (authError || !user) {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
     }
+
+    // Service-role + check métier explicite
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
 
     const { id: workOrderId } = await params;
 
@@ -89,7 +94,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       .from('profiles')
       .select('id, role')
       .eq('user_id', user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile) {
       return NextResponse.json({ error: 'Profil non trouvé' }, { status: 404 });
@@ -107,7 +112,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         )
       `)
       .eq('id', workOrderId)
-      .single();
+      .maybeSingle();
 
     if (woError || !workOrder) {
       return NextResponse.json({ error: 'Intervention non trouvée' }, { status: 404 });
@@ -282,15 +287,19 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
  */
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
       error: authError,
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (authError || !user) {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
     }
+
+    // Service-role + check métier explicite
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
 
     const { id: workOrderId } = await params;
 
@@ -299,7 +308,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       .from('profiles')
       .select('id, role')
       .eq('user_id', user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile) {
       return NextResponse.json({ error: 'Profil non trouvé' }, { status: 404 });
@@ -319,13 +328,21 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         provider:profiles!work_orders_provider_id_fkey(id, prenom, nom)
       `)
       .eq('id', workOrderId)
-      .single();
+      .maybeSingle();
 
     if (woError || !workOrder) {
       return NextResponse.json({ error: 'Intervention non trouvée' }, { status: 404 });
     }
 
-    // Récupérer le timeline
+    // Check métier explicite : provider, owner du bien ou admin (le GET
+    // n'avait aucun contrôle d'accès auparavant — fuite potentielle).
+    const isProviderGet = workOrder.provider_id === profile.id;
+    const isOwnerGet = workOrder.ticket?.properties?.owner_id === profile.id;
+    const isAdminGet = profile.role === 'admin';
+    if (!isProviderGet && !isOwnerGet && !isAdminGet) {
+      return NextResponse.json({ error: 'Accès non autorisé' }, { status: 403 });
+    }
+
     const { data: timeline } = await supabase
       .from('work_order_timeline')
       .select('*')

--- a/app/api/work-orders/[id]/reject/route.ts
+++ b/app/api/work-orders/[id]/reject/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextRequest, NextResponse } from "next/server";
 import { sendTicketUpdateNotification } from "@/lib/services/email-service";
 
@@ -16,21 +17,24 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Récupérer le profil et vérifier le rôle
+    // Service-role + check métier provider assigné
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
+
     const { data: profile } = await supabase
       .from("profiles")
       .select("id, role, prenom, nom")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile || profile.role !== "provider") {
       return NextResponse.json(
@@ -39,15 +43,14 @@ export async function POST(
       );
     }
 
-    // Récupérer l'ordre de travail
-    const { data: workOrder, error: woError } = await supabase
+    const { data: workOrder } = await supabase
       .from("work_orders")
       .select(`
         *,
-        ticket:tickets!inner(
+        ticket:tickets(
           id,
           titre,
-          property:properties!inner(
+          property:properties(
             owner_id,
             adresse_complete
           )
@@ -55,9 +58,9 @@ export async function POST(
       `)
       .eq("id", id)
       .eq("provider_id", profile.id)
-      .single();
+      .maybeSingle();
 
-    if (woError || !workOrder) {
+    if (!workOrder) {
       return NextResponse.json(
         { error: "Ordre de travail non trouvé ou non assigné à vous" },
         { status: 404 }

--- a/app/api/work-orders/[id]/reports/route.ts
+++ b/app/api/work-orders/[id]/reports/route.ts
@@ -9,6 +9,7 @@ export const runtime = 'nodejs';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getServiceClient } from '@/lib/supabase/service-client';
 
 interface RouteParams {
   params: { id: string };
@@ -16,15 +17,18 @@ interface RouteParams {
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
       error: authError,
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (authError || !user) {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
     }
+
+    // Service-role + check métier (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
 
     const workOrderId = params.id;
 
@@ -33,7 +37,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       .from('profiles')
       .select('id, role')
       .eq('user_id', user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile) {
       return NextResponse.json({ error: 'Profil non trouvé' }, { status: 404 });
@@ -52,7 +56,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         )
       `)
       .eq('id', workOrderId)
-      .single();
+      .maybeSingle();
 
     if (!workOrder) {
       return NextResponse.json({ error: 'Intervention non trouvée' }, { status: 404 });
@@ -88,15 +92,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
       error: authError,
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (authError || !user) {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 401 });
     }
+
+    // Service-role + check métier (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
 
     const workOrderId = params.id;
 
@@ -105,7 +112,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       .from('profiles')
       .select('id, role')
       .eq('user_id', user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile || profile.role !== 'provider') {
       return NextResponse.json({ error: 'Seuls les prestataires peuvent créer des rapports' }, { status: 403 });
@@ -117,7 +124,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       .select('id, provider_id, statut')
       .eq('id', workOrderId)
       .eq('provider_id', profile.id)
-      .single();
+      .maybeSingle();
 
     if (!workOrder) {
       return NextResponse.json({ error: 'Intervention non trouvée ou non autorisée' }, { status: 404 });
@@ -151,7 +158,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         .select('id')
         .eq('work_order_id', workOrderId)
         .eq('report_type', report_type)
-        .single();
+        .maybeSingle();
 
       if (existingReport) {
         return NextResponse.json(


### PR DESCRIPTION
## Summary
Phase 5 of the [RLS cascade audit](docs/audits/rls-cascade-audit.md). Closes the remaining 5 work_orders routes (PR #504 already covered the most critical one).

| Route | Was breaking |
|---|---|
| `/api/work-orders/[id]/flow` POST | State machine 9 actions blocked by cascade `tickets→properties` |
| `/api/work-orders/[id]/flow` GET | **Zero business check** — returned work_order to any authed caller |
| `/api/work-orders/[id]/accept` POST | Provider couldn't accept own assignment |
| `/api/work-orders/[id]/reject` POST | Same |
| `/api/work-orders/[id]/complete` POST | Provider couldn't mark intervention done |
| `/api/work-orders/[id]/reports` GET/POST | Reports invisible to legitimate parties |

## Recipe
Service-role read, drop `!inner`, `.maybeSingle()`, explicit provider/owner/admin check after SELECT.

The work_orders module is now **fully covered** by the audit (PR #504 + this PR).

## Status of the audit after this PR
| Phase | Module | Routes closed |
|---|---|---|
| 1 | work_orders + payments critical | 3 |
| 2 | leases | 8 |
| 3 | properties | 9 |
| 4 | documents | 7 |
| **5** | **work_orders restants** | **5** |
| **Total** | | **32 / 58** |

Remaining: ~26 routes (10 leases minor, 1 inspection, ~15 misc).

## Test plan
- [ ] `npx tsc --noEmit` — 32 errors before/after, no regression
- [ ] Smoke `GET /api/work-orders/[id]/flow` as provider assigned (200), as random user (403)
- [ ] Smoke `POST /api/work-orders/[id]/accept` as provider (200), as another provider (404)

https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH)_