### PR TITLE
fix(accounting): auto-seed chart, fix 120/120000 closing bug, add missing accounts

### DIFF
--- a/app/api/accounting/chart/route.ts
+++ b/app/api/accounting/chart/route.ts
@@ -6,9 +6,14 @@
 
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 import { handleApiError, ApiError } from "@/lib/helpers/api-error";
 import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
-import { addCustomAccount } from "@/lib/accounting/chart-amort-ocr";
+import {
+  addCustomAccount,
+  initializeChartOfAccounts,
+} from "@/lib/accounting/chart-amort-ocr";
+import { initializeJournals } from "@/lib/accounting/engine";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
@@ -53,7 +58,9 @@ export async function GET(request: Request) {
       throw new ApiError(400, "entityId est requis");
     }
 
-    const { data: accounts, error } = await (supabase as any)
+    const serviceClient = getServiceClient();
+
+    const { data: accounts, error } = await (serviceClient as any)
       .from("chart_of_accounts")
       .select("*")
       .eq("entity_id", entityId)
@@ -63,7 +70,34 @@ export async function GET(request: Request) {
       throw new ApiError(500, "Erreur lors de la recuperation du plan comptable");
     }
 
-    return NextResponse.json({ success: true, data: { accounts: accounts || [] } });
+    let rows: Array<Record<string, unknown>> = accounts ?? [];
+
+    // Defensive auto-seed: nothing seeds chart_of_accounts at entity
+    // creation today (the trigger fn_legal_entities_bootstrap_exercise
+    // only creates the exercise, not the chart). Without this fallback
+    // the page lands on an empty state forever — and the empty state
+    // message even claims that creating an exercise will fix it, which
+    // is false. We seed PCG by default the first time the chart is
+    // requested, idempotent on the underlying upsert, and also init
+    // journals while we're at it (closeExercise needs CL).
+    if (rows.length === 0) {
+      try {
+        await initializeChartOfAccounts(serviceClient, entityId, "pcg");
+        await initializeJournals(serviceClient, entityId);
+        const { data: seeded } = await (serviceClient as any)
+          .from("chart_of_accounts")
+          .select("*")
+          .eq("entity_id", entityId)
+          .order("account_number", { ascending: true });
+        rows = seeded ?? [];
+      } catch (seedErr) {
+        console.error("[Chart API] auto-seed failed:", seedErr);
+        // Fall through with the empty list — the user can still seed
+        // manually via /api/accounting/chart/seed.
+      }
+    }
+
+    return NextResponse.json({ success: true, data: { accounts: rows } });
   } catch (error) {
     return handleApiError(error);
   }

