### PR TITLE
feat(accounting): enrich PCG (+33), 5 new auto-entries, opt-in VAT

### DIFF
--- a/lib/accounting/chart-amort-ocr.ts
+++ b/lib/accounting/chart-amort-ocr.ts
@@ -48,10 +48,24 @@ export const PCG_OWNER_ACCOUNTS = [
   { account_number: '416000', label: 'Locataires douteux ou litigieux', account_type: 'asset' as const },
   { account_number: '419100', label: 'Provisions de charges recues', account_type: 'liability' as const },
   { account_number: '421000', label: 'Personnel — remuneration', account_type: 'liability' as const },
-  { account_number: '431000', label: 'Securite sociale', account_type: 'liability' as const },
-  { account_number: '444000', label: 'Etat — impots sur les benefices', account_type: 'liability' as const },
-  { account_number: '445660', label: 'TVA deductible', account_type: 'asset' as const },
+  { account_number: '431000', label: 'Securite sociale (URSSAF)', account_type: 'liability' as const },
+  // Cotisations sociales détaillées : indispensables pour SCI ou
+  // agence avec gardien, employé d'immeuble ou propriétaire-exploitant.
+  { account_number: '437000', label: 'Autres organismes sociaux (mutuelle, prevoyance, retraite)', account_type: 'liability' as const },
+  { account_number: '438000', label: 'Charges sociales sur conges payes', account_type: 'liability' as const },
+  { account_number: '444000', label: 'Etat — impots sur les benefices (IS)', account_type: 'liability' as const },
+  // Comptes TVA détaillés : la SCI à l'IS avec option TVA, le LMP, ou
+  // toute location pro doivent ventiler TVA collectee/deductible.
+  { account_number: '445510', label: 'TVA a decaisser', account_type: 'liability' as const },
+  { account_number: '445520', label: 'TVA due intra-communautaire', account_type: 'liability' as const },
+  { account_number: '445580', label: 'TVA a regulariser', account_type: 'liability' as const },
+  { account_number: '445660', label: 'TVA deductible sur biens et services', account_type: 'asset' as const },
+  { account_number: '445662', label: 'TVA deductible sur immobilisations', account_type: 'asset' as const },
+  { account_number: '445670', label: 'Credit de TVA a reporter', account_type: 'asset' as const },
   { account_number: '445710', label: 'TVA collectee', account_type: 'liability' as const },
+  // Comptes courants associes / dividendes — vie sociale SCI/SARL.
+  { account_number: '455000', label: 'Comptes courants associes', account_type: 'liability' as const },
+  { account_number: '457000', label: 'Associes — dividendes a payer', account_type: 'liability' as const },
   { account_number: '467000', label: 'Mandant — compte courant', account_type: 'liability' as const },
   // Classe 5 — Tresorerie
   { account_number: '512100', label: 'Banque — compte courant', account_type: 'asset' as const },
@@ -77,23 +91,56 @@ export const PCG_OWNER_ACCOUNTS = [
   { account_number: '625100', label: 'Deplacements', account_type: 'expense' as const },
   { account_number: '626000', label: 'Frais postaux / telecom', account_type: 'expense' as const },
   { account_number: '627000', label: 'Frais bancaires', account_type: 'expense' as const },
+  // Impots et taxes (635xxx) — autres que sur les benefices.
   { account_number: '635100', label: 'Taxe fonciere', account_type: 'expense' as const },
   { account_number: '635200', label: 'TEOM', account_type: 'expense' as const },
+  { account_number: '635300', label: 'Droits d\'enregistrement (acquisition)', account_type: 'expense' as const },
+  { account_number: '635400', label: 'CFE — cotisation fonciere des entreprises', account_type: 'expense' as const },
+  { account_number: '635600', label: 'IFI — impot sur la fortune immobiliere', account_type: 'expense' as const },
+  { account_number: '637000', label: 'Autres impots, taxes et versements assimiles', account_type: 'expense' as const },
+  // Charges de personnel (64xxx) — pour SCI/agence avec gardien ou employe.
+  { account_number: '641100', label: 'Salaires et appointements', account_type: 'expense' as const },
+  { account_number: '641200', label: 'Conges payes', account_type: 'expense' as const },
+  { account_number: '645100', label: 'Cotisations URSSAF (charges patronales)', account_type: 'expense' as const },
+  { account_number: '645300', label: 'Cotisations retraite (AGIRC-ARRCO)', account_type: 'expense' as const },
+  { account_number: '645400', label: 'Cotisations Pole emploi', account_type: 'expense' as const },
+  { account_number: '647800', label: 'Prevoyance, mutuelle, autres charges sociales', account_type: 'expense' as const },
+  { account_number: '648100', label: 'Medecine du travail / formation', account_type: 'expense' as const },
   { account_number: '654000', label: 'Pertes sur creances irrecouvrables', account_type: 'expense' as const },
   { account_number: '661000', label: 'Interets emprunts', account_type: 'expense' as const },
+  { account_number: '668000', label: 'Autres charges financieres', account_type: 'expense' as const },
+  // Charges exceptionnelles (67xxx) — indemnites versees, rappels d'impots.
   { account_number: '671000', label: 'Charges exceptionnelles', account_type: 'expense' as const },
+  { account_number: '671300', label: 'Indemnites d\'eviction / indemnites versees', account_type: 'expense' as const },
+  { account_number: '671500', label: 'Penalites, amendes fiscales et penales', account_type: 'expense' as const },
   { account_number: '675000', label: 'Valeur comptable elements actif cedes', account_type: 'expense' as const },
+  { account_number: '678000', label: 'Autres charges exceptionnelles', account_type: 'expense' as const },
   { account_number: '681100', label: 'Dotations aux amortissements', account_type: 'expense' as const },
+  // Impots sur les benefices et prelevements sociaux (69xxx).
+  { account_number: '695000', label: 'Impot sur les benefices (IS)', account_type: 'expense' as const },
+  { account_number: '695100', label: 'Prelevements sociaux 17,2% (revenus fonciers IR)', account_type: 'expense' as const },
   { account_number: '699000', label: 'Compte memo / OD', account_type: 'expense' as const },
   // Classe 7 — Produits
   { account_number: '706000', label: 'Loyers', account_type: 'income' as const },
   { account_number: '706100', label: 'Honoraires de gestion', account_type: 'income' as const },
   { account_number: '706300', label: 'Indemnites d\'occupation', account_type: 'income' as const },
-  { account_number: '708000', label: 'Charges recuperees / TEOM', account_type: 'income' as const },
+  // Charges recuperees ventilees (708xxx) — convention immobilier
+  // alignee sur la 2044 et l'audit fiscal. Le 708000 reste un fallback
+  // pour les recuperations non ventilees ; tout nouveau code applicatif
+  // doit cibler le sous-compte adequat (eau, TEOM, electricite, etc.)
+  // afin de rendre la ventilation auditable.
+  { account_number: '708000', label: 'Charges recuperees — non ventilees (fallback)', account_type: 'income' as const },
+  { account_number: '708100', label: 'Charges recuperees — eau', account_type: 'income' as const },
+  { account_number: '708200', label: 'Charges recuperees — TEOM', account_type: 'income' as const },
+  { account_number: '708300', label: 'Charges recuperees — electricite parties privatives', account_type: 'income' as const },
+  { account_number: '708400', label: 'Charges recuperees — chauffage collectif', account_type: 'income' as const },
+  { account_number: '708500', label: 'Charges recuperees — entretien parties communes (copro)', account_type: 'income' as const },
+  { account_number: '708800', label: 'Charges recuperees — autres', account_type: 'income' as const },
   { account_number: '758000', label: 'Produits divers de gestion courante', account_type: 'income' as const },
   { account_number: '758100', label: 'Indemnites d\'assurance', account_type: 'income' as const },
   { account_number: '764000', label: 'Revenus placements', account_type: 'income' as const },
   { account_number: '775000', label: 'Produits cession immobilisations', account_type: 'income' as const },
+  { account_number: '778000', label: 'Autres produits exceptionnels', account_type: 'income' as const },
   { account_number: '791000', label: 'Retenues sur depot de garantie', account_type: 'income' as const },
 ] as const;
 

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -1048,9 +1048,12 @@ const AUTO_ENTRIES: Record<
     source: 'auto:teom_recovered',
     reference: ctx.reference,
     userId: ctx.userId,
+    // Credit 708200 (TEOM specifiquement) au lieu du 708000 generique :
+    // garde la tracabilite par type de charge recuperee pour la 2044
+    // et l'audit fiscal.
     lines: [
       { accountNumber: '635200', debitCents: ctx.amountCents, creditCents: 0 },
-      { accountNumber: '708000', debitCents: 0, creditCents: ctx.amountCents },
+      { accountNumber: '708200', debitCents: 0, creditCents: ctx.amountCents },
     ],
   }),
 

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -148,7 +148,12 @@ export type AutoEntryEvent =
   | 'copro_closing'
   | 'teom_recovered'
   | 'charge_regularization'
