### PR TITLE
Audit module comptabilité — fixes structurels + portail EC + agence Hoguet

### DIFF
--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -255,7 +255,37 @@ export async function createEntry(
     .select()
     .single();
 
-  if (entryError) throw new Error(`Failed to create entry: ${entryError.message}`);
+  if (entryError) {
+    // 23505 unique_violation sur uq_accounting_entries_reference_source
+    // (index unique partiel sur (reference, source) WHERE source LIKE
+    // 'auto:%') : un autre caller concurrent a gagné la course
+    // d'idempotence — l'écriture qu'on voulait poser existe déjà avec
+    // les mêmes (reference, source). On la récupère et la retourne
+    // comme si on venait de la créer. Le caller (ensure*Entry helper)
+    // distingue déjà created vs already_exists via son propre SELECT
+    // en amont — ici on ferme juste la fenêtre TOCTOU entre ce SELECT
+    // et l'INSERT.
+    //
+    // Note : on ne ré-insère PAS les lines (le caller gagnant l'a fait
+    // dans la même transaction côté DB) et on ne re-valide PAS
+    // l'écriture (le caller gagnant gère sa propre validation).
+    if (
+      (entryError as { code?: string }).code === '23505' &&
+      params.reference &&
+      params.source?.startsWith('auto:')
+    ) {
+      const { data: existing } = await supabase
+        .from('accounting_entries')
+        .select('*')
+        .eq('reference', params.reference)
+        .eq('source', params.source)
+        .maybeSingle();
+      if (existing) {
+        return mapEntry(existing as Record<string, unknown>);
+      }
+    }
+    throw new Error(`Failed to create entry: ${entryError.message}`);
+  }
 
   // Insert lines
   const lineInserts = params.lines.map((line) => ({


### PR DESCRIPTION
## Contexte

Audit complet du module comptabilité (cf. session de travail). 25 commits livrés en 5 axes : **fixes structurels comptables**, **flux agence Hoguet end-to-end**, **portail expert-comptable**, **alignement schéma canonique**, et **safeguards de race**.

Ta BDD prod est déjà à jour côté tables (vérifié pendant l'audit). Une migration SQL légère a été appliquée via Studio pendant la session : DROP `mandates` (0 row), RENAME `mandant_accounts` → `mandant_accounts_legacy` (2 rows archivés), ajout d'un index UNIQUE partiel `uq_accounting_entries_reference_source`.

## Vrais bugs corrigés

- 🔴 **CRG Section 3 systématiquement vide** — le builder engine émettait `auto:agency_fee` mais 3 readers (crg-generator, hoguet-report, edge function) attendaient `auto:agency_commission`. Renommé. (`250a632`)
- 🔴 **CRG Sections 1 + 2 vides aussi** — builders `agency_loyer_mandant` et `agency_reversement` n'existaient pas. Ajoutés + déclencheurs câblés. (`ab7fded`, `844172a`, `756c551`)
- 🔴 **Stripe webhook entries fantômes** — `rent_received` posait D 512 / C 706 sur le proprio même quand la property était sous mandat actif (l'argent atterrit en réalité sur 545 de l'agence). Skip ajouté. (`b929fb8`)
- 🔴 **Mode IS lump sum** — `rent_invoiced` mettait tout sur 706 (loyer), provisions incluses. Splittré : 706 pour loyer, 419 100 pour provisions via `provision_called`. (`7c09400`)
- 🔴 **CRG generate stub** — `totalRentCollectedCents = 0` hardcodé, plus double-comptage de la balance à chaque génération. Agrégation réelle depuis `accounting_entries` + suppression de l'increment redondant. (`9c07b5a`)
- 🔴 **Portail EC bug silencieux** — la query envoyait `entityId` (camel) alors que la route lit `entity_id` (snake) → fallback sur `owner_id=profile.id` → l'EC voyait toujours zéro écriture. (`4fcb492`)
- 🔴 **Mandates list/detail désalignés** — GET lisait `agency_mandates` (canonique), POST écrivait dans `mandates` (legacy) → mandats créés invisibles. Migration POST sur `agency_mandates`. (`e2a5a77`, `5ba1464`)
- 🔴 **Régul charges sans compta** — le flux legacy `applyRegularisation` créait l'invoice mais aucune écriture comptable. `auto:charge_regularization` câblé via `bookRegularisationEntry`. (`0830b78`)
- 🔴 **Wizard new mandate fake submit** — `setTimeout(1500)` qui toast-ait sans persister. Wired sur l'API réelle avec lookup owner par email + résolution properties. (`20d6d6f`)

## Nouvelles features

- **Portail Expert-Comptable** : auth guard middleware, KPI summary (recettes/dépenses/résultat), grand-livre format comptable classique (Total + Solde par compte + TOTAL GRAND-LIVRE), bouton "Tout télécharger" pack ZIP, marquer annotation résolue (optimistic UI), filtres status/search sur les écritures, sélecteur exercice. (`4ab65f4`, `4fcb492`, `0829c6b`, `1ac64ea`, `1e567f8`)
- **Agence Hoguet** : trigger automatique `agency_loyer_mandant` + `agency_commission` sur paiement Stripe ou mark-as-paid, helper + endpoint manuel pour `agency_reversement` avec dialog UI dédié, cron mensuel auto-reversements avec dry-run, email mandant à l'envoi du CRG via Resend. (`844172a`, `756c551`, `9a649fd`, `e2f9712`, `7729431`, `6e78899`)
- **Grand-livre owner** : refonte au format comptable classique (lignes Total + Solde par compte avec D/C side-aware, TOTAL GRAND-LIVRE en pied), auto-déploiement au chargement. (`4106980`)
- **AICommandPalette unifiée** : route automatiquement vers `/api/accounting/agent/chat` (TALO RAG) sur les pages `/accounting/*`, sinon agent générique inchangé. Pas de FAB dupliqué. (`77c5421`)

## Safeguards

- Index UNIQUE partiel sur `(reference, source) WHERE source LIKE 'auto:%'` — DB
- `engine.createEntry` catche `23505 unique_violation` et retourne l'existant — verrouille la TOCTOU des helpers `ensure*Entry`. (`990f273`)

## Hygiène

- 2 `@ts-nocheck` retirés (EC files n'avaient pas d'imports Supabase) + 3 `@ts-ignore` centralisés en `let invoicesQuery: any` + 2 `as any` triviaux nettoyés. (`6e7e4f0`)
- Doc `// Callers:` ajoutée sur les routes UI-orphelines `bank/sync` et `bank/import` (cron + fallback OFX). (`4e8123c`)

## Décisions produit validées pendant la session

1. ✅ Mandant schema canonique = `agency_mandates` (Hoguet 1-balance) + archivage legacy `mandant_accounts`
2. ✅ Régul charges : garde 2 tables (`charge_regularisations` legacy user-facing + `charge_regularizations` modern compta), unifie via auto-entry dans `apply`
3. ✅ Mode IS roadmap : compléter la chaîne (split rent/provisions à l'invoice IS)

## Hors scope (résiduels backlog)

- `totalChargesPaidCents` dans CRG generate — stub documenté, nécessite flux "agence paie dépenses property pour propriétaire" non implémenté
- Trigger reversement auto via rapprochement bancaire — gros chantier intégration reconciliation
- Régénération `database.types.ts` via Supabase CLI — nécessite terminal local
- Cleanup définitif `mandant_accounts_legacy` — réconciliation manuelle des soldes positifs requise

## Test plan

- [ ] Owner direct (foncier réel) : émission invoice → paiement Stripe → écriture `rent_received` côté propriétaire ✓
- [ ] Owner sous mandat agence : paiement Stripe → écritures `agency_loyer_mandant` + `agency_commission` côté agence, **rien** côté owner ✓
- [ ] Mode IS : émission invoice → écritures `rent_invoiced` (706) + `provision_called` (419 100) si charges
- [ ] Régul charges legacy : `applyRegularisation` → invoice + écriture `auto:charge_regularization`
- [ ] Agence Reverser au mandant via UI : POST endpoint, balance décrementée, écriture `agency_reversement`
- [ ] Cron monthly reversements `?dryRun=true` : preview sans écriture
- [ ] CRG generate : agrégation réelle des écritures, pas de double-count balance
- [ ] CRG send : email Resend reçu par mandant avec récap chiffré
- [ ] EC portail : auth guard, KPI summary, grand-livre tab, pack ZIP, annotations résolvables, filtres entries
- [ ] Idempotence : webhook Stripe rejoué → pas de doublon (index unique tient)

## Migration SQL appliquée pendant l'audit

```sql
DROP TABLE IF EXISTS public.mandates CASCADE;
ALTER TABLE public.mandant_accounts RENAME TO mandant_accounts_legacy;
CREATE UNIQUE INDEX IF NOT EXISTS uq_accounting_entries_reference_source
  ON public.accounting_entries (reference, source)
  WHERE reference IS NOT NULL AND source LIKE 'auto:%';
```

https://claude.ai/code/session_01Qag3PTuCD4WsEN6ampkYjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qag3PTuCD4WsEN6ampkYjj)_