--- a/lib/accounting/chart-amort-ocr.ts
+++ b/lib/accounting/chart-amort-ocr.ts
@@ -58,14 +58,20 @@ export const PCG_OWNER_ACCOUNTS = [
   { account_number: '512200', label: 'Banque — compte epargne', account_type: 'asset' as const },
   { account_number: '512300', label: 'Banque — depots de garantie', account_type: 'asset' as const },
   { account_number: '530000', label: 'Caisse', account_type: 'asset' as const },
+  // 545000 — Banque mandant (Hoguet). Referenced by agency_loyer_mandant
+  // and agency_reversement auto-entries; without it those auto-entries
+  // produced orphan accounts on the balance.
+  { account_number: '545000', label: 'Banque — compte mandant (Hoguet)', account_type: 'asset' as const },
   { account_number: '581000', label: 'Virements internes', account_type: 'asset' as const },
   // Classe 6 — Charges
   { account_number: '606100', label: 'Fournitures entretien', account_type: 'expense' as const },
+  { account_number: '613200', label: 'Locations immobilieres', account_type: 'expense' as const },
   { account_number: '613000', label: 'Provisions pour charges', account_type: 'expense' as const },
   { account_number: '614100', label: 'Charges reelles recuperables', account_type: 'expense' as const },
   { account_number: '615100', label: 'Travaux et reparations', account_type: 'expense' as const },
   { account_number: '616000', label: 'Assurances', account_type: 'expense' as const },
   { account_number: '622000', label: 'Honoraires comptables', account_type: 'expense' as const },
+  { account_number: '622600', label: 'Honoraires juridiques (avocats, notaires)', account_type: 'expense' as const },
   { account_number: '622800', label: 'Honoraires / commissions divers', account_type: 'expense' as const },
   { account_number: '623000', label: 'Publicite et annonces', account_type: 'expense' as const },
   { account_number: '625100', label: 'Deplacements', account_type: 'expense' as const },
@@ -82,7 +88,10 @@ export const PCG_OWNER_ACCOUNTS = [
   // Classe 7 — Produits
   { account_number: '706000', label: 'Loyers', account_type: 'income' as const },
   { account_number: '706100', label: 'Honoraires de gestion', account_type: 'income' as const },
+  { account_number: '706300', label: 'Indemnites d\'occupation', account_type: 'income' as const },
   { account_number: '708000', label: 'Charges recuperees / TEOM', account_type: 'income' as const },
+  { account_number: '758000', label: 'Produits divers de gestion courante', account_type: 'income' as const },
+  { account_number: '758100', label: 'Indemnites d\'assurance', account_type: 'income' as const },
   { account_number: '764000', label: 'Revenus placements', account_type: 'income' as const },
   { account_number: '775000', label: 'Produits cession immobilisations', account_type: 'income' as const },
   { account_number: '791000', label: 'Retenues sur depot de garantie', account_type: 'income' as const },

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -1334,13 +1334,13 @@ export async function generateClosingEntry(
     // Wait — products were debited to zero. So debit side = class7Net.
     // Charges were credited to zero. So credit side = class6Net.
     // To balance we need credit side += netResult, hence credit 120 of netResult.
-    lines.push({ accountNumber: '120', debitCents: 0, creditCents: netResultCents });
+    lines.push({ accountNumber: '120000', debitCents: 0, creditCents: netResultCents });
   } else if (netResultCents < 0) {
-    // Loss: debit 120
-    lines.push({ accountNumber: '120', debitCents: -netResultCents, creditCents: 0 });
+    // Loss: debit 120000
+    lines.push({ accountNumber: '120000', debitCents: -netResultCents, creditCents: 0 });
   } else if (lines.length > 0) {
-    // Exactly break-even but we still need a reference to 120 for traceability.
-    lines.push({ accountNumber: '120', debitCents: 0, creditCents: 0 });
+    // Exactly break-even but we still need a reference to 120000 for traceability.
+    lines.push({ accountNumber: '120000', debitCents: 0, creditCents: 0 });
   }
 
   if (lines.length === 0) {


### PR DESCRIPTION
## Summary

User reported "le plan comptable n'est pas complet" on the production dashboard. Three distinct problems were stacked.

### 1. No auto-seed at entity creation
`fn_legal_entities_bootstrap_exercise` (migration `20260418170000`) creates the exercise but **nothing** seeds `chart_of_accounts`. The empty-state on `/owner/accounting/chart` even tells the user that creating an exercise will fix it — false.

`GET /api/accounting/chart` now defensively initializes the PCG plan (and journals — `closeExercise` needs the CL journal) the first time the chart is requested for an entity with zero accounts. Same pattern as the defensive exercise bootstrap from PR #534. Idempotent on the underlying upsert.

### 2. `closeExercise` produced an orphan "120" account
`generateClosingEntry` (engine.ts) inserted lines on `accountNumber: '120'` while `PCG_OWNER_ACCOUNTS` only defines `'120000'` (Résultat de l'exercice). Every closed exercise ended up with a "120" row in balance/grand-livre with no label, detached from the rest of the chart. Fixed to `'120000'`.

### 3. Missing accounts referenced by auto-entries and common flows
Added to `PCG_OWNER_ACCOUNTS`:
- **545000** Banque mandant Hoguet — referenced by `agency_loyer_mandant` and `agency_reversement` auto-entries; without it those produced orphan accounts on the balance.
- **613200** Locations immobilières
- **622600** Honoraires juridiques (avocats, notaires)
- **706300** Indemnités d'occupation
- **758000** Produits divers de gestion courante
- **758100** Indemnités d'assurance

## Test plan

- [ ] Open `/owner/accounting/chart` on an entity that had an empty chart → list now populates with the full PCG plan (60+ comptes) on first load.
- [ ] Existing entities with custom additions still see their custom accounts (idempotent upsert).
- [ ] Close an exercise → CL journal entry references `120000` not `120`; the resulting balance shows "Resultat de l'exercice" with its proper label.
- [ ] Trigger an `agency_reversement` auto-entry → 545000 resolves to "Banque — compte mandant (Hoguet)" instead of an orphan code.

https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL)_