### PR TITLE
Add multi-entity Stripe Connect support with entity scoping

### DIFF
--- a/app/api/stripe/connect/accounts/route.ts
+++ b/app/api/stripe/connect/accounts/route.ts
@@ -1,0 +1,91 @@
+export const runtime = "nodejs";
+
+/**
+ * GET /api/stripe/connect/accounts
+ *
+ * Liste tous les comptes Stripe Connect du propriétaire :
+ *   - le compte personnel (entity_id IS NULL)
+ *   - les comptes scopés à une entité juridique (SCI, copropriété…)
+ *
+ * Réponse : ConnectAccountListItem[] (cf. lib/hooks/use-stripe-connect.ts)
+ */
+
+import { NextResponse } from "next/server";
+import { createRouteHandlerClient, createServiceRoleClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  try {
+    const supabase = await createRouteHandlerClient();
+    const serviceClient = createServiceRoleClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile || !["owner", "syndic"].includes(profile.role)) {
+      return NextResponse.json(
+        { error: "Seuls les propriétaires et syndics peuvent lister leurs comptes Connect" },
+        { status: 403 }
+      );
+    }
+
+    const { data: accounts, error } = await serviceClient
+      .from("stripe_connect_accounts")
+      .select(
+        `
+        id,
+        entity_id,
+        stripe_account_id,
+        charges_enabled,
+        payouts_enabled,
+        details_submitted,
+        bank_account_last4,
+        bank_account_bank_name,
+        legal_entities:entity_id ( id, nom, entity_type )
+      `
+      )
+      .eq("profile_id", profile.id)
+      .order("entity_id", { ascending: true, nullsFirst: true });
+
+    if (error) {
+      console.error("[Stripe Connect] Erreur liste comptes:", error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const items = (accounts ?? []).map((account: any) => {
+      const entity = Array.isArray(account.legal_entities)
+        ? account.legal_entities[0]
+        : account.legal_entities;
+
+      return {
+        id: account.id as string,
+        entity_id: (account.entity_id as string | null) ?? null,
+        entity_label: entity?.nom ?? "Compte personnel",
+        stripe_account_id: account.stripe_account_id as string,
+        charges_enabled: Boolean(account.charges_enabled),
+        payouts_enabled: Boolean(account.payouts_enabled),
+        details_submitted: Boolean(account.details_submitted),
+        bank_account_last4: (account.bank_account_last4 as string | null) ?? null,
+        bank_account_bank_name: (account.bank_account_bank_name as string | null) ?? null,
+      };
+    });
+
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error("[Stripe Connect] Erreur liste comptes:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/stripe/connect/payouts/route.ts
+++ b/app/api/stripe/connect/payouts/route.ts
@@ -1,9 +1,9 @@
 export const runtime = "nodejs";
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient, createServiceRoleClient } from "@/lib/supabase/server";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const supabase = await createRouteHandlerClient();
     const serviceClient = createServiceRoleClient();
@@ -22,20 +22,27 @@ export async function GET() {
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "owner") {
+    if (!profile || !["owner", "syndic"].includes(profile.role)) {
       return NextResponse.json(
-        { error: "Seuls les propriétaires peuvent consulter leurs versements bancaires" },
+        { error: "Seuls les propriétaires et syndics peuvent consulter leurs versements bancaires" },
         { status: 403 }
       );
     }
 
-    // S2-2 : compte personnel uniquement (entity_id IS NULL)
-    const { data: connectAccount } = await serviceClient
+    const entityId = request.nextUrl.searchParams.get("entityId");
+
+    let query = serviceClient
       .from("stripe_connect_accounts")
       .select("id")
-      .eq("profile_id", profile.id)
-      .is("entity_id", null)
-      .maybeSingle();
+      .eq("profile_id", profile.id);
+
+    if (entityId) {
+      query = query.eq("entity_id", entityId);
+    } else {
+      query = query.is("entity_id", null);
+    }
+
+    const { data: connectAccount } = await query.maybeSingle();
 
     if (!connectAccount?.id) {
       return NextResponse.json([]);

--- a/app/api/stripe/connect/route.ts
+++ b/app/api/stripe/connect/route.ts
@@ -15,6 +15,8 @@ import {
   buildConnectAccountResponse,
   type StoredConnectAccount,
 } from "@/lib/stripe/connect-account";
+import { PLAN_LIMITS } from "@/lib/subscriptions/plan-limits";
+import { resolveCurrentPlan } from "@/lib/subscriptions/resolve-current-plan";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://talok.fr";
 const CONNECT_CONFLICT_RETRY_ERROR =
@@ -286,6 +288,31 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json().catch(() => ({}));
     const entityId: string | undefined = body.entityId || undefined;
+
+    // Plan gating : la création d'un compte scopé à une entité juridique
+    // requiert un plan supportant le multi-entité (Confort+ pour les owners).
+    // Les syndics sont exemptés (obligation légale ALUR de séparation des comptes
+    // par copropriété) ; les comptes personnels (entityId vide) restent ouverts à tous.
+    if (entityId && profile.role === "owner") {
+      const { data: subscription } = await serviceClient
+        .from("subscriptions")
+        .select("plan_slug")
+        .eq("profile_id", profile.id)
+        .maybeSingle();
+
+      const planSlug = resolveCurrentPlan(subscription?.plan_slug as string | undefined);
+      if (!PLAN_LIMITS[planSlug].hasMultiEntity) {
+        return NextResponse.json(
+          {
+            error:
+              "La gestion multi-entités (SCI) est disponible à partir du plan Confort.",
+            upgrade_required: true,
+            feature: "hasMultiEntity",
+          },
+          { status: 402 }
+        );
+      }
+    }
 
     // Vérifier si un compte existe déjà (personnel ou scopé par entité)
     const existingAccount = await getStoredConnectAccountReference(

--- a/app/api/stripe/connect/transfers/route.ts
+++ b/app/api/stripe/connect/transfers/route.ts
@@ -4,12 +4,14 @@ export const runtime = "nodejs";
  * API Route pour récupérer l'historique des transferts Stripe Connect
  *
  * GET /api/stripe/connect/transfers - Liste les transferts vers le compte du propriétaire
+ *   - Sans entityId : compte personnel (entity_id IS NULL)
+ *   - Avec entityId : compte scopé à l'entité juridique
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient, createServiceRoleClient } from "@/lib/supabase/server";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const supabase = await createRouteHandlerClient();
     const serviceClient = createServiceRoleClient();
@@ -22,34 +24,39 @@ export async function GET() {
       return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
     }
 
-    // Récupérer le profil
     const { data: profile } = await supabase
       .from("profiles")
       .select("id, role")
       .eq("user_id", user.id)
       .single();
 
-    if (!profile || profile.role !== "owner") {
+    if (!profile || !["owner", "syndic"].includes(profile.role)) {
       return NextResponse.json(
-        { error: "Seuls les propriétaires peuvent consulter leurs transferts" },
+        { error: "Seuls les propriétaires et syndics peuvent consulter leurs transferts" },
         { status: 403 }
       );
     }
 
-    // Récupérer le compte Connect personnel (S2-2 : entity_id IS NULL)
-    const { data: connectAccount } = await serviceClient
+    const entityId = request.nextUrl.searchParams.get("entityId");
+
+    let query = serviceClient
       .from("stripe_connect_accounts")
       .select("id")
-      .eq("profile_id", profile.id)
-      .is("entity_id", null)
-      .maybeSingle();
+      .eq("profile_id", profile.id);
+
+    if (entityId) {
+      query = query.eq("entity_id", entityId);
+    } else {
+      query = query.is("entity_id", null);
+    }
+
+    const { data: connectAccount } = await query.maybeSingle();
 
     const connectAccountId = connectAccount?.id;
     if (!connectAccountId) {
       return NextResponse.json([]);
     }
 
-    // Récupérer les transferts
     const { data: transfers, error: transfersError } = await serviceClient
       .from("stripe_transfers")
       .select(

--- a/app/owner/money/tabs/CompteBancaireTab.tsx
+++ b/app/owner/money/tabs/CompteBancaireTab.tsx
@@ -28,6 +28,8 @@ import { GlassCard } from "@/components/ui/glass-card";
 import { AnimatedCounter } from "@/components/ui/animated-counter";
 import { EmptyState } from "@/components/ui/empty-state";
 import { cn } from "@/lib/utils";
+import { useEntityStore } from "@/stores/useEntityStore";
+import { EntitySelector } from "@/components/entities/EntitySelector";
 import {
   useStripeConnectStatus,
   useStripeConnectBalance,
@@ -164,13 +166,19 @@ export function CompteBancaireTab() {
   const { toast } = useToast();
   const [connectLoading, setConnectLoading] = useState(false);
 
+  // Multi-entité : null = compte personnel, sinon scopé à une entité juridique.
+  // L'EntitySelector ne s'affiche que si le propriétaire a déjà créé au moins
+  // une entité juridique (SCI, SARL…).
+  const entities = useEntityStore((s) => s.entities);
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+
   const {
     data: connectData,
     isLoading: statusLoading,
     isError: statusError,
     error: statusErrorValue,
     refetch: refetchStatus,
-  } = useStripeConnectStatus();
+  } = useStripeConnectStatus(selectedEntityId);
   const connectAccount = connectData?.account ?? null;
   const isReady = Boolean(connectData?.has_account && connectAccount?.is_ready);
   const hasAccount = Boolean(connectData?.has_account);
@@ -181,21 +189,21 @@ export function CompteBancaireTab() {
     isError: balanceError,
     error: balanceErrorValue,
     refetch: refetchBalance,
-  } = useStripeConnectBalance(isReady);
+  } = useStripeConnectBalance(isReady, selectedEntityId);
   const {
     data: transfers,
     isLoading: transfersLoading,
     isError: transfersError,
     error: transfersErrorValue,
     refetch: refetchTransfers,
-  } = useStripeTransfers(isReady);
+  } = useStripeTransfers(isReady, selectedEntityId);
   const {
     data: payouts,
     isLoading: payoutsLoading,
     isError: payoutsError,
     error: payoutsErrorValue,
     refetch: refetchPayouts,
-  } = useStripePayouts(isReady);
+  } = useStripePayouts(isReady, selectedEntityId);
 
   useEffect(() => {
     const success = searchParams.get("success");
@@ -247,7 +255,7 @@ export function CompteBancaireTab() {
       const res = await fetch("/api/stripe/connect", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: "{}",
+        body: JSON.stringify({ entityId: selectedEntityId }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Erreur");
@@ -266,7 +274,11 @@ export function CompteBancaireTab() {
 
   const openConnectDashboard = async () => {
     try {
-      const res = await fetch("/api/stripe/connect/dashboard", { method: "POST" });
+      const res = await fetch("/api/stripe/connect/dashboard", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entityId: selectedEntityId }),
+      });
       const data = await res.json();
       const url = data.dashboard_url ?? data.url;
       if (res.ok && url) window.location.href = url;
@@ -322,8 +334,27 @@ export function CompteBancaireTab() {
     );
   }
 
+  const selectedEntity = selectedEntityId
+    ? entities.find((e) => e.id === selectedEntityId) ?? null
+    : null;
+  const scopeLabel = selectedEntity ? selectedEntity.nom : "compte personnel";
+
   return (
     <div className="space-y-6">
+      {/* Sélecteur d'entité — n'apparaît qu'avec au moins une entité juridique */}
+      {entities.length > 0 && (
+        <Card>
+          <CardContent className="pt-6">
+            <EntitySelector
+              value={selectedEntityId}
+              onChange={setSelectedEntityId}
+              label="Compte affiché"
+              hint="Choisissez le compte bancaire à consulter ou à configurer."
+            />
+          </CardContent>
+        </Card>
+      )}
+
       {/* Statut du compte bancaire */}
       <Card>
         <CardHeader>
@@ -331,7 +362,9 @@ export function CompteBancaireTab() {
             <Building2 className="h-5 w-5 text-violet-600" /> Réception des loyers
           </CardTitle>
           <CardDescription>
-            Compte bancaire pour recevoir les paiements de vos locataires via Stripe Connect.
+            {entities.length > 0
+              ? `Compte bancaire pour ${scopeLabel} — encaissez les paiements des locataires via Stripe Connect.`
+              : "Compte bancaire pour recevoir les paiements de vos locataires via Stripe Connect."}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/app/owner/money/tabs/CompteBancaireTab.tsx
+++ b/app/owner/money/tabs/CompteBancaireTab.tsx
@@ -35,8 +35,10 @@ import {
   useStripeConnectBalance,
   useStripeTransfers,
   useStripePayouts,
+  useStripeConnectAccounts,
   type StripeTransfer,
   type StripePayout,
+  type ConnectAccountListItem,
 } from "@/lib/hooks/use-stripe-connect";
 
 const TRANSFER_STATUS: Record<string, { label: string; icon: React.ReactNode; classes: string }> = {
@@ -171,6 +173,7 @@ export function CompteBancaireTab() {
   // une entité juridique (SCI, SARL…).
   const entities = useEntityStore((s) => s.entities);
   const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  const { data: allAccounts } = useStripeConnectAccounts();
 
   const {
     data: connectData,
@@ -353,6 +356,16 @@ export function CompteBancaireTab() {
             />
           </CardContent>
         </Card>
+      )}
+
+      {/* Tableau de bord : tous les comptes Connect existants
+          (utile dès qu'on a 2+ comptes pour visualiser le statut global). */}
+      {allAccounts && allAccounts.length >= 2 && (
+        <ConnectAccountsOverview
+          accounts={allAccounts}
+          selectedEntityId={selectedEntityId}
+          onSelect={setSelectedEntityId}
+        />
       )}
 
       {/* Statut du compte bancaire */}
@@ -727,5 +740,76 @@ export function CompteBancaireTab() {
         </div>
       )}
     </div>
+  );
+}
+
+interface ConnectAccountsOverviewProps {
+  accounts: ConnectAccountListItem[];
+  selectedEntityId: string | null;
+  onSelect: (entityId: string | null) => void;
+}
+
+function ConnectAccountsOverview({
+  accounts,
+  selectedEntityId,
+  onSelect,
+}: ConnectAccountsOverviewProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Wallet className="h-4 w-4 text-violet-600" /> Mes comptes bancaires
+        </CardTitle>
+        <CardDescription>
+          {accounts.length} comptes Stripe Connect actifs. Cliquez pour consulter le détail.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {accounts.map((account) => {
+            const isSelected = (account.entity_id ?? null) === selectedEntityId;
+            const isReady = account.charges_enabled && account.payouts_enabled;
+            const statusBadge = isReady
+              ? { label: "Activé", classes: "bg-emerald-500/15 text-emerald-700 border-emerald-500/30" }
+              : account.details_submitted
+              ? { label: "En vérification", classes: "bg-amber-500/15 text-amber-700 border-amber-500/30" }
+              : { label: "À configurer", classes: "bg-slate-500/15 text-slate-600 border-slate-500/30" };
+
+            return (
+              <button
+                type="button"
+                key={account.id}
+                onClick={() => onSelect(account.entity_id)}
+                className={cn(
+                  "text-left rounded-xl border p-4 transition-all hover:border-violet-400 hover:bg-violet-50/50 dark:hover:bg-violet-950/20",
+                  isSelected
+                    ? "border-violet-500 bg-violet-50/70 dark:bg-violet-950/30 ring-2 ring-violet-500/20"
+                    : "border-border bg-background"
+                )}
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="font-medium truncate">{account.entity_label}</span>
+                  </div>
+                  <Badge variant="outline" className={cn("shrink-0 text-[10px]", statusBadge.classes)}>
+                    {statusBadge.label}
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {account.bank_account_last4
+                    ? `IBAN •••• ${account.bank_account_last4}${
+                        account.bank_account_bank_name
+                          ? ` — ${account.bank_account_bank_name}`
+                          : ""
+                      }`
+                    : "Coordonnées bancaires à renseigner"}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/app/owner/money/tabs/CompteBancaireTab.tsx
+++ b/app/owner/money/tabs/CompteBancaireTab.tsx
@@ -354,7 +354,7 @@ export function CompteBancaireTab() {
                 </div>
               </div>
               <Button variant="outline" onClick={openConnectDashboard} className="gap-2">
-                <ExternalLink className="h-4 w-4" /> Gérer le compte bancaire
+                <ExternalLink className="h-4 w-4" /> Voir mes versements
               </Button>
             </div>
           ) : isOnboardingIncomplete ? (

--- a/lib/hooks/use-stripe-connect.ts
+++ b/lib/hooks/use-stripe-connect.ts
@@ -2,6 +2,10 @@
 
 /**
  * SOTA 2026 : Hooks React Query pour Stripe Connect (compte bancaire propriétaire).
+ *
+ * Multi-entité : chaque hook accepte un `entityId` optionnel.
+ *   - undefined → compte personnel (entity_id IS NULL)
+ *   - UUID      → compte scopé à une entité juridique (SCI, copropriété…)
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -51,20 +55,39 @@ export interface StripePayout {
   created_at: string;
 }
 
+export interface ConnectAccountListItem {
+  id: string;
+  entity_id: string | null;
+  entity_label: string;
+  stripe_account_id: string;
+  charges_enabled: boolean;
+  payouts_enabled: boolean;
+  details_submitted: boolean;
+  bank_account_last4: string | null;
+  bank_account_bank_name: string | null;
+}
+
 // ── Hooks ──
 
 const CONNECT_STATUS_KEY = "stripe-connect-status";
 const CONNECT_BALANCE_KEY = "stripe-connect-balance";
 const CONNECT_TRANSFERS_KEY = "stripe-connect-transfers";
 const CONNECT_PAYOUTS_KEY = "stripe-connect-payouts";
+const CONNECT_ACCOUNTS_KEY = "stripe-connect-accounts";
 
-export function useStripeConnectStatus() {
+function buildScopedUrl(base: string, entityId?: string | null): string {
+  if (!entityId) return base;
+  const sep = base.includes("?") ? "&" : "?";
+  return `${base}${sep}entityId=${encodeURIComponent(entityId)}`;
+}
+
+export function useStripeConnectStatus(entityId?: string | null) {
   const { profile } = useAuth();
 
   return useQuery<ConnectAccountData>({
-    queryKey: [CONNECT_STATUS_KEY, profile?.id],
+    queryKey: [CONNECT_STATUS_KEY, profile?.id, entityId ?? null],
     queryFn: async () => {
-      const res = await fetch("/api/stripe/connect");
+      const res = await fetch(buildScopedUrl("/api/stripe/connect", entityId));
       const data = await res.json();
       if (!res.ok) {
         throw new Error(data.error ?? "Erreur chargement compte Connect");
@@ -76,13 +99,13 @@ export function useStripeConnectStatus() {
   });
 }
 
-export function useStripeConnectBalance(enabled = true) {
+export function useStripeConnectBalance(enabled = true, entityId?: string | null) {
   const { profile } = useAuth();
 
   return useQuery<ConnectBalanceData>({
-    queryKey: [CONNECT_BALANCE_KEY, profile?.id],
+    queryKey: [CONNECT_BALANCE_KEY, profile?.id, entityId ?? null],
     queryFn: async () => {
-      const res = await fetch("/api/stripe/connect/balance");
+      const res = await fetch(buildScopedUrl("/api/stripe/connect/balance", entityId));
       const data = await res.json();
       if (!res.ok) {
         throw new Error(data.error ?? "Erreur chargement solde");
@@ -94,13 +117,13 @@ export function useStripeConnectBalance(enabled = true) {
   });
 }
 
-export function useStripeTransfers(enabled = true) {
+export function useStripeTransfers(enabled = true, entityId?: string | null) {
   const { profile } = useAuth();
 
   return useQuery<StripeTransfer[]>({
-    queryKey: [CONNECT_TRANSFERS_KEY, profile?.id],
+    queryKey: [CONNECT_TRANSFERS_KEY, profile?.id, entityId ?? null],
     queryFn: async () => {
-      const res = await fetch("/api/stripe/connect/transfers");
+      const res = await fetch(buildScopedUrl("/api/stripe/connect/transfers", entityId));
       const data = await res.json();
       if (!res.ok) {
         throw new Error(data.error ?? "Erreur chargement transferts");
@@ -112,16 +135,34 @@ export function useStripeTransfers(enabled = true) {
   });
 }
 
-export function useStripePayouts(enabled = true) {
+export function useStripePayouts(enabled = true, entityId?: string | null) {
   const { profile } = useAuth();
 
   return useQuery<StripePayout[]>({
-    queryKey: [CONNECT_PAYOUTS_KEY, profile?.id],
+    queryKey: [CONNECT_PAYOUTS_KEY, profile?.id, entityId ?? null],
     queryFn: async () => {
-      const res = await fetch("/api/stripe/connect/payouts");
+      const res = await fetch(buildScopedUrl("/api/stripe/connect/payouts", entityId));
       const data = await res.json();
       if (!res.ok) {
         throw new Error(data.error ?? "Erreur chargement versements");
+      }
+      return data;
+    },
+    enabled: !!profile?.id && enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useStripeConnectAccounts(enabled = true) {
+  const { profile } = useAuth();
+
+  return useQuery<ConnectAccountListItem[]>({
+    queryKey: [CONNECT_ACCOUNTS_KEY, profile?.id],
+    queryFn: async () => {
+      const res = await fetch("/api/stripe/connect/accounts");
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error ?? "Erreur chargement comptes Connect");
       }
       return data;
     },


### PR DESCRIPTION
## Summary
This PR adds multi-entity support to the Stripe Connect banking account management system, allowing owners and syndics to manage separate Stripe Connect accounts for different legal entities (SCI, SARL, etc.) while maintaining backward compatibility with personal accounts.

## Key Changes

- **Entity-scoped Stripe Connect accounts**: All Stripe Connect API routes and hooks now accept an optional `entityId` parameter to scope operations to a specific legal entity, with `null` representing the personal account
  - Updated hooks: `useStripeConnectStatus()`, `useStripeConnectBalance()`, `useStripeTransfers()`, `useStripePayouts()`
  - New hook: `useStripeConnectAccounts()` to list all Connect accounts across entities

- **New API endpoint** (`GET /api/stripe/connect/accounts`): Lists all Stripe Connect accounts for the authenticated user, including personal and entity-scoped accounts with their status and bank details

- **UI enhancements**:
  - Added `EntitySelector` component to the banking tab for switching between personal and entity accounts
  - New `ConnectAccountsOverview` component displays all active Connect accounts in a grid with status badges
  - Updated button labels and descriptions to reflect entity context
  - Entity selector only appears when at least one legal entity exists

- **Plan gating**: Creating entity-scoped Connect accounts for owners now requires the "Confort+" plan with `hasMultiEntity` feature enabled. Syndics are exempt (ALUR legal requirement for account separation by property)

- **Request body updates**: Connect creation and dashboard endpoints now accept `entityId` in the request body to specify which entity's account to manage

- **Role expansion**: Syndics (`syndic` role) are now included alongside owners in authorization checks for Connect operations

## Implementation Details

- Entity scoping uses URL query parameters (`?entityId=...`) for GET requests and JSON body for POST requests
- Query keys in React Query include the `entityId` to ensure proper cache isolation between entities
- The `buildScopedUrl()` helper function handles URL construction for entity-scoped API calls
- Backward compatibility maintained: existing personal account flows work unchanged when `entityId` is `null` or undefined

https://claude.ai/code/session_01RLHg9BtEFBpwNwGMaMeq7k