### PR TITLE
feat(accounting): expose toutes les nouvelles pages dans le dashboard

### DIFF
--- a/app/owner/accounting/AccountingDashboard.tsx
+++ b/app/owner/accounting/AccountingDashboard.tsx
@@ -47,6 +47,10 @@ import {
   Receipt,
   Trash2,
   Loader2,
+  BookOpenCheck,
+  Scale,
+  ArrowRightLeft,
+  Home,
 } from "lucide-react";
 import {
   BarChart,
@@ -248,6 +252,49 @@ function AccountingDashboardContent() {
               href="/owner/accounting/exports"
               icon={<Download className="w-5 h-5" />}
               label="Exporter FEC"
+            />
+          </div>
+
+          {/* Consultation comptable */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <QuickAction
+              href="/owner/accounting/grand-livre"
+              icon={<BookOpenCheck className="w-5 h-5" />}
+              label="Grand livre"
+            />
+            <QuickAction
+              href="/owner/accounting/balance"
+              icon={<Scale className="w-5 h-5" />}
+              label="Balance générale"
+            />
+            <QuickAction
+              href="/owner/accounting/rendement"
+              icon={<Home className="w-5 h-5" />}
+              label="Rendement par bien"
+            />
+            <QuickAction
+              href="/owner/accounting/declarations/tva"
+              icon={<Receipt className="w-5 h-5" />}
+              label="Déclaration TVA"
+            />
+          </div>
+
+          {/* Saisie & gestion */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <QuickAction
+              href="/owner/accounting/property-acquisitions"
+              icon={<Building2 className="w-5 h-5" />}
+              label="Acquisition immobilière"
+            />
+            <QuickAction
+              href="/owner/accounting/transfers"
+              icon={<ArrowRightLeft className="w-5 h-5" />}
+              label="Virement interne"
+            />
+            <QuickAction
+              href="/owner/accounting/chart"
+              icon={<Calculator className="w-5 h-5" />}
+              label="Plan comptable"
             />
           </div>
 


### PR DESCRIPTION
## Suite de PR #527 (mergée)

Le dashboard `/owner/accounting` n'exposait que les 4 raccourcis historiques. Cette PR ajoute 2 grilles supplémentaires pour rendre les pages livrées dans #527 (Grand livre, Balance, Rendement par bien, TVA, Acquisitions, Virements, Plan comptable) accessibles **en 1 clic** depuis l'atterrissage comptabilité.

## Changements

- **Ligne 2 (Consultation comptable)** : Grand livre · Balance générale · Rendement par bien · Déclaration TVA
- **Ligne 3 (Saisie & gestion)** : Acquisition immobilière · Virement interne · Plan comptable

Aucun changement de schéma, aucune migration, aucun comportement métier modifié. Pure UX.

## Test plan

- [ ] Ouvrir `/owner/accounting` → 3 grilles de raccourcis affichées
- [ ] Cliquer chacun des 7 nouveaux raccourcis → page correcte chargée

https://claude.ai/code/session_01RnAwWYX7PAJTs6szKnhWxC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnAwWYX7PAJTs6szKnhWxC)_