### PR TITLE
fix(accounting): 7 secondary audit bugs (ownership, empty states, SIREN, headers, fallback)

### DIFF
--- a/app/api/accounting/declarations/[type]/route.ts
+++ b/app/api/accounting/declarations/[type]/route.ts
@@ -342,6 +342,24 @@ export async function GET(
       throw new ApiError(400, "exerciseId et entityId sont requis");
     }
 
+    // Ownership guard. getBalance/getGrandLivre passent par le client
+    // user-scoped donc RLS protege deja, mais on double l'enforcement
+    // avec une lecture explicite : si l'utilisateur passe un entityId
+    // qui ne lui appartient pas, on echoue 403 plutot que de retourner
+    // une declaration vide (ou pire, polluer le compteur de proprietes
+    // partage). Admin bypasse comme partout ailleurs.
+    if (profile.role !== "admin") {
+      const { data: entity } = await (supabase as any)
+        .from("legal_entities")
+        .select("id")
+        .eq("id", entityId)
+        .eq("owner_profile_id", profile.id)
+        .maybeSingle();
+      if (!entity) {
+        throw new ApiError(403, "Acces refuse a cette entite");
+      }
+    }
+
     // Fetch balance and grand livre for the exercise
     const balance = await getBalance(supabase, entityId, exerciseId);
     const grandLivre = await getGrandLivre(supabase, entityId, exerciseId);

--- a/app/api/accounting/fec/[exerciseId]/route.ts
+++ b/app/api/accounting/fec/[exerciseId]/route.ts
@@ -72,21 +72,54 @@ export async function GET(request: Request, context: Context) {
 
     const entityId = exercise.entity_id as string;
 
+    // SIREN officiel de l'entite. Sert :
+    //   - en preview comme valeur reelle (au lieu du sentinel '000000000'
+    //     historique qui validait le format mais aurait genere un FEC
+    //     non utilisable s'il s'echappait)
+    //   - en download pour verifier que le siren passe par le client
+    //     correspond bien a celui de l'entite (evite la generation d'un
+    //     FEC sous une fausse identite, accidentelle ou non).
+    const { data: entityRow } = await (supabase as any)
+      .from("legal_entities")
+      .select("siren")
+      .eq("id", entityId)
+      .maybeSingle();
+    const entitySiren =
+      typeof entityRow?.siren === "string" ? (entityRow.siren as string) : "";
+
     // ---------- Preview mode ----------
     if (preview) {
-      const result = await generateFEC(supabase, entityId, exerciseId, '000000000');
+      // Si l'entite n'a pas de SIREN renseigne, on previsualise quand
+      // meme avec '000000000' pour permettre a l'utilisateur de voir
+      // les erreurs de fond (ecritures non validees, deficits, etc.)
+      // — la validation du SIREN est rappelee dans errors[].
+      const sirenForPreview =
+        entitySiren && /^\d{9}$/.test(entitySiren) ? entitySiren : "000000000";
+      const result = await generateFEC(supabase, entityId, exerciseId, sirenForPreview);
 
       return NextResponse.json({
         valid: result.errors.length === 0,
         errors: result.errors,
         warnings: [],
         lineCount: result.lineCount,
+        sirenUsed: sirenForPreview,
+        sirenIsPlaceholder: sirenForPreview === "000000000",
       });
     }
 
     // ---------- Download mode ----------
     if (!siren) {
       throw new ApiError(400, "Le parametre siren est requis pour le telechargement");
+    }
+    // Garde-fou : le SIREN passe par l'utilisateur doit matcher celui
+    // enregistre sur l'entite. Si la valeur diverge on refuse plutot que
+    // d'emettre un fichier sous une fausse identite. Si l'entite n'a
+    // pas de SIREN, on accepte la valeur fournie (initialisation).
+    if (entitySiren && entitySiren !== siren) {
+      throw new ApiError(
+        400,
+        "Le SIREN fourni ne correspond pas a celui enregistre sur l'entite.",
+      );
     }
 
     const result = await exportFEC(supabase, entityId, exerciseId, siren);

--- a/app/api/accounting/fec/verify/route.ts
+++ b/app/api/accounting/fec/verify/route.ts
@@ -2,13 +2,34 @@
  * API Route: Verify a FEC file against its manifest
  * POST /api/accounting/fec/verify
  *
- * Body: multipart/form-data with a `file` field containing the FEC .txt
- * (or JSON { sha256: string } if the caller already computed it).
+ * Request body — accepte deux formats :
  *
- * Returns whether the SHA-256 of the submitted content matches a manifest
- * stored at export time. Used by the EC portal and the owner export page
- * to guarantee the file in their hands is bit-identical to what TALOK
- * generated.
+ *   1. multipart/form-data avec un champ `file` contenant le FEC .txt
+ *   2. application/json avec la forme camelCase :
+ *        { sha256: string, entityId?: string, year?: number }
+ *      Le serveur ignore les variantes snake_case (`sha256_hex`,
+ *      `entity_id`) — utiliser exclusivement le camelCase.
+ *
+ * Response — application/json en camelCase :
+ *
+ *   {
+ *     match: boolean,
+ *     sha256: string,
+ *     manifest: {
+ *       id: string,
+ *       entityId: string,
+ *       year: number,
+ *       fileSizeBytes: number,
+ *       generatedAt: string,
+ *       generatedBy: string,
+ *     } | null
+ *   }
+ *
+ * `match=true` signifie que le SHA-256 du contenu fourni est strictement
+ * egal a celui d'un manifest archive a l'export. Garantit que le
+ * fichier en main est bit-identique a celui que TALOK a genere.
+ *
+ * Utilise par le portail EC et la page exports proprietaire.
  */
 
 import { NextResponse } from "next/server";

--- a/app/owner/accounting/declarations/DeclarationsClient.tsx
+++ b/app/owner/accounting/declarations/DeclarationsClient.tsx
@@ -85,18 +85,24 @@ function DeclarationsContent() {
     return rest as DeclarationPayload;
   })();
 
