### PR TITLE
chore(admin): deprecate orphan /api/admin/stats + map metrics surface

### DIFF
--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,8 +1,21 @@
 export const runtime = 'nodejs';
 
 /**
- * API Route pour les statistiques admin
- * GET /api/admin/stats
+ * ⚠️ DEPRECATED — `/api/admin/stats` n'est plus appelée par l'UI Talok.
+ * Le hook `useAdminStats` qui pointait vers cette route est lui-même
+ * orphelin (zéro consommateur dans le repo au 2026-04-26).
+ *
+ * Les surfaces actives pour les KPIs admin sont :
+ *   - `/admin/dashboard`         → RPC `admin_stats` directement (cf. `app/admin/_data/fetchAdminStats.ts`)
+ *   - `/admin/metrics`           → `/api/admin/metrics` (KPI étendus + charts)
+ *   - `/admin/metrics-saas`      → `/api/admin/metrics/saas` (MRR / churn / ARPU / LTV)
+ *   - `/admin/reports`           → Supabase direct (export CSV par dates)
+ *   - `/admin/platform-health`   → `/api/admin/health` (latence + Stripe + crons)
+ *
+ * Conservée pour compatibilité avec d'éventuels appels admin manuels mais
+ * loggée pour surveillance. Si aucun warn n'apparaît dans les logs prod
+ * pendant 90 jours, route + hook (`useAdminStats` dans `lib/hooks/use-admin-queries.ts`)
+ * peuvent être supprimés.
  */
 
 import { NextResponse } from "next/server";
@@ -16,9 +29,12 @@ export async function GET(request: Request) {
     });
     if (isAdminAuthError(auth)) return auth;
 
-    const supabase = await createRouteHandlerClient();
+    console.warn(
+      "[DEPRECATED] GET /api/admin/stats called",
+      { admin_user_id: auth.user.id }
+    );
 
-    // Appeler la fonction RPC
+    const supabase = await createRouteHandlerClient();
     const { data, error } = await supabase.rpc("admin_dashboard_stats");
 
     if (error) {

--- a/lib/hooks/use-admin-queries.ts
+++ b/lib/hooks/use-admin-queries.ts
@@ -60,6 +60,17 @@ async function adminMutate<T>(
 }
 
 // ─── Stats ─────────────────────────────────────────────────
+/**
+ * @deprecated `useAdminStats` n'est plus consommée par aucune page (au
+ * 2026-04-26). Les KPIs admin passent par :
+ *   - `fetchAdminStatsV2()` (server-side, dashboard principal)
+ *   - `useAdminMetrics()` (page `/admin/metrics`)
+ *   - hooks dédiés MRR / health (`metrics-saas`, `platform-health`)
+ *
+ * Conservé pour ne pas casser un éventuel usage hors-repo. À supprimer
+ * en même temps que `/api/admin/stats/route.ts` si aucun warn prod n'est
+ * remonté pendant 90 jours.
+ */
 export function useAdminStats() {
   return useQuery({
     queryKey: adminKeys.stats(),


### PR DESCRIPTION
## Summary
Continues the dedup audit started in PR #518. After surveying the four metrics-related pages (`/admin/metrics`, `/admin/metrics-saas`, `/admin/reports`, `/admin/platform-health`) and their data sources, the only real dead code in the cluster is `/api/admin/stats` + its `useAdminStats` hook. The pages themselves are not duplicates.

## Metrics surface (mapped)

| Page | Data source | Slice |
|---|---|---|
| `/admin/dashboard` | `fetchAdminStatsV2()` (RPC `admin_stats` direct) | Global KPIs |
| `/admin/metrics` | `useAdminMetrics()` → `/api/admin/metrics` | Extended KPIs + charts |
| `/admin/metrics-saas` | `/api/admin/metrics/saas` | MRR / churn / ARPU / LTV |
| `/admin/reports` | Supabase direct (browser) | Custom report + CSV export |
| `/admin/platform-health` | `/api/admin/health` | DB latency, Stripe, crons |
| ~~`/api/admin/stats`~~ | `useAdminStats` (orphan hook) | **Dead — 0 consumers** |

## Changes
- `/api/admin/stats` route gets the `@deprecated` header + `console.warn` on each hit (same pattern as `/api/admin/users/[id]` in #518)
- `useAdminStats` hook in `lib/hooks/use-admin-queries.ts` gets a matching `@deprecated` JSDoc pointing at the canonical hooks

## Out of scope (noted, not actioned)
- `/admin/reports` reads Supabase directly from the browser instead of going through an admin API. Probably fine because admins bypass RLS, but it's an inconsistent pattern that deserves its own audit later.
- `/admin/dashboard` and `/admin/metrics` show overlapping KPIs but are intentionally split (quick-view vs analytical-view). Not consolidated.

## Test plan
- [ ] After deploy, monitor prod logs for `[DEPRECATED] /api/admin/stats` warnings; if none in 90 days, route + hook can be deleted
- [ ] Smoke `/admin/dashboard`, `/admin/metrics`, `/admin/metrics-saas`, `/admin/reports`, `/admin/platform-health` all still render

https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH

---
_Generated by [Claude Code](https://claude.ai/code/session_012GUfHWR1focQqYVUhEPEqH)_