### PR TITLE
fix(properties): module biens — édition, upload, cover, accès SCI, multi-rôles

### DIFF
--- a/app/owner/buildings/[id]/BuildingDetailClient.tsx
+++ b/app/owner/buildings/[id]/BuildingDetailClient.tsx
@@ -440,10 +440,8 @@ export function BuildingDetailClient({
       formData.append("type", "photo");
       formData.append("property_id", propertyId);
 
-      const res = await fetch("/api/documents/upload", { method: "POST", body: formData });
-      if (!res.ok) throw new Error("Erreur d'upload");
-
-      const result = await res.json();
+      // apiClient.uploadFile : CSRF + cookies + check response.ok intégrés
+      const result = await apiClient.uploadFile<any>("/documents/upload", formData);
       const doc = result.document || result;
 
       // Get signed URL for the uploaded photo to use as cover
@@ -626,15 +624,8 @@ export function BuildingDetailClient({
       formData.append("type", selectedDocType);
       formData.append("property_id", propertyId);
 
-      const res = await fetch("/api/documents/upload", {
-        method: "POST",
-        body: formData,
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => null);
-        throw new Error(err?.error || "Erreur lors de l'upload");
-      }
-      const result = await res.json();
+      // apiClient.uploadFile : CSRF + cookies + check response.ok intégrés
+      const result = await apiClient.uploadFile<any>("/documents/upload", formData);
       if (result.document) {
         setDocuments(prev => [result.document, ...prev]);
       }

--- a/app/owner/leases/[id]/tabs/components/DocumentUploadDialog.tsx
+++ b/app/owner/leases/[id]/tabs/components/DocumentUploadDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { apiClient } from "@/lib/api-client";
 import {
   Dialog,
   DialogContent,
@@ -108,15 +109,8 @@ export function DocumentUploadDialog({
       formData.append("lease_id", leaseId);
       formData.append("property_id", propertyId);
 
-      const res = await fetch("/api/documents/upload", {
-        method: "POST",
-        body: formData,
-      });
-
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || "Erreur lors de l'upload");
-      }
+      // apiClient.uploadFile : CSRF + cookies + check response.ok intégrés
+      await apiClient.uploadFile<any>("/documents/upload", formData);
 
       toast({
         title: "Document ajouté",

--- a/app/owner/profile/identity/page.tsx
+++ b/app/owner/profile/identity/page.tsx
@@ -152,24 +152,11 @@ export default function OwnerIdentityPage() {
       formData.append("file", file);
       formData.append("type", side === "recto" ? "cni_recto" : "cni_verso");
 
-      const { createClient: createSupabaseClient } = await import("@/lib/supabase/client");
-      const supabase = createSupabaseClient();
-      const { data: { session } } = await supabase.auth.getSession();
-
-      const res = await fetch("/api/documents/upload", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${session?.access_token}`,
-        },
-        body: formData,
-      });
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: "Erreur upload" }));
-        throw new Error(err.error || `Erreur ${res.status}`);
-      }
-
-      const { document: newDoc } = await res.json();
+      // apiClient.uploadFile : CSRF + cookies auth + check response.ok
+      const { document: newDoc } = await apiClient.uploadFile<{ document: any }>(
+        "/documents/upload",
+        formData
+      );
 
       setDocuments(prev => ({ ...prev, [side]: newDoc }));
 

--- a/app/owner/properties/[id]/PropertyDetailsClient.tsx
+++ b/app/owner/properties/[id]/PropertyDetailsClient.tsx
@@ -171,6 +171,10 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
   const [pendingPhotoUrls, setPendingPhotoUrls] = useState<string[]>([]);
   const [photosToDelete, setPhotosToDelete] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
+  // Statut visuel par index dans pendingPhotos : 'pending' (à enregistrer),
+  // 'uploading' (upload en cours), 'failed' (échec). Permet d'afficher un
+  // badge clair par photo et de retenir les fichiers en échec après save.
+  const [uploadStatuses, setUploadStatuses] = useState<Record<number, "pending" | "uploading" | "failed">>({});
   const [tickets, setTickets] = useState<Ticket[]>([]);
 
   // ========== INLINE EDIT: Accès & Sécurité ==========
@@ -259,6 +263,7 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
     setPendingPhotos([]);
     setPendingPhotoUrls([]);
     setPhotosToDelete([]);
+    setUploadStatuses({});
     setIsEditing(true);
   };
 
@@ -270,6 +275,7 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
     setPendingPhotos([]);
     setPendingPhotoUrls([]);
     setPhotosToDelete([]);
+    setUploadStatuses({});
   };
 
   // ========== SAUVEGARDE GLOBALE ==========
@@ -409,7 +415,15 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
             ? "interieur"
             : "vue_generale";
 
-        for (const file of pendingPhotos) {
+        // Tracker quels indices ont échoué pour pouvoir les conserver
+        // dans pendingPhotos après le save (l'utilisateur peut retry).
+        const failedIndices: number[] = [];
+
+        for (let i = 0; i < pendingPhotos.length; i++) {
+          const file = pendingPhotos[i];
+          // Marquer cette photo comme "uploading" → badge bleu animé
+          setUploadStatuses((prev) => ({ ...prev, [i]: "uploading" }));
+
           try {
             const { upload_url } = await apiClient.post<{ upload_url: string; photo: any }>(
               `/properties/${propertyId}/photos/upload-url`,
@@ -426,38 +440,70 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
             });
             if (!uploadResponse.ok) {
               uploadFailures.push(file.name);
+              failedIndices.push(i);
+              setUploadStatuses((prev) => ({ ...prev, [i]: "failed" }));
             }
           } catch (uploadErr) {
             console.error("[PropertyDetails] Erreur upload photo", file.name, uploadErr);
             uploadFailures.push(file.name);
+            failedIndices.push(i);
+            setUploadStatuses((prev) => ({ ...prev, [i]: "failed" }));
           }
         }
-      }
 
-      // 4. Recharger les photos depuis la source de vérité
-      try {
-        const photosResponse = await apiClient.get<{ photos: any[] }>(`/properties/${propertyId}/photos`);
-        setPhotos(photosResponse.photos || []);
-      } catch {
-        // Photos non rechargées - non critique
-      }
+        // 4. Recharger les photos depuis la source de vérité
+        try {
+          const photosResponse = await apiClient.get<{ photos: any[] }>(`/properties/${propertyId}/photos`);
+          setPhotos(photosResponse.photos || []);
+        } catch {
+          // Photos non rechargées - non critique
+        }
 
-      // 5. Cleanup et quitter le mode édition
-      pendingPhotoUrls.forEach((url) => URL.revokeObjectURL(url));
-      setIsEditing(false);
-      setEditedValues({});
-      setPendingPhotos([]);
-      setPendingPhotoUrls([]);
-      setPhotosToDelete([]);
-
-      if (uploadFailures.length > 0) {
-        toast({
-          title: "Upload partiel",
-          description: `Certaines photos n'ont pas pu être uploadées : ${uploadFailures.join(", ")}`,
-          variant: "destructive",
-          duration: 6000,
+        // 5. Nettoyer SEULEMENT les fichiers uploadés avec succès. Les fichiers
+        //    en échec restent dans pendingPhotos avec leur badge "failed" et
+        //    l'utilisateur peut retry ou les supprimer.
+        const failedSet = new Set(failedIndices);
+        const keptFiles: File[] = [];
+        const keptUrls: string[] = [];
+        const newStatuses: Record<number, "pending" | "uploading" | "failed"> = {};
+        pendingPhotos.forEach((f, i) => {
+          if (failedSet.has(i)) {
+            keptFiles.push(f);
+            keptUrls.push(pendingPhotoUrls[i]);
+            newStatuses[keptFiles.length - 1] = "failed";
+          } else {
+            URL.revokeObjectURL(pendingPhotoUrls[i]);
+          }
         });
+        setPendingPhotos(keptFiles);
+        setPendingPhotoUrls(keptUrls);
+        setUploadStatuses(newStatuses);
+
+        if (uploadFailures.length > 0) {
+          // ⚠️ Garder le mode édition pour permettre le retry sur les échecs
+          toast({
+            title: `${uploadFailures.length} photo${uploadFailures.length > 1 ? "s en échec" : " en échec"}`,
+            description: `Photos uploadées : ${pendingPhotos.length - uploadFailures.length}/${pendingPhotos.length}. Réessayez ou supprimez les photos en rouge.`,
+            variant: "destructive",
+            duration: 8000,
+          });
+        } else {
+          // ✅ Tous les uploads ont réussi → on quitte le mode édition
+          setIsEditing(false);
+          setEditedValues({});
+          setPhotosToDelete([]);
+          toast({
+            title: "Modifications enregistrées",
+            description: pendingPhotos.length > 0
+              ? `${pendingPhotos.length} photo${pendingPhotos.length > 1 ? "s ajoutée" + (pendingPhotos.length > 1 ? "s" : "") : " ajoutée"} avec succès.`
+              : "Toutes les modifications ont été sauvegardées.",
+          });
+        }
       } else {
+        // Aucune photo à uploader → quitter le mode édition normalement
+        setIsEditing(false);
+        setEditedValues({});
+        setPhotosToDelete([]);
         toast({
           title: "Modifications enregistrées",
           description: "Toutes les modifications ont été sauvegardées avec succès.",
@@ -541,7 +587,18 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
     if (!files) return;
     const newFiles = Array.from(files);
     const newUrls = newFiles.map((file) => URL.createObjectURL(file));
-    setPendingPhotos((prev) => [...prev, ...newFiles]);
+    setPendingPhotos((prev) => {
+      const startIndex = prev.length;
+      // Initialiser le statut "pending" pour chaque nouvelle photo
+      setUploadStatuses((statuses) => {
+        const next = { ...statuses };
+        newFiles.forEach((_, i) => {
+          next[startIndex + i] = "pending";
+        });
+        return next;
+      });
+      return [...prev, ...newFiles];
+    });
     setPendingPhotoUrls((prev) => [...prev, ...newUrls]);
   };
 
@@ -549,6 +606,16 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
     URL.revokeObjectURL(pendingPhotoUrls[index]);
     setPendingPhotos((prev) => prev.filter((_, i) => i !== index));
     setPendingPhotoUrls((prev) => prev.filter((_, i) => i !== index));
+    // Recalculer les indices des statuts (les indices > index décalent de -1)
+    setUploadStatuses((statuses) => {
+      const next: Record<number, "pending" | "uploading" | "failed"> = {};
+      Object.entries(statuses).forEach(([k, v]) => {
+        const i = parseInt(k, 10);
+        if (i < index) next[i] = v;
+        else if (i > index) next[i - 1] = v;
+      });
+      return next;
+    });
   };
 
   const handleMarkPhotoForDeletion = (photoId: string) => {
@@ -580,7 +647,13 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
   const visibleExistingPhotos = photos.filter((p: any) => !photosToDelete.includes(p.id));
   const allDisplayPhotos = [
     ...visibleExistingPhotos,
-    ...pendingPhotoUrls.map((url, idx) => ({ id: `pending-${idx}`, url, isPending: true, pendingIndex: idx })),
+    ...pendingPhotoUrls.map((url, idx) => ({
+      id: `pending-${idx}`,
+      url,
+      isPending: true,
+      pendingIndex: idx,
+      uploadStatus: uploadStatuses[idx] ?? "pending",
+    })),
   ];
   const mainPhoto = allDisplayPhotos[0];
 
@@ -820,10 +893,29 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
                   
-                  {/* Badge pending */}
-                  {(mainPhoto as any).isPending && (
-                    <Badge className="absolute top-4 left-4 bg-amber-500">En attente d'upload</Badge>
-                  )}
+                  {/* Badge statut upload (pending/uploading/failed) */}
+                  {(mainPhoto as any).isPending && (() => {
+                    const status = (mainPhoto as any).uploadStatus as "pending" | "uploading" | "failed";
+                    if (status === "uploading") {
+                      return (
+                        <Badge className="absolute top-4 left-4 bg-blue-500 gap-1.5">
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                          Upload en cours…
+                        </Badge>
+                      );
+                    }
+                    if (status === "failed") {
+                      return (
+                        <Badge className="absolute top-4 left-4 bg-red-500 gap-1.5">
+                          <AlertTriangle className="h-3 w-3" />
+                          Échec — réessayez
+                        </Badge>
+                      );
+                    }
+                    return (
+                      <Badge className="absolute top-4 left-4 bg-amber-500">À enregistrer</Badge>
+                    );
+                  })()}
 
                   {/* Bouton supprimer en mode édition */}
                   {isEditing && (
@@ -861,10 +953,10 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
                   <div className="absolute bottom-0 left-0 p-6 text-white">
                     <Badge className="mb-2 bg-card/20 backdrop-blur">{property.type}</Badge>
                     <h1 className="text-2xl md:text-3xl font-bold drop-shadow-lg">
-                      {isEditing ? editedValues.adresse_complete : property.adresse_complete}
+                      {String(getValue("adresse_complete") || property.adresse_complete || "")}
                     </h1>
                     <p className="text-white/80">
-                      {isEditing ? `${editedValues.code_postal} ${editedValues.ville}` : `${property.code_postal} ${property.ville}`}
+                      {`${getValue("code_postal") || property.code_postal || ""} ${getValue("ville") || property.ville || ""}`.trim()}
                     </p>
                   </div>
 
@@ -911,9 +1003,28 @@ export function PropertyDetailsClient({ details, propertyId, parentBuilding }: P
                     className="object-cover transition-transform duration-300 group-hover:scale-105"
                   />
                   
-                  {photo.isPending && (
-                    <Badge className="absolute top-2 left-2 bg-amber-500 text-xs">En attente</Badge>
-                  )}
+                  {photo.isPending && (() => {
+                    const status = photo.uploadStatus as "pending" | "uploading" | "failed";
+                    if (status === "uploading") {
+                      return (
+                        <Badge className="absolute top-2 left-2 bg-blue-500 text-xs gap-1">
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                          Upload…
+                        </Badge>
+                      );
+                    }
+                    if (status === "failed") {
+                      return (
+                        <Badge className="absolute top-2 left-2 bg-red-500 text-xs gap-1">
+                          <AlertTriangle className="h-3 w-3" />
+                          Échec
+                        </Badge>
+                      );
+                    }
+                    return (
+                      <Badge className="absolute top-2 left-2 bg-amber-500 text-xs">À enregistrer</Badge>
+                    );
+                  })()}
 
                   {isEditing && (
                     <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/app/tenant/requests/new/page.tsx
+++ b/app/tenant/requests/new/page.tsx
@@ -213,19 +213,37 @@ export default function NewTenantRequestPage() {
       if (!response.ok) throw new Error(data?.error || "Impossible de créer la demande");
 
       const ticketId = data.ticket?.id;
+      const attachmentFailures: string[] = [];
       if (ticketId && files.length > 0) {
         for (const file of files) {
           const fd = new FormData();
           fd.append("file", file);
-          await fetch(`/api/tickets/${ticketId}/attachments`, {
-            method: "POST",
-            body: fd,
-          });
+          try {
+            const attRes = await fetch(`/api/tickets/${ticketId}/attachments`, {
+              method: "POST",
+              body: fd,
+            });
+            if (!attRes.ok) {
+              attachmentFailures.push(file.name);
+            }
+          } catch (attErr) {
+            console.error("[tickets/attachments] upload failed", file.name, attErr);
+            attachmentFailures.push(file.name);
+          }
         }
       }
 
       try { localStorage.removeItem(DRAFT_STORAGE_KEY); } catch { /* ignore */ }
-      toast({ title: "Demande envoyée", description: "Votre ticket est en cours de traitement." });
+      if (attachmentFailures.length > 0) {
+        toast({
+          title: "Demande envoyée — pièces jointes partielles",
+          description: `Le ticket a été créé mais ${attachmentFailures.length} pièce${attachmentFailures.length > 1 ? "s" : ""} jointe${attachmentFailures.length > 1 ? "s" : ""} n'a pas pu être uploadée${attachmentFailures.length > 1 ? "s" : ""} : ${attachmentFailures.join(", ")}. Réessayez depuis la fiche du ticket.`,
+          variant: "destructive",
+          duration: 8000,
+        });
+      } else {
+        toast({ title: "Demande envoyée", description: "Votre ticket est en cours de traitement." });
+      }
       router.push("/tenant/requests");
     } catch (error) {
       toast({

--- a/features/properties/components/v3/property-rooms-photos-tab.tsx
+++ b/features/properties/components/v3/property-rooms-photos-tab.tsx
@@ -124,39 +124,48 @@ export function PropertyRoomsPhotosTab({
     if (!files || files.length === 0) return;
     setUploading(true);
 
+    const failures: string[] = [];
+    let successCount = 0;
     try {
+      // Upload tolérant : on continue la boucle même en cas d'échec ponctuel
+      // pour ne pas perdre les photos qui suivent.
       for (const file of Array.from(files)) {
-        const { upload_url, photo } = await propertiesService.requestPhotoUploadUrl(propertyId, {
-          file_name: file.name,
-          mime_type: file.type,
-          room_id: roomId || undefined,
-          // Si pas de room_id, ajouter un tag par défaut pour les photos sans pièce
-          tag: roomId ? undefined : "vue_generale",
-        } as any);
+        try {
+          const { upload_url } = await propertiesService.requestPhotoUploadUrl(propertyId, {
+            file_name: file.name,
+            mime_type: file.type,
+            room_id: roomId || undefined,
+            tag: roomId ? undefined : "vue_generale",
+          } as any);
 
-        const uploadResponse = await fetch(upload_url, {
-          method: "PUT",
-          headers: { "Content-Type": file.type },
-          body: file,
-        });
+          const uploadResponse = await fetch(upload_url, {
+            method: "PUT",
+            headers: { "Content-Type": file.type },
+            body: file,
+          });
 
-        if (!uploadResponse.ok) {
-          throw new Error(`Erreur upload ${file.name}`);
+          if (!uploadResponse.ok) {
+            failures.push(file.name);
+          } else {
+            successCount += 1;
+          }
+        } catch (uploadErr) {
+          console.error("[property-rooms-photos-tab] upload failed", file.name, uploadErr);
+          failures.push(file.name);
         }
       }
 
-      toast({
-        title: "Succès",
-        description: `${files.length} photo(s) ajoutée(s)`,
-      });
+      if (failures.length > 0) {
+        toast({
+          title: `${failures.length} upload${failures.length > 1 ? "s" : ""} en échec`,
+          description: `${successCount}/${files.length} photos ajoutées. Échecs : ${failures.join(", ")}.`,
+          variant: "destructive",
+        });
+      } else if (successCount > 0) {
+        toast({ title: "Succès", description: `${successCount} photo(s) ajoutée(s)` });
+      }
       // Invalider le cache React Query pour rafraîchir les photos
       queryClient.invalidateQueries({ queryKey: ["photos", propertyId] });
-    } catch (error: unknown) {
-      toast({
-        title: "Erreur",
-        description: error instanceof Error ? error.message : "Impossible d'uploader les photos",
-        variant: "destructive",
-      });
     } finally {
       setUploading(false);
     }

--- a/features/properties/components/v3/rooms-photos-step.tsx
+++ b/features/properties/components/v3/rooms-photos-step.tsx
@@ -355,27 +355,50 @@ export function RoomsPhotosStep({
 
     try {
       const newPhotos: Photo[] = [];
-      // On upload séquentiellement ou en parallèle
+      const failures: string[] = [];
       for (const file of Array.from(files)) {
-        const { upload_url, photo } = await propertiesService.requestPhotoUploadUrl(propertyId, {
-          file_name: file.name,
-          mime_type: file.type,
-          room_id: selectedRoomId || undefined,
-          tag: (selectedTag as any) || undefined,
-        });
+        try {
+          const { upload_url, photo } = await propertiesService.requestPhotoUploadUrl(propertyId, {
+            file_name: file.name,
+            mime_type: file.type,
+            room_id: selectedRoomId || undefined,
+            tag: (selectedTag as any) || undefined,
+          });
 
-        await fetch(upload_url, {
-          method: "PUT",
-          headers: { "Content-Type": file.type },
-          body: file,
-        });
-        newPhotos.push(photo);
+          // Vérification de la réponse Storage : sans ce check, un échec
+          // (403, 500, quota...) passait inaperçu et la photo était listée
+          // alors que le fichier n'avait jamais été uploadé.
+          const uploadResponse = await fetch(upload_url, {
+            method: "PUT",
+            headers: { "Content-Type": file.type },
+            body: file,
+          });
+          if (!uploadResponse.ok) {
+            failures.push(file.name);
+            continue;
+          }
+          newPhotos.push(photo);
+        } catch (uploadErr) {
+          console.error("[rooms-photos-step] upload failed", file.name, uploadErr);
+          failures.push(file.name);
+        }
       }
 
-      const updated = [...photos, ...newPhotos];
-      setPhotos(updated);
-      onPhotosChange?.(updated);
-      toast({ title: "Photos ajoutées", description: `${newPhotos.length} photo(s)` });
+      if (newPhotos.length > 0) {
+        const updated = [...photos, ...newPhotos];
+        setPhotos(updated);
+        onPhotosChange?.(updated);
+      }
+
+      if (failures.length > 0) {
+        toast({
+          title: `${failures.length} upload${failures.length > 1 ? "s" : ""} en échec`,
+          description: `${newPhotos.length}/${files.length} photos ajoutées. Échecs : ${failures.join(", ")}.`,
+          variant: "destructive",
+        });
+      } else {
+        toast({ title: "Photos ajoutées", description: `${newPhotos.length} photo(s)` });
+      }
     } catch (error) {
       toast({ title: "Erreur upload", variant: "destructive" });
     } finally {


### PR DESCRIPTION
## Résumé

Audit complet du module gestion des biens (propriétés) — corrections cross-rôles avec 7 commits.

## Bugs corrigés

### Owner — flux édition + upload photos
- **#1+#2** Photos uploadées dans la mauvaise table (`documents` au lieu de `photos`) + sans CSRF/auth → upload silencieusement échoué
- **#3** ISR cache 1h masquait les modifications
- **#4** `photoTagEnum` tronqué à 4 valeurs → parking/local pro rejetés en validation
- **#5** Digicode/interphone non supprimables une fois renseignés
- **#7** `visite_virtuelle_url` ignoré côté API (`delete updates.visite_virtuelle_url`)
- **#8+#9** Diff payload écrasait `loyer_hc/charges/DPE/clim` à 0/null/false même sans modification utilisateur
- **#10** Pages `/edit` fantômes (redirect client `useEffect`)
- **#11** Membres SCI/`entity_members` bloqués → 404 sur leurs propres biens
- **#14** URLs signées 1h sur `documents.preview_url` → galerie cassait après expiration
- **Bonus** Cover absente dans liste « Mes biens » (lisait `documents` only)

### Cross-rôles (audit complet)
- **agency** : `mockProperties` hardcodées (Jean Dupont, Sophie Bernard...) → fetch DB réel via `/api/agency/properties` avec covers
- **tenant** : `cover_url` jamais calculée → `fetchPropertyCoverUrls` injecté dans dashboard
- **admin** : photos legacy invisibles + liste sans covers
- **legacy `/properties/[id]`** : redirect aveugle vers `/owner` → redirect role-aware

### UI feedback uploads
- Bug d'affichage `undefined undefined` dans le hero après refactor
- État upload visible par photo : « À enregistrer » (ambre) / « Upload en cours… » (bleu spin) / « Échec — réessayez » (rouge)
- Conservation des photos en échec dans `pendingPhotos` pour retry sans tout reperdre

### Audit upload cross-module
- 3 endroits utilisaient `fetch` direct sans CSRF → migrés vers `apiClient.uploadFile`
- 2 endroits ne vérifiaient pas `response.ok` → check + collecte d'échecs
- 1 endroit `throw` au 1er échec → boucle tolérante

## Migration SQL

`supabase/migrations/20260428100000_consolidate_loyer_reference_majore.sql` — consolidation de la colonne `loyer_reference_majore` (deux versions historiques avec/sans accent é). **Déjà appliquée en prod** lors de cette session.

## Test plan

- [ ] Owner : modifier un bien parking, ajouter photo → photo visible + cover dans liste « Mes biens »
- [ ] Tenant : dashboard affiche la photo du logement
- [ ] Agency : liste affiche les biens sous mandat avec covers
- [ ] Admin : `/admin/properties` affiche les covers
- [ ] Liens legacy `/properties/{uuid}` → redirige vers la bonne route par rôle
- [ ] Effacer un digicode existant → accepté
- [ ] Modifier un seul champ ne doit pas écraser les autres (loyer/DPE/switches)

## Commits

| Commit | Sujet |
|---|---|
| `b1475cb` | Owner — flux édition + upload (P1+P2) |
| `994aed8` | Owner — cover + accès SCI + redirects |
| `9b08639` | URLs preview stables + consolidation `loyer_reference_majore` |
| `42df99f` | Migration SQL view CASCADE |
| `0acd7fb` | Cross-rôles — agency réelle, tenant cover, admin cover, redirects |
| `72cf101` | UI feedback par photo + adresse hero |
| `caaab1c` | Audit upload — apiClient.uploadFile + response.ok partout |

https://claude.ai/code/session_013vrbHxN8qruAEHzMQC3TAP

---
_Generated by [Claude Code](https://claude.ai/code/session_013vrbHxN8qruAEHzMQC3TAP)_