### PR TITLE
fix(rls): phase 6 — wrap up leases module + inspection (11 routes)

### DIFF
--- a/app/api/inspections/[iid]/photos/route.ts
+++ b/app/api/inspections/[iid]/photos/route.ts
@@ -94,7 +94,7 @@ export async function POST(
         )
       `)
       .eq("id", iid)
-      .single();
+      .maybeSingle();
 
     if (edlError || !edl) {
       console.error(`[Photos] EDL ${iid} error:`, edlError);
@@ -120,7 +120,7 @@ export async function POST(
         .from("properties")
         .select("owner_id")
         .eq("id", propId)
-        .single();
+        .maybeSingle();
       if (property?.owner_id === profile.id) isOwner = true;
     } else if (edlData.lease?.property?.owner_id === profile.id) {
       isOwner = true;
@@ -277,7 +277,7 @@ export async function GET(
         )
       `)
       .eq("id", iid)
-      .single();
+      .maybeSingle();
 
     if (edlError || !edl) {
       return NextResponse.json(
@@ -302,7 +302,7 @@ export async function GET(
         .from("properties")
         .select("owner_id")
         .eq("id", propId)
-        .single();
+        .maybeSingle();
       if (property?.owner_id === profile.id) isOwner = true;
     } else if (edlData.lease?.property?.owner_id === profile.id) {
       isOwner = true;

--- a/app/api/leases/[id]/autopay/route.ts
+++ b/app/api/leases/[id]/autopay/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { paymentSharesService } from "@/features/tenant/services/payment-shares.service";
 
@@ -35,14 +36,16 @@ export async function POST(
       );
     }
 
-    // Vérifier que la part appartient à l'utilisateur
-    const { data: roommate } = await supabase
+    // Service-role + check métier roommate actif (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: roommate } = await serviceClient
       .from("roommates")
       .select("id")
-      .eq("lease_id", id as any)
-      .eq("user_id", user.id as any)
+      .eq("lease_id", id)
+      .eq("user_id", user.id)
       .is("left_on", null)
-      .single();
+      .maybeSingle();
 
     if (!roommate) {
       return NextResponse.json(
@@ -51,11 +54,11 @@ export async function POST(
       );
     }
 
-    const { data: paymentShare } = await supabase
+    const { data: paymentShare } = await serviceClient
       .from("payment_shares")
       .select("id, roommate_id")
-      .eq("id", paymentShareId as any)
-      .single();
+      .eq("id", paymentShareId)
+      .maybeSingle();
 
     if (!paymentShare || !("roommate_id" in paymentShare) || !("id" in roommate) || (paymentShare as any).roommate_id !== (roommate as any).id) {
       return NextResponse.json(

--- a/app/api/leases/[id]/cancel/route.ts
+++ b/app/api/leases/[id]/cancel/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { sendEmail } from "@/lib/emails/resend.service";
@@ -33,24 +34,27 @@ export async function POST(
   const { id: leaseId } = await params;
 
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // 1. Récupérer le bail avec les infos nécessaires
-    const { data: lease, error: leaseError } = await supabase
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
+
+    const { data: lease } = await supabase
       .from("leases")
       .select(`
         id,
         statut,
         type_bail,
         property_id,
-        property:properties!inner(
+        property:properties(
           id,
           owner_id,
           name,
@@ -65,21 +69,20 @@ export async function POST(
           profile:profiles(id, prenom, nom, email)
         )
       `)
-      .eq("id", leaseId as any)
-      .single();
+      .eq("id", leaseId)
+      .maybeSingle();
 
-    if (leaseError || !lease) {
+    if (!lease) {
       return NextResponse.json({ error: "Bail non trouvé" }, { status: 404 });
     }
 
     const leaseData = lease as any;
 
-    // 2. Vérifier les permissions
     const { data: profile } = await supabase
       .from("profiles")
       .select("id, role")
-      .eq("user_id", user.id as any)
-      .single();
+      .eq("user_id", user.id)
+      .maybeSingle();
 
     const profileData = profile as any;
     const isAdmin = profileData?.role === "admin";

--- a/app/api/leases/[id]/edl/route.ts
+++ b/app/api/leases/[id]/edl/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -17,10 +18,10 @@ export async function GET(
 ) {
   const { id } = await params;
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
@@ -30,28 +31,29 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const type = searchParams.get("type"); // "entree" | "sortie"
 
-    // Vérifier les permissions
+    // Service-role + check métier (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
+
     const { data: profile } = await supabase
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile) {
       return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
     }
 
-    // Vérifier l'accès au bail
-    const { data: lease, error: leaseError } = await supabase
+    const { data: lease } = await supabase
       .from("leases")
       .select(`
         id,
-        property:properties!inner(id, owner_id)
+        property:properties(id, owner_id)
       `)
       .eq("id", leaseId)
-      .single();
+      .maybeSingle();
 
-    if (leaseError || !lease) {
+    if (!lease) {
       return NextResponse.json({ error: "Bail non trouvé" }, { status: 404 });
     }
 
@@ -59,7 +61,6 @@ export async function GET(
     const isOwner = leaseData.property?.owner_id === profile.id;
     const isAdmin = profile.role === "admin";
 
-    // Vérifier si locataire
     let isTenant = false;
     if (!isOwner && !isAdmin) {
       const { data: signer } = await supabase
@@ -67,8 +68,8 @@ export async function GET(
         .select("id")
         .eq("lease_id", leaseId)
         .eq("profile_id", profile.id)
-        .single();
-      
+        .maybeSingle();
+
       isTenant = !!signer;
     }
 

--- a/app/api/leases/[id]/generate-receipt/route.ts
+++ b/app/api/leases/[id]/generate-receipt/route.ts
@@ -43,7 +43,7 @@ export async function POST(
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
-      .single();
+      .maybeSingle();
 
     if (!profile || profile.role !== "owner") {
       return NextResponse.json(
@@ -52,12 +52,11 @@ export async function POST(
       );
     }
 
-    // 3. Vérifier que le bail appartient au propriétaire
     const { data: lease } = await serviceClient
       .from("leases")
-      .select("id, property:properties!inner(owner_id)")
+      .select("id, property:properties(owner_id)")
       .eq("id", leaseId)
-      .single();
+      .maybeSingle();
 
     if (!lease) {
       return NextResponse.json(
@@ -94,7 +93,7 @@ export async function POST(
       .select("id, lease_id")
       .eq("id", invoice_id)
       .eq("lease_id", leaseId)
-      .single();
+      .maybeSingle();
 
     if (!invoice) {
       return NextResponse.json(
@@ -103,7 +102,6 @@ export async function POST(
       );
     }
 
-    // 6. Trouver le dernier paiement succeeded pour cette facture
     const { data: payment } = await serviceClient
       .from("payments")
       .select("id")
@@ -111,7 +109,7 @@ export async function POST(
       .eq("statut", "succeeded")
       .order("date_paiement", { ascending: false })
       .limit(1)
-      .single();
+      .maybeSingle();
 
     if (!payment) {
       return NextResponse.json(

--- a/app/api/leases/[id]/meter-consumption/route.ts
+++ b/app/api/leases/[id]/meter-consumption/route.ts
@@ -9,6 +9,7 @@ export const runtime = 'nodejs';
  */
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -20,10 +21,10 @@ export async function GET(
 ) {
   const { id } = await params;
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
@@ -31,25 +32,56 @@ export async function GET(
 
     const leaseId = id;
 
-    // Vérifier que l'utilisateur a accès à ce bail
-    const { data: lease, error: leaseError } = await supabase
+    // Service-role + check métier owner/tenant/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+    }
+
+    const { data: lease } = await supabase
       .from("leases")
       .select(`
         id,
         property_id,
-        property:properties!inner(
+        property:properties(
           id,
           owner_id
         )
       `)
       .eq("id", leaseId)
-      .single();
+      .maybeSingle();
 
-    if (leaseError || !lease) {
+    if (!lease) {
       return NextResponse.json(
         { error: "Bail non trouvé" },
         { status: 404 }
       );
+    }
+
+    const profileData = profile as { id: string; role: string };
+    const leaseData = lease as { property?: { owner_id?: string } | null };
+    const isAdmin = profileData.role === "admin";
+    const isOwner = leaseData.property?.owner_id === profileData.id;
+    let isTenant = false;
+    if (!isAdmin && !isOwner) {
+      const { data: roommate } = await supabase
+        .from("roommates")
+        .select("id")
+        .eq("lease_id", leaseId)
+        .eq("user_id", user.id)
+        .maybeSingle();
+      isTenant = !!roommate;
+    }
+    if (!isAdmin && !isOwner && !isTenant) {
+      return NextResponse.json({ error: "Accès non autorisé" }, { status: 403 });
     }
 
     // Récupérer les EDL d'entrée et de sortie

--- a/app/api/leases/[id]/punctuality/route.ts
+++ b/app/api/leases/[id]/punctuality/route.ts
@@ -9,54 +9,58 @@ export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id: leaseId } = await params;
-  const supabase = await createClient();
+  const authClient = await createClient();
 
   const {
     data: { user },
     error: authError,
-  } = await supabase.auth.getUser();
+  } = await authClient.auth.getUser();
 
   if (authError || !user) {
     return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
   }
 
-  // Vérifier que l'utilisateur est propriétaire de ce bail
+  // Service-role + check explicite owner/admin
+  // (cf. docs/audits/rls-cascade-audit.md)
+  const supabase = getServiceClient();
+
   const { data: profile } = await supabase
     .from("profiles")
-    .select("id")
+    .select("id, role")
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   if (!profile) {
     return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
   }
 
-  const { data: lease, error: leaseError } = await supabase
+  const { data: lease } = await supabase
     .from("leases")
     .select("id, owner_id")
     .eq("id", leaseId)
-    .single();
+    .maybeSingle();
 
-  if (leaseError || !lease) {
+  if (!lease) {
     return NextResponse.json({ error: "Bail non trouvé" }, { status: 404 });
   }
 
-  if (lease.owner_id !== profile.id) {
+  const isAdmin = profile.role === "admin";
+  if (lease.owner_id !== profile.id && !isAdmin) {
     return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
   }
 
-  // punctuality_score exists in DB (migration 20260329170000) but not yet in generated types
   const { data: scoreRow } = await supabase
     .from("leases")
     .select("punctuality_score" as any)
     .eq("id", leaseId)
-    .single();
+    .maybeSingle();
 
   const score = (scoreRow as any)?.punctuality_score != null
     ? Number((scoreRow as any).punctuality_score)

--- a/app/api/leases/[id]/receipts/route.ts
+++ b/app/api/leases/[id]/receipts/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 import { pdfService } from "@/lib/services/pdf.service";
 import { resolveOwnerIdentity } from "@/lib/entities/resolveOwnerIdentity";
@@ -79,10 +80,10 @@ export async function GET(
 ) {
   const { id } = await params;
   try {
-    const supabase = await createClient();
+    const authClient = await createClient();
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await authClient.auth.getUser();
 
     if (!user) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
@@ -91,32 +92,43 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const month = searchParams.get("month");
 
-    // Vérifier que l'utilisateur est locataire du bail
+    // Service-role + check tenant/signer/owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const supabase = getServiceClient();
+
     const { data: roommate } = await supabase
       .from("roommates")
       .select("id")
-      .eq("lease_id", id as any)
-      .eq("user_id", user.id as any)
+      .eq("lease_id", id)
+      .eq("user_id", user.id)
       .is("left_on", null)
-      .single();
+      .maybeSingle();
 
     if (!roommate) {
-      // Vérifier via lease_signers
       const { data: profile } = await supabase
         .from("profiles")
-        .select("id")
-        .eq("user_id", user.id as any)
-        .single();
+        .select("id, role")
+        .eq("user_id", user.id)
+        .maybeSingle();
 
       if (profile) {
+        const profileData = profile as { id: string; role: string };
         const { data: signer } = await supabase
           .from("lease_signers")
           .select("id")
-          .eq("lease_id", id as any)
-          .eq("profile_id", (profile as any).id as any)
-          .single();
+          .eq("lease_id", id)
+          .eq("profile_id", profileData.id)
+          .maybeSingle();
 
-        if (!signer) {
+        const { data: lease } = await supabase
+          .from("leases")
+          .select("property:properties(owner_id)")
+          .eq("id", id)
+          .maybeSingle();
+        const isOwner = (lease as any)?.property?.owner_id === profileData.id;
+        const isAdmin = profileData.role === "admin";
+
+        if (!signer && !isOwner && !isAdmin) {
           return NextResponse.json(
             { error: "Non autorisé" },
             { status: 403 }
@@ -130,7 +142,6 @@ export async function GET(
       }
     }
 
-    // Récupérer les factures payées (quittances)
     let query = supabase
       .from("invoices")
       .select(

--- a/app/api/leases/[id]/signature-sessions/route.ts
+++ b/app/api/leases/[id]/signature-sessions/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -34,16 +35,19 @@ export async function POST(
       );
     }
 
-    // Vérifier que l'utilisateur est propriétaire du bail
-    const { data: lease } = await supabase
+    // Service-role + check explicite owner/admin
+    // (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: lease } = await serviceClient
       .from("leases")
       .select(`
         id,
         statut,
-        property:properties!inner(owner_id)
+        property:properties(owner_id)
       `)
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!lease) {
       return NextResponse.json(
@@ -60,14 +64,16 @@ export async function POST(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id")
-      .eq("user_id", user.id as any)
-      .single();
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
 
-    const profileData = profile as any;
-    if (leaseData.property.owner_id !== profileData?.id) {
+    const profileData = profile as { id: string; role: string } | null;
+    const isAdmin = profileData?.role === "admin";
+    const isOwner = leaseData.property?.owner_id === profileData?.id;
+    if (!isAdmin && !isOwner) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }

--- a/app/api/leases/[id]/visale/verify/route.ts
+++ b/app/api/leases/[id]/visale/verify/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { NextResponse } from "next/server";
 
 /**
@@ -34,16 +35,18 @@ export async function POST(
       );
     }
 
-    // Vérifier l'accès au bail
-    const { data: lease } = await supabase
+    // Service-role + check métier (cf. docs/audits/rls-cascade-audit.md)
+    const serviceClient = getServiceClient();
+
+    const { data: lease } = await serviceClient
       .from("leases")
       .select(`
         id,
-        property:properties!inner(owner_id),
+        property:properties(owner_id),
         roommates(user_id)
       `)
-      .eq("id", id as any)
-      .single();
+      .eq("id", id)
+      .maybeSingle();
 
     if (!lease) {
       return NextResponse.json(
@@ -52,19 +55,19 @@ export async function POST(
       );
     }
 
-    const { data: profile } = await supabase
+    const { data: profile } = await serviceClient
       .from("profiles")
       .select("id, role")
-      .eq("user_id", user.id as any)
-      .single();
+      .eq("user_id", user.id)
+      .maybeSingle();
 
     const leaseData = lease as any;
     const profileData = profile as any;
     const isAdmin = profileData?.role === "admin";
-    const isOwner = leaseData.property.owner_id === profileData?.id;
+    const isOwner = leaseData.property?.owner_id === profileData?.id;
     const isTenant = leaseData.roommates?.some((r: any) => r.user_id === user.id);
 
-    if (!isOwner && !isTenant) {
+    if (!isAdmin && !isOwner && !isTenant) {
       return NextResponse.json(
         { error: "Accès non autorisé" },
         { status: 403 }

--- a/app/api/v1/leases/route.ts
+++ b/app/api/v1/leases/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 export const runtime = 'nodejs';
 
 import { NextRequest } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import {
   apiError,
   apiSuccess,
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
       if (apiAccessCheck) return apiAccessCheck;
     }
 
-    const supabase = await createClient();
+    const supabase = getServiceClient();
     const { searchParams } = new URL(request.url);
     const { page, limit, offset } = getPaginationParams(searchParams);
 
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest) {
     const apiAccessCheck = await requireApiAccess(auth.profile);
     if (apiAccessCheck) return apiAccessCheck;
 
-    const supabase = await createClient();
+    const supabase = getServiceClient();
     const body = await request.json();
     const { data, error: validationError } = validateBody(CreateLeaseSchema, body);
 


### PR DESCRIPTION
## Summary
Phase 6 of the [RLS cascade audit](docs/audits/rls-cascade-audit.md). Wraps up the leases module (combined with PR #510 — leases slice fully covered) and closes the inspection route.

11 routes touched.

| Route | Was breaking |
|---|---|
| `/api/leases/[id]/cancel` | Owner couldn't cancel own lease |
| `/api/leases/[id]/autopay` | Tenant couldn't toggle autopay on their share |
| `/api/leases/[id]/edl` | EDL list 404 for legitimate parties |
| `/api/leases/[id]/generate-receipt` | Receipt PDF regen path |
| `/api/leases/[id]/meter-consumption` | Tenant couldn't read for charge regul |
| `/api/leases/[id]/punctuality` | Admin couldn't read alongside owner |
| `/api/leases/[id]/receipts` | Owner couldn't see own quittances; was signer-only |
| `/api/leases/[id]/signature-sessions` (non-v1) | eIDAS kickoff blocked |
| `/api/leases/[id]/visale/verify` | Admin couldn't verify alongside owner+tenant |
| `/api/v1/leases` (GET listing) | Listing on cookie client |
| `/api/inspections/[iid]/photos` | Already on service-role; remaining `.single()` → `.maybeSingle()` |

## Status of the audit after this PR
| Phase | Module | Routes closed |
|---|---|---|
| 1 | work_orders + payments critical | 3 |
| 2 | leases (priority 1) | 8 |
| 3 | properties | 9 |
| 4 | documents | 7 |
| 5 | work_orders restants | 5 |
| **6** | **leases minor + inspection** | **11** |
| **Total** | | **43 / 58** |

Leases module: **18 / 18** ✓
Properties module: **9 / 9** ✓ (10th route is the diagnostic, intentionally unfixed)
Documents module: **7 / 7** ✓
Work_orders module: **6 / 6** ✓
Inspections module: **1 / 1** ✓
Payments module: **2 / 2** ✓

Remaining: ~15 misc routes flagged as 🟡 minor or theoretical.

## Test plan
- [ ] `npx tsc --noEmit` — 126 errors before/after, no regression
- [ ] Smoke `GET /api/leases/[id]/receipts` as tenant on own lease (200), as owner (200), as random (403)
- [ ] Smoke `POST /api/leases/[id]/cancel` as owner of property (200), as random (403)

https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH)_