### PR TITLE
fix(accounting): 5 critical fiscal-declaration bugs (entityId, TVA filter, ligne 221, NaN, MV fallback)

### DIFF
--- a/app/api/accounting/declarations/[type]/route.ts
+++ b/app/api/accounting/declarations/[type]/route.ts
@@ -40,10 +40,22 @@ function sumDebit(balance: BalanceItem[], prefix: string): number {
 
 /**
  * Compute 2044 declaration (regime reel - revenus fonciers)
+ *
+ * Ligne 221 ("Frais d'administration et de gestion") accepte au choix :
+ *   1. un forfait legal de 20 EUR / local declare (sans justificatif),
+ *   2. les frais reels (avec justificatifs : honoraires comptables,
+ *      juridiques, divers — comptes 622xxx, plus 627000 frais bancaires).
+ * Le proprietaire doit prendre la solution LA PLUS AVANTAGEUSE. La version
+ * historique forcait le forfait, ce qui sous-evaluait les charges quand
+ * un EC etait paye et gonflait artificiellement le revenu foncier. On
+ * calcule les deux et on retient le max ; les deux sont remontes dans
+ * la reponse pour permettre a l'UI/EC de tracer le choix.
  */
 function compute2044(balance: BalanceItem[], nbLocaux: number) {
   const ligne_215 = sumCredit(balance, "706"); // loyers bruts
-  const ligne_221 = nbLocaux * 2000; // forfait gestion 20 EUR/local
+  const ligne_221_forfait = nbLocaux * 2000; // forfait legal 20 EUR/local
+  const ligne_221_reel = sumDebit(balance, "622") + sumDebit(balance, "627"); // honoraires + frais bancaires
+  const ligne_221 = Math.max(ligne_221_forfait, ligne_221_reel);
   const ligne_222 = sumDebit(balance, "616"); // assurances
   const ligne_223 = sumDebit(balance, "615"); // travaux
   const ligne_224 = sumDebit(balance, "661"); // interets emprunt
@@ -69,6 +81,10 @@ function compute2044(balance: BalanceItem[], nbLocaux: number) {
     type: "2044" as const,
     ligne_215,
     ligne_221,
+    ligne_221_forfait,
+    ligne_221_reel,
+    ligne_221_choice:
+      ligne_221_reel >= ligne_221_forfait ? ("reel" as const) : ("forfait" as const),
     ligne_222,
     ligne_223,
     ligne_224,
@@ -113,13 +129,24 @@ async function compute2072(
     sumDebit(balance, "635");
   const resultat = revenus - charges;
 
-  // Fetch associates and their quote-parts
+  // Fetch associates and their quote-parts. Filtre les quote_part_pct
+  // null/0 : sans cette protection, Math.round(resultat * null / 100)
+  // produit NaN qui se serialise mal en JSON et casse l'UI.
   const { data: associates } = await (supabase as any)
     .from("entity_associates")
     .select("id, name, quote_part_pct")
     .eq("entity_id", entityId);
 
-  const resultat_par_associe = (associates ?? []).map(
+  const validAssociates = (associates ?? []).filter(
+    (a: { quote_part_pct: number | null }) =>
+      typeof a.quote_part_pct === "number" && a.quote_part_pct > 0,
+  );
+  const skippedAssociates = (associates ?? []).filter(
+    (a: { quote_part_pct: number | null }) =>
+      !(typeof a.quote_part_pct === "number" && a.quote_part_pct > 0),
+  );
+
+  const resultat_par_associe = validAssociates.map(
     (a: { id: string; name: string; quote_part_pct: number }) => ({
       associateId: a.id,
       name: a.name,
@@ -134,6 +161,7 @@ async function compute2072(
     charges_deductibles: charges,
     resultat,
     resultat_par_associe,
+    skipped_associates_count: skippedAssociates.length,
   };
 }
 

--- a/app/api/accounting/declarations/tva/route.ts
+++ b/app/api/accounting/declarations/tva/route.ts
@@ -132,6 +132,11 @@ export async function GET(request: Request) {
       )
       .eq("accounting_entries.entity_id", entityId)
       .eq("accounting_entries.is_validated", true)
+      // Exclut les ecritures informationnelles (mode micro-foncier qui pose
+      // des memo entries pour comparer aux donnees reelles). Sans ce filtre,
+      // une SCI hybride avec un bail micro et un bail reel verrait sa CA3
+      // polluee par les memos micro et la TVA serait calculee a faux.
+      .eq("accounting_entries.informational", false)
       .gte("accounting_entries.entry_date", startDate)
       .lte("accounting_entries.entry_date", endDate)
       .or(

--- a/app/owner/accounting/declarations/DeclarationsClient.tsx
+++ b/app/owner/accounting/declarations/DeclarationsClient.tsx
@@ -64,9 +64,15 @@ function DeclarationsContent() {
   const declarationType = regime === "micro-foncier" ? "micro-foncier" : regime === "reel-2044" ? "2044" : regime === "reel-2072" ? "2072" : "2042-cpro";
 
   const { data: declaration, isLoading: declLoading } = useQuery<DeclarationResponse>({
-    queryKey: ["declaration", declarationType, exerciseId],
-    queryFn: () => apiClient.get<DeclarationResponse>(`/accounting/declarations/${declarationType}?exerciseId=${exerciseId}`),
-    enabled: !!exerciseId && step >= 2,
+    queryKey: ["declaration", declarationType, exerciseId, activeEntityId],
+    queryFn: () =>
+      apiClient.get<DeclarationResponse>(
+        // entityId est OBLIGATOIRE cote API (cf. /api/accounting/declarations/[type]/route.ts).
+        // L'oubli renvoyait 400 et cassait silencieusement la preview de
+        // toutes les declarations 2044 / 2065 / 2031 / 2072 / micro-foncier.
+        `/accounting/declarations/${declarationType}?exerciseId=${exerciseId}&entityId=${activeEntityId}`,
+      ),
+    enabled: !!exerciseId && !!activeEntityId && step >= 2,
   });
 
   const declData: DeclarationPayload = (() => {

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -415,17 +415,22 @@ export async function getBalance(
     // ignore and fall through to live aggregation
   }
 
+  // La MV mv_accounting_balance filtre deja informational=false (cf.
+  // migration 20260426180000). Le fallback live doit faire pareil sinon
+  // les memos micro-foncier polluent la balance retournee quand la MV
+  // est vide ou stale.
   const { data, error } = await supabase
     .from('accounting_entry_lines')
     .select(`
       account_number,
       debit_cents,
       credit_cents,
-      accounting_entries!inner(entity_id, exercise_id, is_validated)
+      accounting_entries!inner(entity_id, exercise_id, is_validated, informational)
     `)
     .eq('accounting_entries.entity_id', entityId)
     .eq('accounting_entries.exercise_id', exerciseId)
-    .eq('accounting_entries.is_validated', true);
+    .eq('accounting_entries.is_validated', true)
+    .eq('accounting_entries.informational', false);
 
   if (error) throw new Error(`Failed to fetch balance: ${error.message}`);
 


### PR DESCRIPTION
## Summary

Audit indépendant des routes `/api/accounting/declarations/*` et de la page DeclarationsClient. **5 vrais bugs** qui faussaient la donnée fiscale envoyée à l'utilisateur (sur 16 trouvés par l'audit, 2 étaient des faux positifs et 3 secondaires sont reportés).

### Bug 1 — DeclarationsClient oubliait `entityId`
La page faisait `GET ?exerciseId=X` sans `entityId`. La route exige les deux et renvoyait `400`. Conséquence : **la preview 2044 / 2065 / 2031 / 2072 / micro-foncier était silencieusement cassée** (React Query catchait l'erreur, l'utilisateur voyait un loader sans données). Ajoute `entityId` au queryFn.

### Bug 2 — `/declarations/tva` polluait la CA3 avec les memos micro-foncier
Le filtre `is_validated=true` était bon mais `informational=false` manquait. Les memos posées par le moteur en mode micro-foncier (régime forfaitaire qui ne génère pas de TVA) remontaient sur la CA3 et faussaient le solde collectée/déductible. Ajoute le filtre.

### Bug 3 — `compute2044` ligne 221 forçait le forfait 20 €/local
La 2044 accepte au choix le **forfait légal** (20 €/local sans justif) ou les **frais réels** (honoraires comptables 622xxx, juridiques 622600, frais bancaires 627). Le propriétaire prend le max. La version historique forçait le forfait, sous-évaluant les charges dès qu'un EC était payé → revenu foncier gonflé → impôt sur-facturé.

Calcule maintenant les deux et retient le max ; les deux montants sont remontés (`ligne_221_forfait`, `ligne_221_reel`, `ligne_221_choice`) pour permettre à l'UI/EC d'auditer le choix.

### Bug 4 — `compute2072` produisait `NaN` quand `quote_part_pct` était null
`Math.round(resultat * null / 100)` → `NaN`, qui se sérialise mal en JSON et fait crasher l'UI. Filtre maintenant les associates avec `quote_part_pct` null/0 et expose `skipped_associates_count` dans la réponse pour signaler le problème sans bloquer la génération.

### Bug 5 — `getBalance` live fallback ne filtrait pas `informational=false`
La MV `mv_accounting_balance` exclut déjà les écritures informational (cf. migration `20260426180000`) mais le chemin live (activé quand la MV est vide ou stale, cf. PR #534) ne le faisait pas. Résultat : si la MV n'avait pas été refreshed, `getBalance` retournait des montants pollués par les memos micro. Aligne le filtre live sur celui de la MV.

## Test plan

- [ ] `/owner/accounting/declarations` → choisir un exercice clôturé + régime → la preview affiche maintenant des chiffres au lieu d'un loader infini.
- [ ] Pour une SCI hybride (1 bail réel + 1 bail micro-foncier informational) : la CA3 TVA n'inclut plus les memos micro.
- [ ] 2044 d'une SCI avec 5 lots et 800 € d'honoraires comptables : `ligne_221 = 80000` (réel) et non `10000` (forfait 5×20€). `ligne_221_choice = "reel"`.
- [ ] 2072 d'une SCI avec un associate sans `quote_part_pct` : la déclaration se génère, `skipped_associates_count = 1`, pas de NaN.
- [ ] Dashboard KPIs sur une entité avec MV vide + memos micro : recettes/dépenses ne contiennent plus les memos.

https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL)_