### PR TITLE
fix(nav): mobile parity across all roles — restore missing items

### DIFF
--- a/app/agency/_components/AgencySidebar.tsx
+++ b/app/agency/_components/AgencySidebar.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import {
-  Building2,
-  MoreHorizontal,
-  X,
-} from "lucide-react";
+import { Building2 } from "lucide-react";
 import { getSecondaryRoleManifest } from "@/lib/navigation/secondary-role-manifest";
 import { SignOutButton } from "@/components/auth/sign-out-button";
+import { SharedBottomNav } from "@/components/layout/shared-bottom-nav";
 
 interface AgencySidebarProps {
   profile: {
@@ -36,10 +32,6 @@ function agencyTourId(href: string): string | undefined {
 
 export function AgencySidebar({ profile, agencyName }: AgencySidebarProps) {
   const pathname = usePathname();
-  const [moreOpen, setMoreOpen] = useState(false);
-
-  const mobileMainItems = navigation.slice(0, 4);
-  const mobileMoreItems = navigation.slice(4);
 
   return (
     <>
@@ -126,107 +118,29 @@ export function AgencySidebar({ profile, agencyName }: AgencySidebarProps) {
         </div>
       </aside>
 
-      {/* Mobile Bottom Navigation - 4 items + bouton "Plus" */}
-      <nav
-        className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-xl border-t border-border/50"
-        role="navigation"
-        aria-label="Navigation mobile"
-      >
-        {/* Panel "Plus" - menu déroulant vers le haut */}
-        {moreOpen && (
-          <>
-            {/* Backdrop */}
-            <button
-              className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
-              onClick={() => setMoreOpen(false)}
-              aria-label="Fermer le menu"
-            />
-            {/* Panel */}
-            <div className="absolute bottom-full left-0 right-0 z-50 bg-background border-t border-border/50 rounded-t-2xl shadow-2xl p-4 pb-2 animate-in slide-in-from-bottom-4">
-              <div className="flex items-center justify-between mb-3">
-                <span className="text-sm font-semibold text-foreground">Plus</span>
-                <button
-                  onClick={() => setMoreOpen(false)}
-                  className="p-1 rounded-lg hover:bg-muted"
-                  aria-label="Fermer"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              </div>
-              <div className="grid grid-cols-3 gap-2">
-                {mobileMoreItems.map((item) => {
-                  const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
-                  return (
-                    <Link
-                      key={item.name}
-                      href={item.href}
-                      onClick={() => setMoreOpen(false)}
-                      className={cn(
-                        "flex flex-col items-center justify-center gap-1 p-3 rounded-xl min-h-[68px] transition-colors",
-                        isActive
-                          ? "bg-indigo-50 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400"
-                          : "text-muted-foreground hover:bg-muted/80 hover:text-foreground"
-                      )}
-                      aria-label={item.name}
-                      aria-current={isActive ? "page" : undefined}
-                    >
-                      <item.icon className="w-5 h-5" aria-hidden="true" />
-                      <span className="text-[10px] font-medium text-center leading-tight">{item.name}</span>
-                    </Link>
-                  );
-                })}
-                <SignOutButton
-                  variant="mobile-tile"
-                  onAfterClick={() => setMoreOpen(false)}
-                />
-              </div>
-            </div>
-          </>
-        )}
-        <div className="pb-safe">
-          <div className="grid grid-cols-5 h-14">
-            {mobileMainItems.map((item) => {
-              const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
-              return (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  data-tour={agencyTourId(item.href)}
-                  className={cn(
-                    "flex flex-col items-center justify-center gap-0.5 min-h-[44px] transition-colors",
-                    isActive
-                      ? "text-indigo-600 dark:text-indigo-400"
-                      : "text-muted-foreground hover:text-indigo-500"
-                  )}
-                  aria-label={item.name}
-                  aria-current={isActive ? "page" : undefined}
-                >
-                  <item.icon className="w-5 h-5" aria-hidden="true" />
-                  <span className="text-[10px] font-medium truncate max-w-[56px]">{item.name.slice(0, 8)}</span>
-                </Link>
-              );
-            })}
-            {/* Bouton "Plus" */}
-            <button
-              onClick={() => setMoreOpen((v) => !v)}
-              className={cn(
-                "flex flex-col items-center justify-center gap-0.5 min-h-[44px] transition-colors",
-                moreOpen
-                  ? "text-indigo-600 dark:text-indigo-400"
-                  : "text-muted-foreground hover:text-indigo-500"
-              )}
-              aria-label="Plus d'options"
-              aria-expanded={moreOpen}
-            >
-              <MoreHorizontal className="w-5 h-5" aria-hidden="true" />
-              <span className="text-[10px] font-medium">Plus</span>
-            </button>
-          </div>
-        </div>
-      </nav>
-
-      {/* Spacer pour bottom nav mobile */}
-      <div className="h-14 lg:hidden" aria-hidden="true" />
+      {/* Mobile Bottom Navigation — SharedBottomNav (parité 13/13 via menu Plus) */}
+      <SharedBottomNav
+        items={manifest.navigation.slice(0, 4).map((item) => ({
+          href: item.href,
+          label: item.name,
+          icon: item.icon,
+          tourId: agencyTourId(item.href),
+        }))}
+        moreItems={[
+          ...manifest.navigation.slice(4).map((item) => ({
+            href: item.href,
+            label: item.name,
+            icon: item.icon,
+            tourId: agencyTourId(item.href),
+          })),
+          ...manifest.footerNavigation.map((item) => ({
+            href: item.href,
+            label: item.name,
+            icon: item.icon,
+          })),
+        ]}
+        hideAbove="lg"
+      />
     </>
   );
 }

--- a/app/agency/layout.tsx
+++ b/app/agency/layout.tsx
@@ -20,6 +20,8 @@ import { AgencyThemeWrapper } from "./_components/AgencyThemeWrapper";
 import { PlatformBroadcastBanner } from "@/components/platform-broadcast-banner";
 import { OnboardingWrapper } from "@/components/onboarding/OnboardingWrapper";
 import type { TourRole } from "@/components/onboarding/OnboardingTour";
+import { SignOutButton } from "@/components/auth/sign-out-button";
+import { Building2 } from "lucide-react";
 
 /**
  * Layout Agency - Server Component
@@ -92,6 +94,24 @@ export default async function AgencyLayout({
       <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50/50 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950/30">
         <OfflineIndicator />
 
+        {/* Mobile Header — déconnexion accessible sur mobile (sidebar cachée < lg) */}
+        <div className="lg:hidden fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-xl border-b border-border/50 px-4 py-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div
+                className="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center"
+                aria-hidden="true"
+              >
+                <Building2 className="w-4 h-4 text-white" />
+              </div>
+              <span className="font-semibold text-foreground truncate">
+                {(agencyProfile?.nom_agence as string) || "Mon Agence"}
+              </span>
+            </div>
+            <SignOutButton variant="mobile-icon" />
+          </div>
+        </div>
+
         <div className="flex">
           {/* Sidebar Client Component pour interactivité */}
           <AgencySidebar
@@ -101,7 +121,7 @@ export default async function AgencyLayout({
 
           {/* Main content - SOTA 2026: lg breakpoint unifié */}
           <main
-            className="lg:pl-64 flex-1"
+            className="lg:pl-64 flex-1 pt-14 lg:pt-0"
             role="main"
             aria-label="Contenu principal"
           >

--- a/app/copro/layout.tsx
+++ b/app/copro/layout.tsx
@@ -15,13 +15,14 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
 import { OfflineIndicator } from "@/components/ui/offline-indicator";
 import { SignOutButton } from "@/components/auth/sign-out-button";
+import { SharedBottomNav } from "@/components/layout/shared-bottom-nav";
 import Link from "next/link";
 import {
   Building2, Euro, FileText, Calendar,
   MessageSquare, Bell, Home, Settings
 } from "lucide-react";
 
-const { navigation } = getSecondaryRoleManifest("copro");
+const { navigation, footerNavigation } = getSecondaryRoleManifest("copro");
 
 // COPRO_ROLES importé depuis lib/helpers/role-redirects.ts
 
@@ -191,30 +192,27 @@ export default async function CoproLayout({
             {children}
           </main>
 
-          {/* Mobile Bottom Navigation */}
-          <nav
-            className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-xl border-t border-border/50"
-            role="navigation"
-            aria-label="Navigation mobile"
-          >
-            <div className="pb-safe">
-              <div className="grid grid-cols-5 h-14">
-                {navigation.map((item) => (
-                  <Link
-                    key={item.name}
-                    href={item.href}
-                    className="flex flex-col items-center justify-center gap-0.5 min-h-[44px] text-muted-foreground hover:text-violet-600 dark:hover:text-violet-400 transition-colors"
-                    aria-label={item.name}
-                  >
-                    <item.icon className="w-5 h-5" aria-hidden="true" />
-                    <span className="text-[10px] font-medium truncate max-w-[56px]">{item.name.slice(0, 8)}</span>
-                  </Link>
-                ))}
-              </div>
-            </div>
-          </nav>
-          {/* Spacer pour bottom nav mobile */}
-          <div className="h-14 lg:hidden" aria-hidden="true" />
+          {/* Mobile Bottom Navigation — SharedBottomNav (parité 6/6 + footer via menu Plus) */}
+          <SharedBottomNav
+            items={navigation.slice(0, 4).map((item) => ({
+              href: item.href,
+              label: item.name,
+              icon: item.icon,
+            }))}
+            moreItems={[
+              ...navigation.slice(4).map((item) => ({
+                href: item.href,
+                label: item.name,
+                icon: item.icon,
+              })),
+              ...footerNavigation.map((item) => ({
+                href: item.href,
+                label: item.name,
+                icon: item.icon,
+              })),
+            ]}
+            hideAbove="lg"
+          />
         </div>
       </div>
     </ErrorBoundary>

--- a/app/guarantor/layout.tsx
+++ b/app/guarantor/layout.tsx
@@ -16,6 +16,7 @@ import CsrfTokenInjector from "@/components/security/CsrfTokenInjector";
 import { OfflineIndicator } from "@/components/ui/offline-indicator";
 import { GuarantorSignOutButton } from "./_components/GuarantorSignOutButton";
 import { OnboardingWrapper } from "@/components/onboarding/OnboardingWrapper";
+import { SharedBottomNav } from "@/components/layout/shared-bottom-nav";
 
 /**
  * Layout Guarantor - Server Component
@@ -71,25 +72,24 @@ export default async function GuarantorLayout({ children }: { children: ReactNod
       <div className="min-h-screen bg-background">
         <OfflineIndicator />
 
-        {/* Header simplifié */}
-        <header className="bg-card border-b border-border px-6 py-4">
-          <div className="flex items-center justify-between max-w-7xl mx-auto">
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 flex items-center justify-center text-white font-semibold">
+        {/* Header simplifié — nav horizontale cachée sur mobile, remplacée par bottom nav */}
+        <header className="bg-card border-b border-border px-4 sm:px-6 py-4">
+          <div className="flex items-center justify-between max-w-7xl mx-auto gap-4">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-10 h-10 shrink-0 rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 flex items-center justify-center text-white font-semibold">
                 {profile.prenom?.[0] || "G"}
               </div>
-              <div>
-                <p className="font-medium text-foreground">
+              <div className="min-w-0">
+                <p className="font-medium text-foreground truncate">
                   {profile.prenom} {profile.nom}
                 </p>
                 <p className="text-sm text-muted-foreground">Garant</p>
               </div>
             </div>
-            <nav className="flex items-center gap-4">
+            <nav className="hidden md:flex items-center gap-4">
               {[...manifest.navigation, ...manifest.footerNavigation]
                 .filter((item) => item.name !== "Aide")
                 .map((item) => {
-                  // Propagate data-tour for guarantor tour targeting
                   const tourId = item.href.endsWith("/dashboard")
                     ? "nav-dashboard"
                     : item.href.endsWith("/documents")
@@ -108,13 +108,36 @@ export default async function GuarantorLayout({ children }: { children: ReactNod
                 })}
               <GuarantorSignOutButton />
             </nav>
+            <div className="md:hidden">
+              <GuarantorSignOutButton />
+            </div>
           </div>
         </header>
 
         {/* Contenu principal */}
-        <main className="flex-1 overflow-auto p-6">
+        <main className="flex-1 overflow-auto p-4 sm:p-6">
           <div className="max-w-7xl mx-auto">{children}</div>
         </main>
+
+        {/* Mobile Bottom Navigation — accessibilité 100% sur mobile */}
+        <SharedBottomNav
+          items={manifest.navigation.map((item) => ({
+            href: item.href,
+            label: item.name,
+            icon: item.icon,
+            tourId: item.href.endsWith("/dashboard")
+              ? "nav-dashboard"
+              : item.href.endsWith("/documents")
+              ? "nav-documents"
+              : undefined,
+          }))}
+          moreItems={manifest.footerNavigation.map((item) => ({
+            href: item.href,
+            label: item.name,
+            icon: item.icon,
+          }))}
+          hideAbove="md"
+        />
       </div>
       </OnboardingWrapper>
     </ErrorBoundary>

--- a/app/syndic/layout.tsx
+++ b/app/syndic/layout.tsx
@@ -20,6 +20,7 @@ import { SyndicPlanBanner } from "@/components/syndic/SyndicPlanBanner";
 import { SyndicOnboardingWrapper } from "@/components/syndic/SyndicOnboardingWrapper";
 import { SignOutButton } from "@/components/auth/sign-out-button";
 import { PlatformBroadcastBanner } from "@/components/platform-broadcast-banner";
+import { SharedBottomNav } from "@/components/layout/shared-bottom-nav";
 import Link from "next/link";
 import {
   Building2, Users, Calendar, Euro,
@@ -210,31 +211,26 @@ export default async function SyndicLayout({
           </div>
         </main>
 
-        {/* Mobile Bottom Navigation - Thème light + safe area + touch targets */}
-        <nav
-          className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-xl border-t border-border/50"
-          role="navigation"
-          aria-label="Navigation mobile"
-        >
-          <div className="pb-safe">
-            <div className="grid grid-cols-5 h-14">
-              {[navigation[0], navigation[1], navigation[2], navigation[3], navigation[8]].map((item) => (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className="flex flex-col items-center justify-center gap-0.5 min-h-[44px] text-muted-foreground hover:text-cyan-600 transition-colors"
-                  aria-label={item.name}
-                >
-                  <item.icon className="w-5 h-5" aria-hidden="true" />
-                  <span className="text-[10px] xs:text-[11px] font-medium truncate max-w-[64px]">{item.name.slice(0, 8)}</span>
-                </Link>
-              ))}
-            </div>
-          </div>
-        </nav>
-
-        {/* Spacer pour bottom nav mobile */}
-        <div className="h-14 lg:hidden" aria-hidden="true" />
+        {/* Mobile Bottom Navigation — SharedBottomNav (parité 12/12 items via menu Plus) */}
+        <SharedBottomNav
+          items={[
+            { href: "/syndic/dashboard", label: "Dashboard", icon: LayoutDashboard, tourId: "syndic-dashboard" },
+            { href: "/syndic/sites", label: "Copros", icon: Building2, tourId: "syndic-sites" },
+            { href: "/syndic/accounting", label: "Compta", icon: Calculator, tourId: "syndic-accounting" },
+            { href: "/syndic/calls", label: "Appels", icon: Euro, tourId: "syndic-calls" },
+          ]}
+          moreItems={[
+            { href: "/syndic/assemblies", label: "Assemblées", icon: Calendar, tourId: "syndic-assemblies" },
+            { href: "/syndic/mandates", label: "Mandats", icon: FileText, tourId: "syndic-mandates" },
+            { href: "/syndic/councils", label: "Conseils", icon: Users },
+            { href: "/syndic/fonds-travaux", label: "Fonds travaux", icon: Hammer },
+            { href: "/syndic/expenses", label: "Dépenses", icon: FileText },
+            { href: "/syndic/impayes", label: "Impayés", icon: AlertTriangle },
+            { href: "/syndic/invites", label: "Invitations", icon: UserPlus },
+            { href: "/syndic/settings", label: "Paramètres", icon: Settings },
+          ]}
+          hideAbove="lg"
+        />
       </div>
       </SyndicOnboardingWrapper>
     </ErrorBoundary>

--- a/app/tenant/account-statement/TenantAccountStatementClient.tsx
+++ b/app/tenant/account-statement/TenantAccountStatementClient.tsx
@@ -216,7 +216,52 @@ export function TenantAccountStatementClient({
             PDF.
           </p>
         </div>
-        <div className="overflow-x-auto">
+        {/* Mobile: card layout (< md) */}
+        <div className="md:hidden divide-y divide-border/40">
+          {situation.historique.length === 0 ? (
+            <p className="px-4 py-6 text-center text-sm text-muted-foreground">
+              Aucune echeance enregistree pour le moment.
+            </p>
+          ) : (
+            situation.historique.map((row) => {
+              const variant = STATUS_VARIANT[row.statut];
+              return (
+                <div key={row.periode} className="px-4 py-3 space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {row.periode}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Echeance {new Date(row.date_echeance).toLocaleDateString("fr-FR")}
+                      </p>
+                    </div>
+                    <Badge variant="outline" className={variant.className}>
+                      {variant.label}
+                    </Badge>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2 text-xs">
+                    <div>
+                      <p className="text-muted-foreground">Appele</p>
+                      <p className="font-medium tabular-nums">{formatCurrency(row.montant_appele)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">Paye</p>
+                      <p className="font-medium tabular-nums">{formatCurrency(row.montant_paye)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">Solde</p>
+                      <p className="font-medium tabular-nums">{formatCurrency(row.solde)}</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Desktop: table layout (md+) */}
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-muted/30">
               <tr className="text-left">

--- a/components/layout/admin-sidebar.tsx
+++ b/components/layout/admin-sidebar.tsx
@@ -256,7 +256,7 @@ export function AdminSidebar({ className }: { className?: string }) {
           <Button
             variant="ghost"
             size="icon"
-            className="lg:hidden fixed top-16 left-4 z-50"
+            className="lg:hidden fixed top-3 left-2 sm:top-16 sm:left-4 z-50 bg-background/95 backdrop-blur-sm border border-border/50 shadow-sm"
           >
             <Menu className="h-5 w-5" />
             <span className="sr-only">Ouvrir le menu</span>

--- a/components/layout/owner-app-layout.tsx
+++ b/components/layout/owner-app-layout.tsx
@@ -483,7 +483,9 @@ export function OwnerAppLayout({ children, profile: serverProfile }: OwnerAppLay
               { href: OWNER_ROUTES.contracts.path, label: "Baux", icon: FileText, tourId: "nav-leases" },
             ]}
             moreItems={[
+              { href: OWNER_ROUTES.accounting.path, label: "Comptabilité", icon: Landmark, tourId: "nav-accounting" },
               { href: OWNER_ROUTES.tickets.path, label: "Tickets", icon: Wrench, tourId: "nav-tickets" },
+              { href: "/owner/provider-quotes", label: "Devis", icon: Receipt },
               { href: "/owner/messages", label: "Messages", icon: MessageSquare },
               { href: OWNER_ROUTES.documents.path, label: "Documents", icon: FileCheck, tourId: "nav-documents" },
               { href: "/owner/settings", label: "Paramètres", icon: Settings },

--- a/components/layout/provider-bottom-nav.tsx
+++ b/components/layout/provider-bottom-nav.tsx
@@ -10,6 +10,9 @@ import {
   Shield,
   Settings,
   HelpCircle,
+  MessageSquare,
+  Image as ImageIcon,
+  FolderOpen,
 } from "lucide-react";
 import { SharedBottomNav } from "./shared-bottom-nav";
 
@@ -19,14 +22,16 @@ export function ProviderBottomNav() {
       items={[
         { href: "/provider/dashboard", label: "Dashboard", icon: LayoutDashboard, tourId: "nav-dashboard" },
         { href: "/provider/jobs", label: "Missions", icon: Briefcase, tourId: "nav-jobs" },
+        { href: "/provider/messages", label: "Messages", icon: MessageSquare },
         { href: "/provider/calendar", label: "Calendrier", icon: Calendar, tourId: "nav-calendar" },
-        { href: "/provider/quotes", label: "Devis", icon: FileText, tourId: "nav-quotes" },
       ]}
       moreItems={[
+        { href: "/provider/quotes", label: "Devis", icon: FileText, tourId: "nav-quotes" },
         { href: "/provider/invoices", label: "Factures", icon: Receipt },
-        { href: "/provider/documents", label: "Documents", icon: FileText },
+        { href: "/provider/documents", label: "Documents", icon: FolderOpen },
         { href: "/provider/reviews", label: "Avis", icon: Star, tourId: "nav-reviews" },
         { href: "/provider/compliance", label: "Conformité", icon: Shield },
+        { href: "/provider/portfolio", label: "Portfolio", icon: ImageIcon },
         { href: "/provider/settings", label: "Paramètres", icon: Settings },
         { href: "/provider/help", label: "Aide", icon: HelpCircle },
       ]}

--- a/components/layout/tenant-app-layout.tsx
+++ b/components/layout/tenant-app-layout.tsx
@@ -415,7 +415,7 @@ export function TenantAppLayout({ children, profile: serverProfile }: TenantAppL
           Mobile Bottom Navigation (< md)
           Hidden on tablet+ where rail nav takes over
           ============================================ */}
-      {/* AUDIT UX SOTA 2026: Parité mobile/desktop — même pages accessibles, plus de doublons */}
+      {/* AUDIT UX SOTA 2026: Parité mobile/desktop — 14/14 items accessibles via menu Plus */}
       <SharedBottomNav
         items={[
           { href: "/tenant/dashboard", label: "Accueil", icon: LayoutDashboard, tourId: "nav-dashboard" },
@@ -425,8 +425,13 @@ export function TenantAppLayout({ children, profile: serverProfile }: TenantAppL
         ]}
         moreItems={[
           { href: "/tenant/lease", label: "Mon Logement", icon: Home, tourId: "nav-lease" },
+          { href: "/tenant/inspections", label: "États des lieux", icon: ClipboardCheck, tourId: "nav-inspections" },
+          { href: "/tenant/account-statement", label: "Relevé", icon: Receipt, tourId: "nav-statement" },
+          { href: "/tenant/meters", label: "Compteurs", icon: Gauge, tourId: "nav-meters" },
           { href: "/tenant/messages", label: "Messages", icon: MessageSquare },
           { href: "/tenant/applications", label: "Candidatures", icon: FileSearch },
+          { href: "/tenant/legal-rights", label: "Mes droits", icon: Scale, tourId: "nav-legal-rights" },
+          { href: "/tenant/visits", label: "Visites", icon: Eye, tourId: "nav-visits" },
           { href: "/tenant/settings", label: "Mon Profil", icon: Settings },
           { href: "/tenant/help", label: "Aide", icon: HelpCircle },
         ]}


### PR DESCRIPTION
Mobile bottom navs were missing critical items vs desktop sidebars:

- Syndic: 5/12 → 12/12 (Comptabilité, Appels de fonds, Conseils,
  Fonds travaux, Impayés, Invitations, Paramètres)
- Tenant: 9/14 → 14/14 (États des lieux, Relevé de compte, Compteurs,
  Mes droits, Visites)
- Provider: 10/12 → 12/12 (Messages, Portfolio)
- Owner: 9/11 → 11/11 (Comptabilité, Devis prestataires)
- Copro: replace broken grid-cols-5 (6 items wrapping) with
  SharedBottomNav + footer items in More menu
- Guarantor: add SharedBottomNav for mobile, hide horizontal header
  nav below md to prevent overflow

All roles now use SharedBottomNav (4 primary + N more via sheet),
giving consistent UX, safe-area handling and 44px touch targets.

https://claude.ai/code/session_01C51FxJvJSvTBSLsXKUWpDu