### PR TITLE
Refactor provider quote queries to flatten nested relations

### DIFF
--- a/app/api/owner/provider-quotes/route.ts
+++ b/app/api/owner/provider-quotes/route.ts
@@ -52,11 +52,11 @@ export async function GET(request: NextRequest) {
         created_at,
         provider:profiles!provider_quotes_provider_profile_id_fkey (
           prenom,
-          nom
-        ),
-        provider_profile:provider_profiles!provider_quotes_provider_profile_id_fkey (
-          raison_sociale,
-          company_logo_url
+          nom,
+          provider_profile:provider_profiles (
+            raison_sociale,
+            company_logo_url
+          )
         ),
         property:properties (
           adresse_complete,
@@ -79,11 +79,15 @@ export async function GET(request: NextRequest) {
     }
 
     const enriched = (quotes || []).map((q) => {
-      const provUser = q.provider as { prenom?: string; nom?: string } | null;
-      const provInfo = q.provider_profile as {
-        raison_sociale?: string | null;
-        company_logo_url?: string | null;
+      const provUser = q.provider as {
+        prenom?: string;
+        nom?: string;
+        provider_profile?: {
+          raison_sociale?: string | null;
+          company_logo_url?: string | null;
+        } | null;
       } | null;
+      const provInfo = provUser?.provider_profile ?? null;
       const property = q.property as {
         adresse_complete?: string | null;
         ville?: string | null;

--- a/app/api/provider/quotes/[id]/send/route.ts
+++ b/app/api/provider/quotes/[id]/send/route.ts
@@ -53,10 +53,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         ),
         provider:profiles!provider_quotes_provider_profile_id_fkey (
           prenom,
-          nom
-        ),
-        provider_profile:provider_profiles!provider_quotes_provider_profile_id_fkey (
-          raison_sociale
+          nom,
+          provider_profile:provider_profiles (
+            raison_sociale
+          )
         ),
         property:properties (
           adresse_complete,
@@ -117,8 +117,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       prenom?: string | null;
       nom?: string | null;
     } | null;
-    const providerObj = quote.provider as { prenom?: string | null; nom?: string | null } | null;
-    const providerInfo = quote.provider_profile as { raison_sociale?: string | null } | null;
+    const providerObj = quote.provider as {
+      prenom?: string | null;
+      nom?: string | null;
+      provider_profile?: { raison_sociale?: string | null } | null;
+    } | null;
+    const providerInfo = providerObj?.provider_profile ?? null;
     const propertyObj = quote.property as {
       adresse_complete?: string | null;
       code_postal?: string | null;


### PR DESCRIPTION
## Summary
Restructured Supabase queries in provider quote endpoints to flatten the nested `provider_profile` relation, moving it from a separate top-level field into the `provider` object. This simplifies the data structure and reduces redundancy in the API responses.

## Key Changes
- **Query restructuring**: Moved `provider_profile` relation from a separate query field into a nested field within the `provider` object in both endpoints
- **Type definitions**: Updated TypeScript type definitions to reflect the new nested structure where `provider_profile` is accessed via `provider.provider_profile`
- **Data extraction logic**: Simplified the enrichment/mapping logic by deriving `provInfo` from `provUser?.provider_profile` instead of accessing a separate top-level field

## Files Modified
- `app/api/owner/provider-quotes/route.ts`: Updated GET endpoint query and data mapping
- `app/api/provider/quotes/[id]/send/route.ts`: Updated POST endpoint query and data mapping

## Implementation Details
The changes maintain the same data being fetched while improving the logical organization. Instead of:
```
provider { prenom, nom }
provider_profile { raison_sociale, company_logo_url }
```

The structure is now:
```
provider { 
  prenom, 
  nom,
  provider_profile { raison_sociale, company_logo_url }
}
```

This eliminates the need to track two separate variables for provider information and makes the relationship between the provider and their profile data more explicit in the type system.

https://claude.ai/code/session_01Pr9YVtoSKESBZDEy4Y1ZQE