### PR TITLE
Handle multiple EC access response formats

### DIFF
--- a/app/owner/accounting/ec/ECManageClient.tsx
+++ b/app/owner/accounting/ec/ECManageClient.tsx
@@ -18,7 +18,12 @@ type EcAccessItem = {
   read_only_access: boolean;
 };
 
-type EcAccessResponse = EcAccessItem[] | { data?: EcAccessItem[] };
+type EcAccessResponse =
+  | EcAccessItem[]
+  | { data?: EcAccessItem[] | { accesses?: EcAccessItem[] } | null }
+  | { accesses?: EcAccessItem[] }
+  | null
+  | undefined;
 
 export default function ECManageClient() {
   return (
@@ -60,9 +65,19 @@ function ECManageContent() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["ec-access"] }),
   });
 
-  const ecList: EcAccessItem[] = Array.isArray(data)
-    ? data
-    : (data?.data ?? []);
+  const ecList: EcAccessItem[] = (() => {
+    if (Array.isArray(data)) return data;
+    if (!data || typeof data !== "object") return [];
+    const inner = (data as { data?: unknown }).data;
+    if (Array.isArray(inner)) return inner as EcAccessItem[];
+    if (inner && typeof inner === "object") {
+      const accesses = (inner as { accesses?: unknown }).accesses;
+      if (Array.isArray(accesses)) return accesses as EcAccessItem[];
+    }
+    const topAccesses = (data as { accesses?: unknown }).accesses;
+    if (Array.isArray(topAccesses)) return topAccesses as EcAccessItem[];
+    return [];
+  })();
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-2xl mx-auto space-y-6">


### PR DESCRIPTION
## Summary
Updated the EC access response handling to support multiple API response formats that may be returned from the backend.

## Key Changes
- **Expanded `EcAccessResponse` type** to handle additional response structures:
  - Direct array of `EcAccessItem[]`
  - Object with `data` property containing array or nested object with `accesses`
  - Object with top-level `accesses` property
  - `null` and `undefined` values

- **Refactored data extraction logic** from a simple ternary to a more robust IIFE that:
  - Checks if response is a direct array
  - Validates data type before accessing properties
  - Handles nested `data.accesses` structure
  - Falls back to top-level `accesses` property
  - Returns empty array as final fallback

## Implementation Details
The new extraction logic uses defensive programming with type checks at each level to safely navigate the response object, preventing runtime errors when the API returns unexpected structures. This provides better resilience to API response variations while maintaining type safety.

https://claude.ai/code/session_0181MrbfUVzh5qyvWY1SJzCu