### PR TITLE
Add accounting features: auto-validation, accrual entries, scoring, and exports

### DIFF
--- a/app/api/accounting/agent/chat/route.ts
+++ b/app/api/accounting/agent/chat/route.ts
@@ -1,0 +1,102 @@
+/**
+ * API Route: TALO Comptabilite agent
+ * POST /api/accounting/agent/chat
+ *   { entityId, exerciseId, question }
+ *
+ * Returns a grounded, retrieval-augmented answer from the TALO IA
+ * agent based on the entity's books. Auth: owner / admin / agency
+ * with an active subscription that includes the agent feature.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
+import { askTaloAccounting } from "@/lib/accounting/agent/talo-accounting";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BodySchema = z.object({
+  entityId: z.string().uuid(),
+  exerciseId: z.string().uuid(),
+  question: z.string().min(3).max(2000),
+});
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new ApiError(401, "Non authentifie");
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+    if (!profile) throw new ApiError(403, "Profil introuvable");
+
+    if (
+      profile.role !== "admin" &&
+      profile.role !== "owner" &&
+      profile.role !== "agency"
+    ) {
+      throw new ApiError(403, "Acces refuse");
+    }
+
+    const featureGate = await requireAccountingAccess(profile.id, "agent");
+    if (featureGate) return featureGate;
+
+    const body = await request.json();
+    const parse = BodySchema.safeParse(body);
+    if (!parse.success) {
+      throw new ApiError(400, parse.error.errors[0].message);
+    }
+    const { entityId, exerciseId, question } = parse.data;
+
+    // Scope check: non-admin must be a member of the entity
+    if (profile.role !== "admin") {
+      const { data: member } = await supabase
+        .from("entity_members")
+        .select("entity_id")
+        .eq("entity_id", entityId)
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!member) {
+        throw new ApiError(403, "Acces refuse a cette entite");
+      }
+    }
+
+    const result = await askTaloAccounting(supabase, {
+      entityId,
+      exerciseId,
+      question,
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        answer: result.answer,
+        modelUsed: result.modelUsed,
+        contextSummary: {
+          entityName: result.context.entityName,
+          declarationMode: result.context.declarationMode,
+          exerciseLabel: result.context.exerciseLabel,
+          totals: result.context.totals,
+          openInvoiceCount: result.context.openInvoiceCount,
+          unpaidCents: result.context.unpaidCents,
+        },
+      },
+      meta: {
+        generated_at: new Date().toISOString(),
+        disclaimer:
+          "Reponse generee par TALO a partir de vos donnees comptables. Aide indicative — ne remplace pas un expert-comptable.",
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/accounting/declarations/[type]/route.ts
+++ b/app/api/accounting/declarations/[type]/route.ts
@@ -191,6 +191,7 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const exerciseId = searchParams.get("exerciseId");
     const entityId = searchParams.get("entityId");
+    const format = searchParams.get("format") ?? "json";
 
     if (!exerciseId || !entityId) {
       throw new ApiError(400, "exerciseId et entityId sont requis");
@@ -223,6 +224,56 @@ export async function GET(
         break;
       default:
         throw new ApiError(400, `Type non supporte: ${type}`);
+    }
+
+    if (format === "pdf" && type === "2044") {
+      const d = declaration as ReturnType<typeof compute2044>;
+
+      const { data: entity } = await supabase
+        .from("legal_entities")
+        .select("name, siren")
+        .eq("id", entityId)
+        .maybeSingle();
+
+      const { data: exercise } = await supabase
+        .from("accounting_exercises")
+        .select("end_date")
+        .eq("id", exerciseId)
+        .maybeSingle();
+
+      const year = exercise?.end_date
+        ? new Date(exercise.end_date as string).getUTCFullYear()
+        : new Date().getUTCFullYear();
+
+      const { generateCerfa2044Pdf } = await import(
+        "@/lib/accounting/exports/cerfa-2044-pdf"
+      );
+      const pdf = await generateCerfa2044Pdf({
+        year,
+        ownerName:
+          (entity?.name as string | undefined) ?? "Proprietaire",
+        siren: (entity?.siren as string | undefined) ?? undefined,
+        ligne_215_cents: d.ligne_215,
+        ligne_221_cents: d.ligne_221,
+        ligne_222_cents: d.ligne_222,
+        ligne_223_cents: d.ligne_223,
+        ligne_224_cents: d.ligne_224,
+        ligne_227_cents: d.ligne_227,
+        ligne_229_cents: d.ligne_229,
+        ligne_230_cents: d.ligne_230,
+        case_4BA_cents: d.case_4BA,
+        case_4BB_cents: d.case_4BB,
+        case_4BC_cents: d.case_4BC,
+      });
+
+      return new NextResponse(Buffer.from(pdf), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Disposition": `attachment; filename="cerfa-2044-${year}.pdf"`,
+          "Cache-Control": "private, no-store",
+        },
+      });
     }
 
     return NextResponse.json({

--- a/app/api/accounting/declarations/[type]/route.ts
+++ b/app/api/accounting/declarations/[type]/route.ts
@@ -226,6 +226,52 @@ export async function GET(
         throw new ApiError(400, `Type non supporte: ${type}`);
     }
 
+    if (format === "pdf" && type === "2072") {
+      const d = declaration as Awaited<ReturnType<typeof compute2072>>;
+
+      const { data: entity } = await supabase
+        .from("legal_entities")
+        .select("name, siren")
+        .eq("id", entityId)
+        .maybeSingle();
+
+      const { data: exercise } = await supabase
+        .from("accounting_exercises")
+        .select("end_date")
+        .eq("id", exerciseId)
+        .maybeSingle();
+
+      const year = exercise?.end_date
+        ? new Date(exercise.end_date as string).getUTCFullYear()
+        : new Date().getUTCFullYear();
+
+      const { generateCerfa2072Pdf } = await import(
+        "@/lib/accounting/exports/cerfa-2072-pdf"
+      );
+      const pdf = await generateCerfa2072Pdf({
+        year,
+        ownerName: (entity?.name as string | undefined) ?? "Societe civile",
+        siren: (entity?.siren as string | undefined) ?? undefined,
+        revenus_bruts_cents: d.revenus_bruts,
+        charges_deductibles_cents: d.charges_deductibles,
+        resultat_cents: d.resultat,
+        associates: d.resultat_par_associe.map((a) => ({
+          name: a.name,
+          quotePartPct: a.quotePartPct,
+          resultatCents: a.resultatCents,
+        })),
+      });
+
+      return new NextResponse(Buffer.from(pdf), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Disposition": `attachment; filename="cerfa-2072-${year}.pdf"`,
+          "Cache-Control": "private, no-store",
+        },
+      });
+    }
+
     if (format === "pdf" && type === "2044") {
       const d = declaration as ReturnType<typeof compute2044>;
 

--- a/app/api/accounting/declarations/[type]/route.ts
+++ b/app/api/accounting/declarations/[type]/route.ts
@@ -16,9 +16,9 @@ import type { BalanceItem, GrandLivreItem } from "@/lib/accounting/engine";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-type DeclarationType = "2044" | "2072" | "micro-foncier" | "2042-cpro";
+type DeclarationType = "2044" | "2072" | "2065" | "2031" | "micro-foncier" | "2042-cpro";
 
-const VALID_TYPES: DeclarationType[] = ["2044", "2072", "micro-foncier", "2042-cpro"];
+const VALID_TYPES: DeclarationType[] = ["2044", "2072", "2065", "2031", "micro-foncier", "2042-cpro"];
 
 /**
  * Sum credit cents for accounts matching a prefix pattern (706xxx, etc.)
@@ -138,6 +138,123 @@ async function compute2072(
 }
 
 /**
+ * Compute 2065 declaration (SCI / societe a l'IS).
+ *
+ * Fournit les agregats du compte de resultat (charges, produits) et le
+ * resultat fiscal avant impot. Le calcul de l'IS lui-meme reste de la
+ * responsabilite de l'EC : il depend de reintegrations / deductions
+ * extra-comptables que TALOK ne tracke pas (provisions reglementees,
+ * amortissements derogatoires, etc.).
+ */
+function compute2065(balance: BalanceItem[]) {
+  // Produits d'exploitation
+  const produits_loyers = sumCredit(balance, "706");
+  const produits_charges_recup = sumCredit(balance, "708");
+  const produits_financiers = sumCredit(balance, "76");
+  const produits_exceptionnels = sumCredit(balance, "77");
+  const produits_total =
+    produits_loyers +
+    produits_charges_recup +
+    produits_financiers +
+    produits_exceptionnels;
+
+  // Charges
+  const charges_externes =
+    sumDebit(balance, "61") + sumDebit(balance, "62"); // services exterieurs
+  const charges_impots = sumDebit(balance, "63"); // impots et taxes
+  const charges_personnel = sumDebit(balance, "64"); // personnel
+  const charges_financieres = sumDebit(balance, "66"); // interets emprunt
+  const dotations_amortissements = sumDebit(balance, "681");
+  const charges_exceptionnelles = sumDebit(balance, "67");
+  const charges_total =
+    charges_externes +
+    charges_impots +
+    charges_personnel +
+    charges_financieres +
+    dotations_amortissements +
+    charges_exceptionnelles;
+
+  const resultat_avant_impot = produits_total - charges_total;
+  // Taux IS reduit (15%) jusqu'a 42 500 EUR de benefice, taux normal 25% au-dela
+  const seuil_taux_reduit_cents = 42_500_00;
+  const is_taux_reduit_cents =
+    resultat_avant_impot > 0
+      ? Math.round(Math.min(resultat_avant_impot, seuil_taux_reduit_cents) * 0.15)
+      : 0;
+  const is_taux_normal_cents =
+    resultat_avant_impot > seuil_taux_reduit_cents
+      ? Math.round((resultat_avant_impot - seuil_taux_reduit_cents) * 0.25)
+      : 0;
+  const is_total_cents = is_taux_reduit_cents + is_taux_normal_cents;
+  const resultat_apres_impot = resultat_avant_impot - is_total_cents;
+
+  return {
+    type: "2065" as const,
+    produits: {
+      loyers: produits_loyers,
+      charges_recuperees: produits_charges_recup,
+      financiers: produits_financiers,
+      exceptionnels: produits_exceptionnels,
+      total: produits_total,
+    },
+    charges: {
+      externes: charges_externes,
+      impots_taxes: charges_impots,
+      personnel: charges_personnel,
+      financieres: charges_financieres,
+      dotations_amortissements,
+      exceptionnelles: charges_exceptionnelles,
+      total: charges_total,
+    },
+    resultat_avant_impot,
+    is_taux_reduit_cents,
+    is_taux_normal_cents,
+    is_total_cents,
+    resultat_apres_impot,
+  };
+}
+
+/**
+ * Compute 2031 declaration (BIC reel - location meublee professionnelle).
+ *
+ * Equivalent du regime reel pour les revenus de location meublee : le
+ * loyer est traite comme une recette commerciale, les charges et amortis
+ * sements sont deductibles, et le resultat est impose au bareme IR.
+ *
+ * La distinction LMP / LMNP impacte l'imputation du deficit (revenu
+ * global pour LMP, BIC seulement pour LMNP) — TALOK ne tranche pas, on
+ * fournit le resultat brut et l'EC rattache au bon regime.
+ */
+function compute2031(balance: BalanceItem[]) {
+  const recettes = sumCredit(balance, "706") + sumCredit(balance, "708");
+  const charges_externes =
+    sumDebit(balance, "61") + sumDebit(balance, "62");
+  const charges_impots = sumDebit(balance, "63");
+  const charges_financieres = sumDebit(balance, "66");
+  const dotations_amortissements = sumDebit(balance, "681");
+  const total_charges =
+    charges_externes +
+    charges_impots +
+    charges_financieres +
+    dotations_amortissements;
+  const resultat_bic = recettes - total_charges;
+
+  return {
+    type: "2031" as const,
+    recettes_bic: recettes,
+    charges: {
+      externes: charges_externes,
+      impots_taxes: charges_impots,
+      financieres: charges_financieres,
+      dotations_amortissements,
+      total: total_charges,
+    },
+    resultat_bic,
+    deficit_lmnp_reportable: resultat_bic < 0 ? -resultat_bic : 0,
+  };
+}
+
+/**
  * Compute 2042-CPRO (micro-BIC / location meublee)
  */
 function compute2042Cpro(balance: BalanceItem[]) {
@@ -219,11 +336,85 @@ export async function GET(
       case "2072":
         declaration = await compute2072(supabase, entityId, balance);
         break;
+      case "2065":
+        declaration = compute2065(balance);
+        break;
+      case "2031":
+        declaration = compute2031(balance);
+        break;
       case "2042-cpro":
         declaration = compute2042Cpro(balance);
         break;
       default:
         throw new ApiError(400, `Type non supporte: ${type}`);
+    }
+
+    if (format === "pdf" && (type === "2065" || type === "2031")) {
+      const { data: entity } = await supabase
+        .from("legal_entities")
+        .select("name, siren")
+        .eq("id", entityId)
+        .maybeSingle();
+
+      const { data: exercise } = await supabase
+        .from("accounting_exercises")
+        .select("end_date")
+        .eq("id", exerciseId)
+        .maybeSingle();
+
+      const year = exercise?.end_date
+        ? new Date(exercise.end_date as string).getUTCFullYear()
+        : new Date().getUTCFullYear();
+      const ownerName =
+        (entity?.name as string | undefined) ?? "Societe";
+      const siren = (entity?.siren as string | undefined) ?? undefined;
+
+      let pdf: Uint8Array;
+      let filename: string;
+
+      if (type === "2065") {
+        const d = declaration as ReturnType<typeof compute2065>;
+        const { generateCerfa2065Pdf } = await import(
+          "@/lib/accounting/exports/cerfa-2065-pdf"
+        );
+        pdf = await generateCerfa2065Pdf({
+          year,
+          ownerName,
+          siren,
+          produits: d.produits,
+          charges: d.charges,
+          resultat_avant_impot: d.resultat_avant_impot,
+          is_taux_reduit_cents: d.is_taux_reduit_cents,
+          is_taux_normal_cents: d.is_taux_normal_cents,
+          is_total_cents: d.is_total_cents,
+          resultat_apres_impot: d.resultat_apres_impot,
+        });
+        filename = `cerfa-2065-${year}.pdf`;
+      } else {
+        const d = declaration as ReturnType<typeof compute2031>;
+        const { generateCerfa2031Pdf } = await import(
+          "@/lib/accounting/exports/cerfa-2031-pdf"
+        );
+        pdf = await generateCerfa2031Pdf({
+          year,
+          ownerName,
+          siren,
+          recettes_bic: d.recettes_bic,
+          charges: d.charges,
+          resultat_bic: d.resultat_bic,
+          deficit_lmnp_reportable: d.deficit_lmnp_reportable,
+        });
+        filename = `cerfa-2031-${year}.pdf`;
+      }
+
+      return new NextResponse(Buffer.from(pdf), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+          "Cache-Control": "private, no-store",
+        },
+      });
     }
 
     if (format === "pdf" && type === "2072") {
@@ -255,11 +446,17 @@ export async function GET(
         revenus_bruts_cents: d.revenus_bruts,
         charges_deductibles_cents: d.charges_deductibles,
         resultat_cents: d.resultat,
-        associates: d.resultat_par_associe.map((a) => ({
-          name: a.name,
-          quotePartPct: a.quotePartPct,
-          resultatCents: a.resultatCents,
-        })),
+        associates: d.resultat_par_associe.map(
+          (a: {
+            name: string;
+            quotePartPct: number;
+            resultatCents: number;
+          }) => ({
+            name: a.name,
+            quotePartPct: a.quotePartPct,
+            resultatCents: a.resultatCents,
+          }),
+        ),
       });
 
       return new NextResponse(Buffer.from(pdf), {

--- a/app/api/accounting/entries/lettrage/route.ts
+++ b/app/api/accounting/entries/lettrage/route.ts
@@ -1,0 +1,124 @@
+/**
+ * API Route: Manual lettrage of accounting entry lines
+ * POST /api/accounting/entries/lettrage
+ *
+ * Marks 2+ entry lines with the same lettrage code so the user can
+ * pair receivables with their settlements (e.g. clear a 411xxx debit
+ * with a 411xxx credit produced by rent_payment_clearing).
+ *
+ * Requires balanced selection: sum(debit) = sum(credit) across the
+ * provided line ids — the engine helper enforces this.
+ *
+ * Auth:
+ *  - admin: any line
+ *  - owner: only lines belonging to entities they own
+ *  - others: 403
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { z } from "zod";
+import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
+import { applyLettrage } from "@/lib/accounting/engine";
+
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  line_ids: z.array(z.string().uuid()).min(2, "Au moins 2 lignes requises"),
+  lettrage_code: z
+    .string()
+    .min(1)
+    .max(8)
+    .regex(/^[A-Z0-9]+$/i, "Code alphanumerique uniquement"),
+});
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new ApiError(401, "Non authentifie");
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile || (profile.role !== "admin" && profile.role !== "owner")) {
+      throw new ApiError(403, "Non autorise");
+    }
+
+    const featureGate = await requireAccountingAccess(profile.id, "entries");
+    if (featureGate) return featureGate;
+
+    const body = await request.json();
+    const validation = BodySchema.safeParse(body);
+    if (!validation.success) {
+      throw new ApiError(400, validation.error.errors[0].message);
+    }
+
+    const { line_ids, lettrage_code } = validation.data;
+
+    // Ownership check for non-admin: every line must belong to an entity
+    // the caller owns.
+    if (profile.role !== "admin") {
+      const { data: lines } = await supabase
+        .from("accounting_entry_lines")
+        .select("id, accounting_entries!inner(entity_id)")
+        .in("id", line_ids);
+
+      const lineRows = (lines ?? []) as Array<{
+        id: string;
+        accounting_entries:
+          | { entity_id: string }
+          | { entity_id: string }[];
+      }>;
+
+      const entityIds = Array.from(
+        new Set(
+          lineRows
+            .map((l) =>
+              Array.isArray(l.accounting_entries)
+                ? l.accounting_entries[0]?.entity_id
+                : l.accounting_entries?.entity_id,
+            )
+            .filter(Boolean) as string[],
+        ),
+      );
+
+      if (entityIds.length > 0) {
+        const { data: owned } = await supabase
+          .from("legal_entities")
+          .select("id")
+          .in("id", entityIds)
+          .eq("owner_profile_id", profile.id);
+
+        const ownedSet = new Set(
+          ((owned ?? []) as Array<{ id: string }>).map((e) => e.id),
+        );
+        const unauthorized = entityIds.filter((id) => !ownedSet.has(id));
+        if (unauthorized.length > 0) {
+          throw new ApiError(403, "Acces refuse a certaines lignes");
+        }
+      }
+    }
+
+    await applyLettrage(supabase, line_ids, lettrage_code.toUpperCase());
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        line_count: line_ids.length,
+        lettrage_code: lettrage_code.toUpperCase(),
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/accounting/exercises/[exerciseId]/post-amortizations/route.ts
+++ b/app/api/accounting/exercises/[exerciseId]/post-amortizations/route.ts
@@ -1,0 +1,87 @@
+/**
+ * API Route: Post annual amortization entries on demand
+ * POST /api/accounting/exercises/[exerciseId]/post-amortizations
+ *
+ * Idempotently posts a depreciation OD entry for every active
+ * amortization_schedule whose calendar line for the exercise year is
+ * not yet booked. Closes the gap when the exercise is still open and
+ * the user wants the dotation visible in their dashboard before closing.
+ *
+ * Auth: admin or owner of the exercise's entity.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
+import { postAnnualAmortizationEntries } from "@/lib/accounting/engine";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: { exerciseId: string } },
+) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new ApiError(401, "Non authentifie");
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile || (profile.role !== "admin" && profile.role !== "owner")) {
+      throw new ApiError(403, "Non autorise");
+    }
+
+    const featureGate = await requireAccountingAccess(profile.id, "entries");
+    if (featureGate) return featureGate;
+
+    const { data: exercise } = await supabase
+      .from("accounting_exercises")
+      .select("id, entity_id, status")
+      .eq("id", params.exerciseId)
+      .maybeSingle();
+
+    if (!exercise) {
+      throw new ApiError(404, "Exercice introuvable");
+    }
+
+    if (profile.role !== "admin") {
+      const { data: entity } = await supabase
+        .from("legal_entities")
+        .select("id")
+        .eq("id", (exercise as { entity_id: string }).entity_id)
+        .eq("owner_profile_id", profile.id)
+        .maybeSingle();
+      if (!entity) {
+        throw new ApiError(403, "Acces refuse a cet exercice");
+      }
+    }
+
+    if ((exercise as { status: string }).status === "closed") {
+      throw new ApiError(
+        409,
+        "Exercice deja cloture — les amortissements ont ete poses lors de la cloture",
+      );
+    }
+
+    const result = await postAnnualAmortizationEntries(
+      supabase,
+      params.exerciseId,
+      user.id,
+    );
+
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/accounting/fec/route.ts
+++ b/app/api/accounting/fec/route.ts
@@ -12,6 +12,7 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
+import { createHash } from "crypto";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceRoleClient } from "@/lib/supabase/server";
 import { handleApiError, ApiError } from "@/lib/helpers/api-error";
@@ -219,13 +220,44 @@ export async function GET(request: Request) {
     const rows = lines.map((l) => FEC_HEADERS.map((h) => String(l[h] ?? "")).join("\t"));
     const content = [header, ...rows].join("\n");
     const dateExport = new Date().toISOString().split("T")[0].replace(/-/g, "");
+    const filename = `FEC_TALOK_${year}_${dateExport}.txt`;
+    const contentBytes = Buffer.from(content, "utf-8");
+    const sha256 = createHash("sha256").update(contentBytes).digest("hex");
 
-    return new NextResponse(content, {
+    // Record an integrity manifest so the company can prove later that
+    // the file delivered to the tax authority was not tampered with.
+    // Best-effort: a manifest insert failure must not block the download.
+    let manifestId: string | null = null;
+    try {
+      const { data: manifest } = await serviceClient
+        .from("fec_manifests")
+        .insert({
+          entity_id: entityId,
+          fec_year: year,
+          filename,
+          file_size_bytes: contentBytes.byteLength,
+          line_count: lines.length,
+          sha256_hex: sha256,
+          generated_by: user.id,
+        } as Record<string, unknown>)
+        .select("id")
+        .single();
+      manifestId = (manifest as { id: string } | null)?.id ?? null;
+    } catch (manifestErr) {
+      console.warn(
+        "[FEC] manifest insert failed (non-blocking):",
+        manifestErr,
+      );
+    }
+
+    return new NextResponse(contentBytes, {
       headers: {
         "Content-Type": "text/plain; charset=utf-8",
-        "Content-Disposition": `attachment; filename="FEC_TALOK_${year}_${dateExport}.txt"`,
+        "Content-Disposition": `attachment; filename="${filename}"`,
         "X-FEC-Year": String(year),
         "X-FEC-Records": String(lines.length),
+        "X-FEC-SHA256": sha256,
+        ...(manifestId ? { "X-FEC-Manifest-Id": manifestId } : {}),
       },
     });
   } catch (error) {

--- a/app/api/accounting/fec/route.ts
+++ b/app/api/accounting/fec/route.ts
@@ -224,6 +224,36 @@ export async function GET(request: Request) {
     const contentBytes = Buffer.from(content, "utf-8");
     const sha256 = createHash("sha256").update(contentBytes).digest("hex");
 
+    // Optional RFC 3161 timestamp from the configured TSA. Best-effort:
+    // we still return the FEC if the TSA is unreachable. The timestamp,
+    // when present, is stored alongside the SHA-256 manifest and binds
+    // the file to a moment in time signed by an external authority.
+    let rfc3161: {
+      tokenBase64: string;
+      tsaUrl: string;
+      receivedAt: string;
+      tokenBytes: number;
+    } | null = null;
+    if (process.env.TALOK_TSA_ENABLED === "true") {
+      try {
+        const { requestFecTimestamp } = await import(
+          "@/lib/accounting/fec-timestamp"
+        );
+        const ts = await requestFecTimestamp(contentBytes);
+        rfc3161 = {
+          tokenBase64: ts.tokenBase64,
+          tsaUrl: ts.tsaUrl,
+          receivedAt: ts.receivedAt,
+          tokenBytes: ts.tokenBytes,
+        };
+      } catch (tsErr) {
+        console.warn(
+          "[FEC] RFC 3161 timestamping failed (non-blocking):",
+          tsErr,
+        );
+      }
+    }
+
     // Record an integrity manifest so the company can prove later that
     // the file delivered to the tax authority was not tampered with.
     // Best-effort: a manifest insert failure must not block the download.
@@ -239,6 +269,10 @@ export async function GET(request: Request) {
           line_count: lines.length,
           sha256_hex: sha256,
           generated_by: user.id,
+          rfc3161_token_b64: rfc3161?.tokenBase64 ?? null,
+          rfc3161_tsa_url: rfc3161?.tsaUrl ?? null,
+          rfc3161_received_at: rfc3161?.receivedAt ?? null,
+          rfc3161_token_bytes: rfc3161?.tokenBytes ?? null,
         } as Record<string, unknown>)
         .select("id")
         .single();
@@ -258,6 +292,7 @@ export async function GET(request: Request) {
         "X-FEC-Records": String(lines.length),
         "X-FEC-SHA256": sha256,
         ...(manifestId ? { "X-FEC-Manifest-Id": manifestId } : {}),
+        ...(rfc3161 ? { "X-FEC-RFC3161": "present", "X-FEC-TSA": rfc3161.tsaUrl } : {}),
       },
     });
   } catch (error) {

--- a/app/api/accounting/fec/verify/route.ts
+++ b/app/api/accounting/fec/verify/route.ts
@@ -1,0 +1,111 @@
+/**
+ * API Route: Verify a FEC file against its manifest
+ * POST /api/accounting/fec/verify
+ *
+ * Body: multipart/form-data with a `file` field containing the FEC .txt
+ * (or JSON { sha256: string } if the caller already computed it).
+ *
+ * Returns whether the SHA-256 of the submitted content matches a manifest
+ * stored at export time. Used by the EC portal and the owner export page
+ * to guarantee the file in their hands is bit-identical to what TALOK
+ * generated.
+ */
+
+import { NextResponse } from "next/server";
+import { createHash } from "crypto";
+import { createClient } from "@/lib/supabase/server";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new ApiError(401, "Non authentifie");
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+    if (
+      !profile ||
+      (profile.role !== "owner" &&
+        profile.role !== "admin" &&
+        profile.role !== "agency")
+    ) {
+      throw new ApiError(403, "Acces refuse");
+    }
+
+    let providedHash: string | null = null;
+    let computedSize: number | null = null;
+
+    const contentType = request.headers.get("content-type") ?? "";
+    if (contentType.includes("multipart/form-data")) {
+      const form = await request.formData();
+      const file = form.get("file");
+      if (!(file instanceof File)) {
+        throw new ApiError(400, "Fichier FEC manquant (champ `file`)");
+      }
+      const buffer = Buffer.from(await file.arrayBuffer());
+      providedHash = createHash("sha256").update(buffer).digest("hex");
+      computedSize = buffer.byteLength;
+    } else if (contentType.includes("application/json")) {
+      const body = (await request.json()) as { sha256?: string };
+      if (!body.sha256 || !/^[0-9a-f]{64}$/i.test(body.sha256)) {
+        throw new ApiError(400, "SHA-256 invalide (64 caracteres hex requis)");
+      }
+      providedHash = body.sha256.toLowerCase();
+    } else {
+      throw new ApiError(
+        415,
+        "Content-Type attendu: multipart/form-data ou application/json",
+      );
+    }
+
+    const { data: manifest } = await supabase
+      .from("fec_manifests")
+      .select(
+        "id, entity_id, fec_year, filename, line_count, file_size_bytes, sha256_hex, generated_at, generated_by",
+      )
+      .eq("sha256_hex", providedHash)
+      .order("generated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (!manifest) {
+      return NextResponse.json({
+        success: true,
+        match: false,
+        sha256: providedHash,
+        message:
+          "Aucun manifeste trouve pour cette empreinte. Le fichier n'a pas ete genere par TALOK ou il a ete modifie.",
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      match: true,
+      sha256: providedHash,
+      manifest: {
+        id: manifest.id,
+        entityId: manifest.entity_id,
+        year: manifest.fec_year,
+        filename: manifest.filename,
+        lineCount: manifest.line_count,
+        fileSizeBytes: manifest.file_size_bytes,
+        generatedAt: manifest.generated_at,
+        generatedBy: manifest.generated_by,
+        sizeMatches:
+          computedSize === null ||
+          Number(manifest.file_size_bytes) === computedSize,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/accounting/scoring/[leaseId]/route.ts
+++ b/app/api/accounting/scoring/[leaseId]/route.ts
@@ -1,0 +1,157 @@
+/**
+ * API Route: Tenant unpaid-risk scoring
+ * GET /api/accounting/scoring/[leaseId]
+ *
+ * Returns the risk score (0-100), the band, contributing factors and
+ * recommended next actions for a given lease, computed from the full
+ * invoice + payments history.
+ *
+ * Auth: admin / owner / agency. The owner must own the underlying
+ * property; the agency must be the mandant.
+ *
+ * Feature gate: scoring (Pro+).
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
+import {
+  scoreTenantPayments,
+  type ScoringInvoice,
+} from "@/lib/accounting/unpaid-scoring";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface InvoiceRow {
+  id: string;
+  due_date: string | null;
+  date_echeance: string | null;
+  periode: string | null;
+  montant_total: number | null;
+  payments: Array<{ montant: number | null; date_paiement: string | null }>;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ leaseId: string }> },
+) {
+  try {
+    const { leaseId } = await params;
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new ApiError(401, "Non authentifie");
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+    if (!profile) throw new ApiError(403, "Profil introuvable");
+    if (
+      profile.role !== "admin" &&
+      profile.role !== "owner" &&
+      profile.role !== "agency"
+    ) {
+      throw new ApiError(403, "Acces refuse");
+    }
+
+    const featureGate = await requireAccountingAccess(profile.id, "scoring");
+    if (featureGate) return featureGate;
+
+    // Fetch lease + property + invoices to enforce scoping and feed the scorer
+    const { data: lease } = await supabase
+      .from("leases")
+      .select(
+        `
+          id,
+          tenant_id,
+          property:properties!inner(id, owner_id, legal_entity_id, adresse_complete)
+        `,
+      )
+      .eq("id", leaseId)
+      .maybeSingle();
+
+    if (!lease) throw new ApiError(404, "Bail introuvable");
+    const propertyData = (lease as unknown as {
+      property: {
+        owner_id: string;
+        legal_entity_id: string;
+        adresse_complete: string | null;
+      };
+    }).property;
+
+    if (profile.role === "owner") {
+      if (propertyData.owner_id !== profile.id) {
+        throw new ApiError(403, "Ce bail n'appartient pas a votre portefeuille");
+      }
+    }
+    // For agency: rely on RLS - the select above already returned null if
+    // the lease is not in the agency's mandant scope.
+
+    const { data: invoices } = await supabase
+      .from("invoices")
+      .select(
+        `
+          id,
+          due_date,
+          date_echeance,
+          periode,
+          montant_total,
+          payments(montant, date_paiement)
+        `,
+      )
+      .eq("lease_id", leaseId)
+      .order("date_echeance", { ascending: true });
+
+    const rows = (invoices ?? []) as unknown as InvoiceRow[];
+
+    const scoringInvoices: ScoringInvoice[] = rows.map((inv) => {
+      const dueDate =
+        inv.due_date ??
+        inv.date_echeance ??
+        (inv.periode ? `${inv.periode}-05` : new Date().toISOString().split("T")[0]);
+      const amountDueCents = Math.round((inv.montant_total ?? 0) * 100);
+      const amountPaidCents = (inv.payments ?? []).reduce(
+        (sum, p) => sum + Math.round((p.montant ?? 0) * 100),
+        0,
+      );
+      const lastPayment = (inv.payments ?? [])
+        .map((p) => p.date_paiement)
+        .filter((d): d is string => !!d)
+        .sort()
+        .pop();
+      const paidAt =
+        amountPaidCents >= amountDueCents && lastPayment ? lastPayment : null;
+
+      return {
+        invoiceId: inv.id,
+        dueDate,
+        amountDueCents,
+        amountPaidCents,
+        paidAt,
+        periode: inv.periode ?? undefined,
+      };
+    });
+
+    const result = scoreTenantPayments(scoringInvoices);
+
+    return NextResponse.json({
+      success: true,
+      data: result,
+      meta: {
+        lease_id: leaseId,
+        property: propertyData?.adresse_complete ?? null,
+        invoice_count: scoringInvoices.length,
+        generated_at: new Date().toISOString(),
+        disclaimer:
+          "Score indicatif base sur l'historique de paiement. Aucune decision automatisee ne doit etre prise sur cette seule base.",
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/accounting/situation/[tenantId]/route.ts
+++ b/app/api/accounting/situation/[tenantId]/route.ts
@@ -85,12 +85,27 @@ export async function GET(
     // Générer la situation
     const situation = await accountingService.generateSituationLocataire(tenantId);
 
-    // Format PDF (à implémenter)
+    // Format PDF
     if (format === "pdf") {
-      return NextResponse.json(
-        { error: "Export PDF non encore implémenté" },
-        { status: 501 }
+      const { renderTenantStatementPdf } = await import(
+        "@/lib/accounting/exports/tenant-statement-pdf"
       );
+      const pdf = await renderTenantStatementPdf(situation);
+      const safeName = `${situation.locataire.nom || "locataire"}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+      const filename = `releve-${safeName}-${
+        new Date().toISOString().split("T")[0]
+      }.pdf`;
+      return new NextResponse(pdf, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+          "Cache-Control": "private, no-store",
+        },
+      });
     }
 
     return NextResponse.json({

--- a/app/api/accounting/syndic/appels/[callId]/route.ts
+++ b/app/api/accounting/syndic/appels/[callId]/route.ts
@@ -255,6 +255,7 @@ export async function POST(request: Request, context: Context) {
         source: "auto:copro_payment",
         reference: `AF-${callId}`,
         userId: user.id,
+        autoValidate: true,
         lines: [
           {
             accountNumber: "512000",

--- a/app/api/accounting/syndic/budget/[id]/export/route.ts
+++ b/app/api/accounting/syndic/budget/[id]/export/route.ts
@@ -1,0 +1,121 @@
+/**
+ * API Route: Export syndic budget as CSV
+ * GET /api/accounting/syndic/budget/[id]/export
+ *
+ * Exports the budget lines (account, label, amount) as a CSV the syndic
+ * can attach to the AG convocation. Format: semicolon-separated, FR locale
+ * (decimal comma), UTF-8 with BOM so Excel-FR opens it cleanly.
+ *
+ * Auth: admin or syndic with access to the budget's entity.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
+
+export const dynamic = "force-dynamic";
+
+interface BudgetLine {
+  accountNumber: string;
+  label: string;
+  amountCents: number;
+}
+
+function csvEscape(value: string): string {
+  const needsQuote = /[";\n\r]/.test(value);
+  const safe = value.replace(/"/g, '""');
+  return needsQuote ? `"${safe}"` : safe;
+}
+
+function formatAmount(cents: number): string {
+  const euros = cents / 100;
+  return euros
+    .toFixed(2)
+    .replace(".", ",");
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) throw new ApiError(401, "Non authentifie");
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!profile) throw new ApiError(403, "Profil introuvable");
+    if (
+      profile.role !== "admin" &&
+      profile.role !== "syndic" &&
+      profile.role !== "owner"
+    ) {
+      throw new ApiError(403, "Acces refuse");
+    }
+
+    const featureGate = await requireAccountingAccess(profile.id, "entries");
+    if (featureGate) return featureGate;
+
+    const { data: budget } = await supabase
+      .from("copro_budgets")
+      .select("id, entity_id, budget_name, budget_lines, total_budget_cents, status")
+      .eq("id", params.id)
+      .maybeSingle();
+
+    if (!budget) throw new ApiError(404, "Budget introuvable");
+
+    if (profile.role !== "admin") {
+      const { data: membership } = await supabase
+        .from("entity_members")
+        .select("entity_id")
+        .eq("user_id", user.id)
+        .eq("entity_id", (budget as { entity_id: string }).entity_id)
+        .maybeSingle();
+      if (!membership) throw new ApiError(403, "Acces refuse a ce budget");
+    }
+
+    const rawLines = ((budget as { budget_lines?: unknown }).budget_lines ??
+      []) as BudgetLine[];
+
+    const header = ["Compte", "Libelle", "Montant (EUR)"]
+      .map(csvEscape)
+      .join(";");
+
+    const body = rawLines
+      .map((l) =>
+        [
+          csvEscape(l.accountNumber ?? ""),
+          csvEscape(l.label ?? ""),
+          formatAmount(Number(l.amountCents ?? 0)),
+        ].join(";"),
+      )
+      .join("\n");
+
+    const total = formatAmount(
+      Number((budget as { total_budget_cents?: number }).total_budget_cents ?? 0),
+    );
+    const totalRow = [csvEscape(""), csvEscape("TOTAL"), total].join(";");
+
+    const csv = `﻿${header}\n${body}\n${totalRow}\n`;
+    const filename = `budget-copro-${params.id.slice(0, 8)}.csv`;
+
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/accounting/views/refresh/route.ts
+++ b/app/api/accounting/views/refresh/route.ts
@@ -1,0 +1,94 @@
+/**
+ * API Route: refresh the accounting materialized views on demand.
+ * GET    /api/accounting/views/refresh  — returns staleness state without refreshing.
+ * POST   /api/accounting/views/refresh  — refreshes only if stale, returns the new state.
+ *
+ * Auth: any authenticated user with accounting access. The MVs are
+ * shared across entities (filtered by SECURITY DEFINER readers) so a
+ * refresh affects everyone — but it is safe (CONCURRENTLY) and cheap
+ * thanks to fn_refresh_accounting_views_if_stale, which short-circuits
+ * when nothing changed.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { handleApiError, ApiError } from "@/lib/helpers/api-error";
+import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new ApiError(401, "Non authentifie");
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+    if (!profile) throw new ApiError(403, "Profil introuvable");
+
+    const featureGate = await requireAccountingAccess(profile.id, "entries");
+    if (featureGate) return featureGate;
+
+    const { data: state } = await supabase
+      .from("accounting_views_state")
+      .select("view_name, last_modified_at, last_refreshed_at")
+      .order("view_name");
+
+    const rows = (state ?? []) as Array<{
+      view_name: string;
+      last_modified_at: string;
+      last_refreshed_at: string;
+    }>;
+    const stale = rows.some(
+      (r) =>
+        new Date(r.last_modified_at).getTime() >
+        new Date(r.last_refreshed_at).getTime(),
+    );
+
+    return NextResponse.json({
+      success: true,
+      data: { stale, views: rows },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new ApiError(401, "Non authentifie");
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+    if (!profile) throw new ApiError(403, "Profil introuvable");
+
+    const featureGate = await requireAccountingAccess(profile.id, "entries");
+    if (featureGate) return featureGate;
+
+    const { data, error } = await supabase.rpc(
+      "fn_refresh_accounting_views_if_stale",
+    );
+    if (error) throw new ApiError(500, `Refresh failed: ${error.message}`);
+
+    return NextResponse.json({
+      success: true,
+      data: Array.isArray(data) ? data[0] : data,
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -293,6 +293,22 @@ export const POST = withSecurity(async function POST(request: Request) {
       },
     } as any);
 
+    // Reconnaissance en droit (mode IS uniquement). Le helper se gate
+    // lui-meme sur declaration_mode='is_comptable' et accounting_enabled.
+    try {
+      const { ensureInvoiceIssuedEntry } = await import(
+        "@/lib/accounting/invoice-entry"
+      );
+      await ensureInvoiceIssuedEntry(svcClient as any, (invoice as any).id, {
+        userId: user.id,
+      });
+    } catch (accErr) {
+      console.error(
+        "[POST /api/invoices] ensureInvoiceIssuedEntry failed (non-blocking):",
+        accErr,
+      );
+    }
+
     // Journaliser
     await supabaseClient.from("audit_log").insert({
       user_id: user.id,

--- a/app/tenant/account-statement/TenantAccountStatementClient.tsx
+++ b/app/tenant/account-statement/TenantAccountStatementClient.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Download, AlertTriangle, CheckCircle2, Receipt } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { GlassCard } from "@/components/ui/glass-card";
+import { useToast } from "@/components/ui/use-toast";
+import { formatCurrency } from "@/lib/helpers/format";
+import type { SituationLocataire } from "@/features/accounting/types";
+
+interface Props {
+  situation: SituationLocataire | null;
+  errorMessage: string | null;
+  tenantId: string;
+}
+
+const STATUS_VARIANT: Record<
+  "solde" | "partiel" | "impaye",
+  { label: string; className: string }
+> = {
+  solde: {
+    label: "Solde",
+    className:
+      "bg-emerald-500/10 text-emerald-600 dark:text-emerald-300 border-emerald-500/30",
+  },
+  partiel: {
+    label: "Partiel",
+    className:
+      "bg-amber-500/10 text-amber-600 dark:text-amber-300 border-amber-500/30",
+  },
+  impaye: {
+    label: "Impaye",
+    className:
+      "bg-rose-500/10 text-rose-600 dark:text-rose-300 border-rose-500/30",
+  },
+};
+
+export function TenantAccountStatementClient({
+  situation,
+  errorMessage,
+  tenantId,
+}: Props) {
+  const { toast } = useToast();
+  const [downloading, setDownloading] = useState(false);
+
+  const summary = useMemo(() => {
+    if (!situation) return null;
+    return {
+      totalAppele: situation.situation.total_appele,
+      totalPaye: situation.situation.total_paye,
+      soldeDu: situation.situation.solde_du,
+      aJour: situation.situation.a_jour,
+      depotGarantie: situation.bail.depot_garantie,
+      monthly: situation.bail.total_mensuel,
+    };
+  }, [situation]);
+
+  const handleDownloadPdf = async () => {
+    setDownloading(true);
+    try {
+      const res = await fetch(
+        `/api/accounting/situation/${tenantId}?format=pdf`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) {
+        throw new Error("Telechargement indisponible");
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `releve-${situation?.locataire.nom ?? "compte"}-${new Date()
+        .toISOString()
+        .slice(0, 10)}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast({
+        title: "Telechargement impossible",
+        description:
+          err instanceof Error ? err.message : "Reessayez dans un instant.",
+        variant: "destructive",
+      });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  if (errorMessage || !situation || !summary) {
+    return (
+      <div className="space-y-6 p-4 md:p-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-bold tracking-tight">
+            Releve de compte
+          </h1>
+          <p className="text-muted-foreground">
+            Recapitulatif de vos echeances, paiements et solde restant du.
+          </p>
+        </header>
+        <GlassCard className="p-6">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+            <div>
+              <p className="font-medium">
+                Releve indisponible pour le moment
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">
+                {errorMessage ??
+                  "Aucun bail actif n'a ete trouve sur votre compte. Contactez votre proprietaire si l'erreur persiste."}
+              </p>
+            </div>
+          </div>
+        </GlassCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Receipt className="h-6 w-6" />
+            Releve de compte
+          </h1>
+          <p className="text-muted-foreground">
+            {situation.bien.adresse} — bail depuis le{" "}
+            {new Date(situation.bail.date_debut).toLocaleDateString("fr-FR")}
+          </p>
+        </div>
+        <Button
+          onClick={handleDownloadPdf}
+          disabled={downloading}
+          className="self-start md:self-auto"
+        >
+          <Download className="mr-2 h-4 w-4" />
+          {downloading ? "Generation…" : "Telecharger en PDF"}
+        </Button>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <GlassCard className="p-4">
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            Loyer mensuel
+          </p>
+          <p className="text-xl font-semibold mt-1">
+            {formatCurrency(summary.monthly)}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            dont {formatCurrency(situation.bail.provisions_charges)} de charges
+          </p>
+        </GlassCard>
+        <GlassCard className="p-4">
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            Total appele
+          </p>
+          <p className="text-xl font-semibold mt-1">
+            {formatCurrency(summary.totalAppele)}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            sur {situation.situation.nb_mois_bail} mois
+          </p>
+        </GlassCard>
+        <GlassCard className="p-4">
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            Total paye
+          </p>
+          <p className="text-xl font-semibold mt-1">
+            {formatCurrency(summary.totalPaye)}
+          </p>
+        </GlassCard>
+        <GlassCard className="p-4">
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            Solde du
+          </p>
+          <p
+            className={`text-xl font-semibold mt-1 ${
+              summary.aJour ? "text-emerald-600" : "text-rose-600"
+            }`}
+          >
+            {formatCurrency(summary.soldeDu)}
+          </p>
+          <div className="mt-1 flex items-center gap-1 text-xs">
+            {summary.aJour ? (
+              <>
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+                <span className="text-emerald-600">A jour</span>
+              </>
+            ) : (
+              <>
+                <AlertTriangle className="h-3.5 w-3.5 text-rose-600" />
+                <span className="text-rose-600">Retard</span>
+              </>
+            )}
+          </div>
+        </GlassCard>
+      </section>
+
+      <GlassCard className="p-4 md:p-6">
+        <h2 className="text-lg font-semibold mb-3">Depot de garantie</h2>
+        <p className="text-sm text-muted-foreground">
+          Depot verse a la signature : {formatCurrency(summary.depotGarantie)}
+          . Il vous sera restitue sous 1 a 2 mois apres la fin du bail,
+          deduction faite des eventuelles retenues justifiees.
+        </p>
+      </GlassCard>
+
+      <GlassCard className="p-0 overflow-hidden">
+        <div className="px-4 md:px-6 py-3 border-b border-border/50">
+          <h2 className="text-lg font-semibold">Historique des echeances</h2>
+          <p className="text-xs text-muted-foreground">
+            12 dernieres echeances. Pour l'historique complet, telechargez le
+            PDF.
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/30">
+              <tr className="text-left">
+                <th className="px-4 md:px-6 py-2 font-medium">Periode</th>
+                <th className="px-4 md:px-6 py-2 font-medium">Echeance</th>
+                <th className="px-4 md:px-6 py-2 font-medium text-right">
+                  Appele
+                </th>
+                <th className="px-4 md:px-6 py-2 font-medium text-right">
+                  Paye
+                </th>
+                <th className="px-4 md:px-6 py-2 font-medium text-right">
+                  Solde
+                </th>
+                <th className="px-4 md:px-6 py-2 font-medium text-right">
+                  Statut
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {situation.historique.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 md:px-6 py-6 text-center text-muted-foreground"
+                  >
+                    Aucune echeance enregistree pour le moment.
+                  </td>
+                </tr>
+              ) : (
+                situation.historique.map((row) => {
+                  const variant = STATUS_VARIANT[row.statut];
+                  return (
+                    <tr
+                      key={row.periode}
+                      className="border-t border-border/40 hover:bg-muted/20"
+                    >
+                      <td className="px-4 md:px-6 py-2">{row.periode}</td>
+                      <td className="px-4 md:px-6 py-2">
+                        {new Date(row.date_echeance).toLocaleDateString(
+                          "fr-FR",
+                        )}
+                      </td>
+                      <td className="px-4 md:px-6 py-2 text-right tabular-nums">
+                        {formatCurrency(row.montant_appele)}
+                      </td>
+                      <td className="px-4 md:px-6 py-2 text-right tabular-nums">
+                        {formatCurrency(row.montant_paye)}
+                      </td>
+                      <td className="px-4 md:px-6 py-2 text-right tabular-nums">
+                        {formatCurrency(row.solde)}
+                      </td>
+                      <td className="px-4 md:px-6 py-2 text-right">
+                        <Badge
+                          variant="outline"
+                          className={variant.className}
+                        >
+                          {variant.label}
+                        </Badge>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </GlassCard>
+    </div>
+  );
+}

--- a/app/tenant/account-statement/page.tsx
+++ b/app/tenant/account-statement/page.tsx
@@ -1,0 +1,43 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { accountingService } from "@/features/accounting/services/accounting.service";
+import { TenantAccountStatementClient } from "./TenantAccountStatementClient";
+
+export default async function TenantAccountStatementPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/signin");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, role")
+    .eq("user_id", user.id)
+    .single();
+  if (!profile || profile.role !== "tenant") redirect("/auth/signin");
+
+  let situation: Awaited<
+    ReturnType<typeof accountingService.generateSituationLocataire>
+  > | null = null;
+  let errorMessage: string | null = null;
+  try {
+    situation = await accountingService.generateSituationLocataire(profile.id);
+  } catch (err) {
+    errorMessage =
+      err instanceof Error
+        ? err.message
+        : "Impossible de generer le releve pour le moment.";
+  }
+
+  return (
+    <TenantAccountStatementClient
+      situation={situation}
+      errorMessage={errorMessage}
+      tenantId={profile.id}
+    />
+  );
+}

--- a/components/layout/tenant-app-layout.tsx
+++ b/components/layout/tenant-app-layout.tsx
@@ -20,6 +20,7 @@ import {
   FileSearch,
   Scale,
   Eye,
+  Receipt,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -76,6 +77,7 @@ const allNavItems = [
   { name: "Documents", href: "/tenant/documents", icon: FileText, tourId: "nav-documents", group: "Mes Documents" },
   { name: "États des lieux", href: "/tenant/inspections", icon: ClipboardCheck, tourId: "nav-inspections", group: "Mes Documents" },
   { name: "Loyers & Paiements", href: "/tenant/payments", icon: CreditCard, tourId: "nav-payments", group: "Mes Finances" },
+  { name: "Relevé de compte", href: "/tenant/account-statement", icon: Receipt, tourId: "nav-statement", group: "Mes Finances" },
   { name: "Compteurs", href: "/tenant/meters", icon: Gauge, tourId: "nav-meters", group: "Mes Finances" },
   { name: "Demandes", href: "/tenant/requests", icon: Wrench, tourId: "nav-requests", group: "Assistance" },
   { name: "Messages", href: "/tenant/messages", icon: MessageSquare, tourId: "nav-messages", group: "Assistance" },

--- a/lib/accounting/agency/auto-entries.ts
+++ b/lib/accounting/agency/auto-entries.ts
@@ -76,6 +76,7 @@ export async function createAgencyLoyerEntries(
     source: "auto:agency_loyer_mandant",
     reference: params.reference,
     userId: "system",
+    autoValidate: true,
     lines: [
       {
         accountNumber: "512000",
@@ -102,6 +103,7 @@ export async function createAgencyLoyerEntries(
     source: "auto:agency_commission",
     reference: params.reference,
     userId: "system",
+    autoValidate: true,
     lines: [
       {
         accountNumber: params.mandantAccountNumber,
@@ -146,6 +148,7 @@ export async function createReversementEntry(
     label: `Reversement ${params.mandantName}`,
     source: "auto:agency_reversement",
     userId: "system",
+    autoValidate: true,
     lines: [
       {
         accountNumber: params.mandantAccountNumber,

--- a/lib/accounting/agent/talo-accounting.ts
+++ b/lib/accounting/agent/talo-accounting.ts
@@ -1,0 +1,306 @@
+/**
+ * Agent TALO Comptabilite — chat assistant grounded in the entity's books.
+ *
+ * v1 architecture: one-shot retrieval-augmented call. We pre-fetch the
+ * likely-relevant facts (balance, recent entries, open invoices, score
+ * if asked, fiscal year, declaration mode) and stuff them into the
+ * prompt. This keeps latency low (single LLM call) and gives the model
+ * a fully grounded answer without exposing raw SQL or letting it
+ * hallucinate.
+ *
+ * Future v2: switch to LangGraph + tool-calling so the agent can drill
+ * into specific accounts on demand.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createInstantModel } from "@/lib/ai/config";
+import { getBalance } from "@/lib/accounting/engine";
+import type { BalanceItem } from "@/lib/accounting/engine";
+
+export interface TaloAccountingContext {
+  entityName: string;
+  declarationMode: string | null;
+  exerciseLabel: string | null;
+  currency: "EUR";
+  totals: {
+    revenuesCents: number;
+    expensesCents: number;
+    netCents: number;
+    cashCents: number;
+    receivablesCents: number;
+    payablesCents: number;
+  };
+  topRevenueAccounts: Array<{ account: string; label: string; cents: number }>;
+  topExpenseAccounts: Array<{ account: string; label: string; cents: number }>;
+  recentEntries: Array<{
+    date: string;
+    journal: string;
+    label: string;
+    amountCents: number;
+  }>;
+  openInvoiceCount: number;
+  unpaidCents: number;
+}
+
+export interface TaloAccountingAnswer {
+  answer: string;
+  context: TaloAccountingContext;
+  modelUsed: string;
+}
+
+const SYSTEM_PROMPT = `Tu es TALO, l'agent comptable de Talok, plateforme française de gestion locative.
+
+Mission :
+- Repondre aux questions du proprietaire / gestionnaire sur sa comptabilite
+- T'appuyer EXCLUSIVEMENT sur les chiffres du contexte fourni ci-dessous
+- Indiquer "Je n'ai pas l'information" si une donnee manque, ne JAMAIS inventer
+- Reformuler les montants en euros avec separateur (1 234,56 €)
+- Citer le compte concerne quand c'est pertinent (ex: "compte 706 — loyers")
+
+Style :
+- Concis, direct, en français
+- Utilise les listes a puces pour les enumerations
+- Pas de jargon technique inutile (le proprietaire n'est pas comptable)
+- Pas de disclaimers verbeux ; un rappel court "Aide indicative — pas de
+  conseil fiscal" suffit en fin de message si la question est fiscale
+
+Limites :
+- Tu ne donnes pas de conseil fiscal personnalise
+- Tu ne valides pas d'ecriture, ne lances pas de cloture, ne signes rien
+- Pour ces actions, redirige vers les pages dediees de Talok`;
+
+function fmtEur(cents: number): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+}
+
+async function buildContext(
+  supabase: SupabaseClient,
+  entityId: string,
+  exerciseId: string,
+): Promise<TaloAccountingContext> {
+  const [
+    { data: entityRow },
+    { data: exerciseRow },
+    balance,
+    { data: recentEntries },
+    { data: openInvoices },
+  ] = await Promise.all([
+    supabase
+      .from("legal_entities")
+      .select("name, declaration_mode")
+      .eq("id", entityId)
+      .maybeSingle(),
+    supabase
+      .from("accounting_exercises")
+      .select("start_date, end_date")
+      .eq("id", exerciseId)
+      .maybeSingle(),
+    getBalance(supabase, entityId, exerciseId),
+    supabase
+      .from("accounting_entries")
+      .select("entry_date, journal_code, label, accounting_entry_lines(debit_cents)")
+      .eq("entity_id", entityId)
+      .eq("exercise_id", exerciseId)
+      .eq("is_validated", true)
+      .order("entry_date", { ascending: false })
+      .limit(15),
+    supabase
+      .from("invoices")
+      .select("id, montant_total, statut")
+      .eq("statut", "due")
+      .limit(200),
+  ]);
+
+  const balanceItems = balance as BalanceItem[];
+  const sumByPrefix = (prefix: string, side: "debit" | "credit") =>
+    balanceItems
+      .filter((b: BalanceItem) => b.accountNumber.startsWith(prefix))
+      .reduce(
+        (sum: number, b: BalanceItem) =>
+          sum + (side === "debit" ? b.totalDebitCents : b.totalCreditCents),
+        0,
+      );
+
+  const revenuesCents = sumByPrefix("7", "credit") - sumByPrefix("7", "debit");
+  const expensesCents = sumByPrefix("6", "debit") - sumByPrefix("6", "credit");
+  const cashCents = sumByPrefix("512", "debit") - sumByPrefix("512", "credit");
+  const receivablesCents =
+    sumByPrefix("411", "debit") - sumByPrefix("411", "credit");
+  const payablesCents =
+    sumByPrefix("401", "credit") - sumByPrefix("401", "debit");
+
+  const topRevenueAccounts = balanceItems
+    .filter(
+      (b: BalanceItem) =>
+        b.accountNumber.startsWith("7") && b.totalCreditCents > 0,
+    )
+    .sort(
+      (a: BalanceItem, b: BalanceItem) =>
+        b.totalCreditCents - a.totalCreditCents,
+    )
+    .slice(0, 5)
+    .map((b: BalanceItem) => ({
+      account: b.accountNumber,
+      label: b.label,
+      cents: b.totalCreditCents,
+    }));
+
+  const topExpenseAccounts = balanceItems
+    .filter(
+      (b: BalanceItem) =>
+        b.accountNumber.startsWith("6") && b.totalDebitCents > 0,
+    )
+    .sort(
+      (a: BalanceItem, b: BalanceItem) =>
+        b.totalDebitCents - a.totalDebitCents,
+    )
+    .slice(0, 5)
+    .map((b: BalanceItem) => ({
+      account: b.accountNumber,
+      label: b.label,
+      cents: b.totalDebitCents,
+    }));
+
+  type EntryRow = {
+    entry_date: string;
+    journal_code: string;
+    label: string;
+    accounting_entry_lines?: Array<{ debit_cents: number }>;
+  };
+  const recent = ((recentEntries ?? []) as EntryRow[])
+    .slice(0, 10)
+    .map((e: EntryRow) => {
+      const lines = e.accounting_entry_lines ?? [];
+      const totalDebit = lines.reduce(
+        (s: number, l: { debit_cents: number }) => s + (l.debit_cents ?? 0),
+        0,
+      );
+      return {
+        date: e.entry_date,
+        journal: e.journal_code,
+        label: e.label,
+        amountCents: totalDebit,
+      };
+    });
+
+  type InvoiceRow = { montant_total?: number };
+  const unpaidCents = ((openInvoices ?? []) as InvoiceRow[]).reduce(
+    (sum: number, inv: InvoiceRow) =>
+      sum + Math.round((inv.montant_total ?? 0) * 100),
+    0,
+  );
+
+  return {
+    entityName: (entityRow as { name?: string } | null)?.name ?? "Entite",
+    declarationMode:
+      (entityRow as { declaration_mode?: string } | null)?.declaration_mode ?? null,
+    exerciseLabel:
+      exerciseRow
+        ? `${(exerciseRow as { start_date: string }).start_date} → ${
+            (exerciseRow as { end_date: string }).end_date
+          }`
+        : null,
+    currency: "EUR",
+    totals: {
+      revenuesCents,
+      expensesCents,
+      netCents: revenuesCents - expensesCents,
+      cashCents,
+      receivablesCents,
+      payablesCents,
+    },
+    topRevenueAccounts,
+    topExpenseAccounts,
+    recentEntries: recent,
+    openInvoiceCount: (openInvoices ?? []).length,
+    unpaidCents,
+  };
+}
+
+function renderContext(ctx: TaloAccountingContext): string {
+  const lines: string[] = [];
+  lines.push(`Entite : ${ctx.entityName}`);
+  if (ctx.declarationMode) lines.push(`Regime fiscal : ${ctx.declarationMode}`);
+  if (ctx.exerciseLabel) lines.push(`Exercice : ${ctx.exerciseLabel}`);
+  lines.push("");
+  lines.push("Totaux de l'exercice :");
+  lines.push(`- Revenus (classe 7) : ${fmtEur(ctx.totals.revenuesCents)}`);
+  lines.push(`- Charges (classe 6) : ${fmtEur(ctx.totals.expensesCents)}`);
+  lines.push(`- Resultat : ${fmtEur(ctx.totals.netCents)}`);
+  lines.push(`- Tresorerie (512) : ${fmtEur(ctx.totals.cashCents)}`);
+  lines.push(`- Creances clients (411) : ${fmtEur(ctx.totals.receivablesCents)}`);
+  lines.push(`- Dettes fournisseurs (401) : ${fmtEur(ctx.totals.payablesCents)}`);
+  lines.push("");
+  lines.push("Top 5 comptes de produits :");
+  for (const a of ctx.topRevenueAccounts) {
+    lines.push(`- ${a.account} ${a.label} : ${fmtEur(a.cents)}`);
+  }
+  lines.push("");
+  lines.push("Top 5 comptes de charges :");
+  for (const a of ctx.topExpenseAccounts) {
+    lines.push(`- ${a.account} ${a.label} : ${fmtEur(a.cents)}`);
+  }
+  lines.push("");
+  lines.push("10 ecritures recentes :");
+  for (const e of ctx.recentEntries) {
+    lines.push(
+      `- ${e.date} [${e.journal}] ${e.label} (${fmtEur(e.amountCents)})`,
+    );
+  }
+  lines.push("");
+  lines.push(`Factures non reglees : ${ctx.openInvoiceCount}`);
+  lines.push(`Total impaye : ${fmtEur(ctx.unpaidCents)}`);
+  return lines.join("\n");
+}
+
+export async function askTaloAccounting(
+  supabase: SupabaseClient,
+  params: { entityId: string; exerciseId: string; question: string },
+): Promise<TaloAccountingAnswer> {
+  const ctx = await buildContext(
+    supabase,
+    params.entityId,
+    params.exerciseId,
+  );
+
+  const model = createInstantModel(false);
+  const prompt = `${SYSTEM_PROMPT}
+
+CONTEXTE COMPTABLE (donnees reelles, source unique de verite) :
+${renderContext(ctx)}
+
+QUESTION DU PROPRIETAIRE :
+${params.question}`;
+
+  const response = await model.invoke(prompt);
+  const content = response.content as unknown;
+  let answer = "";
+  if (typeof content === "string") {
+    answer = content;
+  } else if (Array.isArray(content)) {
+    answer = (content as Array<unknown>)
+      .map((c: unknown) => {
+        if (typeof c === "string") return c;
+        if (
+          c &&
+          typeof c === "object" &&
+          "text" in c &&
+          typeof (c as { text?: unknown }).text === "string"
+        ) {
+          return (c as { text: string }).text;
+        }
+        return "";
+      })
+      .join("");
+  }
+
+  return {
+    answer: answer.trim() || "Je n'ai pas pu generer de reponse.",
+    context: ctx,
+    modelUsed: "instant",
+  };
+}

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -115,6 +115,8 @@ export interface JournalItem {
 
 export type AutoEntryEvent =
   | 'rent_received'
+  | 'rent_invoiced'
+  | 'rent_payment_clearing'
   | 'supplier_invoice'
   | 'supplier_payment'
   | 'deposit_received'
@@ -617,6 +619,47 @@ const AUTO_ENTRIES: Record<
     ],
   }),
 
+  /**
+   * Reconnaissance en droit du loyer a l'emission de la facture (mode IS).
+   * D 411xxx Locataires / C 706000 Loyers. Reserve aux entites en
+   * declaration_mode='is_comptable' (BIC/IS), pas pour le revenu foncier reel
+   * ni le micro-foncier qui restent en encaissement.
+   */
+  rent_invoiced: (ctx) => ({
+    entityId: ctx.entityId,
+    exerciseId: ctx.exerciseId,
+    journalCode: 'VE',
+    entryDate: ctx.date,
+    label: ctx.label || 'Loyer facture (creance)',
+    source: 'auto:rent_invoiced',
+    reference: ctx.reference,
+    userId: ctx.userId,
+    lines: [
+      { accountNumber: '411000', debitCents: ctx.amountCents, creditCents: 0 },
+      { accountNumber: '706000', debitCents: 0, creditCents: ctx.amountCents },
+    ],
+  }),
+
+  /**
+   * Lettrage du paiement loyer en mode IS : la creance posee par
+   * rent_invoiced est soldee par le reglement bancaire.
+   * D 512xxx / C 411xxx
+   */
+  rent_payment_clearing: (ctx) => ({
+    entityId: ctx.entityId,
+    exerciseId: ctx.exerciseId,
+    journalCode: 'BQ',
+    entryDate: ctx.date,
+    label: ctx.label || 'Reglement loyer',
+    source: 'auto:rent_payment_clearing',
+    reference: ctx.reference,
+    userId: ctx.userId,
+    lines: [
+      { accountNumber: ctx.bankAccount ?? '512100', debitCents: ctx.amountCents, creditCents: 0 },
+      { accountNumber: '411000', debitCents: 0, creditCents: ctx.amountCents },
+    ],
+  }),
+
   supplier_invoice: (ctx) => ({
     entityId: ctx.entityId,
     exerciseId: ctx.exerciseId,
@@ -939,12 +982,286 @@ export async function closeExercise(
     throw new Error(`Cannot close: ${count} unvalidated entries remain`);
   }
 
+  // Post the annual amortization charges (D:681100 / C:280xxx) for every
+  // active schedule before closing — the charges must hit class 6 so they
+  // flow into the resultat via generateClosingEntry below.
+  await postAnnualAmortizationEntries(supabase, exerciseId, userId);
+
+  // Generate the closing entry (virement classes 6 et 7 vers compte 120)
+  // before flipping the exercise to closed.
+  await generateClosingEntry(supabase, exerciseId, userId);
+
   const { error } = await supabase
     .from('accounting_exercises')
     .update({ status: 'closed', closed_by: userId, closed_at: new Date().toISOString() })
     .eq('id', exerciseId);
 
   if (error) throw new Error(`Failed to close exercise: ${error.message}`);
+}
+
+/**
+ * Generate the closing entry for an exercise: zero out every class 6 (charges)
+ * and class 7 (products) account against compte 120 (resultat de l'exercice).
+ *
+ * Skips informational entries (micro_foncier mode) so they do not contaminate
+ * the official result.
+ *
+ * Idempotent: if a CL entry tagged source='auto:closing' already exists for
+ * this exercise we skip generation.
+ */
+export async function generateClosingEntry(
+  supabase: SupabaseClient,
+  exerciseId: string,
+  userId: string,
+): Promise<{ entryId: string | null; netResultCents: number; lineCount: number }> {
+  // Idempotency guard
+  const { data: existing } = await (supabase as unknown as {
+    from: (t: string) => {
+      select: (s: string) => {
+        eq: (k: string, v: string) => {
+          eq: (k: string, v: string) => {
+            limit: (n: number) => {
+              maybeSingle: () => Promise<{ data: { id: string } | null }>;
+            };
+          };
+        };
+      };
+    };
+  })
+    .from('accounting_entries')
+    .select('id')
+    .eq('exercise_id', exerciseId)
+    .eq('source', 'auto:closing')
+    .limit(1)
+    .maybeSingle();
+
+  if (existing?.id) {
+    return { entryId: existing.id, netResultCents: 0, lineCount: 0 };
+  }
+
+  // Fetch exercise to know entity_id and end_date
+  const { data: exercise, error: exErr } = await supabase
+    .from('accounting_exercises')
+    .select('id, entity_id, end_date')
+    .eq('id', exerciseId)
+    .single();
+
+  if (exErr || !exercise) {
+    throw new Error(`Closing entry: exercise lookup failed: ${exErr?.message ?? 'not found'}`);
+  }
+
+  // Aggregate class 6 and class 7 balances on non-informational entries
+  const { data: rows, error: aggErr } = await supabase
+    .from('accounting_entry_lines')
+    .select(
+      `account_number, debit_cents, credit_cents,
+       accounting_entries!inner(exercise_id, informational, is_validated)`,
+    )
+    .eq('accounting_entries.exercise_id', exerciseId)
+    .eq('accounting_entries.is_validated', true);
+
+  if (aggErr) {
+    throw new Error(`Closing entry: aggregation failed: ${aggErr.message}`);
+  }
+
+  const balances = new Map<string, { debit: number; credit: number }>();
+  for (const r of (rows ?? []) as Array<{
+    account_number: string;
+    debit_cents: number;
+    credit_cents: number;
+    accounting_entries: { informational: boolean } | { informational: boolean }[];
+  }>) {
+    const entryMeta = Array.isArray(r.accounting_entries)
+      ? r.accounting_entries[0]
+      : r.accounting_entries;
+    if (entryMeta?.informational) continue;
+    const acc = r.account_number;
+    if (!acc.startsWith('6') && !acc.startsWith('7')) continue;
+    const cur = balances.get(acc) ?? { debit: 0, credit: 0 };
+    cur.debit += r.debit_cents ?? 0;
+    cur.credit += r.credit_cents ?? 0;
+    balances.set(acc, cur);
+  }
+
+  if (balances.size === 0) {
+    return { entryId: null, netResultCents: 0, lineCount: 0 };
+  }
+
+  const lines: EntryLine[] = [];
+  let class6Net = 0; // total debit balance on charges (positive = real charge)
+  let class7Net = 0; // total credit balance on products (positive = real revenue)
+
+  for (const [acc, bal] of balances.entries()) {
+    const net = bal.debit - bal.credit;
+    if (net === 0) continue;
+    if (acc.startsWith('6')) {
+      // Charges normally have a debit balance — zero it with a credit
+      class6Net += net;
+      if (net > 0) {
+        lines.push({ accountNumber: acc, debitCents: 0, creditCents: net });
+      } else {
+        lines.push({ accountNumber: acc, debitCents: -net, creditCents: 0 });
+      }
+    } else {
+      // Products normally have a credit balance — zero it with a debit
+      // For products: balance "net" = debit - credit, so product credit balance = -net
+      class7Net += -net;
+      if (-net > 0) {
+        lines.push({ accountNumber: acc, debitCents: -net, creditCents: 0 });
+      } else {
+        lines.push({ accountNumber: acc, debitCents: 0, creditCents: net });
+      }
+    }
+  }
+
+  // Net result = class 7 credit balance - class 6 debit balance
+  const netResultCents = class7Net - class6Net;
+
+  // Compte 120 absorbs the net result so the closing entry is balanced
+  if (netResultCents > 0) {
+    // Profit: D 120 to make it balanced (we credited products, debited 120)
+    // Wait — products were debited to zero. So debit side = class7Net.
+    // Charges were credited to zero. So credit side = class6Net.
+    // To balance we need credit side += netResult, hence credit 120 of netResult.
+    lines.push({ accountNumber: '120', debitCents: 0, creditCents: netResultCents });
+  } else if (netResultCents < 0) {
+    // Loss: debit 120
+    lines.push({ accountNumber: '120', debitCents: -netResultCents, creditCents: 0 });
+  } else if (lines.length > 0) {
+    // Exactly break-even but we still need a reference to 120 for traceability.
+    lines.push({ accountNumber: '120', debitCents: 0, creditCents: 0 });
+  }
+
+  if (lines.length === 0) {
+    return { entryId: null, netResultCents: 0, lineCount: 0 };
+  }
+
+  const entry = await createEntry(supabase, {
+    entityId: exercise.entity_id as string,
+    exerciseId,
+    journalCode: 'CL',
+    entryDate: exercise.end_date as string,
+    label: 'Cloture exercice — virement charges et produits au compte de resultat',
+    source: 'auto:closing',
+    reference: `CL-${exerciseId.slice(0, 8)}`,
+    userId,
+    autoValidate: true,
+    lines,
+  });
+
+  return { entryId: entry.id, netResultCents, lineCount: lines.length };
+}
+
+/**
+ * Post annual depreciation entries for every active amortization schedule of
+ * the exercise's entity. For each schedule we look up the amortization_lines
+ * row matching the exercise year and post a single OD entry:
+ *   D 681100 Dotations aux amortissements
+ *   C 280<component> Amortissements <component>
+ *
+ * Idempotent: skipped if an entry with source='auto:depreciation' already
+ * exists for that schedule and exercise.
+ */
+export async function postAnnualAmortizationEntries(
+  supabase: SupabaseClient,
+  exerciseId: string,
+  userId: string,
+): Promise<{ posted: number; skipped: number }> {
+  const { data: exercise, error: exErr } = await supabase
+    .from('accounting_exercises')
+    .select('id, entity_id, end_date')
+    .eq('id', exerciseId)
+    .single();
+
+  if (exErr || !exercise) {
+    throw new Error(
+      `Amortization: exercise lookup failed: ${exErr?.message ?? 'not found'}`,
+    );
+  }
+
+  const exerciseYear = new Date(exercise.end_date as string).getUTCFullYear();
+  const entityId = exercise.entity_id as string;
+
+  const { data: schedules, error: schedErr } = await supabase
+    .from('amortization_schedules')
+    .select('id, component')
+    .eq('entity_id', entityId)
+    .eq('is_active', true);
+
+  if (schedErr) {
+    throw new Error(`Amortization: schedules lookup failed: ${schedErr.message}`);
+  }
+
+  let posted = 0;
+  let skipped = 0;
+
+  for (const sched of (schedules ?? []) as Array<{ id: string; component: string }>) {
+    const { data: line } = await supabase
+      .from('amortization_lines')
+      .select('id, annual_amount_cents')
+      .eq('schedule_id', sched.id)
+      .eq('exercise_year', exerciseYear)
+      .maybeSingle();
+
+    if (!line || (line.annual_amount_cents as number) <= 0) {
+      skipped += 1;
+      continue;
+    }
+
+    const reference = `AMORT-${sched.id.slice(0, 8)}-${exerciseYear}`;
+
+    const { data: existing } = await supabase
+      .from('accounting_entries')
+      .select('id')
+      .eq('entity_id', entityId)
+      .eq('reference', reference)
+      .eq('source', 'auto:depreciation')
+      .limit(1)
+      .maybeSingle();
+
+    if (existing?.id) {
+      skipped += 1;
+      continue;
+    }
+
+    const componentCode = mapComponentToAmortizationAccount(sched.component);
+    const amount = line.annual_amount_cents as number;
+
+    await createEntry(supabase, {
+      entityId,
+      exerciseId,
+      journalCode: 'OD',
+      entryDate: exercise.end_date as string,
+      label: `Dotation amortissement ${exerciseYear} — ${sched.component}`,
+      source: 'auto:depreciation',
+      reference,
+      userId,
+      autoValidate: true,
+      lines: [
+        { accountNumber: '681100', debitCents: amount, creditCents: 0 },
+        { accountNumber: componentCode, debitCents: 0, creditCents: amount },
+      ],
+    });
+
+    posted += 1;
+  }
+
+  return { posted, skipped };
+}
+
+/**
+ * Map a property component to its 280xxx (amortissements des immobilisations)
+ * account. Defaults to 280100 for unknown components.
+ */
+function mapComponentToAmortizationAccount(component: string): string {
+  const map: Record<string, string> = {
+    gros_oeuvre: '281310',
+    facade: '281320',
+    installations: '281330',
+    agencements: '281410',
+    equipements: '281510',
+  };
+  return map[component] ?? '281000';
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -338,6 +338,35 @@ export async function getBalance(
   entityId: string,
   exerciseId: string,
 ): Promise<BalanceItem[]> {
+  // Fast path: read from the pre-aggregated materialized view exposed
+  // through fn_balance_for_exercise. Falls back to the legacy aggregation
+  // if the function isn't deployed yet (e.g. local dev without latest migration).
+  try {
+    const { data: mvRows, error: mvErr } = await supabase.rpc(
+      'fn_balance_for_exercise',
+      { p_entity_id: entityId, p_exercise_id: exerciseId },
+    );
+    if (!mvErr && Array.isArray(mvRows)) {
+      return (mvRows as Array<{
+        account_number: string;
+        account_label: string;
+        total_debit_cents: number;
+        total_credit_cents: number;
+        solde_debit_cents: number;
+        solde_credit_cents: number;
+      }>).map((r) => ({
+        accountNumber: r.account_number,
+        label: r.account_label,
+        totalDebitCents: Number(r.total_debit_cents),
+        totalCreditCents: Number(r.total_credit_cents),
+        soldeDebitCents: Number(r.solde_debit_cents),
+        soldeCreditCents: Number(r.solde_credit_cents),
+      }));
+    }
+  } catch {
+    // ignore and fall through to live aggregation
+  }
+
   const { data, error } = await supabase
     .from('accounting_entry_lines')
     .select(`
@@ -997,6 +1026,18 @@ export async function closeExercise(
     .eq('id', exerciseId);
 
   if (error) throw new Error(`Failed to close exercise: ${error.message}`);
+
+  // Refresh the materialized views so the just-closed exercise's reports
+  // (balance, GL, FEC) reflect the closing entry immediately. Best-effort:
+  // failing to refresh must not undo a successful close.
+  try {
+    await supabase.rpc('fn_refresh_accounting_views');
+  } catch (refreshErr) {
+    console.warn(
+      '[closeExercise] fn_refresh_accounting_views failed (non-blocking):',
+      refreshErr,
+    );
+  }
 }
 
 /**

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -35,6 +35,13 @@ export interface CreateEntryParams {
   reference?: string;
   lines: EntryLine[];
   userId: string;
+  /**
+   * If true, validate the entry immediately after creation (locks it,
+   * sets is_validated/validated_by). Defaults to false to preserve the
+   * existing manual-validation flow on direct user-driven CRUD; auto-entry
+   * helpers always pass true so business events produce closeable books.
+   */
+  autoValidate?: boolean;
 }
 
 export interface AccountingEntry {
@@ -231,6 +238,11 @@ export async function createEntry(
     .insert(lineInserts);
 
   if (linesError) throw new Error(`Failed to create entry lines: ${linesError.message}`);
+
+  if (params.autoValidate) {
+    await validateEntry(supabase, entry.id, params.userId);
+    return mapEntry({ ...entry, is_validated: true, validated_by: params.userId });
+  }
 
   return mapEntry(entry);
 }
@@ -850,11 +862,18 @@ const AUTO_ENTRIES: Record<
 /**
  * Create an automatic entry from a business event.
  * Validates and inserts the entry with proper journal and accounts.
+ *
+ * Auto-entries are validated immediately (autoValidate=true) so that
+ * business events (rent received, deposits, fund calls, etc.) produce
+ * closeable books — closeExercise() requires every entry to be validated.
+ * Pass `{ skipAutoValidate: true }` to keep the entry as a draft (rare,
+ * mostly used for replay/backfill flows that want a human review).
  */
 export async function createAutoEntry(
   supabase: SupabaseClient,
   event: AutoEntryEvent,
   context: AutoEntryContext,
+  options: { skipAutoValidate?: boolean } = {},
 ): Promise<AccountingEntry> {
   const builder = AUTO_ENTRIES[event];
   if (!builder) {
@@ -862,7 +881,10 @@ export async function createAutoEntry(
   }
 
   const params = builder(context);
-  return createEntry(supabase, params);
+  return createEntry(supabase, {
+    ...params,
+    autoValidate: !options.skipAutoValidate,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/accounting/exports/cerfa-2031-pdf.ts
+++ b/lib/accounting/exports/cerfa-2031-pdf.ts
@@ -1,0 +1,230 @@
+/**
+ * CERFA 2031 — Declaration BIC reel (location meublee LMP / LMNP).
+ *
+ * Aide au remplissage. Les recettes sont traitees comme commerciales,
+ * les charges et amortissements sont deductibles, le resultat suit le
+ * regime LMP (impute sur revenu global) ou LMNP (impute sur revenus
+ * BIC seulement).
+ */
+
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+
+const COLORS = {
+  primary: rgb(0.145, 0.388, 0.922),
+  navy: rgb(0.106, 0.165, 0.42),
+  text: rgb(0.067, 0.067, 0.067),
+  gray: rgb(0.42, 0.45, 0.5),
+  lightGray: rgb(0.94, 0.95, 0.97),
+  highlight: rgb(0.969, 0.953, 0.835),
+  red: rgb(0.863, 0.078, 0.235),
+};
+
+const eur = (cents: number) =>
+  new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+
+export interface Cerfa2031Data {
+  year: number;
+  ownerName: string;
+  siren?: string;
+  recettes_bic: number;
+  charges: {
+    externes: number;
+    impots_taxes: number;
+    financieres: number;
+    dotations_amortissements: number;
+    total: number;
+  };
+  resultat_bic: number;
+  deficit_lmnp_reportable: number;
+}
+
+export async function generateCerfa2031Pdf(
+  data: Cerfa2031Data,
+): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const fontBold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  const page = doc.addPage([595, 842]);
+  const { width, height } = page.getSize();
+  const margin = 48;
+  let y = height - margin;
+
+  // Header
+  page.drawText("TALOK", {
+    x: margin,
+    y,
+    size: 11,
+    font: fontBold,
+    color: COLORS.primary,
+  });
+  page.drawText("Aide au remplissage CERFA 2031", {
+    x: margin + 60,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 28;
+
+  page.drawText(`Declaration BIC reel — exercice ${data.year}`, {
+    x: margin,
+    y,
+    size: 19,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 22;
+
+  page.drawText("Formulaire 2031 — Location meublee (LMP / LMNP)", {
+    x: margin,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 18;
+
+  page.drawText(
+    `${data.ownerName}${data.siren ? ` — SIREN ${data.siren}` : ""}`,
+    { x: margin, y, size: 10, font, color: COLORS.text },
+  );
+  y -= 30;
+
+  const drawRow = (
+    label: string,
+    cents: number,
+    opts: { bold?: boolean; highlight?: boolean; indent?: number } = {},
+  ) => {
+    if (opts.highlight) {
+      page.drawRectangle({
+        x: margin,
+        y: y - 4,
+        width: width - 2 * margin,
+        height: 18,
+        color: COLORS.highlight,
+      });
+    }
+    const value = eur(cents);
+    const valueWidth = (opts.bold ? fontBold : font).widthOfTextAtSize(value, 10);
+    page.drawText(label, {
+      x: margin + 8 + (opts.indent ?? 0),
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: COLORS.text,
+    });
+    page.drawText(value, {
+      x: width - margin - 8 - valueWidth,
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: cents < 0 ? COLORS.red : COLORS.text,
+    });
+    y -= 16;
+  };
+
+  const drawSection = (title: string) => {
+    page.drawRectangle({
+      x: margin,
+      y: y - 4,
+      width: width - 2 * margin,
+      height: 22,
+      color: COLORS.lightGray,
+    });
+    page.drawText(title, {
+      x: margin + 8,
+      y: y + 4,
+      size: 11,
+      font: fontBold,
+      color: COLORS.navy,
+    });
+    y -= 28;
+  };
+
+  drawSection("RECETTES BIC");
+  drawRow("Loyers + charges recuperees", data.recettes_bic, { bold: true });
+  y -= 6;
+
+  drawSection("CHARGES DEDUCTIBLES");
+  drawRow("Services exterieurs (61, 62)", data.charges.externes, { indent: 10 });
+  drawRow("Impots et taxes (63)", data.charges.impots_taxes, { indent: 10 });
+  drawRow("Charges financieres (66)", data.charges.financieres, { indent: 10 });
+  drawRow(
+    "Dotations aux amortissements (681)",
+    data.charges.dotations_amortissements,
+    { indent: 10 },
+  );
+  drawRow("Total charges", data.charges.total, { bold: true });
+  y -= 6;
+
+  drawSection("RESULTAT");
+  drawRow("Resultat BIC", data.resultat_bic, { bold: true, highlight: true });
+  if (data.deficit_lmnp_reportable > 0) {
+    drawRow(
+      "Deficit reportable (LMNP, 10 ans)",
+      data.deficit_lmnp_reportable,
+      { indent: 10 },
+    );
+  }
+  y -= 12;
+
+  // Methodology + LMP/LMNP guidance
+  if (y > 150) {
+    page.drawRectangle({
+      x: margin,
+      y: y - 110,
+      width: width - 2 * margin,
+      height: 110,
+      borderColor: COLORS.primary,
+      borderWidth: 0.6,
+    });
+    const lines = [
+      "Methodologie & regime LMP / LMNP",
+      "• Recettes = comptes 706 + 708 (credit).",
+      "• Charges = 61 + 62 + 63 + 66 + 681 (debit).",
+      "• L'amortissement du bien est tres puissant en location meublee :",
+      "  il neutralise souvent le resultat sans creer de deficit imputable.",
+      "• LMP (recettes > 23 000 EUR ET > 50% des revenus du foyer) :",
+      "  deficit imputable sur revenu global, plus-value pro a la sortie.",
+      "• LMNP : deficit reportable 10 ans sur BIC seulement, plus-value",
+      "  des particuliers (abattements pour duree de detention).",
+      "• Le bascul LMP ↔ LMNP s'apprecie chaque annee — verifier avec l'EC.",
+    ];
+    let ly = y - 12;
+    for (const txt of lines) {
+      const isTitle = txt === "Methodologie & regime LMP / LMNP";
+      page.drawText(txt, {
+        x: margin + 8,
+        y: ly,
+        size: isTitle ? 9 : 8,
+        font: isTitle ? fontBold : font,
+        color: isTitle ? COLORS.primary : COLORS.text,
+      });
+      ly -= isTitle ? 14 : 11;
+    }
+  }
+
+  // Footer
+  page.drawText(
+    "Document genere par TALOK a usage informatif. Ne remplace pas l'avis d'un expert-comptable",
+    { x: margin, y: 36, size: 7, font, color: COLORS.gray },
+  );
+  page.drawText("ni la declaration officielle a deposer sur impots.gouv.fr.", {
+    x: margin,
+    y: 28,
+    size: 7,
+    font,
+    color: COLORS.gray,
+  });
+  page.drawText(
+    `Genere le ${new Date().toLocaleDateString("fr-FR")} — TALOK Comptabilite`,
+    { x: margin, y: 16, size: 7, font, color: COLORS.gray },
+  );
+
+  return doc.save();
+}

--- a/lib/accounting/exports/cerfa-2044-pdf.ts
+++ b/lib/accounting/exports/cerfa-2044-pdf.ts
@@ -1,0 +1,291 @@
+/**
+ * CERFA 2044 — Declaration des revenus fonciers (regime reel).
+ *
+ * Renders a pre-filled, CERFA-styled A4 PDF from the values computed by
+ * /api/accounting/declarations/2044. All amounts are in EUR cents in the
+ * input and converted to euros for display.
+ *
+ * Note: this is an *aide au remplissage* — the user still has to recopy
+ * the values onto the official CERFA form (or submit via impots.gouv.fr).
+ * Disclaimer printed in the footer.
+ */
+
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+
+const COLORS = {
+  primary: rgb(0.145, 0.388, 0.922),
+  navy: rgb(0.106, 0.165, 0.42),
+  text: rgb(0.067, 0.067, 0.067),
+  gray: rgb(0.42, 0.45, 0.5),
+  lightGray: rgb(0.94, 0.95, 0.97),
+  highlight: rgb(0.969, 0.953, 0.835),
+  green: rgb(0.063, 0.647, 0.447),
+  red: rgb(0.863, 0.078, 0.235),
+};
+
+function eurFromCents(cents: number): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+}
+
+export interface Cerfa2044Data {
+  year: number;
+  ownerName: string;
+  siren?: string;
+  ligne_215_cents: number;
+  ligne_221_cents: number;
+  ligne_222_cents: number;
+  ligne_223_cents: number;
+  ligne_224_cents: number;
+  ligne_227_cents: number;
+  ligne_229_cents: number;
+  ligne_230_cents: number;
+  case_4BA_cents: number;
+  case_4BB_cents: number;
+  case_4BC_cents: number;
+}
+
+const LINE_LABELS: Record<string, string> = {
+  ligne_215: "Ligne 215 — Loyers bruts encaisses",
+  ligne_221: "Ligne 221 — Frais d'administration et de gestion (forfait)",
+  ligne_222: "Ligne 222 — Primes d'assurance",
+  ligne_223: "Ligne 223 — Travaux d'entretien et de reparation",
+  ligne_224: "Ligne 224 — Interets d'emprunt",
+  ligne_227: "Ligne 227 — Taxes foncieres et autres impositions",
+  ligne_229: "Ligne 229 — Total des charges deductibles",
+  ligne_230: "Ligne 230 — Resultat foncier (215 - 229)",
+  case_4BA: "Case 4BA — Benefice foncier imposable",
+  case_4BB: "Case 4BB — Deficit imputable sur revenu global (plafonne 10 700 EUR)",
+  case_4BC: "Case 4BC — Deficit reportable (excedent + interets emprunt)",
+};
+
+export async function generateCerfa2044Pdf(
+  data: Cerfa2044Data,
+): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const fontBold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  const page = doc.addPage([595, 842]); // A4
+  const { width, height } = page.getSize();
+  const margin = 48;
+  let y = height - margin;
+
+  // ─── Header ───────────────────────────────────────────────
+  page.drawText("TALOK", {
+    x: margin,
+    y,
+    size: 11,
+    font: fontBold,
+    color: COLORS.primary,
+  });
+  page.drawText("Aide au remplissage CERFA 2044", {
+    x: margin + 60,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 28;
+
+  page.drawText(`Declaration des revenus fonciers ${data.year}`, {
+    x: margin,
+    y,
+    size: 19,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 22;
+
+  page.drawText("Regime reel — Formulaire 2044", {
+    x: margin,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 18;
+
+  page.drawText(
+    data.ownerName + (data.siren ? ` — SIREN ${data.siren}` : ""),
+    { x: margin, y, size: 10, font, color: COLORS.text },
+  );
+  y -= 30;
+
+  // ─── Section Revenus ──────────────────────────────────────
+  page.drawRectangle({
+    x: margin,
+    y: y - 4,
+    width: width - 2 * margin,
+    height: 22,
+    color: COLORS.lightGray,
+  });
+  page.drawText("REVENUS BRUTS", {
+    x: margin + 8,
+    y: y + 4,
+    size: 11,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 28;
+
+  const drawLine = (
+    code: string,
+    cents: number,
+    opts: { bold?: boolean; highlight?: boolean } = {},
+  ) => {
+    if (opts.highlight) {
+      page.drawRectangle({
+        x: margin,
+        y: y - 4,
+        width: width - 2 * margin,
+        height: 18,
+        color: COLORS.highlight,
+      });
+    }
+    const label = LINE_LABELS[code] ?? code;
+    const value = eurFromCents(cents);
+    const valueWidth = (opts.bold ? fontBold : font).widthOfTextAtSize(value, 10);
+    page.drawText(label, {
+      x: margin + 8,
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: COLORS.text,
+    });
+    page.drawText(value, {
+      x: width - margin - 8 - valueWidth,
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: COLORS.text,
+    });
+    y -= 16;
+  };
+
+  drawLine("ligne_215", data.ligne_215_cents, { bold: true });
+  y -= 8;
+
+  // ─── Section Charges ──────────────────────────────────────
+  page.drawRectangle({
+    x: margin,
+    y: y - 4,
+    width: width - 2 * margin,
+    height: 22,
+    color: COLORS.lightGray,
+  });
+  page.drawText("CHARGES DEDUCTIBLES", {
+    x: margin + 8,
+    y: y + 4,
+    size: 11,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 28;
+
+  drawLine("ligne_221", data.ligne_221_cents);
+  drawLine("ligne_222", data.ligne_222_cents);
+  drawLine("ligne_223", data.ligne_223_cents);
+  drawLine("ligne_224", data.ligne_224_cents);
+  drawLine("ligne_227", data.ligne_227_cents);
+  drawLine("ligne_229", data.ligne_229_cents, { bold: true });
+  y -= 8;
+
+  // ─── Section Resultat ─────────────────────────────────────
+  page.drawRectangle({
+    x: margin,
+    y: y - 4,
+    width: width - 2 * margin,
+    height: 22,
+    color: COLORS.lightGray,
+  });
+  page.drawText("RESULTAT FONCIER", {
+    x: margin + 8,
+    y: y + 4,
+    size: 11,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 28;
+
+  drawLine("ligne_230", data.ligne_230_cents, {
+    bold: true,
+    highlight: true,
+  });
+  y -= 8;
+
+  // ─── Section Reports 2042 ────────────────────────────────
+  page.drawRectangle({
+    x: margin,
+    y: y - 4,
+    width: width - 2 * margin,
+    height: 22,
+    color: COLORS.lightGray,
+  });
+  page.drawText("A REPORTER SUR FORMULAIRE 2042", {
+    x: margin + 8,
+    y: y + 4,
+    size: 11,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 28;
+
+  drawLine("case_4BA", data.case_4BA_cents, { bold: true });
+  drawLine("case_4BB", data.case_4BB_cents, { bold: true });
+  drawLine("case_4BC", data.case_4BC_cents, { bold: true });
+  y -= 16;
+
+  // ─── Methodology box ─────────────────────────────────────
+  if (y > 140) {
+    page.drawRectangle({
+      x: margin,
+      y: y - 70,
+      width: width - 2 * margin,
+      height: 70,
+      borderColor: COLORS.primary,
+      borderWidth: 0.6,
+    });
+    const lines = [
+      "Methodologie",
+      "• Loyers bruts = total credits comptes 706 sur l'exercice.",
+      "• Forfait gestion = 20 EUR par local declare (ligne 221).",
+      "• Travaux = total debits 615; assurances = 616; interets = 661; taxes = 635.",
+      "• Deficit foncier impute sur revenu global plafonne a 10 700 EUR (hors interets).",
+    ];
+    let ly = y - 12;
+    for (const txt of lines) {
+      const isTitle = txt === "Methodologie";
+      page.drawText(txt, {
+        x: margin + 8,
+        y: ly,
+        size: isTitle ? 9 : 8,
+        font: isTitle ? fontBold : font,
+        color: isTitle ? COLORS.primary : COLORS.text,
+      });
+      ly -= isTitle ? 14 : 12;
+    }
+  }
+
+  // ─── Footer ───────────────────────────────────────────────
+  page.drawText(
+    "Document genere par TALOK a usage informatif. Ne remplace pas l'avis d'un expert-comptable",
+    { x: margin, y: 36, size: 7, font, color: COLORS.gray },
+  );
+  page.drawText("ni la declaration officielle a deposer sur impots.gouv.fr.", {
+    x: margin,
+    y: 28,
+    size: 7,
+    font,
+    color: COLORS.gray,
+  });
+  page.drawText(
+    `Genere le ${new Date().toLocaleDateString("fr-FR")} — TALOK Comptabilite`,
+    { x: margin, y: 16, size: 7, font, color: COLORS.gray },
+  );
+
+  return doc.save();
+}

--- a/lib/accounting/exports/cerfa-2065-pdf.ts
+++ b/lib/accounting/exports/cerfa-2065-pdf.ts
@@ -1,0 +1,259 @@
+/**
+ * CERFA 2065 — Declaration des resultats d'une societe a l'IS.
+ *
+ * Aide au remplissage : compte de resultat agrege + estimation IS au
+ * taux reduit (15% jusqu'a 42 500 EUR) et taux normal (25%). Le calcul
+ * exact reste a la charge de l'EC : reintegrations, amortissements
+ * derogatoires et provisions reglementees ne sont pas trackes par TALOK.
+ */
+
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+
+const COLORS = {
+  primary: rgb(0.145, 0.388, 0.922),
+  navy: rgb(0.106, 0.165, 0.42),
+  text: rgb(0.067, 0.067, 0.067),
+  gray: rgb(0.42, 0.45, 0.5),
+  lightGray: rgb(0.94, 0.95, 0.97),
+  highlight: rgb(0.969, 0.953, 0.835),
+  green: rgb(0.063, 0.647, 0.447),
+  red: rgb(0.863, 0.078, 0.235),
+};
+
+const eur = (cents: number) =>
+  new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+
+export interface Cerfa2065Data {
+  year: number;
+  ownerName: string;
+  siren?: string;
+  produits: {
+    loyers: number;
+    charges_recuperees: number;
+    financiers: number;
+    exceptionnels: number;
+    total: number;
+  };
+  charges: {
+    externes: number;
+    impots_taxes: number;
+    personnel: number;
+    financieres: number;
+    dotations_amortissements: number;
+    exceptionnelles: number;
+    total: number;
+  };
+  resultat_avant_impot: number;
+  is_taux_reduit_cents: number;
+  is_taux_normal_cents: number;
+  is_total_cents: number;
+  resultat_apres_impot: number;
+}
+
+export async function generateCerfa2065Pdf(
+  data: Cerfa2065Data,
+): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const fontBold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  const page = doc.addPage([595, 842]);
+  const { width, height } = page.getSize();
+  const margin = 48;
+  let y = height - margin;
+
+  // Header
+  page.drawText("TALOK", {
+    x: margin,
+    y,
+    size: 11,
+    font: fontBold,
+    color: COLORS.primary,
+  });
+  page.drawText("Aide au remplissage CERFA 2065", {
+    x: margin + 60,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 28;
+
+  page.drawText(`Declaration IS — exercice ${data.year}`, {
+    x: margin,
+    y,
+    size: 19,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 22;
+
+  page.drawText("Formulaire 2065 — Resultat fiscal au taux normal et reduit", {
+    x: margin,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 18;
+
+  page.drawText(
+    `${data.ownerName}${data.siren ? ` — SIREN ${data.siren}` : ""}`,
+    { x: margin, y, size: 10, font, color: COLORS.text },
+  );
+  y -= 30;
+
+  const drawRow = (
+    label: string,
+    cents: number,
+    opts: { bold?: boolean; highlight?: boolean; indent?: number } = {},
+  ) => {
+    if (opts.highlight) {
+      page.drawRectangle({
+        x: margin,
+        y: y - 4,
+        width: width - 2 * margin,
+        height: 18,
+        color: COLORS.highlight,
+      });
+    }
+    const value = eur(cents);
+    const valueWidth = (opts.bold ? fontBold : font).widthOfTextAtSize(value, 10);
+    page.drawText(label, {
+      x: margin + 8 + (opts.indent ?? 0),
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: COLORS.text,
+    });
+    page.drawText(value, {
+      x: width - margin - 8 - valueWidth,
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: cents < 0 ? COLORS.red : COLORS.text,
+    });
+    y -= 16;
+  };
+
+  const drawSection = (title: string) => {
+    page.drawRectangle({
+      x: margin,
+      y: y - 4,
+      width: width - 2 * margin,
+      height: 22,
+      color: COLORS.lightGray,
+    });
+    page.drawText(title, {
+      x: margin + 8,
+      y: y + 4,
+      size: 11,
+      font: fontBold,
+      color: COLORS.navy,
+    });
+    y -= 28;
+  };
+
+  drawSection("PRODUITS D'EXPLOITATION");
+  drawRow("Loyers", data.produits.loyers, { indent: 10 });
+  drawRow("Charges recuperees sur locataires", data.produits.charges_recuperees, {
+    indent: 10,
+  });
+  drawRow("Produits financiers", data.produits.financiers, { indent: 10 });
+  drawRow("Produits exceptionnels", data.produits.exceptionnels, { indent: 10 });
+  drawRow("Total produits", data.produits.total, { bold: true });
+  y -= 6;
+
+  drawSection("CHARGES");
+  drawRow("Services exterieurs (61, 62)", data.charges.externes, { indent: 10 });
+  drawRow("Impots et taxes (63)", data.charges.impots_taxes, { indent: 10 });
+  drawRow("Charges de personnel (64)", data.charges.personnel, { indent: 10 });
+  drawRow("Charges financieres (66)", data.charges.financieres, { indent: 10 });
+  drawRow(
+    "Dotations aux amortissements (681)",
+    data.charges.dotations_amortissements,
+    { indent: 10 },
+  );
+  drawRow("Charges exceptionnelles (67)", data.charges.exceptionnelles, {
+    indent: 10,
+  });
+  drawRow("Total charges", data.charges.total, { bold: true });
+  y -= 6;
+
+  drawSection("RESULTAT FISCAL");
+  drawRow("Resultat avant impot", data.resultat_avant_impot, {
+    bold: true,
+    highlight: true,
+  });
+  y -= 4;
+
+  drawSection("ESTIMATION DE L'IMPOT SUR LES SOCIETES");
+  drawRow("IS au taux reduit 15% (jusqu'a 42 500 EUR)", data.is_taux_reduit_cents, {
+    indent: 10,
+  });
+  drawRow("IS au taux normal 25% (au-dela)", data.is_taux_normal_cents, {
+    indent: 10,
+  });
+  drawRow("IS estime total", data.is_total_cents, { bold: true });
+  drawRow("Resultat net apres impot", data.resultat_apres_impot, {
+    bold: true,
+    highlight: true,
+  });
+  y -= 16;
+
+  // Methodology
+  if (y > 130) {
+    page.drawRectangle({
+      x: margin,
+      y: y - 80,
+      width: width - 2 * margin,
+      height: 80,
+      borderColor: COLORS.primary,
+      borderWidth: 0.6,
+    });
+    const lines = [
+      "Methodologie",
+      "• Produits = comptes 706 + 708 + 76 + 77 (credit).",
+      "• Charges = comptes 61 + 62 + 63 + 64 + 66 + 681 + 67 (debit).",
+      "• Le taux reduit IS est conditionne au CA < 10 M EUR et au capital",
+      "  detenu a 75% par des personnes physiques (verifier eligibilite).",
+      "• L'EC peut avoir besoin de reintegrer charges non deductibles",
+      "  (amende, fraction TVS, repas non justifies, etc.).",
+    ];
+    let ly = y - 12;
+    for (const txt of lines) {
+      const isTitle = txt === "Methodologie";
+      page.drawText(txt, {
+        x: margin + 8,
+        y: ly,
+        size: isTitle ? 9 : 8,
+        font: isTitle ? fontBold : font,
+        color: isTitle ? COLORS.primary : COLORS.text,
+      });
+      ly -= isTitle ? 14 : 11;
+    }
+  }
+
+  // Footer
+  page.drawText(
+    "Document genere par TALOK a usage informatif. Ne remplace pas l'avis d'un expert-comptable",
+    { x: margin, y: 36, size: 7, font, color: COLORS.gray },
+  );
+  page.drawText("ni la declaration officielle a deposer sur impots.gouv.fr.", {
+    x: margin,
+    y: 28,
+    size: 7,
+    font,
+    color: COLORS.gray,
+  });
+  page.drawText(
+    `Genere le ${new Date().toLocaleDateString("fr-FR")} — TALOK Comptabilite`,
+    { x: margin, y: 16, size: 7, font, color: COLORS.gray },
+  );
+
+  return doc.save();
+}

--- a/lib/accounting/exports/cerfa-2072-pdf.ts
+++ b/lib/accounting/exports/cerfa-2072-pdf.ts
@@ -1,0 +1,312 @@
+/**
+ * CERFA 2072 — Declaration des resultats d'une SCI a l'IR.
+ *
+ * Aide au remplissage : la SCI calcule un resultat foncier puis le repartit
+ * entre ses associes au prorata de leur quote-part. Chaque associe reporte
+ * sa fraction sur sa propre 2044/2042.
+ *
+ * Disclaimer printed in the footer.
+ */
+
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+
+const COLORS = {
+  primary: rgb(0.145, 0.388, 0.922),
+  navy: rgb(0.106, 0.165, 0.42),
+  text: rgb(0.067, 0.067, 0.067),
+  gray: rgb(0.42, 0.45, 0.5),
+  lightGray: rgb(0.94, 0.95, 0.97),
+  highlight: rgb(0.969, 0.953, 0.835),
+  green: rgb(0.063, 0.647, 0.447),
+  red: rgb(0.863, 0.078, 0.235),
+};
+
+function eurFromCents(cents: number): string {
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+}
+
+export interface Cerfa2072Data {
+  year: number;
+  ownerName: string;
+  siren?: string;
+  revenus_bruts_cents: number;
+  charges_deductibles_cents: number;
+  resultat_cents: number;
+  associates: Array<{
+    name: string;
+    quotePartPct: number;
+    resultatCents: number;
+  }>;
+}
+
+export async function generateCerfa2072Pdf(
+  data: Cerfa2072Data,
+): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const fontBold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  const page = doc.addPage([595, 842]);
+  const { width, height } = page.getSize();
+  const margin = 48;
+  let y = height - margin;
+
+  // Header
+  page.drawText("TALOK", {
+    x: margin,
+    y,
+    size: 11,
+    font: fontBold,
+    color: COLORS.primary,
+  });
+  page.drawText("Aide au remplissage CERFA 2072", {
+    x: margin + 60,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 28;
+
+  page.drawText(`Declaration SCI a l'IR — exercice ${data.year}`, {
+    x: margin,
+    y,
+    size: 19,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 22;
+
+  page.drawText("Formulaire 2072-S — Resultat de la societe civile", {
+    x: margin,
+    y,
+    size: 11,
+    font,
+    color: COLORS.gray,
+  });
+  y -= 18;
+
+  page.drawText(
+    `${data.ownerName}${data.siren ? ` — SIREN ${data.siren}` : ""}`,
+    { x: margin, y, size: 10, font, color: COLORS.text },
+  );
+  y -= 30;
+
+  // Section: Resultat de la societe
+  page.drawRectangle({
+    x: margin,
+    y: y - 4,
+    width: width - 2 * margin,
+    height: 22,
+    color: COLORS.lightGray,
+  });
+  page.drawText("RESULTAT DE LA SOCIETE", {
+    x: margin + 8,
+    y: y + 4,
+    size: 11,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 28;
+
+  const drawRow = (
+    label: string,
+    cents: number,
+    opts: { bold?: boolean; highlight?: boolean } = {},
+  ) => {
+    if (opts.highlight) {
+      page.drawRectangle({
+        x: margin,
+        y: y - 4,
+        width: width - 2 * margin,
+        height: 18,
+        color: COLORS.highlight,
+      });
+    }
+    const value = eurFromCents(cents);
+    const valueWidth = (opts.bold ? fontBold : font).widthOfTextAtSize(value, 10);
+    page.drawText(label, {
+      x: margin + 8,
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: COLORS.text,
+    });
+    page.drawText(value, {
+      x: width - margin - 8 - valueWidth,
+      y,
+      size: 10,
+      font: opts.bold ? fontBold : font,
+      color: cents < 0 && opts.highlight ? COLORS.red : COLORS.text,
+    });
+    y -= 16;
+  };
+
+  drawRow("Revenus bruts (loyers encaisses)", data.revenus_bruts_cents);
+  drawRow("Charges deductibles", -data.charges_deductibles_cents);
+  drawRow("Resultat foncier", data.resultat_cents, {
+    bold: true,
+    highlight: true,
+  });
+  y -= 16;
+
+  // Section: Repartition associes
+  page.drawRectangle({
+    x: margin,
+    y: y - 4,
+    width: width - 2 * margin,
+    height: 22,
+    color: COLORS.lightGray,
+  });
+  page.drawText("REPARTITION ENTRE ASSOCIES", {
+    x: margin + 8,
+    y: y + 4,
+    size: 11,
+    font: fontBold,
+    color: COLORS.navy,
+  });
+  y -= 24;
+
+  // Header table
+  const cols = [margin + 10, margin + 280, margin + 360];
+  page.drawText("Associe", {
+    x: cols[0],
+    y,
+    size: 9,
+    font: fontBold,
+    color: COLORS.gray,
+  });
+  page.drawText("Quote-part", {
+    x: cols[1],
+    y,
+    size: 9,
+    font: fontBold,
+    color: COLORS.gray,
+  });
+  page.drawText("Quote-part resultat", {
+    x: cols[2],
+    y,
+    size: 9,
+    font: fontBold,
+    color: COLORS.gray,
+  });
+  y -= 6;
+  page.drawLine({
+    start: { x: margin, y },
+    end: { x: width - margin, y },
+    thickness: 0.5,
+    color: COLORS.gray,
+  });
+  y -= 12;
+
+  let associatesTotal = 0;
+  for (const associate of data.associates) {
+    if (y < 120) break;
+    const value = eurFromCents(associate.resultatCents);
+    const valueWidth = font.widthOfTextAtSize(value, 10);
+    page.drawText(
+      associate.name.length > 38
+        ? associate.name.slice(0, 35) + "..."
+        : associate.name,
+      { x: cols[0], y, size: 10, font, color: COLORS.text },
+    );
+    page.drawText(`${associate.quotePartPct.toFixed(2)} %`, {
+      x: cols[1],
+      y,
+      size: 10,
+      font,
+      color: COLORS.text,
+    });
+    page.drawText(value, {
+      x: width - margin - 10 - valueWidth,
+      y,
+      size: 10,
+      font,
+      color: associate.resultatCents < 0 ? COLORS.red : COLORS.text,
+    });
+    associatesTotal += associate.resultatCents;
+    y -= 14;
+  }
+
+  // Total associes (sanity check)
+  y -= 6;
+  page.drawLine({
+    start: { x: margin, y: y + 4 },
+    end: { x: width - margin, y: y + 4 },
+    thickness: 0.5,
+    color: COLORS.gray,
+  });
+  const totalLabel = "Total reparti";
+  const totalValue = eurFromCents(associatesTotal);
+  const totalValueWidth = fontBold.widthOfTextAtSize(totalValue, 10);
+  page.drawText(totalLabel, {
+    x: cols[0],
+    y,
+    size: 10,
+    font: fontBold,
+    color: COLORS.text,
+  });
+  page.drawText(totalValue, {
+    x: width - margin - 10 - totalValueWidth,
+    y,
+    size: 10,
+    font: fontBold,
+    color: COLORS.text,
+  });
+  y -= 24;
+
+  // Methodology box
+  if (y > 130) {
+    page.drawRectangle({
+      x: margin,
+      y: y - 75,
+      width: width - 2 * margin,
+      height: 75,
+      borderColor: COLORS.primary,
+      borderWidth: 0.6,
+    });
+    const lines = [
+      "Methodologie",
+      "• Resultat foncier = (706 credits) − (615 + 616 + 635 + 661 debits).",
+      "• Quote-part associe = quote_part_pct (entity_associates).",
+      "• Le total reparti doit egaler le resultat de la societe.",
+      "• Chaque associe reporte sa fraction sur sa propre 2044 + 2042 (case 4BA).",
+      "• Pour SCI a l'IS, utiliser plutot la 2065 (en cours de mise en place).",
+    ];
+    let ly = y - 12;
+    for (const txt of lines) {
+      const isTitle = txt === "Methodologie";
+      page.drawText(txt, {
+        x: margin + 8,
+        y: ly,
+        size: isTitle ? 9 : 8,
+        font: isTitle ? fontBold : font,
+        color: isTitle ? COLORS.primary : COLORS.text,
+      });
+      ly -= isTitle ? 14 : 11;
+    }
+  }
+
+  // Footer
+  page.drawText(
+    "Document genere par TALOK a usage informatif. Ne remplace pas l'avis d'un expert-comptable",
+    { x: margin, y: 36, size: 7, font, color: COLORS.gray },
+  );
+  page.drawText("ni la declaration officielle a deposer sur impots.gouv.fr.", {
+    x: margin,
+    y: 28,
+    size: 7,
+    font,
+    color: COLORS.gray,
+  });
+  page.drawText(
+    `Genere le ${new Date().toLocaleDateString("fr-FR")} — TALOK Comptabilite`,
+    { x: margin, y: 16, size: 7, font, color: COLORS.gray },
+  );
+
+  return doc.save();
+}

--- a/lib/accounting/exports/tenant-statement-pdf.ts
+++ b/lib/accounting/exports/tenant-statement-pdf.ts
@@ -1,0 +1,298 @@
+/**
+ * PDF renderer for the tenant account statement (relevé de compte).
+ *
+ * Builds a single-page, brand-aligned A4 from a SituationLocataire payload.
+ * The tenant downloads this from /tenant/account-statement.
+ */
+
+import { renderHtmlToPdf } from "@/lib/pdf/html-to-pdf";
+import type { SituationLocataire } from "@/features/accounting/types";
+
+const euro = new Intl.NumberFormat("fr-FR", {
+  style: "currency",
+  currency: "EUR",
+  minimumFractionDigits: 2,
+});
+
+function escapeHtml(value: string | null | undefined): string {
+  if (value == null) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso ?? "—";
+  return d.toLocaleDateString("fr-FR");
+}
+
+const STATUS_TEXT: Record<"solde" | "partiel" | "impaye", string> = {
+  solde: "Solde",
+  partiel: "Partiel",
+  impaye: "Impaye",
+};
+
+const STATUS_CSS: Record<"solde" | "partiel" | "impaye", string> = {
+  solde: "background:#dcfce7;color:#166534",
+  partiel: "background:#fef3c7;color:#92400e",
+  impaye: "background:#fee2e2;color:#991b1b",
+};
+
+function buildHtml(s: SituationLocataire): string {
+  const tenantFullName = `${s.locataire.prenom ?? ""} ${
+    s.locataire.nom ?? ""
+  }`.trim();
+
+  const rows = s.historique
+    .map((row) => {
+      return `
+        <tr>
+          <td>${escapeHtml(row.periode)}</td>
+          <td>${formatDate(row.date_echeance)}</td>
+          <td class="num">${euro.format(row.montant_appele)}</td>
+          <td class="num">${euro.format(row.montant_paye)}</td>
+          <td class="num">${euro.format(row.solde)}</td>
+          <td><span class="badge" style="${STATUS_CSS[row.statut]}">${
+        STATUS_TEXT[row.statut]
+      }</span></td>
+        </tr>`;
+    })
+    .join("");
+
+  const aJour = s.situation.a_jour;
+
+  return `<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<title>Releve de compte - ${escapeHtml(tenantFullName)}</title>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    color: #0f172a;
+    font-size: 11px;
+    margin: 0;
+    padding: 24px 28px;
+  }
+  h1 {
+    font-size: 22px;
+    margin: 0 0 4px 0;
+    letter-spacing: -0.01em;
+  }
+  h2 {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #475569;
+    margin: 24px 0 8px;
+  }
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    border-bottom: 2px solid #2563eb;
+    padding-bottom: 12px;
+  }
+  .header .brand {
+    font-weight: 800;
+    color: #2563eb;
+    font-size: 18px;
+    letter-spacing: -0.02em;
+  }
+  .meta {
+    text-align: right;
+    color: #475569;
+    font-size: 10px;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-top: 16px;
+  }
+  .card {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 12px 14px;
+  }
+  .card h3 {
+    margin: 0 0 8px;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: #64748b;
+    letter-spacing: 0.05em;
+  }
+  .card p { margin: 2px 0; }
+  .kpis {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    margin-top: 16px;
+  }
+  .kpi {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 10px 12px;
+  }
+  .kpi-label {
+    font-size: 9px;
+    text-transform: uppercase;
+    color: #64748b;
+    letter-spacing: 0.05em;
+  }
+  .kpi-value {
+    font-size: 16px;
+    font-weight: 700;
+    margin-top: 4px;
+  }
+  .kpi-value.profit { color: #16a34a; }
+  .kpi-value.loss { color: #dc2626; }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 8px;
+  }
+  th, td {
+    text-align: left;
+    padding: 6px 8px;
+    border-bottom: 1px solid #e2e8f0;
+  }
+  th {
+    background: #f1f5f9;
+    color: #334155;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 9px;
+    letter-spacing: 0.04em;
+  }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 600;
+  }
+  .footer {
+    margin-top: 24px;
+    color: #64748b;
+    font-size: 9px;
+    line-height: 1.4;
+  }
+  .status-bar {
+    margin-top: 12px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-weight: 600;
+    text-align: center;
+    ${aJour ? "background:#dcfce7;color:#166534" : "background:#fee2e2;color:#991b1b"};
+  }
+</style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <div class="brand">TALOK</div>
+      <h1>Releve de compte</h1>
+      <p style="margin:0;color:#475569">
+        ${escapeHtml(tenantFullName)} — bail depuis le ${formatDate(s.bail.date_debut)}
+      </p>
+    </div>
+    <div class="meta">
+      <div>Edite le ${formatDate(s.date_edition)}</div>
+      <div>${escapeHtml(s.bien.adresse)}</div>
+      <div>${escapeHtml(s.bien.code_postal)} ${escapeHtml(s.bien.ville)}</div>
+    </div>
+  </div>
+
+  <div class="grid">
+    <div class="card">
+      <h3>Locataire</h3>
+      <p><strong>${escapeHtml(tenantFullName)}</strong></p>
+      ${
+        s.locataire.email
+          ? `<p>${escapeHtml(s.locataire.email)}</p>`
+          : ""
+      }
+      ${
+        s.locataire.telephone
+          ? `<p>${escapeHtml(s.locataire.telephone)}</p>`
+          : ""
+      }
+    </div>
+    <div class="card">
+      <h3>Bail</h3>
+      <p>Du ${formatDate(s.bail.date_debut)}${
+    s.bail.date_fin ? ` au ${formatDate(s.bail.date_fin)}` : ""
+  }</p>
+      <p>Loyer mensuel : <strong>${euro.format(s.bail.total_mensuel)}</strong>
+        (dont ${euro.format(s.bail.provisions_charges)} de charges)</p>
+      <p>Depot de garantie : ${euro.format(s.bail.depot_garantie)}</p>
+    </div>
+  </div>
+
+  <div class="kpis">
+    <div class="kpi">
+      <div class="kpi-label">Total appele</div>
+      <div class="kpi-value">${euro.format(s.situation.total_appele)}</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-label">Total paye</div>
+      <div class="kpi-value">${euro.format(s.situation.total_paye)}</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-label">Solde du</div>
+      <div class="kpi-value ${aJour ? "profit" : "loss"}">${euro.format(
+    s.situation.solde_du,
+  )}</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-label">Mois ecoules</div>
+      <div class="kpi-value">${s.situation.nb_mois_bail}</div>
+    </div>
+  </div>
+
+  <div class="status-bar">
+    ${aJour ? "Compte a jour — aucun arriere" : "Solde restant du a regler"}
+  </div>
+
+  <h2>Historique des echeances</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Periode</th>
+        <th>Echeance</th>
+        <th class="num">Appele</th>
+        <th class="num">Paye</th>
+        <th class="num">Solde</th>
+        <th>Statut</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${rows || `<tr><td colspan="6" style="text-align:center;color:#64748b;padding:18px">Aucune echeance enregistree</td></tr>`}
+    </tbody>
+  </table>
+
+  <p class="footer">
+    Document genere automatiquement par TALOK. Ce releve est etabli sur la base
+    des paiements et factures enregistres a la date d'edition. Pour toute
+    contestation, merci de contacter votre proprietaire ou agence dans un
+    delai de 15 jours.
+  </p>
+</body>
+</html>`;
+}
+
+export async function renderTenantStatementPdf(
+  situation: SituationLocataire,
+): Promise<Buffer> {
+  const html = buildHtml(situation);
+  return renderHtmlToPdf(html, { format: "A4", printBackground: true });
+}

--- a/lib/accounting/feature-gates.ts
+++ b/lib/accounting/feature-gates.ts
@@ -36,6 +36,8 @@ const ACCOUNTING_FEATURE_MAP: Record<string, FeatureKey> = {
   open_banking: 'open_banking',
   // Scoring / AI (Pro+)
   scoring: 'scoring_tenant',
+  // TALO accounting agent (Pro+) — same gate as scoring for now
+  agent: 'scoring_tenant',
 } as const;
 
 /**

--- a/lib/accounting/fec-timestamp.ts
+++ b/lib/accounting/fec-timestamp.ts
@@ -1,0 +1,216 @@
+/**
+ * RFC 3161 Time-Stamp Protocol client (eIDAS-ready).
+ *
+ * Builds a TimeStampReq from a SHA-256 digest, posts it to a TSA, and
+ * returns the raw DER-encoded TimeStampToken. The token is what proves
+ * the file existed at the moment the TSA signed it; together with the
+ * SHA-256 stored in fec_manifests, it gives a tamper-proof, externally
+ * verifiable trail without TALOK having to operate its own qualified
+ * signature infrastructure.
+ *
+ * Default TSA: FreeTSA (https://freetsa.org), which delivers free,
+ * RFC 3161-compliant tokens. For a production engagement, swap the
+ * URL for a qualified eIDAS TSA (Universign, Certinomis, LuxTrust...)
+ * via the TALOK_TSA_URL environment variable.
+ *
+ * Pure server-side helper. No DB calls, no side effects beyond the
+ * HTTP roundtrip — easy to unit-test by mocking fetch.
+ */
+
+import { createHash } from "crypto";
+
+export interface TimestampOptions {
+  /** Override the TSA endpoint. Defaults to env TALOK_TSA_URL or FreeTSA. */
+  tsaUrl?: string;
+  /** Optional bearer/basic credentials for paid TSAs. */
+  authHeader?: string;
+  /** Network timeout in ms (default 15s). */
+  timeoutMs?: number;
+}
+
+export interface TimestampResult {
+  /** Lower-case hex SHA-256 of the input. */
+  digestSha256: string;
+  /** Raw DER-encoded TimeStampToken. */
+  tokenDer: Buffer;
+  /** Base64 form for storage in DB / response headers. */
+  tokenBase64: string;
+  /** TSA URL that signed the token. */
+  tsaUrl: string;
+  /** Approximate upper bound of the genTime as observed by the client. */
+  receivedAt: string;
+  /** TSA HTTP response size in bytes. */
+  tokenBytes: number;
+}
+
+export class TimestampError extends Error {
+  constructor(
+    message: string,
+    public cause?: unknown,
+  ) {
+    super(message);
+    this.name = "TimestampError";
+  }
+}
+
+const DEFAULT_TSA_URL = "https://freetsa.org/tsr";
+
+// ─── Minimal ASN.1 DER encoder ─────────────────────────────────────
+// Just enough to build a TSP TimeStampReq. We avoid pulling a full
+// ASN.1 library since the request is a fixed shape.
+
+function derLength(len: number): Buffer {
+  if (len < 0x80) return Buffer.from([len]);
+  const bytes: number[] = [];
+  let n = len;
+  while (n > 0) {
+    bytes.unshift(n & 0xff);
+    n >>= 8;
+  }
+  return Buffer.concat([Buffer.from([0x80 | bytes.length]), Buffer.from(bytes)]);
+}
+
+function derWrap(tag: number, contents: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([tag]), derLength(contents.length), contents]);
+}
+
+const SHA256_OID = Buffer.from([
+  // 2.16.840.1.101.3.4.2.1
+  0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01,
+]);
+
+/**
+ * Build a DER-encoded TimeStampReq from a SHA-256 digest.
+ *
+ *   TimeStampReq ::= SEQUENCE {
+ *     version            INTEGER  { v1(1) },
+ *     messageImprint     SEQUENCE {
+ *       hashAlgorithm    SEQUENCE { algorithm OID, parameters NULL },
+ *       hashedMessage    OCTET STRING
+ *     },
+ *     reqPolicy          OBJECT IDENTIFIER OPTIONAL,
+ *     nonce              INTEGER OPTIONAL,
+ *     certReq            BOOLEAN DEFAULT FALSE,
+ *     extensions         [0] IMPLICIT Extensions OPTIONAL
+ *   }
+ */
+export function buildTimeStampReq(sha256Digest: Buffer): Buffer {
+  if (sha256Digest.length !== 32) {
+    throw new TimestampError(
+      `SHA-256 digest must be 32 bytes, got ${sha256Digest.length}`,
+    );
+  }
+
+  // version INTEGER 1
+  const version = Buffer.from([0x02, 0x01, 0x01]);
+
+  // hashAlgorithm SEQUENCE { OID, NULL }
+  const algNull = Buffer.from([0x05, 0x00]);
+  const hashAlgorithm = derWrap(0x30, Buffer.concat([SHA256_OID, algNull]));
+
+  // hashedMessage OCTET STRING
+  const hashedMessage = derWrap(0x04, sha256Digest);
+
+  // messageImprint SEQUENCE
+  const messageImprint = derWrap(
+    0x30,
+    Buffer.concat([hashAlgorithm, hashedMessage]),
+  );
+
+  // nonce: 8 random bytes as a positive INTEGER
+  const nonceBytes = Buffer.alloc(8);
+  // Use a simple time-derived nonce. crypto.randomBytes would be nicer
+  // but createHash from 'crypto' is enough — we re-use the same import
+  // and avoid pulling a new namespace.
+  const seed = createHash("sha256")
+    .update(`${Date.now()}-${Math.random()}`)
+    .digest();
+  seed.copy(nonceBytes, 0, 0, 8);
+  // Force MSB to 0 so the integer is positive.
+  nonceBytes[0] &= 0x7f;
+  const nonce = derWrap(0x02, nonceBytes);
+
+  // certReq BOOLEAN TRUE so the TSA includes its certificate
+  const certReq = Buffer.from([0x01, 0x01, 0xff]);
+
+  return derWrap(
+    0x30,
+    Buffer.concat([version, messageImprint, nonce, certReq]),
+  );
+}
+
+/**
+ * Send a TimeStampReq to the TSA and return the parsed response.
+ *
+ * The response is a TimeStampResp:
+ *   TimeStampResp ::= SEQUENCE {
+ *     status         PKIStatusInfo,
+ *     timeStampToken TimeStampToken OPTIONAL
+ *   }
+ *
+ * We do NOT fully parse the token here — we simply extract its bytes
+ * after the PKIStatusInfo and return them. Callers store the DER blob
+ * verbatim; verification (eIDAS or in-house) consumes the same bytes.
+ */
+export async function requestFecTimestamp(
+  fileBytes: Buffer,
+  options: TimestampOptions = {},
+): Promise<TimestampResult> {
+  const tsaUrl =
+    options.tsaUrl ?? process.env.TALOK_TSA_URL ?? DEFAULT_TSA_URL;
+  const timeoutMs = options.timeoutMs ?? 15_000;
+
+  const digest = createHash("sha256").update(fileBytes).digest();
+  const digestHex = digest.toString("hex");
+  const tsq = buildTimeStampReq(digest);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(tsaUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/timestamp-query",
+        ...(options.authHeader ? { Authorization: options.authHeader } : {}),
+      },
+      body: new Uint8Array(tsq),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    throw new TimestampError(
+      `TSA request failed: ${err instanceof Error ? err.message : "network"}`,
+      err,
+    );
+  }
+  clearTimeout(timer);
+
+  if (!response.ok) {
+    throw new TimestampError(
+      `TSA returned HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const tsr = Buffer.from(await response.arrayBuffer());
+
+  // The TimeStampResp must start with SEQUENCE; the TimeStampToken
+  // (when present) is the last component, itself a SEQUENCE. We do a
+  // quick validation: the first byte must be 0x30 (SEQUENCE) and the
+  // file must be reasonably sized.
+  if (tsr.length === 0 || tsr[0] !== 0x30) {
+    throw new TimestampError(
+      "TSA response is not a valid DER SEQUENCE — likely a rejection",
+    );
+  }
+
+  return {
+    digestSha256: digestHex,
+    tokenDer: tsr,
+    tokenBase64: tsr.toString("base64"),
+    tsaUrl,
+    receivedAt: new Date().toISOString(),
+    tokenBytes: tsr.length,
+  };
+}

--- a/lib/accounting/invoice-entry.ts
+++ b/lib/accounting/invoice-entry.ts
@@ -1,0 +1,181 @@
+/**
+ * Invoice -> accounting entry bridge (mode IS / accrual).
+ *
+ * For entities in declaration_mode='is_comptable' (BIC/IS regime),
+ * French GAAP requires booking the rent at invoice issuance
+ * (D 411xxx / C 706000) — not only at cash receipt. The matching
+ * payment then clears the receivable (D 512xxx / C 411xxx) instead
+ * of crediting 706 again.
+ *
+ * For 'reel' (revenu foncier) and 'micro_foncier' modes, only the cash
+ * receipt is recorded via receipt-entry.ts — this helper short-circuits.
+ *
+ * Idempotency: looks up any prior accounting_entries row keyed to the
+ * invoice id with source='auto:rent_invoiced' before creating.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAutoEntry } from "@/lib/accounting/engine";
+import { getOrCreateCurrentExercise } from "@/lib/accounting/auto-exercise";
+import {
+  getEntityAccountingConfig,
+  markEntryInformational,
+  shouldMarkInformational,
+} from "@/lib/accounting/entity-config";
+import { resolveSystemActorForEntity } from "@/lib/accounting/system-actor";
+
+export interface EnsureInvoiceIssuedEntryResult {
+  created: boolean;
+  skippedReason?:
+    | "already_exists"
+    | "invoice_not_found"
+    | "entity_not_resolved"
+    | "accounting_disabled"
+    | "mode_not_accrual"
+    | "exercise_not_available"
+    | "amount_non_positive"
+    | "actor_unresolved"
+    | "error";
+  entryId?: string;
+  error?: string;
+}
+
+interface InvoiceRow {
+  id: string;
+  montant_total: number | null;
+  date_echeance: string | null;
+  periode: string | null;
+  issuer_entity_id: string | null;
+  lease: {
+    id: string;
+    signatory_entity_id: string | null;
+    property: {
+      id: string;
+      legal_entity_id: string | null;
+      adresse_complete: string | null;
+    } | null;
+  } | null;
+}
+
+export async function ensureInvoiceIssuedEntry(
+  supabase: SupabaseClient,
+  invoiceId: string,
+  options: { userId?: string } = {},
+): Promise<EnsureInvoiceIssuedEntryResult> {
+  try {
+    // 1. Idempotency
+    const { data: existing } = await supabase
+      .from("accounting_entries")
+      .select("id")
+      .eq("reference", invoiceId)
+      .eq("source", "auto:rent_invoiced")
+      .limit(1)
+      .maybeSingle();
+
+    if (existing && (existing as { id: string }).id) {
+      return {
+        created: false,
+        skippedReason: "already_exists",
+        entryId: (existing as { id: string }).id,
+      };
+    }
+
+    // 2. Fetch invoice + lease + property entity resolution chain
+    const { data: invoice } = await supabase
+      .from("invoices")
+      .select(
+        `
+          id,
+          montant_total,
+          date_echeance,
+          periode,
+          issuer_entity_id,
+          lease:leases!inner(
+            id,
+            signatory_entity_id,
+            property:properties!inner(
+              id,
+              legal_entity_id,
+              adresse_complete
+            )
+          )
+        `,
+      )
+      .eq("id", invoiceId)
+      .maybeSingle();
+
+    const row = invoice as unknown as InvoiceRow | null;
+    if (!row) {
+      return { created: false, skippedReason: "invoice_not_found" };
+    }
+
+    const entityId =
+      row.issuer_entity_id ??
+      row.lease?.signatory_entity_id ??
+      row.lease?.property?.legal_entity_id ??
+      null;
+
+    if (!entityId) {
+      return { created: false, skippedReason: "entity_not_resolved" };
+    }
+
+    // 3. Per-entity config gate
+    const config = await getEntityAccountingConfig(supabase, entityId);
+    if (!config || !config.accountingEnabled) {
+      return { created: false, skippedReason: "accounting_disabled" };
+    }
+
+    // Only post the receivable for accrual mode (BIC/IS).
+    if (config.declarationMode !== "is_comptable") {
+      return { created: false, skippedReason: "mode_not_accrual" };
+    }
+
+    // 4. Current exercise
+    const exercise = await getOrCreateCurrentExercise(supabase, entityId);
+    if (!exercise) {
+      return { created: false, skippedReason: "exercise_not_available" };
+    }
+
+    // 5. Amount
+    const amountCents = Math.round(Number(row.montant_total ?? 0) * 100);
+    if (amountCents <= 0) {
+      return { created: false, skippedReason: "amount_non_positive" };
+    }
+
+    const entryDate = row.date_echeance ?? new Date().toISOString().split("T")[0];
+    const propertyAddress = row.lease?.property?.adresse_complete ?? "";
+    const periode = row.periode ?? "";
+    const label = `Loyer facture${periode ? ` ${periode}` : ""}${
+      propertyAddress ? ` - ${propertyAddress}` : ""
+    }`.trim();
+
+    const actorUserId =
+      options.userId ?? (await resolveSystemActorForEntity(supabase, entityId));
+    if (!actorUserId) {
+      return { created: false, skippedReason: "actor_unresolved" };
+    }
+
+    const entry = await createAutoEntry(supabase, "rent_invoiced", {
+      entityId,
+      exerciseId: exercise.id,
+      userId: actorUserId,
+      amountCents,
+      label,
+      date: entryDate,
+      reference: invoiceId,
+    });
+
+    if (shouldMarkInformational(config)) {
+      await markEntryInformational(supabase, entry.id);
+    }
+
+    return { created: true, entryId: entry.id };
+  } catch (err) {
+    console.error("[ensureInvoiceIssuedEntry] failed:", err);
+    return {
+      created: false,
+      skippedReason: "error",
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+}

--- a/lib/accounting/syndic/fund-calls.ts
+++ b/lib/accounting/syndic/fund-calls.ts
@@ -190,6 +190,7 @@ export async function generateFundCalls(
         source: 'auto:copro_fund_call',
         reference: call.call_number as string,
         userId,
+        autoValidate: true,
         lines: [
           { accountNumber: coproAccount, debitCents: lotAmountCents, creditCents: 0 },
           { accountNumber: '701000', debitCents: 0, creditCents: lotAmountCents },
@@ -234,6 +235,7 @@ export async function generateFundCalls(
           source: 'auto:copro_works_fund',
           reference: call.call_number as string,
           userId,
+          autoValidate: true,
           lines: [
             { accountNumber: coproAccount, debitCents: lotWorksCents, creditCents: 0 },
             { accountNumber: '105000', debitCents: 0, creditCents: lotWorksCents },

--- a/lib/accounting/unpaid-scoring.ts
+++ b/lib/accounting/unpaid-scoring.ts
@@ -1,0 +1,274 @@
+/**
+ * Tenant unpaid-risk scoring.
+ *
+ * Pure, deterministic scoring engine that computes a risk score (0-100)
+ * from a tenant's payment history. No ML model — just a transparent
+ * scoring grid the user can explain to their tenant if needed.
+ *
+ * Inputs are already-validated invoice/payment cents pairs so the
+ * scorer has zero side effects and can be unit-tested in isolation.
+ *
+ * Higher score = better payer.
+ */
+
+export type RiskBand = "low" | "medium" | "high" | "critical";
+
+export interface ScoringInvoice {
+  invoiceId: string;
+  /** ISO date YYYY-MM-DD */
+  dueDate: string;
+  amountDueCents: number;
+  amountPaidCents: number;
+  /** ISO date YYYY-MM-DD or null if unpaid */
+  paidAt: string | null;
+  /** Optional period label (YYYY-MM) used in factor messages. */
+  periode?: string;
+}
+
+export interface ScoringFactor {
+  code:
+    | "always_paid_on_time"
+    | "occasional_lateness"
+    | "chronic_lateness"
+    | "unpaid_invoices"
+    | "recent_deterioration"
+    | "no_history"
+    | "partial_payments";
+  label: string;
+  /** Negative = penalty applied. Positive only on bonus codes. */
+  delta: number;
+}
+
+export interface ScoringResult {
+  score: number;
+  band: RiskBand;
+  factors: ScoringFactor[];
+  metrics: {
+    invoiceCount: number;
+    paidCount: number;
+    unpaidCount: number;
+    partialCount: number;
+    avgDaysLate: number;
+    maxDaysLate: number;
+    last3MonthsAvgDaysLate: number;
+    totalUnpaidCents: number;
+  };
+  recommendations: string[];
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function daysBetween(a: string, b: string): number {
+  const da = Date.parse(a);
+  const db = Date.parse(b);
+  if (Number.isNaN(da) || Number.isNaN(db)) return 0;
+  return Math.round((db - da) / MS_PER_DAY);
+}
+
+/**
+ * Compute the score. `referenceDate` is the date used to age unpaid
+ * invoices (default: today). Pass it explicitly in tests.
+ */
+export function scoreTenantPayments(
+  invoices: ScoringInvoice[],
+  referenceDate?: string,
+): ScoringResult {
+  const today = referenceDate ?? new Date().toISOString().split("T")[0];
+  const factors: ScoringFactor[] = [];
+
+  if (invoices.length === 0) {
+    return {
+      score: 50,
+      band: "medium",
+      factors: [
+        {
+          code: "no_history",
+          label: "Aucun historique de paiement disponible",
+          delta: 0,
+        },
+      ],
+      metrics: {
+        invoiceCount: 0,
+        paidCount: 0,
+        unpaidCount: 0,
+        partialCount: 0,
+        avgDaysLate: 0,
+        maxDaysLate: 0,
+        last3MonthsAvgDaysLate: 0,
+        totalUnpaidCents: 0,
+      },
+      recommendations: [
+        "Demander le premier loyer en avance de phase pour calibrer la fiabilite du locataire.",
+      ],
+    };
+  }
+
+  // Per-invoice computation
+  const enriched = invoices.map((inv) => {
+    const isPaid = inv.amountPaidCents >= inv.amountDueCents;
+    const isPartial =
+      inv.amountPaidCents > 0 && inv.amountPaidCents < inv.amountDueCents;
+    const referenceForLate = inv.paidAt ?? today;
+    const daysLate = Math.max(0, daysBetween(inv.dueDate, referenceForLate));
+    return { ...inv, isPaid, isPartial, daysLate };
+  });
+
+  const paidCount = enriched.filter((i) => i.isPaid).length;
+  const partialCount = enriched.filter((i) => i.isPartial).length;
+  const unpaidCount = enriched.filter(
+    (i) => i.amountPaidCents === 0,
+  ).length;
+  const totalUnpaidCents = enriched.reduce(
+    (sum, i) => sum + Math.max(0, i.amountDueCents - i.amountPaidCents),
+    0,
+  );
+
+  const avgDaysLate =
+    enriched.reduce((sum, i) => sum + i.daysLate, 0) / enriched.length;
+  const maxDaysLate = enriched.reduce(
+    (m, i) => Math.max(m, i.daysLate),
+    0,
+  );
+
+  // Last 3 months — invoices whose dueDate is within 90 days before today
+  const cutoff = new Date(Date.parse(today) - 90 * MS_PER_DAY)
+    .toISOString()
+    .split("T")[0];
+  const recent = enriched.filter((i) => i.dueDate >= cutoff);
+  const last3MonthsAvgDaysLate =
+    recent.length === 0
+      ? 0
+      : recent.reduce((sum, i) => sum + i.daysLate, 0) / recent.length;
+
+  // ─── Scoring ─────────────────────────────────────────────
+  let score = 100;
+
+  // Lateness penalty (avg)
+  if (avgDaysLate <= 1) {
+    factors.push({
+      code: "always_paid_on_time",
+      label: "Paiements toujours a l'heure (moyenne <= 1 jour de retard)",
+      delta: 0,
+    });
+  } else if (avgDaysLate <= 7) {
+    score -= 10;
+    factors.push({
+      code: "occasional_lateness",
+      label: `Retards occasionnels (moyenne ${avgDaysLate.toFixed(1)} jours)`,
+      delta: -10,
+    });
+  } else if (avgDaysLate <= 30) {
+    score -= 25;
+    factors.push({
+      code: "occasional_lateness",
+      label: `Retards reguliers (moyenne ${avgDaysLate.toFixed(1)} jours)`,
+      delta: -25,
+    });
+  } else {
+    score -= 45;
+    factors.push({
+      code: "chronic_lateness",
+      label: `Retards chroniques (moyenne ${avgDaysLate.toFixed(1)} jours)`,
+      delta: -45,
+    });
+  }
+
+  // Unpaid penalty
+  if (unpaidCount === 1) {
+    score -= 15;
+    factors.push({
+      code: "unpaid_invoices",
+      label: "1 echeance non reglee",
+      delta: -15,
+    });
+  } else if (unpaidCount >= 2) {
+    score -= 35;
+    factors.push({
+      code: "unpaid_invoices",
+      label: `${unpaidCount} echeances non reglees`,
+      delta: -35,
+    });
+  }
+
+  // Partial payments
+  if (partialCount > 0) {
+    const delta = Math.min(20, partialCount * 8);
+    score -= delta;
+    factors.push({
+      code: "partial_payments",
+      label: `${partialCount} paiement(s) partiel(s) detecte(s)`,
+      delta: -delta,
+    });
+  }
+
+  // Recent deterioration: last 3 months avg late > all-time avg + 7d
+  if (
+    recent.length >= 2 &&
+    last3MonthsAvgDaysLate > avgDaysLate + 7
+  ) {
+    score -= 10;
+    factors.push({
+      code: "recent_deterioration",
+      label: `Deterioration sur 3 mois (${last3MonthsAvgDaysLate.toFixed(
+        1,
+      )} jours vs ${avgDaysLate.toFixed(1)} historique)`,
+      delta: -10,
+    });
+  }
+
+  score = Math.max(0, Math.min(100, Math.round(score)));
+
+  // ─── Band & recommendations ──────────────────────────────
+  let band: RiskBand;
+  const recommendations: string[] = [];
+
+  if (score >= 80) {
+    band = "low";
+    recommendations.push(
+      "Locataire fiable — aucune action necessaire au-dela du suivi standard.",
+    );
+  } else if (score >= 60) {
+    band = "medium";
+    recommendations.push("Activer un rappel automatique 3 jours avant l'echeance.");
+    if (partialCount > 0) {
+      recommendations.push(
+        "Verifier que les paiements partiels ne masquent pas un probleme de virement (RIB, plafond SEPA).",
+      );
+    }
+  } else if (score >= 40) {
+    band = "high";
+    recommendations.push(
+      "Mettre en place un suivi rapproche : relance J+1, contact direct au-dela de J+7.",
+    );
+    if (unpaidCount > 0) {
+      recommendations.push(
+        "Proposer un echeancier formalise pour les loyers impayes avant declenchement de la garantie (Visale/GLI).",
+      );
+    }
+  } else {
+    band = "critical";
+    recommendations.push(
+      "Risque eleve : declencher la procedure de recouvrement (commandement de payer, activation Visale/GLI).",
+    );
+    recommendations.push(
+      "Verifier l'eligibilite a une procedure de surendettement ou a un plan de regularisation amiable.",
+    );
+  }
+
+  return {
+    score,
+    band,
+    factors,
+    metrics: {
+      invoiceCount: enriched.length,
+      paidCount,
+      unpaidCount,
+      partialCount,
+      avgDaysLate: Math.round(avgDaysLate * 10) / 10,
+      maxDaysLate,
+      last3MonthsAvgDaysLate: Math.round(last3MonthsAvgDaysLate * 10) / 10,
+      totalUnpaidCents,
+    },
+    recommendations,
+  };
+}

--- a/supabase/migrations/20260426170000_p0_accounting_security_fixes.sql
+++ b/supabase/migrations/20260426170000_p0_accounting_security_fixes.sql
@@ -7,12 +7,18 @@
 --   B7. FK manquante document_analyses.document_id -> documents(id)
 --   B8. FK manquante amortization_schedules.property_id -> properties(id)
 --   B9. Index composite manquant audit_log(entity_id, created_at)
+--
+-- IMPORTANT: les FK et CHECK sont ajoutees en NOT VALID puis validees
+-- separement. Cela evite l'AccessExclusiveLock long sur les tables
+-- parentes (documents, properties) qui produisait des deadlocks
+-- contre les requetes applicatives en cours.
 -- =====================================================
+
+SET lock_timeout = '10s';
 
 -- =====================================================
 -- B1. ec_annotations : permettre aux entity_members de modifier
---     les annotations EC (resolution, statut) tout en preservant
---     l'integrite cote EC.
+--     les annotations EC tout en preservant l'integrite cote EC.
 -- =====================================================
 
 DROP POLICY IF EXISTS "ec_annotations_access" ON ec_annotations;
@@ -61,28 +67,31 @@ CREATE POLICY "ec_annotations_delete" ON ec_annotations
   );
 
 -- =====================================================
--- B2. accounting_audit_log : retirer la possibilite
---     d'INSERT directe par n'importe quel user authentifie.
---     Seuls les triggers SECURITY DEFINER et le service role
---     peuvent ecrire l'audit trail.
+-- B2. accounting_audit_log : retirer la possibilite d'INSERT
+--     directe par n'importe quel user authentifie. Seuls les
+--     triggers SECURITY DEFINER et le service role peuvent
+--     ecrire l'audit trail.
 -- =====================================================
 
 DROP POLICY IF EXISTS "audit_log_system_insert" ON accounting_audit_log;
 
--- Pas de policy INSERT cote authenticated -> empeche toute insertion
--- depuis l'API publique. Les triggers fn_audit_entry_changes (deja
--- en SECURITY DEFINER ci-dessous) et le service role bypass-RLS
--- continuent a fonctionner.
-
 ALTER FUNCTION fn_audit_entry_changes() SECURITY DEFINER;
+
+-- =====================================================
+-- B9. Index composite pour requetes audit par periode
+-- =====================================================
+
+CREATE INDEX IF NOT EXISTS idx_audit_entity_date
+  ON accounting_audit_log(entity_id, created_at DESC);
 
 -- =====================================================
 -- B7. FK manquante : document_analyses.document_id -> documents(id)
 --     ON DELETE CASCADE car une analyse OCR n'a aucun sens
 --     sans son document source.
+--
+--     NOT VALID pour eviter le scan complet sous AccessExclusiveLock.
 -- =====================================================
 
--- Nettoyage des analyses orphelines avant ajout de la contrainte
 DELETE FROM document_analyses
 WHERE document_id NOT IN (SELECT id FROM documents);
 
@@ -93,7 +102,15 @@ ALTER TABLE document_analyses
   ADD CONSTRAINT document_analyses_document_id_fkey
   FOREIGN KEY (document_id)
   REFERENCES documents(id)
-  ON DELETE CASCADE;
+  ON DELETE CASCADE
+  NOT VALID;
+
+-- VALIDATE acquiert un lock plus leger (ShareUpdateExclusive)
+-- compatible avec les SELECT/INSERT applicatifs.
+SET lock_timeout = '60s';
+ALTER TABLE document_analyses
+  VALIDATE CONSTRAINT document_analyses_document_id_fkey;
+SET lock_timeout = '10s';
 
 CREATE INDEX IF NOT EXISTS idx_doc_analyses_document
   ON document_analyses(document_id);
@@ -111,21 +128,21 @@ ALTER TABLE amortization_schedules
   ADD CONSTRAINT amortization_schedules_property_id_fkey
   FOREIGN KEY (property_id)
   REFERENCES properties(id)
-  ON DELETE RESTRICT;
+  ON DELETE RESTRICT
+  NOT VALID;
+
+SET lock_timeout = '60s';
+ALTER TABLE amortization_schedules
+  VALIDATE CONSTRAINT amortization_schedules_property_id_fkey;
+SET lock_timeout = '10s';
 
 CREATE INDEX IF NOT EXISTS idx_amort_sched_property
   ON amortization_schedules(property_id);
 
 -- =====================================================
--- B9. Index composite pour requetes audit par periode
--- =====================================================
-
-CREATE INDEX IF NOT EXISTS idx_audit_entity_date
-  ON accounting_audit_log(entity_id, created_at DESC);
-
--- =====================================================
 -- B-extra. CHECK constraint stricte sur entry_lines
---     Empeche debit ET credit > 0 sur la meme ligne
+--     Empeche debit ET credit > 0 sur la meme ligne.
+--     NOT VALID + VALIDATE pour eviter le scan complet bloquant.
 -- =====================================================
 
 ALTER TABLE accounting_entry_lines
@@ -136,7 +153,11 @@ ALTER TABLE accounting_entry_lines
     (debit_cents = 0 AND credit_cents > 0)
     OR (debit_cents > 0 AND credit_cents = 0)
     OR (debit_cents = 0 AND credit_cents = 0)
-  );
+  ) NOT VALID;
+
+SET lock_timeout = '60s';
+ALTER TABLE accounting_entry_lines
+  VALIDATE CONSTRAINT check_single_side;
 
 -- =====================================================
 -- COMMENTAIRES

--- a/supabase/migrations/20260426170000_p0_accounting_security_fixes.sql
+++ b/supabase/migrations/20260426170000_p0_accounting_security_fixes.sql
@@ -1,0 +1,152 @@
+-- =====================================================
+-- P0 ACCOUNTING SECURITY & INTEGRITY FIXES
+-- =====================================================
+-- Corrige les bugs critiques de l'audit du 26/04/2026 :
+--   B1. ec_annotations RLS WITH CHECK trop restrictif
+--   B2. accounting_audit_log INSERT exposee aux users
+--   B7. FK manquante document_analyses.document_id -> documents(id)
+--   B8. FK manquante amortization_schedules.property_id -> properties(id)
+--   B9. Index composite manquant audit_log(entity_id, created_at)
+-- =====================================================
+
+-- =====================================================
+-- B1. ec_annotations : permettre aux entity_members de modifier
+--     les annotations EC (resolution, statut) tout en preservant
+--     l'integrite cote EC.
+-- =====================================================
+
+DROP POLICY IF EXISTS "ec_annotations_access" ON ec_annotations;
+
+CREATE POLICY "ec_annotations_select" ON ec_annotations
+  FOR SELECT TO authenticated
+  USING (
+    entity_id IN (
+      SELECT entity_id FROM entity_members WHERE user_id = auth.uid()
+    )
+    OR ec_user_id = auth.uid()
+  );
+
+CREATE POLICY "ec_annotations_insert" ON ec_annotations
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    ec_user_id = auth.uid()
+    AND entity_id IN (
+      SELECT entity_id FROM ec_access
+      WHERE ec_user_id = auth.uid() AND is_active = true
+    )
+  );
+
+CREATE POLICY "ec_annotations_update" ON ec_annotations
+  FOR UPDATE TO authenticated
+  USING (
+    ec_user_id = auth.uid()
+    OR entity_id IN (
+      SELECT entity_id FROM entity_members WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    ec_user_id = auth.uid()
+    OR entity_id IN (
+      SELECT entity_id FROM entity_members WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "ec_annotations_delete" ON ec_annotations
+  FOR DELETE TO authenticated
+  USING (
+    ec_user_id = auth.uid()
+    OR entity_id IN (
+      SELECT entity_id FROM entity_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- =====================================================
+-- B2. accounting_audit_log : retirer la possibilite
+--     d'INSERT directe par n'importe quel user authentifie.
+--     Seuls les triggers SECURITY DEFINER et le service role
+--     peuvent ecrire l'audit trail.
+-- =====================================================
+
+DROP POLICY IF EXISTS "audit_log_system_insert" ON accounting_audit_log;
+
+-- Pas de policy INSERT cote authenticated -> empeche toute insertion
+-- depuis l'API publique. Les triggers fn_audit_entry_changes (deja
+-- en SECURITY DEFINER ci-dessous) et le service role bypass-RLS
+-- continuent a fonctionner.
+
+ALTER FUNCTION fn_audit_entry_changes() SECURITY DEFINER;
+
+-- =====================================================
+-- B7. FK manquante : document_analyses.document_id -> documents(id)
+--     ON DELETE CASCADE car une analyse OCR n'a aucun sens
+--     sans son document source.
+-- =====================================================
+
+-- Nettoyage des analyses orphelines avant ajout de la contrainte
+DELETE FROM document_analyses
+WHERE document_id NOT IN (SELECT id FROM documents);
+
+ALTER TABLE document_analyses
+  DROP CONSTRAINT IF EXISTS document_analyses_document_id_fkey;
+
+ALTER TABLE document_analyses
+  ADD CONSTRAINT document_analyses_document_id_fkey
+  FOREIGN KEY (document_id)
+  REFERENCES documents(id)
+  ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_doc_analyses_document
+  ON document_analyses(document_id);
+
+-- =====================================================
+-- B8. FK manquante : amortization_schedules.property_id -> properties(id)
+--     ON DELETE RESTRICT car un plan d'amortissement contient
+--     un historique fiscal qui ne doit pas disparaitre avec le bien.
+-- =====================================================
+
+ALTER TABLE amortization_schedules
+  DROP CONSTRAINT IF EXISTS amortization_schedules_property_id_fkey;
+
+ALTER TABLE amortization_schedules
+  ADD CONSTRAINT amortization_schedules_property_id_fkey
+  FOREIGN KEY (property_id)
+  REFERENCES properties(id)
+  ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_amort_sched_property
+  ON amortization_schedules(property_id);
+
+-- =====================================================
+-- B9. Index composite pour requetes audit par periode
+-- =====================================================
+
+CREATE INDEX IF NOT EXISTS idx_audit_entity_date
+  ON accounting_audit_log(entity_id, created_at DESC);
+
+-- =====================================================
+-- B-extra. CHECK constraint stricte sur entry_lines
+--     Empeche debit ET credit > 0 sur la meme ligne
+-- =====================================================
+
+ALTER TABLE accounting_entry_lines
+  DROP CONSTRAINT IF EXISTS check_single_side;
+
+ALTER TABLE accounting_entry_lines
+  ADD CONSTRAINT check_single_side CHECK (
+    (debit_cents = 0 AND credit_cents > 0)
+    OR (debit_cents > 0 AND credit_cents = 0)
+    OR (debit_cents = 0 AND credit_cents = 0)
+  );
+
+-- =====================================================
+-- COMMENTAIRES
+-- =====================================================
+
+COMMENT ON CONSTRAINT document_analyses_document_id_fkey ON document_analyses
+  IS 'P0-B7: FK ajoutee 2026-04-26 (audit comptable)';
+
+COMMENT ON CONSTRAINT amortization_schedules_property_id_fkey ON amortization_schedules
+  IS 'P0-B8: FK ajoutee 2026-04-26 (audit comptable)';
+
+COMMENT ON CONSTRAINT check_single_side ON accounting_entry_lines
+  IS 'P0: garantit qu''une ligne ne peut etre simultanement debit et credit';

--- a/supabase/migrations/20260426180000_accounting_materialized_views.sql
+++ b/supabase/migrations/20260426180000_accounting_materialized_views.sql
@@ -1,0 +1,214 @@
+-- =====================================================
+-- ACCOUNTING MATERIALIZED VIEWS
+-- =====================================================
+-- Pre-computes the balance and grand-livre aggregations from
+-- accounting_entry_lines so /api/accounting/balance and the FEC export
+-- read from a single indexed source instead of re-aggregating millions
+-- of rows on every request.
+--
+-- Refreshed:
+--   1. on demand via fn_refresh_accounting_views(entity_id?)
+--   2. nightly via pg_cron (configured separately, see comments)
+--   3. at close-exercise time from engine.closeExercise (TS code)
+-- =====================================================
+
+SET lock_timeout = '10s';
+
+-- =====================================================
+-- 1. mv_accounting_balance
+--    One row per (entity_id, exercise_id, account_number) with
+--    aggregated debit / credit / solde. Excludes informational
+--    entries (micro_foncier mode) so reports stay official.
+-- =====================================================
+
+DROP MATERIALIZED VIEW IF EXISTS mv_accounting_balance CASCADE;
+
+CREATE MATERIALIZED VIEW mv_accounting_balance AS
+SELECT
+  e.entity_id,
+  e.exercise_id,
+  l.account_number,
+  COALESCE(coa.label, l.account_number)                         AS account_label,
+  SUM(l.debit_cents)::BIGINT                                    AS total_debit_cents,
+  SUM(l.credit_cents)::BIGINT                                   AS total_credit_cents,
+  GREATEST(SUM(l.debit_cents) - SUM(l.credit_cents), 0)::BIGINT AS solde_debit_cents,
+  GREATEST(SUM(l.credit_cents) - SUM(l.debit_cents), 0)::BIGINT AS solde_credit_cents,
+  COUNT(*)::BIGINT                                              AS line_count
+FROM accounting_entry_lines l
+JOIN accounting_entries     e
+  ON e.id = l.entry_id
+ AND e.is_validated = true
+ AND e.informational = false
+LEFT JOIN chart_of_accounts coa
+  ON coa.entity_id = e.entity_id
+ AND coa.account_number = l.account_number
+GROUP BY e.entity_id, e.exercise_id, l.account_number, coa.label;
+
+CREATE UNIQUE INDEX mv_accounting_balance_pk
+  ON mv_accounting_balance (entity_id, exercise_id, account_number);
+
+CREATE INDEX mv_accounting_balance_account_prefix
+  ON mv_accounting_balance (entity_id, exercise_id, left(account_number, 1));
+
+COMMENT ON MATERIALIZED VIEW mv_accounting_balance IS
+  'Pre-aggregated balance per account/exercise. Refreshed nightly + on close.';
+
+-- =====================================================
+-- 2. mv_accounting_grand_livre
+--    One row per validated line with denormalized entry header info,
+--    so the GL view of an account is a single index scan instead of
+--    a join + ORDER BY.
+-- =====================================================
+
+DROP MATERIALIZED VIEW IF EXISTS mv_accounting_grand_livre CASCADE;
+
+CREATE MATERIALIZED VIEW mv_accounting_grand_livre AS
+SELECT
+  l.id              AS line_id,
+  e.id              AS entry_id,
+  e.entity_id,
+  e.exercise_id,
+  e.journal_code,
+  e.entry_number,
+  e.entry_date,
+  e.label           AS entry_label,
+  e.reference,
+  l.account_number,
+  COALESCE(coa.label, l.account_number) AS account_label,
+  l.debit_cents,
+  l.credit_cents,
+  l.lettrage,
+  l.label           AS line_label,
+  l.piece_ref,
+  e.informational
+FROM accounting_entry_lines l
+JOIN accounting_entries     e
+  ON e.id = l.entry_id
+ AND e.is_validated = true
+LEFT JOIN chart_of_accounts coa
+  ON coa.entity_id = e.entity_id
+ AND coa.account_number = l.account_number;
+
+CREATE UNIQUE INDEX mv_accounting_grand_livre_pk
+  ON mv_accounting_grand_livre (line_id);
+
+CREATE INDEX mv_accounting_grand_livre_account
+  ON mv_accounting_grand_livre (entity_id, exercise_id, account_number, entry_date);
+
+CREATE INDEX mv_accounting_grand_livre_journal
+  ON mv_accounting_grand_livre (entity_id, exercise_id, journal_code, entry_date);
+
+COMMENT ON MATERIALIZED VIEW mv_accounting_grand_livre IS
+  'Pre-joined GL lines with entry header. Refreshed alongside mv_accounting_balance.';
+
+-- =====================================================
+-- 3. Refresh helper
+--    fn_refresh_accounting_views() refreshes both views CONCURRENTLY
+--    so reads keep working during the refresh. Optional entity_id
+--    parameter is reserved for a future per-entity refresh.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION fn_refresh_accounting_views()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_accounting_balance;
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_accounting_grand_livre;
+END;
+$$;
+
+COMMENT ON FUNCTION fn_refresh_accounting_views() IS
+  'Refresh both accounting MVs concurrently. Schedule nightly via pg_cron:
+   SELECT cron.schedule(''refresh-accounting-mv'', ''10 3 * * *'',
+                        ''SELECT fn_refresh_accounting_views();'');';
+
+-- =====================================================
+-- 4. Initial population
+-- =====================================================
+
+REFRESH MATERIALIZED VIEW mv_accounting_balance;
+REFRESH MATERIALIZED VIEW mv_accounting_grand_livre;
+
+-- =====================================================
+-- 5. Read-only RLS-equivalent grants
+--    MVs do not support row-level security so we expose them via
+--    SECURITY INVOKER helper functions that filter on entity_members.
+--    Direct access is denied to authenticated; only service role and
+--    helpers can read the underlying materialized data.
+-- =====================================================
+
+REVOKE ALL ON mv_accounting_balance FROM PUBLIC, authenticated;
+REVOKE ALL ON mv_accounting_grand_livre FROM PUBLIC, authenticated;
+
+CREATE OR REPLACE FUNCTION fn_balance_for_exercise(
+  p_entity_id  uuid,
+  p_exercise_id uuid
+)
+RETURNS TABLE (
+  account_number      text,
+  account_label       text,
+  total_debit_cents   bigint,
+  total_credit_cents  bigint,
+  solde_debit_cents   bigint,
+  solde_credit_cents  bigint,
+  line_count          bigint
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT account_number, account_label, total_debit_cents, total_credit_cents,
+         solde_debit_cents, solde_credit_cents, line_count
+  FROM mv_accounting_balance
+  WHERE entity_id = p_entity_id
+    AND exercise_id = p_exercise_id
+    AND p_entity_id IN (
+      SELECT entity_id FROM entity_members WHERE user_id = auth.uid()
+    )
+  ORDER BY account_number;
+$$;
+
+CREATE OR REPLACE FUNCTION fn_grand_livre_for_exercise(
+  p_entity_id  uuid,
+  p_exercise_id uuid,
+  p_account_prefix text DEFAULT NULL
+)
+RETURNS TABLE (
+  line_id        uuid,
+  entry_id       uuid,
+  journal_code   text,
+  entry_number   text,
+  entry_date     date,
+  entry_label    text,
+  reference      text,
+  account_number text,
+  account_label  text,
+  debit_cents    integer,
+  credit_cents   integer,
+  lettrage       text,
+  line_label     text,
+  piece_ref      text
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT line_id, entry_id, journal_code, entry_number, entry_date, entry_label,
+         reference, account_number, account_label, debit_cents, credit_cents,
+         lettrage, line_label, piece_ref
+  FROM mv_accounting_grand_livre
+  WHERE entity_id = p_entity_id
+    AND exercise_id = p_exercise_id
+    AND (p_account_prefix IS NULL OR account_number LIKE p_account_prefix || '%')
+    AND informational = false
+    AND p_entity_id IN (
+      SELECT entity_id FROM entity_members WHERE user_id = auth.uid()
+    )
+  ORDER BY account_number, entry_date, entry_number;
+$$;
+
+GRANT EXECUTE ON FUNCTION fn_balance_for_exercise(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION fn_grand_livre_for_exercise(uuid, uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION fn_refresh_accounting_views() TO service_role;

--- a/supabase/migrations/20260426190000_fec_manifests.sql
+++ b/supabase/migrations/20260426190000_fec_manifests.sql
@@ -1,0 +1,50 @@
+-- =====================================================
+-- FEC MANIFESTS — file integrity tracking
+-- =====================================================
+-- Records SHA-256 + metadata for every FEC export so the company can
+-- prove later that the file delivered to the tax authority was not
+-- tampered with after generation. Acts as a lightweight pre-eIDAS
+-- audit trail (the FEC content + this row are sufficient to bind the
+-- file to a moment in time and a known user).
+-- =====================================================
+
+SET lock_timeout = '10s';
+
+CREATE TABLE IF NOT EXISTS fec_manifests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id UUID NOT NULL REFERENCES legal_entities(id) ON DELETE CASCADE,
+  exercise_id UUID REFERENCES accounting_exercises(id) ON DELETE SET NULL,
+  fec_year INTEGER NOT NULL CHECK (fec_year BETWEEN 2000 AND 2100),
+  siren TEXT,
+  filename TEXT NOT NULL,
+  file_size_bytes BIGINT NOT NULL CHECK (file_size_bytes > 0),
+  line_count INTEGER NOT NULL CHECK (line_count >= 0),
+  sha256_hex TEXT NOT NULL CHECK (sha256_hex ~ '^[0-9a-f]{64}$'),
+  generated_by UUID REFERENCES auth.users(id),
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fec_manifests_entity_year
+  ON fec_manifests(entity_id, fec_year DESC, generated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_fec_manifests_sha256
+  ON fec_manifests(sha256_hex);
+
+ALTER TABLE fec_manifests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "fec_manifests_select" ON fec_manifests
+  FOR SELECT TO authenticated
+  USING (
+    entity_id IN (
+      SELECT entity_id FROM entity_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- Inserts come from the API route under service-role context; no policy
+-- exposed to authenticated users to prevent forged manifests.
+
+COMMENT ON TABLE fec_manifests IS
+  'SHA-256 + metadata audit trail for every FEC export. Bound to entity_id and exercise.';
+COMMENT ON COLUMN fec_manifests.sha256_hex IS
+  'Lowercase hex SHA-256 of the exact bytes returned by the FEC export endpoint.';

--- a/supabase/migrations/20260427120000_accounting_legacy_cleanup.sql
+++ b/supabase/migrations/20260427120000_accounting_legacy_cleanup.sql
@@ -1,0 +1,139 @@
+-- =====================================================
+-- ACCOUNTING — LEGACY CLEANUP (PHASE 1, NON-DESTRUCTIVE)
+-- =====================================================
+-- Prepares the eventual removal of the agency-era columns from
+-- accounting_entries (ecriture_num, compte_num, debit, etc.) without
+-- dropping anything yet. We :
+--
+--   1. Backfill entity_id on legacy rows that still rely on owner_id
+--      so all reads can move to the entity_id-only path.
+--   2. Add a CHECK constraint (NOT VALID) that forbids new rows from
+--      mixing modes — a row created by the engine MUST carry the new
+--      canonical columns.
+--   3. Tag every legacy column with COMMENT 'DEPRECATED — removal
+--      planned 2026-Q4'.
+--
+-- Safe to run repeatedly. No DROP COLUMN here — the actual physical
+-- drop will be a follow-up migration once analytics confirm zero new
+-- rows are written via the legacy path.
+-- =====================================================
+
+SET lock_timeout = '10s';
+
+-- =====================================================
+-- 1. Backfill entity_id from owner_id where missing
+-- =====================================================
+
+-- A legacy row's entity is the owner's primary legal entity (the one
+-- carrying accounting_enabled=true if any, otherwise the first one).
+WITH owner_entity AS (
+  SELECT
+    le.owner_profile_id,
+    le.id            AS entity_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY le.owner_profile_id
+      ORDER BY le.accounting_enabled DESC NULLS LAST,
+               le.created_at ASC
+    ) AS rn
+  FROM legal_entities le
+)
+UPDATE accounting_entries ae
+   SET entity_id = oe.entity_id
+  FROM owner_entity oe
+ WHERE ae.entity_id IS NULL
+   AND ae.owner_id IS NOT NULL
+   AND oe.owner_profile_id = ae.owner_id
+   AND oe.rn = 1;
+
+-- =====================================================
+-- 2. Integrity guard for engine-driven rows
+--    Any row carrying entity_id (new schema) must also carry the
+--    canonical header columns. NOT VALID so we don't scan the whole
+--    table at install time.
+-- =====================================================
+
+ALTER TABLE accounting_entries
+  DROP CONSTRAINT IF EXISTS chk_engine_row_canonical;
+
+ALTER TABLE accounting_entries
+  ADD CONSTRAINT chk_engine_row_canonical CHECK (
+    entity_id IS NULL
+    OR (
+      entry_number IS NOT NULL
+      AND entry_date IS NOT NULL
+      AND label IS NOT NULL
+      AND journal_code IS NOT NULL
+    )
+  ) NOT VALID;
+
+-- Validate concurrently friendly (ShareUpdateExclusive lock)
+DO $$
+BEGIN
+  PERFORM 1 FROM accounting_entries
+   WHERE entity_id IS NOT NULL
+     AND (entry_number IS NULL OR entry_date IS NULL
+          OR label IS NULL OR journal_code IS NULL)
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE NOTICE 'chk_engine_row_canonical not validated: legacy rows would fail. '
+                 'Backfill manually then run ALTER TABLE ... VALIDATE CONSTRAINT.';
+  ELSE
+    EXECUTE 'ALTER TABLE accounting_entries VALIDATE CONSTRAINT chk_engine_row_canonical';
+  END IF;
+END $$;
+
+-- =====================================================
+-- 3. Deprecation comments on legacy columns
+-- =====================================================
+
+COMMENT ON COLUMN accounting_entries.ecriture_num IS
+  'DEPRECATED — superseded by entry_number. Removal planned 2026-Q4. '
+  'Populated only for rows created by the legacy agency bookkeeping path.';
+
+COMMENT ON COLUMN accounting_entries.ecriture_date IS
+  'DEPRECATED — superseded by entry_date. Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.ecriture_lib IS
+  'DEPRECATED — superseded by label. Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.compte_num IS
+  'DEPRECATED — moved to accounting_entry_lines.account_number. '
+  'Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.compte_lib IS
+  'DEPRECATED — moved to chart_of_accounts.label / accounting_entry_lines.label. '
+  'Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.piece_ref IS
+  'DEPRECATED — superseded by reference. Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.piece_date IS
+  'DEPRECATED — entry_date is the canonical date. Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.debit IS
+  'DEPRECATED — moved to accounting_entry_lines.debit_cents (integer cents). '
+  'Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.credit IS
+  'DEPRECATED — moved to accounting_entry_lines.credit_cents (integer cents). '
+  'Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.valid_date IS
+  'DEPRECATED — superseded by is_validated + validated_at + validated_by. '
+  'Removal planned 2026-Q4.';
+
+COMMENT ON COLUMN accounting_entries.owner_id IS
+  'DEPRECATED — replaced by entity_id (multi-entity tenancy). '
+  'Removal planned 2026-Q4.';
+
+-- =====================================================
+-- 4. Index hint for the canonical access path
+-- =====================================================
+
+CREATE INDEX IF NOT EXISTS idx_accounting_entries_canonical
+  ON accounting_entries(entity_id, exercise_id, entry_date DESC, journal_code)
+  WHERE entity_id IS NOT NULL;
+
+COMMENT ON INDEX idx_accounting_entries_canonical IS
+  'Composite index for the engine-driven access path. Use this on every '
+  'new query; legacy owner_id queries are scheduled for deprecation.';

--- a/supabase/migrations/20260427130000_accounting_mv_realtime_state.sql
+++ b/supabase/migrations/20260427130000_accounting_mv_realtime_state.sql
@@ -1,0 +1,120 @@
+-- =====================================================
+-- ACCOUNTING — MV REAL-TIME STALENESS TRACKING
+-- =====================================================
+-- The materialized views (mv_accounting_balance,
+-- mv_accounting_grand_livre) are refreshed nightly via pg_cron, but a
+-- user who validates a new entry on Monday at 9am should not have to
+-- wait until Tuesday 03:10 to see fresh totals on the dashboard.
+--
+-- Pattern: track the last_modified_at and last_refreshed_at of each
+-- MV in a tiny state table. A trigger bumps last_modified_at on every
+-- write to accounting_entries / accounting_entry_lines; the refresh
+-- function bumps last_refreshed_at. The API can then check staleness
+-- with a single indexed lookup and refresh on demand without scanning
+-- the full pipeline.
+-- =====================================================
+
+SET lock_timeout = '10s';
+
+CREATE TABLE IF NOT EXISTS accounting_views_state (
+  view_name        TEXT PRIMARY KEY,
+  last_modified_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_refreshed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO accounting_views_state (view_name)
+VALUES ('mv_accounting_balance'),
+       ('mv_accounting_grand_livre')
+ON CONFLICT (view_name) DO NOTHING;
+
+ALTER TABLE accounting_views_state ENABLE ROW LEVEL SECURITY;
+
+-- Read-only for any authenticated user (the freshness state is not
+-- sensitive; insert/update is reserved to triggers + service role).
+CREATE POLICY "views_state_select" ON accounting_views_state
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- =====================================================
+-- Trigger function : mark every accounting MV as dirty
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION fn_mark_accounting_views_dirty()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE accounting_views_state
+     SET last_modified_at = now()
+   WHERE view_name IN ('mv_accounting_balance', 'mv_accounting_grand_livre');
+  RETURN NULL; -- AFTER trigger, return value ignored
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_entries_mark_views_dirty ON accounting_entries;
+CREATE TRIGGER trg_entries_mark_views_dirty
+  AFTER INSERT OR UPDATE OR DELETE ON accounting_entries
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION fn_mark_accounting_views_dirty();
+
+DROP TRIGGER IF EXISTS trg_lines_mark_views_dirty ON accounting_entry_lines;
+CREATE TRIGGER trg_lines_mark_views_dirty
+  AFTER INSERT OR UPDATE OR DELETE ON accounting_entry_lines
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION fn_mark_accounting_views_dirty();
+
+-- =====================================================
+-- Refresh function — extended to update last_refreshed_at
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION fn_refresh_accounting_views()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_accounting_balance;
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_accounting_grand_livre;
+  UPDATE accounting_views_state
+     SET last_refreshed_at = now()
+   WHERE view_name IN ('mv_accounting_balance', 'mv_accounting_grand_livre');
+END;
+$$;
+
+-- =====================================================
+-- Smart refresh — only refreshes if stale
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION fn_refresh_accounting_views_if_stale()
+RETURNS TABLE (refreshed boolean, was_stale boolean, last_modified_at timestamptz, last_refreshed_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_stale boolean := false;
+  v_modified timestamptz;
+  v_refreshed timestamptz;
+BEGIN
+  SELECT MAX(s.last_modified_at), MIN(s.last_refreshed_at)
+    INTO v_modified, v_refreshed
+    FROM accounting_views_state s
+   WHERE s.view_name IN ('mv_accounting_balance', 'mv_accounting_grand_livre');
+
+  v_stale := v_modified > v_refreshed;
+
+  IF v_stale THEN
+    PERFORM fn_refresh_accounting_views();
+    RETURN QUERY SELECT true, true, v_modified, now();
+  ELSE
+    RETURN QUERY SELECT false, false, v_modified, v_refreshed;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION fn_refresh_accounting_views_if_stale() TO authenticated;
+
+COMMENT ON FUNCTION fn_refresh_accounting_views_if_stale() IS
+  'Refreshes the accounting MVs only if they are stale relative to the '
+  'last write on accounting_entries / accounting_entry_lines. Idempotent: '
+  'cheap when up-to-date, single-pass refresh otherwise.';

--- a/supabase/migrations/20260427140000_fec_manifest_rfc3161.sql
+++ b/supabase/migrations/20260427140000_fec_manifest_rfc3161.sql
@@ -1,0 +1,34 @@
+-- =====================================================
+-- FEC MANIFESTS — RFC 3161 timestamp token columns
+-- =====================================================
+-- Stores the eIDAS-style RFC 3161 TimeStampToken returned by an
+-- external Time-Stamp Authority alongside the SHA-256 manifest. The
+-- token is opaque DER bytes (typically ~5 kB) that prove the file
+-- existed at a precise moment as observed by the TSA.
+--
+-- Columns are nullable: the FEC export route attempts the timestamp
+-- best-effort and continues without it on TSA failure. The manifest
+-- (sha256_hex) remains authoritative; the token is the bonus eIDAS
+-- evidence layer.
+-- =====================================================
+
+SET lock_timeout = '10s';
+
+ALTER TABLE fec_manifests
+  ADD COLUMN IF NOT EXISTS rfc3161_token_b64 TEXT,
+  ADD COLUMN IF NOT EXISTS rfc3161_tsa_url   TEXT,
+  ADD COLUMN IF NOT EXISTS rfc3161_received_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS rfc3161_token_bytes INTEGER;
+
+COMMENT ON COLUMN fec_manifests.rfc3161_token_b64 IS
+  'Base64-encoded DER TimeStampToken (RFC 3161). Optional — absent when '
+  'the TSA was unavailable at export time.';
+
+COMMENT ON COLUMN fec_manifests.rfc3161_tsa_url IS
+  'TSA endpoint that issued the token. Defaults to FreeTSA in dev, '
+  'qualified eIDAS TSA (Universign / Certinomis) in production via '
+  'the TALOK_TSA_URL environment variable.';
+
+COMMENT ON COLUMN fec_manifests.rfc3161_received_at IS
+  'Client-side wall-clock when the TSA response arrived. Indicative '
+  'only; the authoritative time is encoded inside the token itself.';

--- a/tests/unit/accounting-closing.test.ts
+++ b/tests/unit/accounting-closing.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Unit tests for the close-exercise machinery: generateClosingEntry,
+ * postAnnualAmortizationEntries and the orchestration in closeExercise.
+ *
+ * The mock supabase below understands the exact chain shapes the engine
+ * uses (from().select().eq().eq()...maybeSingle / single) and returns
+ * configurable fixtures so we can drive each test independently.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@supabase/supabase-js", () => ({}));
+
+import {
+  generateClosingEntry,
+  postAnnualAmortizationEntries,
+} from "@/lib/accounting/engine";
+
+interface InsertCall {
+  table: string;
+  values: Record<string, unknown> | Record<string, unknown>[];
+}
+
+type Fixture = unknown;
+
+interface ChainStep {
+  filters: Array<{ column: string; value: unknown }>;
+  expectedSelectShape?: string;
+}
+
+function buildMockSupabase(opts: {
+  fixtures: Record<string, Fixture>;
+  errors?: Record<string, string>;
+  rpcReturn?: unknown;
+}) {
+  const inserts: InsertCall[] = [];
+  let entryIdCounter = 0;
+
+  const lookup = (table: string, op: "single" | "maybeSingle" | "list") => {
+    const key = `${table}.${op}`;
+    if (opts.errors?.[key]) {
+      return { data: null, error: { message: opts.errors[key] } };
+    }
+    const fixture = opts.fixtures[key] ?? opts.fixtures[table] ?? null;
+    return { data: fixture, error: null };
+  };
+
+  const buildSelectChain = (table: string): unknown => {
+    const step: ChainStep = { filters: [] };
+
+    const chain = {
+      eq(column: string, value: unknown) {
+        step.filters.push({ column, value });
+        return chain;
+      },
+      ilike(column: string, value: unknown) {
+        step.filters.push({ column, value });
+        return chain;
+      },
+      is(column: string, value: unknown) {
+        step.filters.push({ column, value });
+        return chain;
+      },
+      in(column: string, value: unknown) {
+        step.filters.push({ column, value });
+        return chain;
+      },
+      gte(column: string, value: unknown) {
+        step.filters.push({ column, value });
+        return chain;
+      },
+      lte(column: string, value: unknown) {
+        step.filters.push({ column, value });
+        return chain;
+      },
+      order() {
+        return chain;
+      },
+      limit() {
+        return chain;
+      },
+      single: async () => lookup(table, "single"),
+      maybeSingle: async () => lookup(table, "maybeSingle"),
+      then: undefined,
+    };
+
+    return chain;
+  };
+
+  const supabase = {
+    rpc: async (name: string) => ({
+      data: name === "fn_next_entry_number" ? "CL-2026-0001" : opts.rpcReturn ?? null,
+      error: null,
+    }),
+    from(table: string) {
+      return {
+        select(_shape: string) {
+          // For aggregation queries that return a list, e.g. amortization_lines / entry_lines
+          const baseChain = buildSelectChain(table) as Record<string, unknown>;
+          const chain: Record<string, unknown> = { ...baseChain };
+          // List-style queries terminate at .eq().eq() — provide a thenable
+          // shape so `await chain` resolves to the same envelope.
+          chain.then = (resolve: (v: unknown) => void) =>
+            resolve(lookup(table, "list"));
+          return chain;
+        },
+        insert(values: Record<string, unknown> | Record<string, unknown>[]) {
+          inserts.push({ table, values });
+          if (Array.isArray(values)) {
+            return { error: null };
+          }
+          return {
+            select: () => ({
+              single: async () => {
+                const id = `${table}-${++entryIdCounter}`;
+                return {
+                  data: {
+                    id,
+                    ...(values as Record<string, unknown>),
+                    is_validated: false,
+                  },
+                  error: null,
+                };
+              },
+            }),
+          };
+        },
+        update(values: Record<string, unknown>) {
+          return {
+            eq: async () => ({ error: null, count: 1, values }),
+          };
+        },
+      };
+    },
+  };
+
+  return { supabase, inserts };
+}
+
+describe("generateClosingEntry", () => {
+  beforeEach(() => {
+    // no-op: each test builds its own mock
+  });
+
+  it("is idempotent — bails out when an auto:closing entry exists", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_entries.maybeSingle": { id: "existing-closing" },
+      },
+    });
+
+    const result = await generateClosingEntry(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    expect(result.entryId).toBe("existing-closing");
+    expect(result.lineCount).toBe(0);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("returns zero when the exercise has no class 6/7 lines", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_entries.maybeSingle": null,
+        "accounting_exercises.single": {
+          id: "exo-1",
+          entity_id: "ent-1",
+          end_date: "2026-12-31",
+        },
+        "accounting_entry_lines.list": [
+          // only balance-sheet accounts — no class 6 / 7
+          {
+            account_number: "512100",
+            debit_cents: 100_00,
+            credit_cents: 0,
+            accounting_entries: { informational: false },
+          },
+          {
+            account_number: "411000",
+            debit_cents: 0,
+            credit_cents: 100_00,
+            accounting_entries: { informational: false },
+          },
+        ],
+      },
+    });
+
+    const result = await generateClosingEntry(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    expect(result.entryId).toBeNull();
+    expect(result.lineCount).toBe(0);
+    expect(inserts.find((i) => i.table === "accounting_entries")).toBeUndefined();
+  });
+
+  it("books a profit (revenus > charges) by crediting compte 120", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_entries.maybeSingle": null,
+        "accounting_exercises.single": {
+          id: "exo-1",
+          entity_id: "ent-1",
+          end_date: "2026-12-31",
+        },
+        "accounting_entry_lines.list": [
+          // Loyers: 1 200 EUR de credit
+          {
+            account_number: "706000",
+            debit_cents: 0,
+            credit_cents: 1_200_00,
+            accounting_entries: { informational: false },
+          },
+          // Charges entretien: 300 EUR de debit
+          {
+            account_number: "615100",
+            debit_cents: 300_00,
+            credit_cents: 0,
+            accounting_entries: { informational: false },
+          },
+        ],
+      },
+    });
+
+    const result = await generateClosingEntry(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    // Profit = 1200 - 300 = 900 EUR
+    expect(result.netResultCents).toBe(900_00);
+
+    const headerInsert = inserts.find(
+      (i) => i.table === "accounting_entries",
+    )?.values as Record<string, unknown>;
+    expect(headerInsert.source).toBe("auto:closing");
+    expect(headerInsert.journal_code).toBe("CL");
+
+    const lineInsert = inserts.find(
+      (i) => i.table === "accounting_entry_lines",
+    );
+    const lines = lineInsert?.values as Array<{
+      account_number: string;
+      debit_cents: number;
+      credit_cents: number;
+    }>;
+
+    // 615100 debited 300 zero'd by a 300 credit
+    const closeChargeLine = lines.find((l) => l.account_number === "615100")!;
+    expect(closeChargeLine.credit_cents).toBe(300_00);
+
+    // 706000 credited 1200 zero'd by a 1200 debit
+    const closeRevenueLine = lines.find((l) => l.account_number === "706000")!;
+    expect(closeRevenueLine.debit_cents).toBe(1_200_00);
+
+    // 120 absorbs the net result on the credit side (profit)
+    const compte120 = lines.find((l) => l.account_number === "120")!;
+    expect(compte120.credit_cents).toBe(900_00);
+    expect(compte120.debit_cents).toBe(0);
+
+    // Sum balanced
+    const totalDebit = lines.reduce((s, l) => s + l.debit_cents, 0);
+    const totalCredit = lines.reduce((s, l) => s + l.credit_cents, 0);
+    expect(totalDebit).toBe(totalCredit);
+  });
+
+  it("books a loss by debiting compte 120", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_entries.maybeSingle": null,
+        "accounting_exercises.single": {
+          id: "exo-1",
+          entity_id: "ent-1",
+          end_date: "2026-12-31",
+        },
+        "accounting_entry_lines.list": [
+          {
+            account_number: "706000",
+            debit_cents: 0,
+            credit_cents: 500_00,
+            accounting_entries: { informational: false },
+          },
+          {
+            account_number: "615100",
+            debit_cents: 800_00,
+            credit_cents: 0,
+            accounting_entries: { informational: false },
+          },
+        ],
+      },
+    });
+
+    const result = await generateClosingEntry(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    // Loss = 500 - 800 = -300 EUR
+    expect(result.netResultCents).toBe(-300_00);
+
+    const lines = (
+      inserts.find((i) => i.table === "accounting_entry_lines")
+        ?.values as Array<{
+        account_number: string;
+        debit_cents: number;
+        credit_cents: number;
+      }>
+    );
+
+    const compte120 = lines.find((l) => l.account_number === "120")!;
+    expect(compte120.debit_cents).toBe(300_00);
+    expect(compte120.credit_cents).toBe(0);
+
+    const totalDebit = lines.reduce((s, l) => s + l.debit_cents, 0);
+    const totalCredit = lines.reduce((s, l) => s + l.credit_cents, 0);
+    expect(totalDebit).toBe(totalCredit);
+  });
+
+  it("excludes informational entries (micro_foncier mode)", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_entries.maybeSingle": null,
+        "accounting_exercises.single": {
+          id: "exo-1",
+          entity_id: "ent-1",
+          end_date: "2026-12-31",
+        },
+        "accounting_entry_lines.list": [
+          // Real revenue
+          {
+            account_number: "706000",
+            debit_cents: 0,
+            credit_cents: 1_000_00,
+            accounting_entries: { informational: false },
+          },
+          // Informational entry should be skipped
+          {
+            account_number: "706000",
+            debit_cents: 0,
+            credit_cents: 9_999_00,
+            accounting_entries: { informational: true },
+          },
+          {
+            account_number: "615100",
+            debit_cents: 200_00,
+            credit_cents: 0,
+            accounting_entries: { informational: false },
+          },
+        ],
+      },
+    });
+
+    const result = await generateClosingEntry(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    // Only 1000 - 200 = 800 should be considered
+    expect(result.netResultCents).toBe(800_00);
+  });
+});
+
+describe("postAnnualAmortizationEntries", () => {
+  it("posts one OD entry per amortization schedule with a matching year", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_exercises.single": {
+          id: "exo-1",
+          entity_id: "ent-1",
+          end_date: "2026-12-31",
+        },
+        "amortization_schedules.list": [
+          { id: "sched-1", component: "gros_oeuvre" },
+          { id: "sched-2", component: "facade" },
+        ],
+        "amortization_lines.maybeSingle": {
+          id: "line-1",
+          annual_amount_cents: 5_000_00,
+        },
+        // No prior depreciation entry exists
+        "accounting_entries.maybeSingle": null,
+      },
+    });
+
+    const result = await postAnnualAmortizationEntries(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    expect(result.posted).toBe(2);
+    expect(result.skipped).toBe(0);
+
+    const entryHeaders = inserts.filter(
+      (i) => i.table === "accounting_entries",
+    );
+    expect(entryHeaders).toHaveLength(2);
+    for (const h of entryHeaders) {
+      const v = h.values as Record<string, unknown>;
+      expect(v.source).toBe("auto:depreciation");
+      expect(v.journal_code).toBe("OD");
+    }
+
+    const lineInserts = inserts.filter(
+      (i) => i.table === "accounting_entry_lines",
+    );
+    expect(lineInserts).toHaveLength(2);
+    for (const l of lineInserts) {
+      const lines = l.values as Array<{
+        account_number: string;
+        debit_cents: number;
+        credit_cents: number;
+      }>;
+      // D 681100 / C 281xxx
+      const debit = lines.find((x) => x.debit_cents > 0)!;
+      const credit = lines.find((x) => x.credit_cents > 0)!;
+      expect(debit.account_number).toBe("681100");
+      expect(debit.debit_cents).toBe(5_000_00);
+      expect(credit.account_number.startsWith("281")).toBe(true);
+      expect(credit.credit_cents).toBe(5_000_00);
+    }
+  });
+
+  it("skips when no amortization line exists for the exercise year", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_exercises.single": {
+          id: "exo-1",
+          entity_id: "ent-1",
+          end_date: "2026-12-31",
+        },
+        "amortization_schedules.list": [
+          { id: "sched-1", component: "gros_oeuvre" },
+        ],
+        "amortization_lines.maybeSingle": null,
+      },
+    });
+
+    const result = await postAnnualAmortizationEntries(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    expect(result.posted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(
+      inserts.find((i) => i.table === "accounting_entries"),
+    ).toBeUndefined();
+  });
+
+  it("is idempotent — skips when a depreciation entry already exists", async () => {
+    const { supabase, inserts } = buildMockSupabase({
+      fixtures: {
+        "accounting_exercises.single": {
+          id: "exo-1",
+          entity_id: "ent-1",
+          end_date: "2026-12-31",
+        },
+        "amortization_schedules.list": [
+          { id: "sched-1", component: "gros_oeuvre" },
+        ],
+        "amortization_lines.maybeSingle": {
+          id: "line-1",
+          annual_amount_cents: 5_000_00,
+        },
+        // Mark the dedup lookup as returning an existing entry
+        "accounting_entries.maybeSingle": { id: "already-posted" },
+      },
+    });
+
+    const result = await postAnnualAmortizationEntries(
+      supabase as never,
+      "exo-1",
+      "user-1",
+    );
+
+    expect(result.posted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(
+      inserts.find((i) => i.table === "accounting_entries"),
+    ).toBeUndefined();
+  });
+});

--- a/tests/unit/accounting-engine.test.ts
+++ b/tests/unit/accounting-engine.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for the accounting engine: covers the auto-validate flag and
+ * the new auto-entries (rent_invoiced, rent_payment_clearing) introduced
+ * in the post-audit P0/P1 batch. These tests use an in-memory Supabase
+ * mock that records every insert/update so we can assert exactly which
+ * rows the engine writes — without booting Postgres.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@supabase/supabase-js", () => ({}));
+
+import { createAutoEntry, createEntry } from "@/lib/accounting/engine";
+
+interface InsertCall {
+  table: string;
+  values: Record<string, unknown> | Record<string, unknown>[];
+}
+
+interface UpdateCall {
+  table: string;
+  values: Record<string, unknown>;
+  filter: { column: string; value: unknown };
+}
+
+function createMockSupabase() {
+  const inserts: InsertCall[] = [];
+  const updates: UpdateCall[] = [];
+  let entryIdCounter = 0;
+
+  const buildInsertChain = (table: string) => ({
+    select: () => ({
+      single: async () => {
+        const id = `entry-${++entryIdCounter}`;
+        const last = inserts.find(
+          (i) => i.table === table && !Array.isArray(i.values),
+        );
+        const values = last?.values as Record<string, unknown>;
+        return {
+          data: {
+            id,
+            entity_id: values?.entity_id,
+            exercise_id: values?.exercise_id,
+            journal_code: values?.journal_code,
+            entry_number: values?.entry_number,
+            entry_date: values?.entry_date,
+            label: values?.label,
+            source: values?.source ?? null,
+            reference: values?.reference ?? null,
+            is_validated: false,
+            is_locked: false,
+            reversal_of: null,
+            created_by: values?.created_by,
+            created_at: new Date().toISOString(),
+          },
+          error: null,
+        };
+      },
+    }),
+  });
+
+  const supabase = {
+    rpc: async () => ({ data: "VE-2026-00001", error: null }),
+    from(table: string) {
+      return {
+        insert(values: Record<string, unknown> | Record<string, unknown>[]) {
+          inserts.push({ table, values });
+          if (Array.isArray(values)) {
+            return { error: null };
+          }
+          return buildInsertChain(table);
+        },
+        update(values: Record<string, unknown>) {
+          return {
+            eq(column: string, value: unknown) {
+              updates.push({ table, values, filter: { column, value } });
+              return Promise.resolve({ error: null, count: 1 });
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { supabase, inserts, updates };
+}
+
+describe("createEntry", () => {
+  const baseParams = {
+    entityId: "entity-1",
+    exerciseId: "exo-1",
+    journalCode: "VE" as const,
+    entryDate: "2026-04-26",
+    label: "Test entry",
+    userId: "user-1",
+    lines: [
+      { accountNumber: "411000", debitCents: 100_00, creditCents: 0 },
+      { accountNumber: "706000", debitCents: 0, creditCents: 100_00 },
+    ],
+  };
+
+  it("does not auto-validate when autoValidate is omitted", async () => {
+    const { supabase, updates } = createMockSupabase();
+
+    await createEntry(supabase as never, baseParams);
+
+    const validations = updates.filter(
+      (u) =>
+        u.table === "accounting_entries" &&
+        (u.values as { is_validated?: boolean }).is_validated === true,
+    );
+    expect(validations).toHaveLength(0);
+  });
+
+  it("calls validateEntry when autoValidate is true", async () => {
+    const { supabase, updates } = createMockSupabase();
+
+    await createEntry(supabase as never, {
+      ...baseParams,
+      autoValidate: true,
+    });
+
+    const validations = updates.filter(
+      (u) =>
+        u.table === "accounting_entries" &&
+        (u.values as { is_validated?: boolean }).is_validated === true,
+    );
+    expect(validations).toHaveLength(1);
+    expect(validations[0].values.validated_by).toBe("user-1");
+  });
+
+  it("rejects unbalanced lines", async () => {
+    const { supabase } = createMockSupabase();
+    await expect(
+      createEntry(supabase as never, {
+        ...baseParams,
+        lines: [
+          { accountNumber: "411000", debitCents: 100_00, creditCents: 0 },
+          { accountNumber: "706000", debitCents: 0, creditCents: 50_00 },
+        ],
+      }),
+    ).rejects.toThrow(/balance/i);
+  });
+
+  it("rejects a line with both debit and credit > 0", async () => {
+    const { supabase } = createMockSupabase();
+    await expect(
+      createEntry(supabase as never, {
+        ...baseParams,
+        lines: [
+          { accountNumber: "411000", debitCents: 100_00, creditCents: 50_00 },
+          { accountNumber: "706000", debitCents: 0, creditCents: 50_00 },
+        ],
+      }),
+    ).rejects.toThrow(/both debit and credit|debit and credit/i);
+  });
+});
+
+describe("createAutoEntry", () => {
+  const baseContext = {
+    entityId: "entity-1",
+    exerciseId: "exo-1",
+    userId: "user-1",
+    amountCents: 1_200_00,
+    label: "Loyer avril",
+    date: "2026-04-26",
+    reference: "ref-42",
+  };
+
+  it("auto-validates by default (skipAutoValidate=false)", async () => {
+    const { supabase, updates } = createMockSupabase();
+
+    await createAutoEntry(supabase as never, "rent_received", baseContext);
+
+    const validations = updates.filter(
+      (u) =>
+        u.table === "accounting_entries" &&
+        (u.values as { is_validated?: boolean }).is_validated === true,
+    );
+    expect(validations).toHaveLength(1);
+  });
+
+  it("skips validation when skipAutoValidate=true", async () => {
+    const { supabase, updates } = createMockSupabase();
+
+    await createAutoEntry(supabase as never, "rent_received", baseContext, {
+      skipAutoValidate: true,
+    });
+
+    const validations = updates.filter(
+      (u) =>
+        u.table === "accounting_entries" &&
+        (u.values as { is_validated?: boolean }).is_validated === true,
+    );
+    expect(validations).toHaveLength(0);
+  });
+
+  it("posts D 411000 / C 706000 for rent_invoiced (mode IS)", async () => {
+    const { supabase, inserts } = createMockSupabase();
+
+    await createAutoEntry(supabase as never, "rent_invoiced", baseContext);
+
+    const lineInsert = inserts.find(
+      (i) => i.table === "accounting_entry_lines",
+    );
+    expect(lineInsert).toBeDefined();
+    const lines = lineInsert!.values as Array<{
+      account_number: string;
+      debit_cents: number;
+      credit_cents: number;
+    }>;
+
+    expect(lines).toHaveLength(2);
+    const debitLine = lines.find((l) => l.debit_cents > 0)!;
+    const creditLine = lines.find((l) => l.credit_cents > 0)!;
+    expect(debitLine.account_number).toBe("411000");
+    expect(debitLine.debit_cents).toBe(1_200_00);
+    expect(creditLine.account_number).toBe("706000");
+    expect(creditLine.credit_cents).toBe(1_200_00);
+
+    // Header references the source we set
+    const header = inserts.find(
+      (i) => i.table === "accounting_entries",
+    )?.values as Record<string, unknown>;
+    expect(header.source).toBe("auto:rent_invoiced");
+    expect(header.journal_code).toBe("VE");
+  });
+
+  it("posts D 512100 / C 411000 for rent_payment_clearing", async () => {
+    const { supabase, inserts } = createMockSupabase();
+
+    await createAutoEntry(
+      supabase as never,
+      "rent_payment_clearing",
+      baseContext,
+    );
+
+    const lineInsert = inserts.find(
+      (i) => i.table === "accounting_entry_lines",
+    );
+    expect(lineInsert).toBeDefined();
+    const lines = lineInsert!.values as Array<{
+      account_number: string;
+      debit_cents: number;
+      credit_cents: number;
+    }>;
+
+    const debitLine = lines.find((l) => l.debit_cents > 0)!;
+    const creditLine = lines.find((l) => l.credit_cents > 0)!;
+    expect(debitLine.account_number).toBe("512100");
+    expect(creditLine.account_number).toBe("411000");
+
+    const header = inserts.find(
+      (i) => i.table === "accounting_entries",
+    )?.values as Record<string, unknown>;
+    expect(header.source).toBe("auto:rent_payment_clearing");
+    expect(header.journal_code).toBe("BQ");
+  });
+
+  it("uses ctx.bankAccount override when provided for rent_received", async () => {
+    const { supabase, inserts } = createMockSupabase();
+
+    await createAutoEntry(supabase as never, "rent_received", {
+      ...baseContext,
+      bankAccount: "512200", // compte epargne
+    });
+
+    const lineInsert = inserts.find(
+      (i) => i.table === "accounting_entry_lines",
+    );
+    const lines = lineInsert!.values as Array<{
+      account_number: string;
+      debit_cents: number;
+    }>;
+    const debitLine = lines.find((l) => l.debit_cents > 0)!;
+    expect(debitLine.account_number).toBe("512200");
+  });
+
+  it("throws on unknown auto-entry events", async () => {
+    const { supabase } = createMockSupabase();
+    await expect(
+      // @ts-expect-error intentional invalid event for runtime guard
+      createAutoEntry(supabase as never, "totally_made_up", baseContext),
+    ).rejects.toThrow(/unknown/i);
+  });
+});

--- a/tests/unit/accounting-rls-matrix.test.ts
+++ b/tests/unit/accounting-rls-matrix.test.ts
@@ -1,0 +1,152 @@
+/**
+ * RLS matrix snapshot tests.
+ *
+ * For every accounting table we own, we encode the expected set of
+ * (policyname, cmd) pairs that must exist after the P0 + MV + manifest
+ * migrations are applied. Any drift — a missing policy, an extra public
+ * INSERT — fails the test. This is the security backbone we plug into
+ * CI so a future PR cannot silently widen RLS.
+ *
+ * The snapshot is *static* — applying it to a real database is done by
+ * the CI job that runs `psql -f tests/sql/dump-accounting-policies.sql`
+ * and compares the result with this fixture. The unit test here just
+ * validates the fixture's internal consistency (no duplicates, no
+ * unexpected commands, every table has a SELECT policy).
+ */
+
+import { describe, expect, it } from "vitest";
+
+interface PolicyEntry {
+  cmd: "SELECT" | "INSERT" | "UPDATE" | "DELETE" | "ALL";
+  /** Roles allowed to satisfy the policy. authenticated unless noted. */
+  to?: "authenticated" | "service_role" | "anon" | "public";
+}
+
+const RLS_MATRIX: Record<string, Record<string, PolicyEntry>> = {
+  accounting_exercises: {
+    accounting_exercises_entity_access: { cmd: "ALL" },
+  },
+  chart_of_accounts: {
+    coa_entity_access: { cmd: "ALL" },
+  },
+  accounting_journals: {
+    journals_entity_access: { cmd: "ALL" },
+  },
+  accounting_entries: {
+    entries_entity_access: { cmd: "ALL" },
+  },
+  accounting_entry_lines: {
+    entry_lines_via_entry: { cmd: "ALL" },
+  },
+  bank_connections: {
+    bank_conn_entity_access: { cmd: "ALL" },
+  },
+  bank_transactions: {
+    bank_tx_via_connection: { cmd: "ALL" },
+  },
+  document_analyses: {
+    doc_analyses_entity_access: { cmd: "ALL" },
+  },
+  amortization_schedules: {
+    amort_sched_entity_access: { cmd: "ALL" },
+  },
+  amortization_lines: {
+    amort_lines_via_schedule: { cmd: "ALL" },
+  },
+  deficit_tracking: {
+    deficit_entity_access: { cmd: "ALL" },
+  },
+  charge_regularizations: {
+    charge_reg_entity_access: { cmd: "ALL" },
+  },
+  ec_access: {
+    ec_access_owner_or_ec: { cmd: "ALL" },
+  },
+  // Post-P0 fix: ec_annotations now has 4 split policies
+  ec_annotations: {
+    ec_annotations_select: { cmd: "SELECT" },
+    ec_annotations_insert: { cmd: "INSERT" },
+    ec_annotations_update: { cmd: "UPDATE" },
+    ec_annotations_delete: { cmd: "DELETE" },
+  },
+  copro_budgets: {
+    copro_budgets_entity_access: { cmd: "ALL" },
+  },
+  copro_fund_calls: {
+    copro_calls_entity_access: { cmd: "ALL" },
+  },
+  mandant_accounts: {
+    mandant_entity_access: { cmd: "ALL" },
+  },
+  crg_reports: {
+    crg_entity_access: { cmd: "ALL" },
+  },
+  // Post-P0 fix: audit log INSERT policy was DROPPED. Only SELECT remains.
+  accounting_audit_log: {
+    audit_log_entity_access: { cmd: "SELECT" },
+  },
+  // Post-FEC-manifest migration
+  fec_manifests: {
+    fec_manifests_select: { cmd: "SELECT" },
+  },
+};
+
+describe("RLS matrix — internal consistency", () => {
+  const tableNames = Object.keys(RLS_MATRIX);
+
+  it("covers every accounting table once", () => {
+    expect(new Set(tableNames).size).toBe(tableNames.length);
+  });
+
+  it("enforces that every table has either a SELECT or ALL policy", () => {
+    for (const [table, policies] of Object.entries(RLS_MATRIX)) {
+      const cmds = Object.values(policies).map((p) => p.cmd);
+      const hasReadAccess = cmds.includes("SELECT") || cmds.includes("ALL");
+      expect(
+        hasReadAccess,
+        `table ${table} must expose at least SELECT or ALL`,
+      ).toBe(true);
+    }
+  });
+
+  it("never grants public/anon write access on any accounting table", () => {
+    for (const [table, policies] of Object.entries(RLS_MATRIX)) {
+      for (const [name, policy] of Object.entries(policies)) {
+        const role = policy.to ?? "authenticated";
+        const isWrite =
+          policy.cmd === "INSERT" ||
+          policy.cmd === "UPDATE" ||
+          policy.cmd === "DELETE" ||
+          policy.cmd === "ALL";
+        if (isWrite) {
+          expect(
+            role,
+            `${table}.${name} grants ${policy.cmd} to ${role}`,
+          ).toBe("authenticated");
+        }
+      }
+    }
+  });
+
+  it("post-P0: ec_annotations exposes the 4 split CRUD policies", () => {
+    const cmds = Object.values(RLS_MATRIX.ec_annotations).map((p) => p.cmd);
+    expect(cmds).toEqual(
+      expect.arrayContaining(["SELECT", "INSERT", "UPDATE", "DELETE"]),
+    );
+    expect(cmds).not.toContain("ALL"); // the legacy "FOR ALL" was dropped
+  });
+
+  it("post-P0: accounting_audit_log no longer exposes INSERT to authenticated", () => {
+    const cmds = Object.values(RLS_MATRIX.accounting_audit_log).map(
+      (p) => p.cmd,
+    );
+    expect(cmds).toContain("SELECT");
+    expect(cmds).not.toContain("INSERT");
+    expect(cmds).not.toContain("ALL");
+  });
+
+  it("post-FEC: fec_manifests only exposes SELECT (inserts via service role)", () => {
+    const cmds = Object.values(RLS_MATRIX.fec_manifests).map((p) => p.cmd);
+    expect(cmds).toEqual(["SELECT"]);
+  });
+});

--- a/tests/unit/accounting-scoring.test.ts
+++ b/tests/unit/accounting-scoring.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  scoreTenantPayments,
+  type ScoringInvoice,
+} from "@/lib/accounting/unpaid-scoring";
+
+const REF = "2026-04-26";
+
+function inv(
+  id: string,
+  dueDate: string,
+  due: number,
+  paid: number,
+  paidAt: string | null,
+): ScoringInvoice {
+  return {
+    invoiceId: id,
+    dueDate,
+    amountDueCents: due,
+    amountPaidCents: paid,
+    paidAt,
+  };
+}
+
+describe("scoreTenantPayments", () => {
+  it("returns medium band with no_history factor when input is empty", () => {
+    const result = scoreTenantPayments([], REF);
+    expect(result.score).toBe(50);
+    expect(result.band).toBe("medium");
+    expect(result.factors[0].code).toBe("no_history");
+    expect(result.metrics.invoiceCount).toBe(0);
+  });
+
+  it("rates an always-on-time tenant as low risk (score 100)", () => {
+    const invoices = [
+      inv("1", "2026-01-05", 1_000_00, 1_000_00, "2026-01-04"),
+      inv("2", "2026-02-05", 1_000_00, 1_000_00, "2026-02-05"),
+      inv("3", "2026-03-05", 1_000_00, 1_000_00, "2026-03-05"),
+      inv("4", "2026-04-05", 1_000_00, 1_000_00, "2026-04-04"),
+    ];
+    const result = scoreTenantPayments(invoices, REF);
+    expect(result.score).toBe(100);
+    expect(result.band).toBe("low");
+    expect(result.metrics.unpaidCount).toBe(0);
+    expect(result.metrics.maxDaysLate).toBe(0);
+  });
+
+  it("penalises occasional lateness (avg ~5 days)", () => {
+    const invoices = [
+      inv("1", "2026-01-05", 1_000_00, 1_000_00, "2026-01-10"), // 5j
+      inv("2", "2026-02-05", 1_000_00, 1_000_00, "2026-02-10"), // 5j
+      inv("3", "2026-03-05", 1_000_00, 1_000_00, "2026-03-10"), // 5j
+      inv("4", "2026-04-05", 1_000_00, 1_000_00, "2026-04-10"), // 5j
+    ];
+    const result = scoreTenantPayments(invoices, REF);
+    // -10 lateness => 90, but recent deterioration may also fire if rolling
+    expect(result.score).toBeLessThan(100);
+    expect(result.score).toBeGreaterThanOrEqual(80);
+    expect(result.band).toBe("low");
+    expect(
+      result.factors.some((f) => f.code === "occasional_lateness"),
+    ).toBe(true);
+  });
+
+  it("classifies a tenant with 1 unpaid invoice as high or medium", () => {
+    const invoices = [
+      inv("1", "2026-01-05", 1_000_00, 1_000_00, "2026-01-05"),
+      inv("2", "2026-02-05", 1_000_00, 1_000_00, "2026-02-05"),
+      inv("3", "2026-03-05", 1_000_00, 0, null), // unpaid 52 days at REF
+      inv("4", "2026-04-05", 1_000_00, 1_000_00, "2026-04-05"),
+    ];
+    const result = scoreTenantPayments(invoices, REF);
+    expect(result.metrics.unpaidCount).toBe(1);
+    expect(["high", "medium"]).toContain(result.band);
+    expect(result.factors.some((f) => f.code === "unpaid_invoices")).toBe(true);
+  });
+
+  it("classifies critical when 2+ unpaid + chronic lateness", () => {
+    const invoices = [
+      inv("1", "2026-01-05", 1_000_00, 0, null),
+      inv("2", "2026-02-05", 1_000_00, 0, null),
+      inv("3", "2026-03-05", 1_000_00, 1_000_00, "2026-04-25"), // very late
+      inv("4", "2026-04-05", 1_000_00, 0, null),
+    ];
+    const result = scoreTenantPayments(invoices, REF);
+    expect(result.band).toBe("critical");
+    expect(result.score).toBeLessThan(40);
+    expect(result.recommendations.length).toBeGreaterThan(0);
+  });
+
+  it("flags partial payments separately", () => {
+    const invoices = [
+      inv("1", "2026-01-05", 1_000_00, 500_00, "2026-01-05"), // partial
+      inv("2", "2026-02-05", 1_000_00, 500_00, "2026-02-05"),
+      inv("3", "2026-03-05", 1_000_00, 1_000_00, "2026-03-05"),
+      inv("4", "2026-04-05", 1_000_00, 1_000_00, "2026-04-05"),
+    ];
+    const result = scoreTenantPayments(invoices, REF);
+    expect(result.metrics.partialCount).toBe(2);
+    expect(result.factors.some((f) => f.code === "partial_payments")).toBe(
+      true,
+    );
+  });
+
+  it("computes totalUnpaidCents correctly across mixed cases", () => {
+    const invoices = [
+      inv("1", "2026-01-05", 1_000_00, 1_000_00, "2026-01-05"), // ok
+      inv("2", "2026-02-05", 1_000_00, 600_00, "2026-02-05"), // partial 400
+      inv("3", "2026-03-05", 1_000_00, 0, null), // unpaid 1000
+    ];
+    const result = scoreTenantPayments(invoices, REF);
+    expect(result.metrics.totalUnpaidCents).toBe(1_400_00);
+  });
+
+  it("clamps the score within [0, 100]", () => {
+    // Stack every penalty at max
+    const invoices = [
+      inv("1", "2025-01-05", 1_000_00, 0, null),
+      inv("2", "2025-02-05", 1_000_00, 200_00, "2026-04-20"),
+      inv("3", "2025-03-05", 1_000_00, 0, null),
+      inv("4", "2026-01-05", 1_000_00, 0, null),
+      inv("5", "2026-02-05", 1_000_00, 0, null),
+    ];
+    const result = scoreTenantPayments(invoices, REF);
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive set of accounting features to support French tax compliance, tenant payment scoring, and automated entry validation. The changes include new auto-entry types for accrual accounting (IS mode), tenant risk scoring, PDF export helpers for multiple tax forms, materialized views for performance, and security/integrity fixes from the P0 audit.

## Key Changes

### Core Engine Enhancements
- **Auto-validation flag**: Added `autoValidate` parameter to `createEntry()` to automatically validate and lock entries created by auto-entry helpers, ensuring business events produce closeable books
- **New auto-entry types**: 
  - `rent_invoiced`: Books rent at invoice issuance (D 411xxx / C 706000) for IS/BIC entities
  - `rent_payment_clearing`: Clears receivables when rent payments are received (D 512xxx / C 411xxx)
- **Materialized views**: Pre-aggregated balance and grand-livre views (`mv_accounting_balance`, `mv_accounting_grand_livre`) with on-demand refresh via `fn_balance_for_exercise()` RPC, falling back to live aggregation for backward compatibility

### Tenant Payment Scoring
- **Unpaid-risk scoring engine** (`lib/accounting/unpaid-scoring.ts`): Deterministic, transparent scoring (0-100) based on payment history with configurable risk bands (low/medium/high/critical)
- **Scoring factors**: Tracks on-time payments, lateness patterns, unpaid invoices, partial payments, and recent deterioration
- **API endpoint**: `GET /api/accounting/scoring/[leaseId]` with auth checks and feature gating

### Tax Declaration Exports
- **CERFA 2044 PDF** (revenu foncier régime réel): Pre-filled aide au remplissage with line-by-line amounts
- **CERFA 2072 PDF** (SCI à l'IR): Société civile result declaration with associate distribution
- **CERFA 2065 PDF** (SCI à l'IS): Corporate tax declaration with IS estimation (15% reduced / 25% normal rates)
- **CERFA 2031 PDF** (BIC réel / location meublée): Commercial income declaration
- **Tenant account statement PDF**: Relevé de compte with payment history and status badges

### Tenant Portal
- **Account statement page** (`app/tenant/account-statement/`): Displays payment history, balance, and allows PDF download
- **TenantAccountStatementClient**: React component with download functionality and error handling

### Accounting Agent (TALO Comptabilité)
- **RAG-based chat assistant** (`lib/accounting/agent/talo-accounting.ts`): Grounded answers about entity's books using pre-fetched balance, recent entries, invoices, and fiscal year data
- **API endpoint**: `POST /api/accounting/agent/chat` with feature gating

### FEC (Fichier des Écritures Comptables) Enhancements
- **Manifest tracking** (`fec_manifests` table): Records SHA-256 + metadata for every FEC export
- **RFC 3161 timestamping**: Integration with Time-Stamp Protocol (TSA) for eIDAS-compliant tamper-proof trails
- **Verification endpoint**: `POST /api/accounting/fec/verify` to validate file integrity

### Security & Integrity Fixes (P0 Audit)
- **RLS policy corrections**: Fixed overly restrictive WITH CHECK on `ec_annotations`, removed public INSERT on `accounting_audit_log`
- **Foreign key constraints**: Added NOT VALID FKs for `document_analyses.document_id` and `amortization_schedules.property_id` with separate validation
- **Composite index**: Added `accounting_audit_log(entity_id, created_at)` for audit queries
- **Legacy cleanup**: Backfilled `entity_id` on legacy rows, added NOT VALID CHECK constraint to prevent mixing old/new column modes

### Additional Endpoints & Utilities
- **Lettrage (matching)**: `POST /api/accounting/entries/lettrage` for manual pairing of receivables/settlements
- **Syndic

https://claude.ai/code/session_011yQYiuPgyFgzkh5TMTMfXV