### PR TITLE
Centralize API envelope unwrapping logic

### DIFF
--- a/app/owner/accounting/exports/ExportsPageClient.tsx
+++ b/app/owner/accounting/exports/ExportsPageClient.tsx
@@ -149,11 +149,19 @@ function ExportsContent() {
     queryKey: ["ec_access", entityId],
     queryFn: async () => {
       try {
+        // The endpoint shape is `{ success, data: { accesses: [...] } }`.
+        // Older variants returned the raw array or `{ data: [...] }`, so we
+        // accept all three to stay forward/backward compatible — without the
+        // `.accesses` unwrap, `ecAccess.find(...)` throws "find is not a
+        // function" because we'd hand react-query the wrapper object.
         const response = await apiClient.get<
-          { success?: boolean; data?: ECAccess[] } | ECAccess[]
+          | { success?: boolean; data?: { accesses?: ECAccess[] } | ECAccess[] }
+          | ECAccess[]
         >(`/accounting/ec/access?entityId=${entityId}`);
         if (Array.isArray(response)) return response;
-        return response?.data ?? [];
+        const data = response?.data;
+        if (Array.isArray(data)) return data;
+        return data?.accesses ?? [];
       } catch (err) {
         // Endpoint may not exist in all environments — degrade gracefully.
         console.warn("[ExportsPageClient] ec-access query failed:", err);
@@ -164,7 +172,8 @@ function ExportsContent() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const activeEC = ecAccess?.find((ec) => ec.is_active) ?? null;
+  const activeEC =
+    Array.isArray(ecAccess) ? ecAccess.find((ec) => ec.is_active) ?? null : null;
 
   // ── FEC preview ───────────────────────────────────────────────────
 

--- a/app/owner/accounting/exports/ExportsPageClient.tsx
+++ b/app/owner/accounting/exports/ExportsPageClient.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { ExportCard } from "@/components/accounting/ExportCard";
 import { apiClient } from "@/lib/api-client";
+import { unwrapList } from "@/lib/helpers/api-envelope";
 import { useAuth } from "@/lib/hooks/use-auth";
 import { useEntityStore } from "@/stores/useEntityStore";
 import {
@@ -90,17 +91,15 @@ function ExportsContent() {
 
   // ── Exercise selector ─────────────────────────────────────────────
 
-  // API envelope shape: `{ success, data: { exercises: [...] } }`. Keep the
-  // raw-array fallback so the code is resilient if the shape ever changes.
+  // API envelope shape: `{ success, data: { exercises: [...] } }`.
+  // unwrapList also accepts the raw array / `{ data: [] }` legacy shapes.
   const { data: exercises } = useQuery<AccountingExercise[]>({
     queryKey: ["accounting", "exercises", entityId],
     queryFn: async () => {
-      const response = await apiClient.get<
-        | { success?: boolean; data?: { exercises: AccountingExercise[] } }
-        | AccountingExercise[]
-      >(`/accounting/exercises?entityId=${entityId}`);
-      if (Array.isArray(response)) return response;
-      return response?.data?.exercises ?? [];
+      const response = await apiClient.get<unknown>(
+        `/accounting/exercises?entityId=${entityId}`,
+      );
+      return unwrapList<AccountingExercise>(response, "exercises");
     },
     enabled: !!entityId,
     staleTime: 5 * 60 * 1000,
@@ -149,19 +148,14 @@ function ExportsContent() {
     queryKey: ["ec_access", entityId],
     queryFn: async () => {
       try {
-        // The endpoint shape is `{ success, data: { accesses: [...] } }`.
-        // Older variants returned the raw array or `{ data: [...] }`, so we
-        // accept all three to stay forward/backward compatible — without the
-        // `.accesses` unwrap, `ecAccess.find(...)` throws "find is not a
-        // function" because we'd hand react-query the wrapper object.
-        const response = await apiClient.get<
-          | { success?: boolean; data?: { accesses?: ECAccess[] } | ECAccess[] }
-          | ECAccess[]
-        >(`/accounting/ec/access?entityId=${entityId}`);
-        if (Array.isArray(response)) return response;
-        const data = response?.data;
-        if (Array.isArray(data)) return data;
-        return data?.accesses ?? [];
+        // Endpoint returns `{ success, data: { accesses: [...] } }`.
+        // unwrapList prevents the `find is not a function` regression that
+        // happened when this code returned `response.data` (the wrapper)
+        // straight to react-query.
+        const response = await apiClient.get<unknown>(
+          `/accounting/ec/access?entityId=${entityId}`,
+        );
+        return unwrapList<ECAccess>(response, "accesses");
       } catch (err) {
         // Endpoint may not exist in all environments — degrade gracefully.
         console.warn("[ExportsPageClient] ec-access query failed:", err);
@@ -172,8 +166,7 @@ function ExportsContent() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const activeEC =
-    Array.isArray(ecAccess) ? ecAccess.find((ec) => ec.is_active) ?? null : null;
+  const activeEC = ecAccess?.find((ec) => ec.is_active) ?? null;
 
   // ── FEC preview ───────────────────────────────────────────────────
 

--- a/lib/helpers/api-envelope.ts
+++ b/lib/helpers/api-envelope.ts
@@ -1,0 +1,25 @@
+/**
+ * Unwrap a list payload from the standard Talok API envelope.
+ *
+ * The convention server-side is `{ success, data: { <key>: [...] } }` but a
+ * handful of older routes return `{ success, data: [...] }` or even the raw
+ * array. Consumers that called `.find` / `.map` directly on `response?.data`
+ * crashed when the wrapper changed shape (see /owner/accounting/exports
+ * where `H.find is not a function` tripped the owner error boundary). This
+ * helper centralises the three cases so the call site is a single line and
+ * regressions stay contained.
+ *
+ * Pass `key` when the array lives under `data.<key>` (e.g. `accesses`,
+ * `exercises`). Omit it when the array is at `data` directly.
+ */
+export function unwrapList<T>(response: unknown, key?: string): T[] {
+  if (Array.isArray(response)) return response as T[];
+  if (!response || typeof response !== "object") return [];
+  const data = (response as { data?: unknown }).data;
+  if (Array.isArray(data)) return data as T[];
+  if (key && data && typeof data === "object") {
+    const inner = (data as Record<string, unknown>)[key];
+    if (Array.isArray(inner)) return inner as T[];
+  }
+  return [];
+}

--- a/lib/hooks/use-accounting-dashboard.ts
+++ b/lib/hooks/use-accounting-dashboard.ts
@@ -9,6 +9,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api-client";
+import { unwrapList } from "@/lib/helpers/api-envelope";
 import { useAuth } from "./use-auth";
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -73,14 +74,10 @@ export function useAccountingDashboard(options: UseAccountingDashboardOptions = 
       if (!entityId) return null;
       try {
         // Server returns `{ success, data: { exercises: [...] } }`.
-        // Fallback accepts a raw array so the hook is resilient if the
-        // shape ever gets simplified.
-        const response = await apiClient.get<
-          AccountingApiEnvelope<{ exercises: AccountingExercise[] }> | AccountingExercise[]
-        >(`/accounting/exercises?entityId=${entityId}`);
-        const exercises: AccountingExercise[] = Array.isArray(response)
-          ? response
-          : response?.data?.exercises ?? [];
+        const response = await apiClient.get<unknown>(
+          `/accounting/exercises?entityId=${entityId}`,
+        );
+        const exercises = unwrapList<AccountingExercise>(response, "exercises");
         return (
           exercises.find((e) => e.status === "open") ?? exercises[0] ?? null
         );
@@ -128,11 +125,10 @@ export function useAccountingDashboard(options: UseAccountingDashboardOptions = 
       if (!entityId) return [];
       try {
         // Server returns `{ success, data: AccountingEntry[], meta }`.
-        const response = await apiClient.get<
-          AccountingApiEnvelope<AccountingEntry[]> | AccountingEntry[]
-        >(`/accounting/entries?entityId=${entityId}&limit=5&sort=created_at:desc`);
-        if (Array.isArray(response)) return response;
-        return response?.data ?? [];
+        const response = await apiClient.get<unknown>(
+          `/accounting/entries?entityId=${entityId}&limit=5&sort=created_at:desc`,
+        );
+        return unwrapList<AccountingEntry>(response);
       } catch (error) {
         console.error("[useAccountingDashboard] entries query failed:", error);
         throw error;


### PR DESCRIPTION
## Summary
Introduces a new `unwrapList` helper function to standardize how API responses are parsed across the codebase, eliminating duplicated envelope-unwrapping logic and preventing regressions from shape mismatches.

## Key Changes
- **New helper**: Added `lib/helpers/api-envelope.ts` with `unwrapList<T>()` function that handles three API response shapes:
  - Standard envelope: `{ success, data: { <key>: [...] } }`
  - Legacy envelope: `{ success, data: [...] }`
  - Raw array: `[...]`

- **Updated `ExportsPageClient.tsx`**:
  - Replaced inline envelope unwrapping logic for exercises query with `unwrapList(response, "exercises")`
  - Replaced inline envelope unwrapping logic for EC access query with `unwrapList(response, "accesses")`
  - Added explanatory comment about preventing the `find is not a function` regression

- **Updated `use-accounting-dashboard.ts`**:
  - Replaced inline envelope unwrapping for exercises query with `unwrapList(response, "exercises")`
  - Replaced inline envelope unwrapping for entries query with `unwrapList(response)`
  - Removed now-unnecessary `AccountingApiEnvelope` type annotations

## Implementation Details
The `unwrapList` helper centralizes envelope handling to prevent issues where code calling `.find()` or `.map()` directly on `response?.data` would crash if the API response shape changed. By consolidating this logic in one place, regressions stay contained and call sites remain simple and readable.

https://claude.ai/code/session_015VnhRdNpkd4vrD5PXwUu2x