### PR TITLE
feat(accounting): expose 'Nouvel exercice' UI + honour entity fiscal config

### DIFF
--- a/app/owner/accounting/exercises/ExercisesClient.tsx
+++ b/app/owner/accounting/exercises/ExercisesClient.tsx
@@ -1,12 +1,23 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api-client";
 import { useEntityStore } from "@/stores/useEntityStore";
 import { useToast } from "@/components/ui/use-toast";
 import Link from "next/link";
-import { ArrowLeft, Lock, Unlock, Calendar, Loader2 } from "lucide-react";
+import { ArrowLeft, Lock, Unlock, Calendar, Loader2, Plus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { validateFiscalYearRange } from "@/lib/entities/fiscal-year-defaults";
 
 export default function ExercisesClient() {
   return (<PlanGate feature="bank_reconciliation" mode="block"><ExercisesContent /></PlanGate>);
@@ -35,6 +46,34 @@ function ExercisesContent() {
     queryKey: ["exercises", activeEntityId],
     queryFn: () => apiClient.get<ExercisesResponse>(`/accounting/exercises?entityId=${activeEntityId}`),
     enabled: !!activeEntityId,
+  });
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newStart, setNewStart] = useState("");
+  const [newEnd, setNewEnd] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const createMutation = useMutation<unknown, Error, { startDate: string; endDate: string }>({
+    mutationFn: (payload) =>
+      apiClient.post(`/accounting/exercises`, {
+        entityId: activeEntityId,
+        startDate: payload.startDate,
+        endDate: payload.endDate,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["exercises"] });
+      setCreateOpen(false);
+      setCreateError(null);
+      toast({
+        title: "Exercice créé",
+        description: `Période ${newStart} → ${newEnd} ouverte.`,
+      });
+    },
+    onError: (err) => {
+      setCreateError(
+        err instanceof Error ? err.message : "Création impossible. Réessayez.",
+      );
+    },
   });
 
   const closeMutation = useMutation<CloseResponse, Error, string>({
@@ -76,9 +115,65 @@ function ExercisesContent() {
   const openExercises = exercises.filter(e => e.status === "open");
   const closedExercises = exercises.filter(e => e.status === "closed");
 
+  // Default period for a new exercise: continues right after the latest
+  // existing exercise, on a 1-year span. Falls back to current calendar year
+  // when no exercise exists.
+  const defaultPeriod = useMemo(() => {
+    const latest = exercises
+      .map((e) => e.end_date)
+      .filter((d): d is string => Boolean(d))
+      .sort()
+      .at(-1);
+
+    if (latest) {
+      const next = new Date(`${latest}T00:00:00Z`);
+      next.setUTCDate(next.getUTCDate() + 1);
+      const start = next.toISOString().slice(0, 10);
+      const endDate = new Date(next);
+      endDate.setUTCFullYear(endDate.getUTCFullYear() + 1);
+      endDate.setUTCDate(endDate.getUTCDate() - 1);
+      return { start, end: endDate.toISOString().slice(0, 10) };
+    }
+
+    const year = new Date().getUTCFullYear();
+    return { start: `${year}-01-01`, end: `${year}-12-31` };
+  }, [exercises]);
+
+  function openCreateDialog() {
+    setNewStart(defaultPeriod.start);
+    setNewEnd(defaultPeriod.end);
+    setCreateError(null);
+    setCreateOpen(true);
+  }
+
+  function submitCreate() {
+    const validation = validateFiscalYearRange(newStart, newEnd);
+    if (!validation.valid) {
+      setCreateError(validation.error ?? "Dates invalides");
+      return;
+    }
+    createMutation.mutate({ startDate: newStart, endDate: newEnd });
+  }
+
   return (
     <div className="p-4 sm:p-6 lg:p-8 space-y-6">
-      <div className="flex items-center gap-3"><Link href="/owner/accounting" className="text-muted-foreground hover:text-foreground"><ArrowLeft className="w-5 h-5" /></Link><h1 className="text-xl font-bold text-foreground">Exercices comptables</h1></div>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Link href="/owner/accounting" className="text-muted-foreground hover:text-foreground">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <h1 className="text-xl font-bold text-foreground">Exercices comptables</h1>
+        </div>
+        <button
+          type="button"
+          onClick={openCreateDialog}
+          disabled={!activeEntityId}
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          <Plus className="w-4 h-4" />
+          Nouvel exercice
+        </button>
+      </div>
 
       {isLoading ? <div className="space-y-3">{[1,2].map(i => <div key={i} className="h-24 bg-muted rounded-xl animate-pulse" />)}</div> : (
         <>
@@ -122,8 +217,72 @@ function ExercisesContent() {
               ))}
             </div>
           )}
+          {exercises.length === 0 && (
+            <div className="bg-card rounded-xl border border-dashed border-border p-8 text-center">
+              <Calendar className="mx-auto w-8 h-8 text-muted-foreground" />
+              <p className="mt-3 text-sm font-medium">Aucun exercice comptable</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Créez votre premier exercice pour démarrer la comptabilité.
+              </p>
+            </div>
+          )}
         </>
       )}
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Nouvel exercice comptable</DialogTitle>
+            <DialogDescription>
+              La période ne doit pas chevaucher un exercice existant. Les dates
+              proposées prolongent automatiquement le dernier exercice.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="newStart">Début</Label>
+              <Input
+                id="newStart"
+                type="date"
+                value={newStart}
+                onChange={(e) => setNewStart(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="newEnd">Fin</Label>
+              <Input
+                id="newEnd"
+                type="date"
+                value={newEnd}
+                onChange={(e) => setNewEnd(e.target.value)}
+              />
+            </div>
+          </div>
+          {createError && (
+            <p className="text-sm text-destructive">{createError}</p>
+          )}
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setCreateOpen(false)}
+              className="rounded-lg border border-border px-4 py-2 text-sm font-medium"
+            >
+              Annuler
+            </button>
+            <button
+              type="button"
+              onClick={submitCreate}
+              disabled={createMutation.isPending}
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {createMutation.isPending && (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              )}
+              Créer l&apos;exercice
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/lib/accounting/auto-exercise.ts
+++ b/lib/accounting/auto-exercise.ts
@@ -2,22 +2,96 @@
  * Auto-exercise helper
  *
  * Finds or creates the current accounting exercise for an entity.
- * Auto-seeds chart of accounts and journals on first exercise creation.
+ * Respects the entity's configured fiscal year (premier_exercice_debut/fin
+ * + date_cloture_exercice) so non-calendar exercises (e.g. 01/07 → 30/06)
+ * are honoured. Auto-seeds chart of accounts and journals on first exercise
+ * creation.
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { initializeChartOfAccounts } from "@/lib/accounting/chart-amort-ocr";
 import { initializeJournals } from "@/lib/accounting/engine";
 