-  | 'subscription_paid';
+  | 'subscription_paid'
+  | 'loan_payment'
+  | 'tax_paid'
+  | 'social_charges_foncier_paid'
+  | 'payroll'
+  | 'insurance_indemnity_received';
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -670,6 +675,23 @@ interface AutoEntryContext {
   bankAccount?: string;
   /** Target copro lot account */
   coproAccount?: string;
+  /**
+   * Override du compte de charge fiscale pour `tax_paid`. Permet de
+   * cibler 635100 (taxe fonciere), 635400 (CFE), 635600 (IFI), ou
+   * 695000 (IS) sans avoir un builder par taxe. Defaut : 635100.
+   */
+  taxAccount?: string;
+  /**
+   * Taux de TVA en basis points (1 % = 100 bps) pour les builders qui
+   * supportent la ventilation TVA. Quand renseigne et > 0, amountCents
+   * est interprete comme un montant TTC ; HT et TVA sont injectes
+   * automatiquement sur les comptes adequats (445660 deductible /
+   * 445710 collectee). 0 ou undefined → mode HT historique, aucune
+   * ligne TVA generee.
+   * Exemples : 2000 = 20 %, 1000 = 10 %, 850 = 8,5 % (DROM),
+   * 550 = 5,5 %, 210 = 2,1 % (presse), 0 = exonere.
+   */
+  vatRateBps?: number;
   // ── Axes analytiques (cf. migration 20260427200000) ──
   // Propagés sur TOUTES les lignes de l'écriture pour permettre P&L par bien
   // et grand livre par tiers. Optionnels : aucun changement de comportement
@@ -680,6 +702,32 @@ interface AutoEntryContext {
   /** Tiers (locataire/fournisseur/propriétaire) pour sous-compte auxiliaire. */
   thirdPartyType?: 'tenant' | 'landlord' | 'vendor' | 'mandant' | 'copro_owner' | 'employee' | 'tax_authority';
   thirdPartyId?: string;
+}
+
+/**
+ * Decompose un montant TTC en (HT, TVA) avec arrondi standard.
+ * Le ratio est `vatRateBps / (10000 + vatRateBps)` pour rester
+ * 100 % en INTEGER cents (jamais de float intermediaire).
+ *
+ * Exemple : splitTTC(120_00, 2000) → { htCents: 100_00, vatCents: 20_00 }
+ *
+ * REGLE : si vatRateBps <= 0, retourne { htCents: ttcCents, vatCents: 0 }
+ *         (tout le montant est HT/exonere).
+ */
+export function splitTTC(
+  ttcCents: number,
+  vatRateBps: number,
+): { htCents: number; vatCents: number } {
+  if (!Number.isInteger(ttcCents) || ttcCents < 0) {
+    throw new Error('splitTTC: ttcCents doit etre un entier positif');
+  }
+  if (!vatRateBps || vatRateBps <= 0) {
+    return { htCents: ttcCents, vatCents: 0 };
+  }
+  const denom = 10000 + vatRateBps;
+  const vatCents = Math.round((ttcCents * vatRateBps) / denom);
+  const htCents = ttcCents - vatCents;
+  return { htCents, vatCents };
 }
 
 /** Helper : applique les axes analytiques du contexte sur chaque ligne. */
@@ -800,20 +848,35 @@ const AUTO_ENTRIES: Record<
     ],
   }),
 