-  // Derive the fiscal year from the selected closed exercise. Fall back to
-  // the current calendar year if the exercise cannot be resolved.
+  // Derive the fiscal year from the selected closed exercise. Pas de
+  // fallback silencieux sur l'annee courante : avant, si exerciseId
+  // designait un exercice qu'on n'avait pas reussi a charger (changement
+  // d'entite, race condition), on retombait sur new Date().getFullYear()
+  // → le PDF telechargait avec "Exercice 2026" alors que la donnee
+  // venait de l'exercice clos 2025. selectedYear = null bloque les
+  // actions PDF en aval (handleDownloadPDF ouvre un toast explicite).
   const selectedExercise = (closedExercises ?? []).find((e) => e.id === exerciseId);
-  const selectedYear = selectedExercise
+  const selectedYear: number | null = selectedExercise
     ? parseInt(selectedExercise.start_date.slice(0, 4), 10)
-    : new Date().getFullYear();
+    : null;
 
   const handleDownloadPDF = async () => {
-    if (!activeEntityId || !exerciseId) {
+    if (!activeEntityId || !exerciseId || selectedYear == null) {
       toast({
         title: "Action impossible",
-        description: "Sélectionnez une entité et un exercice clôturé.",
+        description:
+          "Sélectionnez une entité et un exercice clôturé valide. Si l'exercice ne se charge pas, recharge la page.",
         variant: "destructive",
       });
       return;
@@ -134,10 +140,11 @@ function DeclarationsContent() {
   };
 
   const handleSendEC = async () => {
-    if (!activeEntityId || !exerciseId) {
+    if (!activeEntityId || !exerciseId || selectedYear == null) {
       toast({
         title: "Action impossible",
-        description: "Sélectionnez une entité et un exercice clôturé.",
+        description:
+          "Sélectionnez une entité et un exercice clôturé valide. Si l'exercice ne se charge pas, recharge la page.",
         variant: "destructive",
       });
       return;

--- a/app/owner/accounting/exports/ExportsPageClient.tsx
+++ b/app/owner/accounting/exports/ExportsPageClient.tsx
@@ -38,7 +38,10 @@ interface ECAccess {
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-async function downloadBlob(url: string, filename: string) {
+async function downloadBlob(
+  url: string,
+  filename: string,
+): Promise<{ headers: Headers }> {
   const res = await fetch(url, { credentials: "include" });
   if (!res.ok) throw new Error("Erreur lors du telechargement");
   const blob = await res.blob();
@@ -50,6 +53,11 @@ async function downloadBlob(url: string, filename: string) {
   a.click();
   a.remove();
   URL.revokeObjectURL(href);
+  // On retourne les headers pour que les callers puissent surfacer
+  // les meta cote serveur (ex: X-Talok-Pack-Skipped quand certains
+  // documents n'ont pas pu etre integres au ZIP). Sans ca, l'header
+  // etait pose mais jamais consomme cote client.
+  return { headers: res.headers };
 }
 
 // ── Main component ──────────────────────────────────────────────────
@@ -439,15 +447,35 @@ function ExportsContent() {
           <button
             type="button"
             disabled={!exerciseId || !entityId || !!loadingMap["pack-zip"]}
-            onClick={() =>
-              exerciseId &&
-              entityId &&
-              handleDownload(
-                "pack-zip",
-                `/accounting/exports/pack?entityId=${encodeURIComponent(entityId)}&exerciseId=${exerciseId}`,
-                `talok-pack-${currentExercise?.label ?? "exercice"}.zip`,
-              )
-            }
+            onClick={async () => {
+              if (!exerciseId || !entityId) return;
+              setLoading("pack-zip", true);
+              try {
+                const { headers } = await downloadBlob(
+                  `/api/accounting/exports/pack?entityId=${encodeURIComponent(entityId)}&exerciseId=${exerciseId}`,
+                  `talok-pack-${currentExercise?.label ?? "exercice"}.zip`,
+                );
+                // Le backend pose X-Talok-Pack-Skipped quand certains
+                // documents (FEC invalide, balance vide, etc.) n'ont pas
+                // pu etre integres. Avant, l'header etait silencieux —
+                // on alerte maintenant l'utilisateur que son ZIP est
+                // incomplet pour qu'il sache pourquoi avant de le
+                // transmettre a son EC.
+                const skipped = headers.get("x-talok-pack-skipped");
+                if (skipped) {
+                  // window.alert evite d'introduire un nouveau hook
+                  // (useToast n'est pas deja branche dans cette page).
+                  // Le ZIP a deja telecharge via downloadBlob.
+                  window.alert(
+                    `Pack telecharge, mais ces documents n'ont pas pu etre inclus :\n\n${skipped.replace(/ \| /g, "\n")}\n\nVerifie les avant transmission a ton EC.`,
+                  );
+                }
+              } catch (err) {
+                console.error("[ExportsPage] Pack download error:", err);
+              } finally {
+                setLoading("pack-zip", false);
+              }
+            }}
             className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary hover:bg-primary/90 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loadingMap["pack-zip"]

--- a/app/owner/accounting/exports/components/CahierExportPanel.tsx
+++ b/app/owner/accounting/exports/components/CahierExportPanel.tsx
@@ -42,7 +42,7 @@ export function CahierExportPanel({
         </div>
       </div>
 
-      {balance && (
+      {balance ? (
         <div className="grid grid-cols-3 gap-2 text-center">
           <div className="bg-muted/30 rounded-lg p-2">
             <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
@@ -69,6 +69,15 @@ export function CahierExportPanel({
             </p>
           </div>
         </div>
+      ) : (
+        // Empty state quand aucune balance n'est disponible (entite sans
+        // exercice ou sans ecritures validees). Sans cet etat, l'utilisateur
+        // voyait juste le titre + le bouton, sans signal que les chiffres
+        // manquaient — le PDF telecharge serait vide.
+        <p className="text-xs text-muted-foreground italic px-1">
+          Aucune ecriture validee sur l&apos;exercice. Le recapitulatif sera
+          genere une fois la balance alimentee.
+        </p>
       )}
 
       <button
@@ -80,7 +89,7 @@ export function CahierExportPanel({
             `recap_annuel_${exerciseLabel}.pdf`,
           )
         }
-        disabled={downloading}
+        disabled={downloading || !balance}
         className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border bg-muted/50 hover:bg-muted text-foreground border-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-auto"
       >
         {downloading ? "Telechargement..." : "Telecharger PDF"}

--- a/lib/accounting/exports/cerfa-2044-pdf.ts
+++ b/lib/accounting/exports/cerfa-2044-pdf.ts
@@ -252,7 +252,7 @@ export async function generateCerfa2044Pdf(
     const lines = [
       "Methodologie",
       "• Loyers bruts = total credits comptes 706 sur l'exercice.",
-      "• Forfait gestion = 20 EUR par local declare (ligne 221).",
+      "• Frais d'administration et gestion (ligne 221) = max(forfait 20 EUR/local; reels 622xxx + 627).",
       "• Travaux = total debits 615; assurances = 616; interets = 661; taxes = 635.",
       "• Deficit foncier impute sur revenu global plafonne a 10 700 EUR (hors interets).",
     ];


### PR DESCRIPTION
## Summary

Lot H — nettoyage des **7 bugs secondaires** flaggés par l'audit Exports/Déclarations qui n'avaient pas d'impact direct sur la conformité fiscale. Regroupés en un seul commit pour limiter la friction PR.

| # | Sévérité | Bug | Fix |
|---|---|---|---|
| **#13** | MOYENNE | `/declarations/[type]` n'enforçait pas explicitement la propriété de l'entité avant `getBalance`/`getGrandLivre` (RLS protégeait déjà, mais pas de défense en profondeur) | Lookup `legal_entities.owner_profile_id` ; 403 si mismatch (admin bypasse) |
| **#5** | MOYENNE | `CahierExportPanel` sans empty state quand balance null → utilisateur voyait juste le bouton "Télécharger PDF" sans signal | Empty state explicite + bouton désactivé tant que balance non chargée |
| **#6** | MOYENNE | Header `X-Talok-Pack-Skipped` posé par le backend mais jamais consommé côté client → ZIP incomplet sans signal | `downloadBlob` retourne désormais les `Headers` ; le bouton pack inspecte l'header et alerte l'utilisateur via `window.alert` |
| **#14** | MOYENNE | Texte CERFA 2044 PDF affichait "Forfait gestion = 20 EUR par local" alors que depuis Lot F on calcule `max(forfait, réel 622+627)` | Texte aligné sur le calcul réel |
| **#16** | FAIBLE | Fallback silencieux sur `new Date().getFullYear()` si `selectedExercise` non résolu → PDF avec mauvaise année | `selectedYear: number \| null` ; toast explicite quand null |
| **#3** | HAUTE | Preview FEC hardcodait SIREN `'000000000'` → fichier inutilisable s'il s'échappait. Download mode acceptait n'importe quel SIREN du client | Preview utilise SIREN réel (`legal_entities.siren`), fallback `'000000000'` uniquement si non renseigné. Download vérifie que le SIREN client matche celui de l'entité → 400 si divergent |
| **#7** | FAIBLE | `/fec/verify` shape de réponse non documentée (camelCase vs snake_case ambigu) | JSDoc complet : body accepté (multipart OU JSON camelCase), shape réponse en camelCase, variantes snake_case ignorées |

## Stats

```
 7 files changed, 144 insertions(+), 28 deletions(-)
```

## Test plan

- [ ] **#13** : User A passe `?entityId={id de SCI de User B}` à `/api/accounting/declarations/2044` → `403 Acces refuse a cette entite`. Admin passe → OK.
- [ ] **#5** : Page `/owner/accounting/exports` sur entité sans exercice → tile "Récapitulatif annuel" affiche le message empty state, bouton PDF disabled.
- [ ] **#6** : Bouton "Télécharger le pack (ZIP)" sur exercice avec FEC invalide → ZIP télécharge + `window.alert` liste les fichiers skippés.
- [ ] **#14** : PDF CERFA 2044 généré → encart méthodologie affiche "Frais d'administration et gestion (ligne 221) = max(forfait 20 EUR/local; reels 622xxx + 627)".
- [ ] **#16** : Sur DeclarationsClient, simuler `selectedExercise=undefined` → bouton "Télécharger PDF" → toast "Action impossible. Sélectionnez une entité et un exercice clôturé valide".
- [ ] **#3** preview : `GET /api/accounting/fec/{exerciseId}?preview=true` sur entité avec SIREN `123456789` → réponse `sirenUsed: "123456789", sirenIsPlaceholder: false`. Sur entité sans SIREN → `sirenIsPlaceholder: true`.
- [ ] **#3** download : `GET /api/accounting/fec/{exerciseId}?siren=999999999` sur entité avec SIREN `123456789` → 400 "SIREN ne correspond pas".
- [ ] **#7** : Lecture du JSDoc → format camelCase clair, snake_case explicitement écarté.

## Bilan global de la session — 8 PRs mergées sur `main`

| PR | Sujet |
|---|---|
| #534 | Dashboard KPIs branchés, synthèse balance, MV fallback, mapping camelCase exercices |
| #535 | Auto-seed chart of accounts, fix `120` → `120000`, `545000` mandant |
| #536 | PCG enrichi 66 → 99 comptes, 5 auto-entries, TVA opt-in |
| #537 | TVA sur loyers, `recoverable_charge_received`, fix régul charges déséquilibrée |
| #538 | 11 templates UI dans QuickEntryForm |
| #541 | 5 bugs critiques déclarations fiscales (entityId, ligne 221, NaN, MV, micro-foncier) |
| #542 | Hygiène FEC : kill route dépréciée, délégation legacy au moteur |
| **#XXX** | **(this) 7 bugs secondaires de l'audit nettoyés** |

https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH8oPyeHFuDuDpGahsQ2DL)_