### PR TITLE
fix(accounting): wire dashboard KPIs, balance synthesis, exercise mapping, MV fallback

### DIFF
--- a/app/api/accounting/dashboard/widgets/route.ts
+++ b/app/api/accounting/dashboard/widgets/route.ts
@@ -67,27 +67,68 @@ function yearOf(dateString: string | null | undefined): number | null {
   return Number.isFinite(y) ? y : null;
 }
 
+async function fetchBalanceRows(
+  supabase: ReturnType<typeof getServiceClient>,
+  entityId: string,
+  exerciseId: string,
+): Promise<BalanceRow[]> {
+  // Try the pre-aggregated MV via fn_balance_for_exercise first. The MV
+  // is only refreshed at exercise close / nightly via pg_cron, so for
+  // an open exercise with freshly-validated entries it can be empty or
+  // stale — in that case we fall through to a live aggregation on
+  // accounting_entry_lines so KPIs stay truthful.
+  const { data: mvRows, error: mvErr } = await (supabase as any).rpc(
+    "fn_balance_for_exercise",
+    { p_entity_id: entityId, p_exercise_id: exerciseId },
+  );
+  if (!mvErr && Array.isArray(mvRows) && mvRows.length > 0) {
+    return mvRows as BalanceRow[];
+  }
+
+  const { data: liveRows } = await (supabase as any)
+    .from("accounting_entry_lines")
+    .select(
+      `account_number, debit_cents, credit_cents,
+       accounting_entries!inner(entity_id, exercise_id, is_validated, informational)`,
+    )
+    .eq("accounting_entries.entity_id", entityId)
+    .eq("accounting_entries.exercise_id", exerciseId)
+    .eq("accounting_entries.is_validated", true);
+
+  const aggregated = new Map<string, { debit: number; credit: number }>();
+  for (const line of (liveRows ?? []) as Array<{
+    account_number: string;
+    debit_cents: number;
+    credit_cents: number;
+    accounting_entries:
+      | { informational: boolean }
+      | { informational: boolean }[];
+  }>) {
+    const meta = Array.isArray(line.accounting_entries)
+      ? line.accounting_entries[0]
+      : line.accounting_entries;
+    if (meta?.informational) continue;
+    const cur = aggregated.get(line.account_number) ?? { debit: 0, credit: 0 };
+    cur.debit += n(line.debit_cents);
+    cur.credit += n(line.credit_cents);
+    aggregated.set(line.account_number, cur);
+  }
+  return Array.from(aggregated.entries()).map(([account, totals]) => ({
+    account_number: account,
+    total_debit_cents: totals.debit,
+    total_credit_cents: totals.credit,
+  }));
+}
+
 async function aggregateExerciseBalance(
   supabase: ReturnType<typeof getServiceClient>,
   entityId: string,
   exerciseId: string,
 ): Promise<{ revenueCents: number; expensesCents: number }> {
-  // Lit l'agrégation déjà matérialisée par mv_accounting_balance via la
-  // function SECURITY DEFINER (qui filtre sur entity_members). Fallback :
-  // requête directe sur accounting_entry_lines si la MV n'a pas encore
-  // été refresh sur cet exercice.
-  const { data: rows, error } = await (supabase as any).rpc(
-    "fn_balance_for_exercise",
-    { p_entity_id: entityId, p_exercise_id: exerciseId },
-  );
-
-  if (error || !Array.isArray(rows)) {
-    return { revenueCents: 0, expensesCents: 0 };
-  }
-
+  const rows = await fetchBalanceRows(supabase, entityId, exerciseId);
   let revenueCents = 0;
   let expensesCents = 0;
-  for (const row of rows as BalanceRow[]) {
+  for (const row of rows) {
     const cls = row.account_number.charAt(0);
     if (cls === "7") {
       revenueCents += n(row.total_credit_cents) - n(row.total_debit_cents);
@@ -106,14 +147,9 @@ async function recoverableCharges(
   // Comptes 708xxx = "Produits annexes / charges récupérées".
   // Le solde créditeur correspond aux charges effectivement récupérées
   // sur le locataire pendant l'exercice.
-  const { data: rows } = await (supabase as any).rpc(
-    "fn_balance_for_exercise",
-    { p_entity_id: entityId, p_exercise_id: exerciseId },
-  );
-  if (!Array.isArray(rows)) return 0;
-
+  const rows = await fetchBalanceRows(supabase, entityId, exerciseId);
   let total = 0;
-  for (const row of rows as BalanceRow[]) {
+  for (const row of rows) {
     if (row.account_number.startsWith("708")) {
       total += n(row.total_credit_cents) - n(row.total_debit_cents);
     }

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -377,14 +377,18 @@ export async function getBalance(
   exerciseId: string,
 ): Promise<BalanceItem[]> {
   // Fast path: read from the pre-aggregated materialized view exposed
-  // through fn_balance_for_exercise. Falls back to the legacy aggregation
-  // if the function isn't deployed yet (e.g. local dev without latest migration).
+  // through fn_balance_for_exercise. We only trust the MV when it
+  // returns rows — if it returns an empty array the MV may simply be
+  // stale (it is only refreshed at exercise close, nightly via pg_cron,
+  // or on-demand via fn_refresh_accounting_views), so we fall through
+  // to the live aggregation to stay correct on freshly-validated
+  // entries. Falls back the same way if the function isn't deployed.
   try {
     const { data: mvRows, error: mvErr } = await supabase.rpc(
       'fn_balance_for_exercise',
       { p_entity_id: entityId, p_exercise_id: exerciseId },
     );
-    if (!mvErr && Array.isArray(mvRows)) {
+    if (!mvErr && Array.isArray(mvRows) && mvRows.length > 0) {
       return (mvRows as Array<{
         account_number: string;
         account_label: string;


### PR DESCRIPTION
## Summary

Reported issue: KPIs of the accounting dashboard rendered 0 € everywhere, the monthly chart never appeared, and the Balance / Grand-livre subtitles showed "undefined → undefined". The Top biens widget paradoxically showed real revenue (125 €) on the same exercise, exposing an internal inconsistency.

Three root causes were chained together — each commit fixes one.

### `0da29d9` — Dashboard hook ↔ API shape mismatch
- Hook expected `AccountingBalance` (revenue/expenses/result/monthlySeries).
- API returned `BalanceItem[]` (per-account breakdown).
- Added `?format=summary` mode on `/api/accounting/exercises/[id]/balance` that aggregates classes 6/7 and the monthly series **server-side** (no financial math frontend, per skill rule).
- Added a Recettes / Charges / Résultat synthesis banner at the top of the Balance page — the headline summary expected of a balance générale.

### `17502e9` — snake_case ↔ camelCase + defensive bootstrap
- `/api/accounting/exercises` returned raw snake_case rows; 5 consumers (Balance, Grand-livre, Rendement, Exports, dashboard hook) read camelCase → "Exercice du undefined au undefined" everywhere.
- Response now exposes both cases plus a synthesized `label` ("Exercice 2026").
- Added a defensive bootstrap: if an entity has zero rows in `accounting_exercises` (pre-dates the trigger from `20260418170000_enforce_fiscal_year_dates`, or trigger raced), one is created on the fly from `premier_exercice_debut/fin`.

### `5c5d603` — Stale materialized view masking real data
- `getBalance()` and the widgets `aggregateExerciseBalance` / `recoverableCharges` all read from `fn_balance_for_exercise`, which serves the MV `mv_accounting_balance`.
- That MV is only refreshed at exercise close, nightly via pg_cron, or on-demand — for an open exercise with freshly validated entries it stays empty.
- `v_pnl_by_property` (used by Top biens) is a regular view → live → showed 125 € while the others showed 0.
- Both call sites now treat an empty MV result as "stale, fall through" and run the live aggregation against `accounting_entry_lines`. The MV fast path stays intact when populated, so no perf regression on entities with thousands of entries.

## Test plan

- [ ] Open `/owner/accounting` on the production account that reported the bug → Recettes / Dépenses / Résultat reflect classes 7 / 6 / Δ.
- [ ] Monthly chart renders when at least one validated entry exists.
- [ ] Subtitle reads "Exercice : Exercice 2026 (En cours)" instead of "undefined".
- [ ] Open `/owner/accounting/balance` → synthesis banner (Recettes / Charges / Résultat) appears above the per-class tables.
- [ ] "2026 vs N-1" widget aligns with Top biens (was 0 € while Top biens showed 125 €).
- [ ] Existing snake_case consumers (`/owner/accounting/exercises`, `/owner/accounting/declarations`, `/ec/[entityId]`) keep working — the response now carries both shapes.

https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL)_