-  supplier_invoice: (ctx) => ({
-    entityId: ctx.entityId,
-    exerciseId: ctx.exerciseId,
-    journalCode: 'ACH',
-    entryDate: ctx.date,
-    label: ctx.label || 'Facture fournisseur',
-    source: 'auto:supplier_invoice',
-    reference: ctx.reference,
-    userId: ctx.userId,
-    lines: [
-      { accountNumber: '615100', debitCents: ctx.amountCents, creditCents: 0 },
-      { accountNumber: '401000', debitCents: 0, creditCents: ctx.amountCents },
-    ],
-  }),
+  supplier_invoice: (ctx) => {
+    // Si vatRateBps est renseigne et > 0, on traite amountCents comme
+    // un TTC : on ventile HT en 615100 et TVA en 445660 (deductible).
+    // Sinon (mode historique), tout le montant atterrit sur 615100.
+    const { htCents, vatCents } = splitTTC(ctx.amountCents, ctx.vatRateBps ?? 0);
+    const lines: EntryLine[] = [
+      { accountNumber: '615100', debitCents: htCents, creditCents: 0, label: 'Travaux HT' },
+    ];
+    if (vatCents > 0) {
+      lines.push({
+        accountNumber: '445660',
+        debitCents: vatCents,
+        creditCents: 0,
+        label: 'TVA deductible',
+      });
+    }
+    lines.push({ accountNumber: '401000', debitCents: 0, creditCents: ctx.amountCents });
+    return {
+      entityId: ctx.entityId,
+      exerciseId: ctx.exerciseId,
+      journalCode: 'ACH',
+      entryDate: ctx.date,
+      label: ctx.label || 'Facture fournisseur',
+      source: 'auto:supplier_invoice',
+      reference: ctx.reference,
+      userId: ctx.userId,
+      lines: withAxes(ctx, lines),
+    };
+  },
 
   supplier_payment: (ctx) => ({
     entityId: ctx.entityId,
@@ -937,21 +1000,36 @@ const AUTO_ENTRIES: Record<
    * D 467MXXX (compte courant mandant) / C 706100 (Honoraires de gestion).
    * Pour scoper sur un mandant précis, passer thirdPartyType='mandant' +
    * thirdPartyId : l'auxiliary-resolver substitue 467000 par 467MXXXXX.
+   *
+   * Avec vatRateBps > 0 : amountCents est traite comme TTC. La TVA
+   * collectee (445710) est ventilee, et le 706100 ne recoit que le HT.
    */
-  agency_commission: (ctx) => ({
-    entityId: ctx.entityId,
-    exerciseId: ctx.exerciseId,
-    journalCode: 'VE',
-    entryDate: ctx.date,
-    label: ctx.label || 'Honoraires agence',
-    source: 'auto:agency_commission',
-    reference: ctx.reference,
-    userId: ctx.userId,
-    lines: withAxes(ctx, [
+  agency_commission: (ctx) => {
+    const { htCents, vatCents } = splitTTC(ctx.amountCents, ctx.vatRateBps ?? 0);
+    const lines: EntryLine[] = [
       { accountNumber: '467000', debitCents: ctx.amountCents, creditCents: 0 },
-      { accountNumber: '706100', debitCents: 0, creditCents: ctx.amountCents },
-    ]),
-  }),
+      { accountNumber: '706100', debitCents: 0, creditCents: htCents, label: 'Honoraires HT' },
+    ];
+    if (vatCents > 0) {
+      lines.push({
+        accountNumber: '445710',
+        debitCents: 0,
+        creditCents: vatCents,
+        label: 'TVA collectee',
+      });
+    }
+    return {
+      entityId: ctx.entityId,
+      exerciseId: ctx.exerciseId,
+      journalCode: 'VE',
+      entryDate: ctx.date,
+      label: ctx.label || 'Honoraires agence',
+      source: 'auto:agency_commission',
+      reference: ctx.reference,
+      userId: ctx.userId,
+      lines: withAxes(ctx, lines),
+    };
+  },
 
   /**
    * Reversement net au propriétaire mandant (loyers - commissions - charges).
@@ -1101,6 +1179,143 @@ const AUTO_ENTRIES: Record<
       { accountNumber: '622800', debitCents: ctx.amountCents, creditCents: 0 },
       { accountNumber: ctx.bankAccount ?? '512100', debitCents: 0, creditCents: ctx.amountCents },
     ],
+  }),
+
+  /**
+   * Echeance d'un credit immobilier : split entre interets (charge
+   * deductible classe 6) et capital (remboursement de la dette
+   * classe 1). amountCents = montant total preleve, secondaryAmountCents
+   * = portion interets. Capital rembourse = amountCents - secondaryAmountCents.
+   * D 661000 (interets) / D 164000 (capital) / C 512100 (banque).
+   */
+  loan_payment: (ctx) => {
+    const interestCents = ctx.secondaryAmountCents ?? 0;
+    const capitalCents = ctx.amountCents - interestCents;
+    if (capitalCents < 0) {
+      throw new Error('loan_payment: secondaryAmountCents (interets) doit etre <= amountCents (echeance totale)');
+    }
+    const lines: EntryLine[] = [];
+    if (interestCents > 0) {
+      lines.push({ accountNumber: '661000', debitCents: interestCents, creditCents: 0, label: 'Interets' });
+    }
+    if (capitalCents > 0) {
+      lines.push({ accountNumber: '164000', debitCents: capitalCents, creditCents: 0, label: 'Capital rembourse' });
+    }
+    lines.push({
+      accountNumber: ctx.bankAccount ?? '512100',
+      debitCents: 0,
+      creditCents: ctx.amountCents,
+    });
+    return {
+      entityId: ctx.entityId,
+      exerciseId: ctx.exerciseId,
+      journalCode: 'BQ',
+      entryDate: ctx.date,
+      label: ctx.label || 'Echeance credit immobilier',
+      source: 'auto:loan_payment',
+      reference: ctx.reference,
+      userId: ctx.userId,
+      lines: withAxes(ctx, lines),
+    };
+  },
+
+  /**
+   * Paiement d'une taxe / impot. Le compte de charge est passe via
+   * ctx.taxAccount (defaut 635100 taxe fonciere). Exemples :
+   *   taxAccount=635100 → taxe fonciere
+   *   taxAccount=635400 → CFE
+   *   taxAccount=635600 → IFI
+   *   taxAccount=695000 → IS
+   * D taxAccount / C 512100.
+   */
+  tax_paid: (ctx) => ({
+    entityId: ctx.entityId,
+    exerciseId: ctx.exerciseId,
+    journalCode: 'BQ',
+    entryDate: ctx.date,
+    label: ctx.label || 'Paiement taxe / impot',
+    source: 'auto:tax_paid',
+    reference: ctx.reference,
+    userId: ctx.userId,
+    lines: withAxes(ctx, [
+      { accountNumber: ctx.taxAccount ?? '635100', debitCents: ctx.amountCents, creditCents: 0 },
+      { accountNumber: ctx.bankAccount ?? '512100', debitCents: 0, creditCents: ctx.amountCents },
+    ]),
+  }),
+
+  /**
+   * Prelevements sociaux 17,2 % sur revenus fonciers (regime IR).
+   * CSG 9,2 + CRDS 0,5 + solidarite 7,5 = 17,2 % du revenu foncier net.
+   * D 695100 / C 512100.
+   */
+  social_charges_foncier_paid: (ctx) => ({
+    entityId: ctx.entityId,
+    exerciseId: ctx.exerciseId,
+    journalCode: 'BQ',
+    entryDate: ctx.date,
+    label: ctx.label || 'Prelevements sociaux 17,2% sur revenus fonciers',
+    source: 'auto:social_charges_foncier_paid',
+    reference: ctx.reference,
+    userId: ctx.userId,
+    lines: withAxes(ctx, [
+      { accountNumber: '695100', debitCents: ctx.amountCents, creditCents: 0 },
+      { accountNumber: ctx.bankAccount ?? '512100', debitCents: 0, creditCents: ctx.amountCents },
+    ]),
+  }),
+
+  /**
+   * Paie d'un gardien / employe d'immeuble. Version simplifiee :
+   *   amountCents          = brut
+   *   secondaryAmountCents = cotisations patronales totales
+   * Le tout debite contre la banque pour eviter de gerer un cycle
+   * 421/431 separe (le comptable peut affiner manuellement si besoin).
+   * D 641100 (brut) + D 645100 (cotisations) / C 512100.
+   */
+  payroll: (ctx) => {
+    const cotisationsCents = ctx.secondaryAmountCents ?? 0;
+    const total = ctx.amountCents + cotisationsCents;
+    const lines: EntryLine[] = [
+      { accountNumber: '641100', debitCents: ctx.amountCents, creditCents: 0, label: 'Salaire brut' },
+    ];
+    if (cotisationsCents > 0) {
+      lines.push({
+        accountNumber: '645100',
+        debitCents: cotisationsCents,
+        creditCents: 0,
+        label: 'Cotisations sociales patronales',
+      });
+    }
+    lines.push({ accountNumber: ctx.bankAccount ?? '512100', debitCents: 0, creditCents: total });
+    return {
+      entityId: ctx.entityId,
+      exerciseId: ctx.exerciseId,
+      journalCode: 'BQ',
+      entryDate: ctx.date,
+      label: ctx.label || 'Paie gardien / employe',
+      source: 'auto:payroll',
+      reference: ctx.reference,
+      userId: ctx.userId,
+      lines: withAxes(ctx, lines),
+    };
+  },
+
+  /**
+   * Indemnite d'assurance recue suite a sinistre.
+   * D 512100 / C 758100.
+   */
+  insurance_indemnity_received: (ctx) => ({
+    entityId: ctx.entityId,
+    exerciseId: ctx.exerciseId,
+    journalCode: 'BQ',
+    entryDate: ctx.date,
+    label: ctx.label || 'Indemnite d\'assurance recue',
+    source: 'auto:insurance_indemnity_received',
+    reference: ctx.reference,
+    userId: ctx.userId,
+    lines: withAxes(ctx, [
+      { accountNumber: ctx.bankAccount ?? '512100', debitCents: ctx.amountCents, creditCents: 0 },
+      { accountNumber: '758100', debitCents: 0, creditCents: ctx.amountCents },
+    ]),
   }),
 };
 


### PR DESCRIPTION
## Summary

Suite de la conversation "le plan comptable n'est pas complet" (PR #535 a posé l'auto-seed et 6 comptes critiques). Cette PR comble les vrais trous : ~33 comptes ajoutés, 5 nouveaux auto-entries pour les scénarios fiscaux/sociaux courants, et une ventilation TVA opt-in sur les builders qui en ont besoin.

### Lot A — PCG enrichi (66 → 99 comptes)

| Catégorie | Comptes ajoutés |
|---|---|
| **TVA** | 445510 TVA à décaisser, 445520 intra-com, 445580 à régulariser, 445662 TVA déd. immos, 445670 crédit TVA |
| **Personnel** | 437000 autres organismes sociaux, 438000 charges sur CP, 641100 salaires, 641200 CP, 645100 URSSAF, 645300 retraite, 645400 Pôle emploi, 647800 prévoyance, 648100 médecine W |
| **Fiscalité** | 635300 droits enregistrement, 635400 CFE, 635600 IFI, 637000 autres impôts, 695000 IS, 695100 prélèvements sociaux 17,2% |
| **Vie sociale** | 455000 CC associés, 457000 dividendes à payer |
| **Exceptionnel** | 671300 indemnités d'éviction, 671500 pénalités/amendes, 678000 autres charges except., 778000 autres produits except., 668000 autres charges fin. |
| **708 ventilé** | 708000 fallback, 708100 eau, 708200 TEOM, 708300 électricité, 708400 chauffage, 708500 entretien copro, 708800 autres |

Plus : `teom_recovered` re-route vers `708200` (au lieu du 708000 générique) pour préserver la traçabilité par type de charge récupérée pour la 2044 et l'audit fiscal.

### Lot B — 5 nouveaux auto-entries

- **`loan_payment`** — échéance crédit immo, split intérêts (661000) / capital (164000) / banque. `amountCents` = total prélevé, `secondaryAmountCents` = portion intérêts.
- **`tax_paid`** — paiement générique d'une taxe ; compte cible via `ctx.taxAccount` (635100 défaut, 635400 CFE, 635600 IFI, 695000 IS).
- **`social_charges_foncier_paid`** — prélèvements sociaux 17,2% sur revenus fonciers IR. D 695100 / C 512100.
- **`payroll`** — paie gardien (version simplifiée). `amountCents` = brut, `secondaryAmountCents` = cotisations patronales. D 641100 + D 645100 / C 512100.
- **`insurance_indemnity_received`** — indemnité assurance reçue. D 512100 / C 758100.

### Lot C — TVA opt-in

- **`splitTTC(ttcCents, vatRateBps)`** — utilitaire exporté, décompose un TTC `INTEGER` en (HT, TVA) sans float intermédiaire.
- **`AutoEntryContext.vatRateBps`** — taux en basis points (2000=20%, 1000=10%, 850=8,5% DROM, 550=5,5%, 0=exonéré).
- **`supplier_invoice`** — si `vatRateBps > 0` : ventile HT (615100) + TVA déductible (445660) face au fournisseur en TTC.
- **`agency_commission`** — si `vatRateBps > 0` : ventile HT (706100) + TVA collectée (445710) face au mandant en TTC.

Sans `vatRateBps`, les builders gardent leur comportement HT historique. Aucun caller existant cassé.

## Test plan

- [ ] `/owner/accounting/chart` : 99 comptes PCG owner après auto-seed (vs 66 avant), classes 4/6/7 toutes enrichies.
- [ ] `teom_recovered` produit une écriture créditant `708200` (visible sur grand-livre et balance, label "Charges recuperees — TEOM").
- [ ] Appel `createAutoEntry('loan_payment', { amountCents: 800_00, secondaryAmountCents: 200_00, ... })` → 3 lignes équilibrées : 661000 D 200, 164000 D 600, 512100 C 800.
- [ ] `createAutoEntry('supplier_invoice', { amountCents: 120_00, vatRateBps: 2000, ... })` → 615100 D 100, 445660 D 20, 401000 C 120.
- [ ] `createAutoEntry('agency_commission', { amountCents: 600_00, vatRateBps: 2000, ... })` → 467000 D 600, 706100 C 500, 445710 C 100.
- [ ] `splitTTC(120_00, 2000)` retourne `{ htCents: 100_00, vatCents: 20_00 }` ; `splitTTC(120_00, 0)` retourne `{ htCents: 120_00, vatCents: 0 }`.

https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL)_