### PR TITLE
fix(mobile): nav parity across all roles + responsive tables

### DIFF
--- a/app/owner/finances/invoices/InvoicesListClient.tsx
+++ b/app/owner/finances/invoices/InvoicesListClient.tsx
@@ -119,7 +119,40 @@ export function InvoicesListClient() {
       ) : (
         <Card>
           <CardContent className="p-0">
-            <div className="overflow-x-auto">
+            {/* Mobile: card list (< md) */}
+            <div className="md:hidden divide-y">
+              {invoices.map((invoice) => (
+                <button
+                  key={invoice.id}
+                  type="button"
+                  onClick={() =>
+                    router.push(`/owner/finances/invoices/${invoice.id}`)
+                  }
+                  className="w-full px-4 py-3 text-left hover:bg-muted/30 transition-colors"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-2 mb-1">
+                        <p className="font-medium truncate">{invoice.periode}</p>
+                        <p className="text-sm font-semibold tabular-nums shrink-0">
+                          {formatCurrency(invoice.montant_total)}
+                        </p>
+                      </div>
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="text-xs text-muted-foreground">
+                          Échéance {formatDate(invoice.due_date)}
+                        </p>
+                        <InvoiceStatusBadge status={invoice.statut} />
+                      </div>
+                    </div>
+                    <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            {/* Desktop: table (md+) */}
+            <div className="hidden md:block overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/50">

--- a/app/owner/finances/payments/page.tsx
+++ b/app/owner/finances/payments/page.tsx
@@ -110,7 +110,34 @@ export default function PaymentsHistoryPage() {
       ) : (
         <Card>
           <CardContent className="p-0">
-            <div className="overflow-x-auto">
+            {/* Mobile: card list (< md) */}
+            <div className="md:hidden divide-y">
+              {payments.map((payment) => (
+                <div key={payment.id} className="px-4 py-3">
+                  <div className="flex items-center justify-between gap-2 mb-1">
+                    <p className="text-sm font-medium">
+                      {formatDate(payment.date_paiement)}
+                    </p>
+                    <p className="text-sm font-semibold tabular-nums">
+                      {formatCurrency(payment.montant)}
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-xs text-muted-foreground">
+                      {METHOD_LABELS[payment.moyen] || payment.moyen}
+                    </p>
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[payment.statut] || ""}`}
+                    >
+                      {payment.statut === "succeeded" ? "Confirmé" : payment.statut}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Desktop: table (md+) */}
+            <div className="hidden md:block overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/50">


### PR DESCRIPTION
## Contexte

Audit mobile complet — la navigation cachait des items critiques sur mobile selon le rôle, et plusieurs tables forçaient un scroll horizontal sans alternative card layout.

| Rôle | Avant | Après |
|------|-------|-------|
| Owner | 9/11 items mobile | **11/11** |
| Tenant | 9/14 items mobile | **14/14** |
| Provider | 10/12 items mobile | **12/12** |
| Agency | 13/13 (paradigme custom) | **13/13 via SharedBottomNav** |
| Syndic | **5/12 (perte de 58%)** | **12/12** |
| Admin | 100% (overlap < 320px) | **100% sans overlap** |
| Guarantor | nav non responsive | **100% via SharedBottomNav** |
| Copro | 6 items dans `grid-cols-5` cassé | **layout corrigé** |

## Changements

### Commit 1 — `d145c7e` Bloquants & majeurs

Items restaurés par rôle (réintégrés via `SharedBottomNav` "More" sheet) :
- **Syndic** : Comptabilité, Appels de fonds, Conseils syndicaux, Fonds travaux, Impayés, Invitations, Paramètres
- **Tenant** : États des lieux, Relevé de compte, Compteurs, Mes droits, Visites
- **Provider** : Messages, Portfolio
- **Owner** : Comptabilité, Devis prestataires
- **Copro** : `grid-cols-5` avec 6 items → `SharedBottomNav` (4 + 4)
- **Guarantor** : ajout d'un `SharedBottomNav` mobile (header horizontal cassait < 640px)

### Commit 2 — `b193685` Cohérence UX P3

- **Agency** : remplacement du panel "More" custom par `SharedBottomNav` (tous les rôles utilisent maintenant le même paradigme). Header mobile ajouté dans `agency/layout.tsx` avec `SignOutButton variant="mobile-icon"` (sidebar cachée < lg).
- **Admin** : `MenuButton` repositionné `top-3 left-2 sm:top-16 sm:left-4` avec backdrop, ne chevauche plus le contenu < 320px.
- **Tenant** `/account-statement` : table 6 colonnes → cards mobiles < md, table préservée md+.

### Commit 3 — `5aa6264` Tables critiques mobile

Card layout mobile pour deux tables financières propriétaires fréquemment consultées sur mobile :
- `/owner/finances/invoices` (période + montant + échéance + statut, tappable → détail)
- `/owner/finances/payments` (date + montant + moyen + statut)

Pattern réutilisable : `md:hidden` cards / `hidden md:block` table.

## Fichiers modifiés (12)

```
app/agency/_components/AgencySidebar.tsx           | -136 +24
app/agency/layout.tsx                              |  +18
app/copro/layout.tsx                               | -23 +23
app/guarantor/layout.tsx                           | -8 +35
app/owner/finances/invoices/InvoicesListClient.tsx | +35
app/owner/finances/payments/page.tsx               | +29
app/syndic/layout.tsx                              | -25 +21
app/tenant/account-statement/...Client.tsx         | +47
components/layout/admin-sidebar.tsx                | +1 -1
components/layout/owner-app-layout.tsx             | +2
components/layout/provider-bottom-nav.tsx          | +6 -3
components/layout/tenant-app-layout.tsx            | +5 -2
```

## Hors scope (volontairement non traité)

- **Tables accounting** (chart, entries, balance, grand-livre, transfers, amortization, ~20 fichiers) : usage desktop par les comptables/EC, perte de lisibilité métier en card. À garder en `overflow-x-auto`.
- **Tables admin/syndic** : usage typiquement desktop.
- **`core-shell-header.tsx:54`** (logo `md:hidden`) : non-bug — logo volontairement caché à `md+` car la rail nav (Tenant/Owner) l'affiche déjà.

## Test plan

- [ ] Owner mobile (< 640px) : ouvrir le menu "Plus" → vérifier accès Comptabilité + Devis prestataires
- [ ] Tenant mobile : ouvrir "Plus" → États des lieux, Relevé, Compteurs, Mes droits, Visites accessibles
- [ ] Provider mobile : Messages directement dans la barre principale
- [ ] Syndic mobile : ouvrir "Plus" → 8 items secondaires (Assemblées, Mandats, Conseils, Fonds travaux, Dépenses, Impayés, Invitations, Paramètres)
- [ ] Agency mobile : header avec bouton déconnexion, bottom nav `SharedBottomNav` cohérente
- [ ] Copro mobile : 4 items principaux + 4 dans "Plus" (Documents, Signalements, Paramètres, Aide)
- [ ] Guarantor mobile : bottom nav présente (anciennement absente)
- [ ] Admin < 320px : `MenuButton` ne chevauche plus le contenu
- [ ] Tenant `/account-statement` mobile : cards à la place de la table
- [ ] Owner `/finances/invoices` et `/finances/payments` mobile : cards tappables

## Vérifications

- ✅ Aucune erreur TypeScript sur les fichiers modifiés
- ✅ Pattern `SharedBottomNav` réutilisé partout (safe-area iOS, touch targets 44px, sheet "Plus")
- ✅ Aucun `lib/subscriptions/plans.ts`, template de bail, ou DB Supabase touché

https://claude.ai/code/session_01C51FxJvJSvTBSLsXKUWpDu

---
_Generated by [Claude Code](https://claude.ai/code/session_01C51FxJvJSvTBSLsXKUWpDu)_