+interface FiscalConfig {
+  premier_exercice_debut: string | null;
+  premier_exercice_fin: string | null;
+  date_cloture_exercice: string | null;
+}
+
+function parseIsoDate(value: string): Date {
+  return new Date(`${value}T00:00:00Z`);
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function addDays(d: Date, days: number): Date {
+  const next = new Date(d);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function addYears(d: Date, years: number): Date {
+  const next = new Date(d);
+  next.setUTCFullYear(next.getUTCFullYear() + years);
+  return next;
+}
+
 /**
- * Get the current open exercise covering today, or create a calendar-year exercise.
+ * Compute the next accounting period for an entity.
+ *
+ * - If a previous exercise exists, the new period starts the day after its
+ *   end_date and spans one year minus one day.
+ * - Otherwise, defaults are taken from the entity's fiscal config. When today
+ *   is past the configured first-exercise end, the period is projected
+ *   forward by one-year increments anchored on date_cloture_exercice.
+ */
+export function computeNextPeriod(
+  config: FiscalConfig,
+  latestEndDate: string | null,
+  referenceDate: Date = new Date(),
+): { start: string; end: string } {
+  if (latestEndDate) {
+    const start = addDays(parseIsoDate(latestEndDate), 1);
+    const end = addDays(addYears(start, 1), -1);
+    return { start: toIsoDate(start), end: toIsoDate(end) };
+  }
+
+  const debut = config.premier_exercice_debut;
+  const fin = config.premier_exercice_fin;
+
+  if (debut && fin) {
+    const finDate = parseIsoDate(fin);
+    // Today still falls within the configured first exercise → use it as-is.
+    if (referenceDate.getTime() <= finDate.getTime()) {
+      return { start: debut, end: fin };
+    }
+    // Project forward in 1-year increments until end >= today.
+    let start = parseIsoDate(debut);
+    let end = finDate;
+    while (referenceDate.getTime() > end.getTime()) {
+      start = addYears(start, 1);
+      end = addYears(end, 1);
+    }
+    return { start: toIsoDate(start), end: toIsoDate(end) };
+  }
+
+  const year = referenceDate.getUTCFullYear();
+  return { start: `${year}-01-01`, end: `${year}-12-31` };
+}
+
+/**
+ * Get the current open exercise covering today, or create one aligned on the
+ * entity's fiscal-year configuration.
+ *
  * On first exercise creation, auto-seeds chart of accounts (PCG) and journals.
  */
 export async function getOrCreateCurrentExercise(
   supabase: SupabaseClient,
   entityId: string,
 ) {
-  const today = new Date().toISOString().split("T")[0];
+  const today = toIsoDate(new Date());
 
   // 1. Find open exercise covering today
   const { data: exercise } = await supabase
@@ -31,14 +105,38 @@ export async function getOrCreateCurrentExercise(
 
   if (exercise) return exercise;
 
-  // 2. Create calendar-year exercise (Jan 1 - Dec 31)
-  const year = new Date().getFullYear();
+  // 2. Compute the period that should cover today, honouring the entity's
+  //    configured fiscal year and chaining from the most recent exercise.
+  const [{ data: entity }, { data: latest }] = await Promise.all([
+    (supabase as any)
+      .from("legal_entities")
+      .select("premier_exercice_debut, premier_exercice_fin, date_cloture_exercice")
+      .eq("id", entityId)
+      .maybeSingle(),
+    (supabase as any)
+      .from("accounting_exercises")
+      .select("end_date")
+      .eq("entity_id", entityId)
+      .order("end_date", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  const period = computeNextPeriod(
+    {
+      premier_exercice_debut: entity?.premier_exercice_debut ?? null,
+      premier_exercice_fin: entity?.premier_exercice_fin ?? null,
+      date_cloture_exercice: entity?.date_cloture_exercice ?? null,
+    },
+    latest?.end_date ?? null,
+  );
+
   const { data: newExercise, error } = await supabase
     .from("accounting_exercises")
     .insert({
       entity_id: entityId,
-      start_date: `${year}-01-01`,
-      end_date: `${year}-12-31`,
+      start_date: period.start,
+      end_date: period.end,
     })
     .select()
     .single();

--- a/tests/unit/auto-exercise-period.test.ts
+++ b/tests/unit/auto-exercise-period.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for computeNextPeriod — the pure helper that decides which
+ * accounting period to create when no open exercise covers today.
+ *
+ * Covers:
+ *  - Chains from the latest existing exercise (end_date + 1, span 1 year)
+ *  - Honours entity's configured first exercise when no exercise exists
+ *  - Projects the configured period forward when today is past the
+ *    configured first-exercise end (handles non-calendar fiscal years)
+ *  - Falls back to the calendar year when no config is set
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { computeNextPeriod } from "@/lib/accounting/auto-exercise";
+
+describe("computeNextPeriod", () => {
+  it("chains from the latest exercise's end_date on a 1-year span", () => {
+    const period = computeNextPeriod(
+      {
+        premier_exercice_debut: "2024-01-01",
+        premier_exercice_fin: "2024-12-31",
+        date_cloture_exercice: "12-31",
+      },
+      "2026-12-31",
+      new Date("2027-04-15T00:00:00Z"),
+    );
+
+    expect(period).toEqual({ start: "2027-01-01", end: "2027-12-31" });
+  });
+
+  it("chains across a non-calendar fiscal year (01/07 -> 30/06)", () => {
+    const period = computeNextPeriod(
+      {
+        premier_exercice_debut: "2024-07-01",
+        premier_exercice_fin: "2025-06-30",
+        date_cloture_exercice: "06-30",
+      },
+      "2025-06-30",
+      new Date("2025-09-01T00:00:00Z"),
+    );
+
+    expect(period).toEqual({ start: "2025-07-01", end: "2026-06-30" });
+  });
+
+  it("uses the configured first exercise when no exercise exists yet", () => {
+    const period = computeNextPeriod(
+      {
+        premier_exercice_debut: "2026-03-15",
+        premier_exercice_fin: "2026-12-31",
+        date_cloture_exercice: "12-31",
+      },
+      null,
+      new Date("2026-04-27T00:00:00Z"),
+    );
+
+    expect(period).toEqual({ start: "2026-03-15", end: "2026-12-31" });
+  });
+
+  it("projects the configured period forward when today is past first-exercise end", () => {
+    const period = computeNextPeriod(
+      {
+        premier_exercice_debut: "2024-07-01",
+        premier_exercice_fin: "2025-06-30",
+        date_cloture_exercice: "06-30",
+      },
+      null,
+      new Date("2026-09-01T00:00:00Z"),
+    );
+
+    expect(period).toEqual({ start: "2026-07-01", end: "2027-06-30" });
+  });
+
+  it("falls back to the calendar year when nothing is configured", () => {
+    const period = computeNextPeriod(
+      {
+        premier_exercice_debut: null,
+        premier_exercice_fin: null,
+        date_cloture_exercice: null,
+      },
+      null,
+      new Date("2026-04-27T00:00:00Z"),
+    );
+
+    expect(period).toEqual({ start: "2026-01-01", end: "2026-12-31" });
+  });
+});


### PR DESCRIPTION
- Add 'Nouvel exercice' button and creation dialog in /owner/accounting/exercises.
  Defaults the new period to the day after the latest exercise on a 1-year
  span; the existing POST /api/accounting/exercises already validates overlap.
- Fix getOrCreateCurrentExercise to read premier_exercice_debut/fin from
  legal_entities and chain from the most recent exercise instead of always
  defaulting to the calendar year. Non-calendar fiscal years (eg 01/07 -> 30/06)
  are now honoured when an exercise is auto-created.
- Add unit tests covering the chaining, projection forward, and calendar-year
  fallback branches of computeNextPeriod.