### PR TITLE
feat(accounting): exercise config + draft entry deletion

### DIFF
--- a/app/api/accounting/exercises/[exerciseId]/close/route.ts
+++ b/app/api/accounting/exercises/[exerciseId]/close/route.ts
@@ -8,6 +8,7 @@ import { createClient } from "@/lib/supabase/server";
 import { handleApiError, ApiError } from "@/lib/helpers/api-error";
 import { requireAccountingAccess } from "@/lib/accounting/feature-gates";
 import { closeExercise, createEntry, validateEntry, getBalance } from "@/lib/accounting/engine";
+import { computeNextPeriod } from "@/lib/accounting/auto-exercise";
 
 export const dynamic = "force-dynamic";
 
@@ -212,28 +213,45 @@ export async function POST(
       warnings.push("Envoi automatique au expert-comptable non effectue");
     }
 
-    // Step 6: Create next exercise if needed
-    const nextStart = new Date(exercise.end_date);
-    nextStart.setDate(nextStart.getDate() + 1);
-    const nextEnd = new Date(nextStart);
-    nextEnd.setFullYear(nextEnd.getFullYear() + 1);
-    nextEnd.setDate(nextEnd.getDate() - 1);
+    // Step 6: Create next exercise if needed.
+    //
+    // Use computeNextPeriod so we share the exact same period math as the UI
+    // dialog and getOrCreateCurrentExercise — TZ-safe (UTC) and respectful of
+    // the entity's configured fiscal year for entities with no other history.
+    //
+    // Existence check is a real overlap test on the computed [start, end]
+    // window: a manually-pre-created N+2 must NOT mask a missing N+1.
+    const { data: entityForFiscal } = await (supabase as any)
+      .from("legal_entities")
+      .select("premier_exercice_debut, premier_exercice_fin, date_cloture_exercice")
+      .eq("id", entityId)
+      .maybeSingle();
 
-    const { data: existingNext } = await (supabase as any)
+    const nextPeriod = computeNextPeriod(
+      {
+        premier_exercice_debut: entityForFiscal?.premier_exercice_debut ?? null,
+        premier_exercice_fin: entityForFiscal?.premier_exercice_fin ?? null,
+        date_cloture_exercice: entityForFiscal?.date_cloture_exercice ?? null,
+      },
+      exercise.end_date,
+    );
+
+    const { data: overlapping } = await (supabase as any)
       .from("accounting_exercises")
       .select("id")
       .eq("entity_id", entityId)
-      .gte("start_date", nextStart.toISOString().split("T")[0])
+      .lte("start_date", nextPeriod.end)
+      .gte("end_date", nextPeriod.start)
       .limit(1);
 
     let newExercise = null;
-    if (!existingNext || existingNext.length === 0) {
+    if (!overlapping || overlapping.length === 0) {
       const { data: created } = await (supabase as any)
         .from("accounting_exercises")
         .insert({
           entity_id: entityId,
-          start_date: nextStart.toISOString().split("T")[0],
-          end_date: nextEnd.toISOString().split("T")[0],
+          start_date: nextPeriod.start,
+          end_date: nextPeriod.end,
         })
         .select()
         .single();

--- a/app/owner/accounting/entries/EntriesPageClient.tsx
+++ b/app/owner/accounting/entries/EntriesPageClient.tsx
@@ -78,6 +78,8 @@ function EntriesPageContent() {
     error,
     validateEntries,
     isValidating,
+    deleteEntries,
+    isDeleting,
   } = useAccountingEntries({
     journalCode: journalCode || undefined,
     search: search || undefined,
@@ -121,6 +123,17 @@ function EntriesPageContent() {
       setSelected(new Set());
     } catch {
       // Error handled by mutation
+    }
+  };
+
+  const handleDeleteSelected = async () => {
+    if (selected.size === 0) return;
+    try {
+      await deleteEntries(Array.from(selected));
+      setSelected(new Set());
+    } catch {
+      // Error handled by mutation; the bulk dialog stays closed regardless
+      // because partial successes still landed and the list will refetch.
     }
   };
 
@@ -199,7 +212,9 @@ function EntriesPageContent() {
       <BulkActions
         selectedCount={selected.size}
         isValidating={isValidating}
+        isDeleting={isDeleting}
         onValidateSelected={handleValidateSelected}
+        onDeleteSelected={handleDeleteSelected}
       />
 
       {/* Loading */}

--- a/app/owner/accounting/entries/components/BulkActions.tsx
+++ b/app/owner/accounting/entries/components/BulkActions.tsx
@@ -1,48 +1,132 @@
 "use client";
 
 /**
- * BulkActions — action bar shown when at least one draft entry is
- * selected. Currently exposes only "validate selected"; delete is not
- * wired yet because the corresponding backend route is admin-only and
- * goes through a different flow.
+ * BulkActions — action bar shown when at least one draft entry is selected.
  *
- * Dumb component: the parent owns the selection Set and the validate
- * mutation; we just render the CTA.
+ * Exposes both "validate selected" (turns drafts into intangible journal
+ * entries) and "delete selected" (removes drafts permanently). The delete
+ * action is restricted to drafts at the API layer too — the bulk button
+ * here is just convenience for the common "I selected a batch of mistaken
+ * imports, drop them" workflow.
+ *
+ * Dumb component: the parent owns the selection Set and both mutations.
  */
 
-import { Loader2, CheckCircle2 } from "lucide-react";
+import { useState } from "react";
+import { Loader2, CheckCircle2, Trash2, X } from "lucide-react";
 
 interface BulkActionsProps {
   selectedCount: number;
   isValidating: boolean;
+  isDeleting: boolean;
   onValidateSelected: () => void;
+  onDeleteSelected: () => void;
 }
 
 export function BulkActions({
   selectedCount,
   isValidating,
+  isDeleting,
   onValidateSelected,
+  onDeleteSelected,
 }: BulkActionsProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
   if (selectedCount === 0) return null;
+
+  const busy = isValidating || isDeleting;
+
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-4 py-2.5">
-      <span className="text-sm font-medium text-foreground">
-        {selectedCount} ecriture{selectedCount > 1 ? "s" : ""} selectionnee
-        {selectedCount > 1 ? "s" : ""}
-      </span>
-      <button
-        type="button"
-        onClick={onValidateSelected}
-        disabled={isValidating}
-        className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
-      >
-        {isValidating ? (
-          <Loader2 className="w-3.5 h-3.5 animate-spin" />
-        ) : (
-          <CheckCircle2 className="w-3.5 h-3.5" />
-        )}
-        Valider les {selectedCount} selectionnees
-      </button>
-    </div>
+    <>
+      <div className="flex items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-4 py-2.5">
+        <span className="text-sm font-medium text-foreground">
+          {selectedCount} ecriture{selectedCount > 1 ? "s" : ""} selectionnee
+          {selectedCount > 1 ? "s" : ""}
+        </span>
+        <button
+          type="button"
+          onClick={onValidateSelected}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          {isValidating ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <CheckCircle2 className="w-3.5 h-3.5" />
+          )}
+          Valider les {selectedCount} selectionnees
+        </button>
+        <button
+          type="button"
+          onClick={() => setConfirmOpen(true)}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-rose-500/40 bg-card px-3 py-1.5 text-sm font-medium text-rose-600 hover:bg-rose-500/10 transition-colors disabled:opacity-50"
+        >
+          {isDeleting ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Trash2 className="w-3.5 h-3.5" />
+          )}
+          Supprimer la selection
+        </button>
+      </div>
+
+      {confirmOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+          onClick={() => !isDeleting && setConfirmOpen(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="bg-card rounded-xl border border-border w-full max-w-md mx-4 p-5 space-y-4 shadow-xl"
+          >
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-foreground">
+                  Supprimer {selectedCount} brouillon
+                  {selectedCount > 1 ? "s" : ""} ?
+                </h2>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Les écritures sélectionnées seront supprimées définitivement.
+                  Cette action est irréversible. Les écritures déjà validées
+                  doivent être contre-passées à la place.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setConfirmOpen(false)}
+                disabled={isDeleting}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Fermer"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => setConfirmOpen(false)}
+                disabled={isDeleting}
+                className="rounded-lg border border-border bg-card px-3 py-2 text-xs hover:bg-muted/50 disabled:opacity-50"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onDeleteSelected();
+                  setConfirmOpen(false);
+                }}
+                disabled={isDeleting}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-3 py-2 text-xs font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+              >
+                {isDeleting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                Supprimer définitivement
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/app/owner/accounting/entries/components/DeleteEntryButton.tsx
+++ b/app/owner/accounting/entries/components/DeleteEntryButton.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api-client";
+import { Trash2, Loader2, X } from "lucide-react";
+
+interface DeleteEntryButtonProps {
+  entryId: string;
+  entryNumber: string;
+  entryLabel: string;
+  /** "icon" for in-table compact, "button" for the detail page header. */
+  variant?: "icon" | "button";
+}
+
+/**
+ * Bouton + modal de confirmation pour supprimer un brouillon.
+ *
+ * Une écriture validée ne peut pas être supprimée (intangibilité comptable,
+ * art. A47 LPF) — utiliser ReverseEntryButton à la place. Le garde-fou est
+ * dupliqué côté API : DELETE /api/accounting/entries/:id renvoie 400 si
+ * `is_validated` ou `valid_date` est posé.
+ */
+export function DeleteEntryButton({
+  entryId,
+  entryNumber,
+  entryLabel,
+  variant = "icon",
+}: DeleteEntryButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: async () =>
+      apiClient.delete(`/accounting/entries/${entryId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["accounting", "entries"] });
+      queryClient.invalidateQueries({ queryKey: ["accounting", "balance-generale"] });
+      queryClient.invalidateQueries({ queryKey: ["accounting", "grand-livre"] });
+      setOpen(false);
+    },
+    onError: (err: Error) => {
+      setError(err.message ?? "Erreur lors de la suppression");
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    deleteMutation.mutate();
+  };
+
+  return (
+    <>
+      {variant === "icon" ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:text-rose-600 hover:bg-rose-500/10 transition-colors"
+          title="Supprimer ce brouillon"
+          aria-label="Supprimer"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 py-1.5 text-xs hover:bg-rose-500/10 hover:text-rose-600 hover:border-rose-500/40 transition-colors"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+          Supprimer
+        </button>
+      )}
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+          onClick={() => !deleteMutation.isPending && setOpen(false)}
+        >
+          <form
+            onClick={(e) => e.stopPropagation()}
+            onSubmit={handleSubmit}
+            className="bg-card rounded-xl border border-border w-full max-w-md mx-4 p-5 space-y-4 shadow-xl"
+          >
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-foreground">
+                  Supprimer ce brouillon ?
+                </h2>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Cette écriture n'a pas encore été validée — elle peut être
+                  supprimée définitivement. Une écriture validée doit être
+                  contre-passée à la place (intangibilité comptable).
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                disabled={deleteMutation.isPending}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Fermer"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="rounded-lg bg-muted/30 border border-border px-3 py-2 text-xs space-y-0.5">
+              <div>
+                <span className="text-muted-foreground">N° écriture :</span>{" "}
+                <span className="font-mono">{entryNumber}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Libellé :</span>{" "}
+                {entryLabel}
+              </div>
+            </div>
+
+            {error && <p className="text-xs text-destructive">{error}</p>}
+
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg border border-border bg-card px-3 py-2 text-xs hover:bg-muted/50 disabled:opacity-50"
+              >
+                Annuler
+              </button>
+              <button
+                type="submit"
+                disabled={deleteMutation.isPending}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-3 py-2 text-xs font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+              >
+                {deleteMutation.isPending && (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                )}
+                Supprimer définitivement
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/owner/accounting/entries/components/EntryRow.tsx
+++ b/app/owner/accounting/entries/components/EntryRow.tsx
@@ -17,6 +17,7 @@ import type { AccountingEntryRow as AccountingEntryRowData } from "@/lib/hooks/u
 import { formatCents } from "@/lib/utils/format-cents";
 import { cn } from "@/lib/utils";
 import { ReverseEntryButton } from "./ReverseEntryButton";
+import { DeleteEntryButton } from "./DeleteEntryButton";
 
 // ── Helpers (shared with parent via re-export) ─────────────────────
 
@@ -180,13 +181,22 @@ export function EntryRow({ entry, isSelected, onToggleSelect }: EntryRowProps) {
         <SourceBadge source={entry.source} />
       </td>
       <td className="px-3 py-3 text-center">
-        {!entryIsDraft && !entry.reversal_of && (
-          <ReverseEntryButton
+        {entryIsDraft ? (
+          <DeleteEntryButton
             entryId={entry.id}
             entryNumber={entryNumber}
             entryLabel={entryLabel}
             variant="icon"
           />
+        ) : (
+          !entry.reversal_of && (
+            <ReverseEntryButton
+              entryId={entry.id}
+              entryNumber={entryNumber}
+              entryLabel={entryLabel}
+              variant="icon"
+            />
+          )
         )}
       </td>
     </tr>

--- a/app/owner/accounting/exercises/ExercisesClient.tsx
+++ b/app/owner/accounting/exercises/ExercisesClient.tsx
@@ -37,6 +37,7 @@ function ExercisesContent() {
     success?: boolean;
     data?: {
       closedExercise?: { id: string; year: number };
+      newExercise?: { id: string; start_date: string; end_date: string } | null;
       warnings?: string[];
     };
     error?: string;
@@ -85,12 +86,21 @@ function ExercisesContent() {
       queryClient.invalidateQueries({ queryKey: ["exercises"] });
       setClosingId(null);
       const warnings = result?.data?.warnings ?? [];
+      const newExercise = result?.data?.newExercise;
+      const parts: string[] = [];
+      if (newExercise) {
+        parts.push(
+          `Nouvel exercice ouvert : ${newExercise.start_date} → ${newExercise.end_date}.`,
+        );
+      } else {
+        parts.push("Amortissements, déficit et à-nouveaux ont été générés.");
+      }
+      if (warnings.length > 0) {
+        parts.push(`${warnings.length} avertissement(s) : ${warnings.join(" — ")}`);
+      }
       toast({
         title: "Exercice clôturé",
-        description:
-          warnings.length > 0
-            ? `Clôture effectuée avec ${warnings.length} avertissement(s) : ${warnings.join(" — ")}`
-            : "Amortissements, déficit et à-nouveaux ont été générés.",
+        description: parts.join(" "),
       });
     },
     onError: (err) => {

--- a/lib/hooks/use-accounting-entries.ts
+++ b/lib/hooks/use-accounting-entries.ts
@@ -178,6 +178,36 @@ export function useAccountingEntries(params: UseAccountingEntriesParams) {
     },
   });
 
+  // -- Delete mutation -----------------------------------------------------
+  // The API only exposes per-id DELETE; we fan out the requests in parallel.
+  // Settle-don't-throw so a single 4xx (eg. someone validated the entry
+  // between selection and submission) doesn't drop the others on the floor.
+  const deleteMutation = useMutation({
+    mutationFn: async (entryIds: string[]) => {
+      const results = await Promise.allSettled(
+        entryIds.map((id) => apiClient.delete(`/accounting/entries/${id}`)),
+      );
+      const failures = results
+        .map((r, i) => ({ r, id: entryIds[i] }))
+        .filter((x) => x.r.status === "rejected");
+      if (failures.length > 0) {
+        const reason = (failures[0].r as PromiseRejectedResult).reason;
+        const msg = reason instanceof Error ? reason.message : String(reason);
+        throw new Error(
+          failures.length === entryIds.length
+            ? msg
+            : `${failures.length}/${entryIds.length} suppression(s) ont échoué : ${msg}`,
+        );
+      }
+      return { deleted: entryIds.length };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["accounting", "entries"] });
+      queryClient.invalidateQueries({ queryKey: ["accounting", "balance-generale"] });
+      queryClient.invalidateQueries({ queryKey: ["accounting", "grand-livre"] });
+    },
+  });
+
   return {
     entries,
     total,
@@ -190,6 +220,8 @@ export function useAccountingEntries(params: UseAccountingEntriesParams) {
     mutate: () => queryClient.invalidateQueries({ queryKey: ["accounting", "entries"] }),
     validateEntries: validateMutation.mutateAsync,
     isValidating: validateMutation.isPending,
+    deleteEntries: deleteMutation.mutateAsync,
+    isDeleting: deleteMutation.isPending,
   };
 }
 


### PR DESCRIPTION
## Summary

Closes the gaps around accounting-period configuration and draft-entry housekeeping that surfaced while reviewing `/owner/accounting/exercises` and `/owner/accounting/entries`.

### Exercises
- Expose **« Nouvel exercice »** in the exercises page (button + dialog with overlap-safe defaults). The `POST /api/accounting/exercises` route already validated chevauchement; it just had no UI.
- `getOrCreateCurrentExercise` now reads `legal_entities.premier_exercice_debut/fin/date_cloture_exercice` and chains from the most recent exercise instead of always falling back to the calendar year. Non-calendar fiscal years (eg. 01/07 → 30/06) are honoured.
- The close-exercise route's "Step 6 — create next exercise" was using local-time `Date` arithmetic (TZ-fragile) and gating creation on `start_date >= nextStart` (a manually-pre-created N+2 silently masked a missing N+1). Both replaced by the shared `computeNextPeriod` helper + a real overlap check on `[start, end]`.
- The close success toast now surfaces the auto-created N+1 dates (`newExercise` was already in the API response, just discarded).

### Draft entries
- New **DeleteEntryButton** (icon + confirm dialog) in the Action column for every brouillon row — `DELETE /api/accounting/entries/:id` already permitted it but no UI ever called it.
- BulkActions gains **« Supprimer la sélection »** with its own confirm dialog. `useAccountingEntries` exposes `deleteEntries` which fans the per-id DELETE calls out via `Promise.allSettled` and reports partial-failure counts.
- Validated entries are unaffected — they still only show the contre-passation button (intangibilité comptable, art. A47 LPF).

## Test plan

- [ ] On `/owner/accounting/exercises`, click « Nouvel exercice » → dialog pre-fills period chained from latest exercise → create → row appears in « En cours »
- [ ] Try to create with an overlapping date range → API returns 409 → error surfaced in dialog
- [ ] Close an exercise → toast shows the new N+1 period
- [ ] On `/owner/accounting/entries`, locate a Brouillon row → click 🗑️ → confirm → row disappears
- [ ] Select multiple drafts → click « Supprimer la sélection » → confirm → all removed
- [ ] On a Validé row, no 🗑️ shown — only ↩ contre-passer
- [ ] Run unit tests: `auto-exercise-period.test.ts` covers the 5 branches of `computeNextPeriod`

https://claude.ai/code/session_01CaUGiTwYK6DeS61TM9UEWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaUGiTwYK6DeS61TM9UEWZ)_