### PR TITLE
Inscription & invitations : verrouillage rôle, modules copro/agency, hardening sécu

### DIFF
--- a/app/api/agency/invitations/[token]/accept/route.ts
+++ b/app/api/agency/invitations/[token]/accept/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
+import { applyRateLimit } from "@/lib/security/rate-limit";
 
 /**
  * POST /api/agency/invitations/[token]/accept
@@ -16,10 +17,13 @@ import { getServiceClient } from "@/lib/supabase/service-client";
 const paramsSchema = z.object({ token: z.string().min(10) });
 
 export async function POST(
-  _request: Request,
+  request: Request,
   { params }: { params: { token: string } }
 ) {
   try {
+    const rateLimitResponse = await applyRateLimit(request, "inviteAccept");
+    if (rateLimitResponse) return rateLimitResponse;
+
     const parsed = paramsSchema.safeParse(params);
     if (!parsed.success) {
       return NextResponse.json({ error: "Token invalide" }, { status: 400 });

--- a/app/api/agency/invitations/[token]/accept/route.ts
+++ b/app/api/agency/invitations/[token]/accept/route.ts
@@ -1,0 +1,170 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+/**
+ * POST /api/agency/invitations/[token]/accept
+ *
+ * Cas du collaborateur qui a déjà un compte (profile.role='agency') et
+ * clique le lien d'invitation. Le pendant côté signup neuf est traité
+ * dans /api/v1/auth/register (résolution + création agency_managers).
+ */
+const paramsSchema = z.object({ token: z.string().min(10) });
+
+export async function POST(
+  _request: Request,
+  { params }: { params: { token: string } }
+) {
+  try {
+    const parsed = paramsSchema.safeParse(params);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Token invalide" }, { status: 400 });
+    }
+    const { token } = parsed.data;
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const service = getServiceClient();
+    const { data: profile } = await service
+      .from("profiles")
+      .select("id, role, email")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile?.id) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+    }
+    if (profile.role !== "agency") {
+      return NextResponse.json(
+        {
+          error: "Seul un compte agence peut accepter cette invitation.",
+          code: "ROLE_MISMATCH",
+        },
+        { status: 403 }
+      );
+    }
+
+    const { data: invitation } = await service
+      .from("agency_invitations")
+      .select("id, email, status, expires_at, accepted_at, declined_at, agency_profile_id, role_agence, can_sign_documents")
+      .eq("invitation_token", token)
+      .maybeSingle();
+
+    if (!invitation) {
+      return NextResponse.json({ error: "Invitation introuvable" }, { status: 404 });
+    }
+    if (invitation.status === "accepted" || invitation.accepted_at) {
+      return NextResponse.json({ error: "Cette invitation a déjà été utilisée." }, { status: 409 });
+    }
+    if (invitation.status === "declined" || invitation.declined_at) {
+      return NextResponse.json({ error: "Cette invitation a été refusée." }, { status: 409 });
+    }
+    if (invitation.status === "cancelled") {
+      return NextResponse.json({ error: "Cette invitation a été annulée." }, { status: 409 });
+    }
+    if (
+      invitation.status === "expired" ||
+      (invitation.expires_at && new Date(invitation.expires_at as string) < new Date())
+    ) {
+      return NextResponse.json({ error: "Cette invitation a expiré." }, { status: 410 });
+    }
+
+    const userEmail = (user.email || profile.email || "").toLowerCase().trim();
+    const inviteEmail = String(invitation.email).toLowerCase().trim();
+    if (userEmail !== inviteEmail) {
+      return NextResponse.json(
+        {
+          error: "L'email de votre compte ne correspond pas à l'invitation.",
+          details: `Cette invitation est destinée à ${invitation.email}.`,
+        },
+        { status: 403 }
+      );
+    }
+
+    // Lier dans agency_managers (idempotent via UNIQUE(agency_profile_id, user_profile_id))
+    const { data: manager, error: managerError } = await service
+      .from("agency_managers")
+      .upsert(
+        {
+          agency_profile_id: invitation.agency_profile_id,
+          user_profile_id: profile.id,
+          role_agence: invitation.role_agence,
+          can_sign_documents: !!invitation.can_sign_documents,
+          is_active: true,
+        },
+        { onConflict: "agency_profile_id,user_profile_id" }
+      )
+      .select("id")
+      .maybeSingle();
+
+    if (managerError) {
+      console.error("[agency-accept] manager upsert failed:", managerError);
+      return NextResponse.json(
+        { error: "Erreur lors de la liaison à l'agence" },
+        { status: 500 }
+      );
+    }
+
+    // Acceptation atomique
+    const { data: updated, error: updateError } = await service
+      .from("agency_invitations")
+      .update({
+        status: "accepted",
+        accepted_at: new Date().toISOString(),
+        accepted_profile_id: profile.id,
+        agency_manager_id: manager?.id ?? null,
+      })
+      .eq("id", invitation.id)
+      .eq("status", "pending")
+      .select("id");
+
+    if (updateError) {
+      console.error("[agency-accept] update failed:", updateError);
+      return NextResponse.json({ error: "Erreur lors de l'acceptation" }, { status: 500 });
+    }
+    if (!updated || updated.length === 0) {
+      return NextResponse.json({ error: "Cette invitation a déjà été utilisée." }, { status: 409 });
+    }
+
+    try {
+      await service.from("audit_log").insert({
+        user_id: user.id,
+        action: "agency_invitation_accepted",
+        entity_type: "agency_invitation",
+        entity_id: invitation.id,
+        metadata: {
+          agency_profile_id: invitation.agency_profile_id,
+          role_agence: invitation.role_agence,
+          email: inviteEmail,
+        } as Record<string, unknown>,
+      });
+    } catch {
+      // audit non bloquant
+    }
+
+    return NextResponse.json({
+      success: true,
+      role: "agency" as const,
+      role_agence: invitation.role_agence,
+      agency_profile_id: invitation.agency_profile_id,
+      agency_manager_id: manager?.id ?? null,
+      message: "Invitation acceptée. Vous êtes maintenant lié à l'agence.",
+    });
+  } catch (error: unknown) {
+    console.error("[agency-accept] error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/agency/invitations/route.ts
+++ b/app/api/agency/invitations/route.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
 import { sendEmail } from "@/lib/services/email-service";
+import { applyRateLimit } from "@/lib/security/rate-limit";
 
 /**
  * Endpoints d'invitations agence (collaborateurs).
@@ -53,6 +54,9 @@ async function getCallerProfile() {
 
 export async function POST(request: NextRequest) {
   try {
+    const rateLimitResponse = await applyRateLimit(request, "agencyInvite");
+    if (rateLimitResponse) return rateLimitResponse;
+
     const ctx = await getCallerProfile();
     if (!ctx) return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     const { user, profile, service } = ctx;

--- a/app/api/agency/invitations/route.ts
+++ b/app/api/agency/invitations/route.ts
@@ -1,0 +1,227 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { sendEmail } from "@/lib/services/email-service";
+
+/**
+ * Endpoints d'invitations agence (collaborateurs).
+ *
+ * - POST   /api/agency/invitations    : créer (auth = profile.role IN ('agency','admin'))
+ * - GET    /api/agency/invitations    : lister les invitations de l'agence du caller
+ *
+ * Le flux d'acceptation est géré côté signup via /api/v1/auth/register
+ * (verrouillage rôle + lien agency_managers post-signUp) ou côté
+ * post-login via POST /api/agency/invitations/[token]/accept.
+ */
+
+const CreateAgencyInvitationSchema = z.object({
+  email: z
+    .string()
+    .email("Email invalide")
+    .transform((v) => v.trim().toLowerCase()),
+  prenom: z.string().min(1).max(80).optional(),
+  nom: z.string().min(1).max(80).optional(),
+  telephone: z.string().optional(),
+  role_agence: z
+    .enum(["directeur", "gestionnaire", "assistant", "comptable"])
+    .default("gestionnaire"),
+  can_sign_documents: z.boolean().default(false),
+  personal_message: z.string().max(1000).optional(),
+});
+
+async function getCallerProfile() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) return null;
+
+  const service = getServiceClient();
+  const { data: profile } = await service
+    .from("profiles")
+    .select("id, role, prenom, nom, email")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!profile) return null;
+  return { user, profile, service };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const ctx = await getCallerProfile();
+    if (!ctx) return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    const { user, profile, service } = ctx;
+
+    if (profile.role !== "agency" && profile.role !== "admin" && profile.role !== "platform_admin") {
+      return NextResponse.json(
+        { error: "Seules les agences peuvent inviter des collaborateurs.", code: "ROLE_FORBIDDEN" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const parsed = CreateAgencyInvitationSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parsed.error.errors },
+        { status: 400 }
+      );
+    }
+    const data = parsed.data;
+
+    // L'agency_profile_id du caller : pour profile.role='agency', c'est son
+    // propre profile.id. Pour admin, on accepte un body.agency_profile_id
+    // explicite (admin agit pour le compte d'une agence).
+    let agencyProfileId: string | null = profile.id;
+    if (profile.role === "admin" || profile.role === "platform_admin") {
+      const adminBody = body as { agency_profile_id?: string };
+      if (!adminBody.agency_profile_id) {
+        return NextResponse.json(
+          { error: "agency_profile_id requis pour un admin", code: "MISSING_AGENCY_ID" },
+          { status: 400 }
+        );
+      }
+      agencyProfileId = adminBody.agency_profile_id;
+    }
+
+    // Empêcher les doublons sur (agence, email) en pending/sent
+    const { data: existing } = await service
+      .from("agency_invitations")
+      .select("id, status")
+      .eq("agency_profile_id", agencyProfileId)
+      .eq("email", data.email)
+      .in("status", ["pending", "accepted"])
+      .maybeSingle();
+    if (existing) {
+      return NextResponse.json(
+        { error: "Une invitation est déjà en cours pour cet email." },
+        { status: 409 }
+      );
+    }
+
+    const { data: invitation, error: insertError } = await service
+      .from("agency_invitations")
+      .insert({
+        agency_profile_id: agencyProfileId,
+        invited_by: profile.id,
+        email: data.email,
+        prenom: data.prenom ?? null,
+        nom: data.nom ?? null,
+        telephone: data.telephone ?? null,
+        role_agence: data.role_agence,
+        can_sign_documents: data.can_sign_documents,
+        personal_message: data.personal_message ?? null,
+      })
+      .select()
+      .single();
+
+    if (insertError || !invitation) {
+      console.error("[agency-invite] insert error:", insertError);
+      return NextResponse.json(
+        { error: insertError?.message || "Erreur lors de la création de l'invitation" },
+        { status: 500 }
+      );
+    }
+
+    // Email d'invitation
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
+    const inviteUrl = `${appUrl}/signup/role?role=agency&invite=${invitation.invitation_token}&email=${encodeURIComponent(data.email)}`;
+    const inviterName = `${profile.prenom || ""} ${profile.nom || ""}`.trim() || "Votre agence";
+
+    try {
+      await sendEmail({
+        to: data.email,
+        subject: `Invitation à rejoindre ${inviterName} sur Talok`,
+        html: `
+<!DOCTYPE html>
+<html lang="fr">
+<body style="margin:0;padding:0;font-family:Manrope,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f3f4f6;">
+  <div style="max-width:600px;margin:0 auto;padding:40px 20px;">
+    <div style="background:white;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+      <div style="background:linear-gradient(135deg,#1D4ED8 0%,#3B82F6 100%);padding:32px;text-align:center;">
+        <span style="font-size:24px;font-weight:800;color:white;">TALOK</span>
+      </div>
+      <div style="padding:40px;">
+        <h1 style="margin:0 0 16px;font-size:24px;color:#111827;">Invitation collaborateur</h1>
+        <p style="color:#374151;font-size:16px;line-height:1.6;">
+          ${inviterName} vous invite à rejoindre l'équipe en tant que
+          <strong>${data.role_agence}</strong> sur Talok.
+        </p>
+        ${data.personal_message ? `
+        <div style="background:#f9fafb;border-left:4px solid #2563EB;padding:16px 20px;margin:24px 0;border-radius:0 8px 8px 0;">
+          <p style="margin:0;color:#374151;font-style:italic;">${data.personal_message}</p>
+        </div>` : ""}
+        <div style="text-align:center;margin:32px 0;">
+          <a href="${inviteUrl}" style="display:inline-block;background:linear-gradient(135deg,#1D4ED8,#3B82F6);color:white;padding:14px 32px;border-radius:8px;text-decoration:none;font-weight:600;">
+            Accepter l'invitation
+          </a>
+        </div>
+        <p style="color:#6b7280;font-size:14px;">
+          Ce lien expire le ${new Date(invitation.expires_at).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}.
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+        `.trim(),
+        tags: [{ name: "type", value: "agency_invitation" }],
+        idempotencyKey: `agency-invitation/${invitation.id}`,
+      });
+
+      await service
+        .from("agency_invitations")
+        .update({ sent_at: new Date().toISOString() })
+        .eq("id", invitation.id);
+    } catch (emailError) {
+      console.error("[agency-invite] email error:", emailError);
+      // Non bloquant : l'invitation est créée, l'agence peut renvoyer.
+    }
+
+    return NextResponse.json(invitation, { status: 201 });
+  } catch (error: unknown) {
+    console.error("[agency-invite] error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET() {
+  try {
+    const ctx = await getCallerProfile();
+    if (!ctx) return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    const { profile, service } = ctx;
+
+    if (profile.role !== "agency" && profile.role !== "admin" && profile.role !== "platform_admin") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const query = service
+      .from("agency_invitations")
+      .select("*")
+      .order("created_at", { ascending: false });
+
+    // Pour les agences : limité à leurs propres invitations
+    if (profile.role === "agency") {
+      query.eq("agency_profile_id", profile.id);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  } catch (error: unknown) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/invites/[token]/route.ts
+++ b/app/api/copro/invites/[token]/route.ts
@@ -12,6 +12,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { sendEmail } from '@/lib/services/email-service';
 import { emailTemplates } from '@/lib/emails/templates';
+import { applyRateLimit } from '@/lib/security/rate-limit';
 
 interface RouteParams {
   params: { token: string };
@@ -46,9 +47,12 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 // POST: Accepter une invitation
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
+    const rateLimitResponse = await applyRateLimit(request, 'inviteAccept');
+    if (rateLimitResponse) return rateLimitResponse;
+
     const supabase = await createClient();
     const { token } = params;
-    
+
     // Vérifier l'authentification
     const { data: { user }, error: authError } = await supabase.auth.getUser();
     if (authError || !user) {

--- a/app/api/copro/invites/route.ts
+++ b/app/api/copro/invites/route.ts
@@ -10,6 +10,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { requireCoproFeature } from '@/lib/helpers/copro-feature-gate';
+import { applyRateLimit } from '@/lib/security/rate-limit';
 import { z } from 'zod';
 
 // Schéma pour une invitation
@@ -101,6 +102,9 @@ export async function GET(request: NextRequest) {
 // POST: Créer des invitations
 export async function POST(request: NextRequest) {
   try {
+    const rateLimitResponse = await applyRateLimit(request, 'coproInvite');
+    if (rateLimitResponse) return rateLimitResponse;
+
     // S1-2 : auth + feature gate copro_module
     const access = await requireCoproFeature();
     if (access instanceof NextResponse) return access;

--- a/app/api/guarantors/invitations/accept/route.ts
+++ b/app/api/guarantors/invitations/accept/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
+import { applyRateLimit } from "@/lib/security/rate-limit";
 
 /**
  * POST /api/guarantors/invitations/accept
@@ -20,6 +21,9 @@ const acceptSchema = z.object({
 
 export async function POST(request: Request) {
   try {
+    const rateLimitResponse = await applyRateLimit(request, "inviteAccept");
+    if (rateLimitResponse) return rateLimitResponse;
+
     const supabase = await createClient();
     const {
       data: { user },

--- a/app/api/guarantors/invitations/accept/route.ts
+++ b/app/api/guarantors/invitations/accept/route.ts
@@ -1,0 +1,152 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+/**
+ * POST /api/guarantors/invitations/accept
+ *
+ * Accepte une invitation garant standalone (table `guarantor_invitations`)
+ * pour un utilisateur déjà authentifié. Le pendant côté signup neuf est
+ * traité directement dans /api/v1/auth/register (résolution + marquage
+ * post-signUp).
+ */
+const acceptSchema = z.object({
+  token: z.string().min(10, "Token invalide"),
+});
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { token } = acceptSchema.parse(body);
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role, email")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile?.id) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+    }
+
+    if (profile.role !== "guarantor") {
+      return NextResponse.json(
+        {
+          error: "Seul un compte garant peut accepter cette invitation.",
+          code: "ROLE_MISMATCH",
+        },
+        { status: 403 }
+      );
+    }
+
+    const { data: invitation } = await serviceClient
+      .from("guarantor_invitations")
+      .select("id, guarantor_email, status, expires_at, accepted_at, declined_at, lease_id")
+      .eq("invitation_token", token)
+      .maybeSingle();
+
+    if (!invitation) {
+      return NextResponse.json({ error: "Invitation introuvable" }, { status: 404 });
+    }
+    if (invitation.status === "accepted" || invitation.accepted_at) {
+      return NextResponse.json({ error: "Cette invitation a déjà été utilisée." }, { status: 409 });
+    }
+    if (invitation.status === "declined" || invitation.declined_at) {
+      return NextResponse.json({ error: "Cette invitation a été refusée." }, { status: 409 });
+    }
+    if (
+      invitation.status === "expired" ||
+      (invitation.expires_at && new Date(invitation.expires_at as string) < new Date())
+    ) {
+      return NextResponse.json({ error: "Cette invitation a expiré." }, { status: 410 });
+    }
+
+    const userEmail = (user.email || profile.email || "").toLowerCase().trim();
+    const inviteEmail = String(invitation.guarantor_email).toLowerCase().trim();
+    if (userEmail !== inviteEmail) {
+      return NextResponse.json(
+        {
+          error: "L'email de votre compte ne correspond pas à l'invitation.",
+          details: `Cette invitation est destinée à ${invitation.guarantor_email}.`,
+        },
+        { status: 403 }
+      );
+    }
+
+    // Update conditionnel sur status='pending' pour éviter les race conditions
+    const { data: updated, error: updateError } = await serviceClient
+      .from("guarantor_invitations")
+      .update({
+        status: "accepted",
+        accepted_at: new Date().toISOString(),
+        guarantor_profile_id: profile.id,
+      })
+      .eq("id", invitation.id)
+      .eq("status", "pending")
+      .select("id");
+
+    if (updateError) {
+      console.error("[guarantor-accept] update failed:", updateError);
+      return NextResponse.json(
+        { error: "Erreur lors de l'acceptation" },
+        { status: 500 }
+      );
+    }
+    if (!updated || updated.length === 0) {
+      return NextResponse.json(
+        { error: "Cette invitation a déjà été utilisée." },
+        { status: 409 }
+      );
+    }
+
+    try {
+      await serviceClient.from("audit_log").insert({
+        user_id: user.id,
+        action: "guarantor_invitation_accepted",
+        entity_type: "guarantor_invitation",
+        entity_id: invitation.id,
+        metadata: {
+          lease_id: invitation.lease_id,
+          email: inviteEmail,
+        } as Record<string, unknown>,
+      });
+    } catch {
+      // audit non bloquant
+    }
+
+    return NextResponse.json({
+      success: true,
+      lease_id: invitation.lease_id,
+      role: "guarantor" as const,
+      message: "Invitation acceptée. Vous êtes maintenant lié au bail.",
+    });
+  } catch (error: unknown) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Données invalides", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("[guarantor-accept] error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/guarantors/invite/route.ts
+++ b/app/api/guarantors/invite/route.ts
@@ -11,9 +11,13 @@ import { createServiceRoleClient, createRouteHandlerClient } from "@/lib/supabas
 import { createGuarantorInvitationSchema } from "@/lib/validations/guarantor";
 import { sendEmail } from "@/lib/services/email-service";
 import { emailTemplates } from "@/lib/emails/templates";
+import { applyRateLimit } from "@/lib/security/rate-limit";
 
 export async function POST(request: NextRequest) {
   try {
+    const rateLimitResponse = await applyRateLimit(request, "leaseInvite");
+    if (rateLimitResponse) return rateLimitResponse;
+
     const supabase = await createRouteHandlerClient();
     const { data: { user }, error: authError } = await supabase.auth.getUser();
 

--- a/app/api/guarantors/invite/route.ts
+++ b/app/api/guarantors/invite/route.ts
@@ -115,7 +115,10 @@ export async function POST(request: NextRequest) {
 
     const propertyAddress = (lease?.property as any)?.adresse_complete || "";
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://app.talok.fr";
-    const inviteUrl = `${appUrl}/auth/signup?role=guarantor&token=${invitation.invitation_token}&email=${encodeURIComponent(validatedData.guarantor_email)}`;
+    // Format unifié : on passe par /signup/role qui propage `invite=` jusqu'à
+    // /signup/account où la bannière "Inscription par invitation" est affichée
+    // et le rôle est verrouillé côté API par /api/v1/auth/register.
+    const inviteUrl = `${appUrl}/signup/role?role=guarantor&invite=${invitation.invitation_token}&email=${encodeURIComponent(validatedData.guarantor_email)}`;
 
     // Envoyer l'email d'invitation
     try {

--- a/app/api/invitations/accept/route.ts
+++ b/app/api/invitations/accept/route.ts
@@ -4,6 +4,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
+import { mapInvitationRoleToUserRole, type InvitationRole } from "@/lib/invitations/role-mapper";
 import { z } from "zod";
 
 const acceptSchema = z.object({
@@ -211,6 +212,8 @@ export async function POST(request: Request) {
       }
     }
 
+    const applicativeRole = mapInvitationRoleToUserRole(invitation.role as InvitationRole);
+
     // 11. Audit log (user_id = auth user id, pas profile_id)
     try {
       await serviceClient.from("audit_log").insert({
@@ -221,6 +224,7 @@ export async function POST(request: Request) {
         metadata: {
           lease_id: invitation.lease_id,
           invitation_role: invitation.role,
+          applicative_role: applicativeRole,
           lease_linked: leaseLinked,
           email: invitationEmail,
         } as Record<string, unknown>,
@@ -233,7 +237,8 @@ export async function POST(request: Request) {
       success: true,
       lease_id: invitation.lease_id,
       lease_linked: leaseLinked,
-      role: invitation.role,
+      role: applicativeRole,
+      invitation_role: invitation.role,
       message: leaseLinked
         ? "Invitation acceptée. Vous êtes maintenant lié au bail."
         : "Invitation acceptée.",

--- a/app/api/invitations/validate/route.ts
+++ b/app/api/invitations/validate/route.ts
@@ -3,13 +3,14 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase/service-client";
+import { resolveInvitationByToken } from "@/lib/invitations/server-resolver";
 
 /**
  * GET /api/invitations/validate?token=xxx
  *
- * FIX P1-E9: Valide un token d'invitation côté serveur avec service_role.
- * Remplace l'appel direct via invitationsService (client-side, anon key)
- * qui échouait sur les RLS pour les utilisateurs non connectés.
+ * Valide un token d'invitation côté serveur avec service_role et résout
+ * indistinctement les invitations bail (`invitations`) et garant standalone
+ * (`guarantor_invitations`) via lib/invitations/server-resolver.
  *
  * Cette route est publique (pas d'auth requise) car l'utilisateur
  * peut ne pas encore avoir de compte.
@@ -26,44 +27,31 @@ export async function GET(request: NextRequest) {
     }
 
     const serviceClient = getServiceClient();
+    const result = await resolveInvitationByToken(serviceClient as any, token);
 
-    // Récupérer l'invitation par token
-    const { data: invitation, error: invError } = await serviceClient
-      .from("invitations")
-      .select("id, email, role, property_id, lease_id, expires_at, used_at")
-      .eq("token", token)
-      .single();
-
-    if (invError || !invitation) {
-      return NextResponse.json({
-        valid: false,
-        error: "Invitation non trouvée",
-      });
+    if (!result.ok) {
+      const message = (() => {
+        switch (result.error.kind) {
+          case "not_found":
+            return "Invitation non trouvée";
+          case "expired":
+            return "Cette invitation a expiré. Demandez un nouveau lien à votre propriétaire.";
+          case "already_used":
+            return "Cette invitation a déjà été utilisée.";
+          case "declined":
+            return "Cette invitation a été refusée.";
+        }
+      })();
+      return NextResponse.json({ valid: false, error: message });
     }
 
-    // Vérifier l'expiration
-    if (new Date(invitation.expires_at as string) < new Date()) {
-      return NextResponse.json({
-        valid: false,
-        error: "Cette invitation a expiré. Demandez un nouveau lien à votre propriétaire.",
-      });
-    }
-
-    // Vérifier si déjà utilisée
-    if (invitation.used_at) {
-      return NextResponse.json({
-        valid: false,
-        error: "Cette invitation a déjà été utilisée.",
-      });
-    }
-
-    // Retourner les données publiques de l'invitation (sans le token lui-même)
     return NextResponse.json({
       valid: true,
       invitation: {
-        id: invitation.id,
-        email: invitation.email,
-        role: invitation.role,
+        id: result.invitation.id,
+        email: result.invitation.email,
+        role: result.invitation.invitationRole,
+        source: result.invitation.source,
       },
     });
   } catch (error) {

--- a/app/api/leases/[id]/signers/route.ts
+++ b/app/api/leases/[id]/signers/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { randomBytes } from "crypto";
 import { sendLeaseInviteEmail } from "@/lib/services/email-service";
+import { applyRateLimit } from "@/lib/security/rate-limit";
 
 const addSignerSchema = z.object({
   email: z.string().email("Email invalide"),
@@ -86,6 +87,9 @@ export async function POST(
 ) {
   const { id } = await params;
   try {
+    const rateLimitResponse = await applyRateLimit(request, "leaseInvite");
+    if (rateLimitResponse) return rateLimitResponse;
+
     const supabase = await createClient();
     const serviceClient = getServiceClient();
     const {

--- a/app/api/v1/auth/register/route.ts
+++ b/app/api/v1/auth/register/route.ts
@@ -9,6 +9,7 @@ import { RegisterSchema } from "@/lib/api/schemas";
 import { applyRateLimit } from "@/lib/security/rate-limit";
 import { verifyTurnstileToken } from "@/lib/security/turnstile";
 import { getAuthCallbackUrl } from "@/lib/utils/redirect-url";
+import { mapInvitationRoleToUserRole, type InvitationRole } from "@/lib/invitations/role-mapper";
 
 /**
  * POST /api/v1/auth/register
@@ -38,7 +39,50 @@ export async function POST(request: NextRequest) {
       email: data.email,
       role: data.role,
       has_telephone: !!data.telephone,
+      has_invite: !!data.inviteToken,
     });
+
+    // Verrouillage rôle via invitation : si un token est fourni, on lookup
+    // l'invitation côté serveur et on force le rôle final. Cela bloque les
+    // tentatives de détournement (ex: lien `garant` → signup `owner`).
+    if (data.inviteToken) {
+      const adminClient = supabaseAdmin();
+      const { data: invitation, error: invErr } = await adminClient
+        .from("invitations")
+        .select("id, email, role, expires_at, used_at")
+        .eq("token", data.inviteToken)
+        .maybeSingle();
+
+      if (invErr || !invitation) {
+        return apiError("Invitation introuvable", 404, "INVITE_NOT_FOUND");
+      }
+      if (invitation.used_at) {
+        return apiError("Cette invitation a déjà été utilisée.", 409, "INVITE_ALREADY_USED");
+      }
+      if (new Date(invitation.expires_at as string) < new Date()) {
+        return apiError("Cette invitation a expiré.", 410, "INVITE_EXPIRED");
+      }
+      if (String(invitation.email).toLowerCase().trim() !== data.email) {
+        return apiError(
+          "L'email saisi ne correspond pas à l'invitation.",
+          403,
+          "INVITE_EMAIL_MISMATCH"
+        );
+      }
+
+      const expectedRole = mapInvitationRoleToUserRole(invitation.role as InvitationRole);
+      if (expectedRole !== data.role) {
+        console.warn("[register] role override forced by invitation", {
+          email: data.email,
+          requested: data.role,
+          forced: expectedRole,
+          invitation_role: invitation.role,
+        });
+        // Verrouillage strict : on force le rôle au lieu d'accepter celui du
+        // client, qui peut avoir été manipulé via l'URL `?role=...`.
+        data.role = expectedRole;
+      }
+    }
 
     const supabase = await createClient();
 

--- a/app/api/v1/auth/register/route.ts
+++ b/app/api/v1/auth/register/route.ts
@@ -9,7 +9,7 @@ import { RegisterSchema } from "@/lib/api/schemas";
 import { applyRateLimit } from "@/lib/security/rate-limit";
 import { verifyTurnstileToken } from "@/lib/security/turnstile";
 import { getAuthCallbackUrl } from "@/lib/utils/redirect-url";
-import { mapInvitationRoleToUserRole, type InvitationRole } from "@/lib/invitations/role-mapper";
+import { resolveInvitationByToken, type ResolvedInvitation } from "@/lib/invitations/server-resolver";
 
 /**
  * POST /api/v1/auth/register
@@ -43,26 +43,30 @@ export async function POST(request: NextRequest) {
     });
 
     // Verrouillage rôle via invitation : si un token est fourni, on lookup
-    // l'invitation côté serveur et on force le rôle final. Cela bloque les
-    // tentatives de détournement (ex: lien `garant` → signup `owner`).
+    // l'invitation côté serveur (table `invitations` ou `guarantor_invitations`)
+    // et on force le rôle final. Cela bloque les tentatives de détournement
+    // (ex: lien `garant` → signup `owner`).
+    let resolvedInvitation: ResolvedInvitation | null = null;
     if (data.inviteToken) {
       const adminClient = supabaseAdmin();
-      const { data: invitation, error: invErr } = await adminClient
-        .from("invitations")
-        .select("id, email, role, expires_at, used_at")
-        .eq("token", data.inviteToken)
-        .maybeSingle();
+      const result = await resolveInvitationByToken(adminClient, data.inviteToken);
 
-      if (invErr || !invitation) {
-        return apiError("Invitation introuvable", 404, "INVITE_NOT_FOUND");
+      if (!result.ok) {
+        switch (result.error.kind) {
+          case "not_found":
+            return apiError("Invitation introuvable", 404, "INVITE_NOT_FOUND");
+          case "already_used":
+            return apiError("Cette invitation a déjà été utilisée.", 409, "INVITE_ALREADY_USED");
+          case "expired":
+            return apiError("Cette invitation a expiré.", 410, "INVITE_EXPIRED");
+          case "declined":
+            return apiError("Cette invitation a été refusée.", 409, "INVITE_DECLINED");
+        }
       }
-      if (invitation.used_at) {
-        return apiError("Cette invitation a déjà été utilisée.", 409, "INVITE_ALREADY_USED");
-      }
-      if (new Date(invitation.expires_at as string) < new Date()) {
-        return apiError("Cette invitation a expiré.", 410, "INVITE_EXPIRED");
-      }
-      if (String(invitation.email).toLowerCase().trim() !== data.email) {
+
+      resolvedInvitation = result.invitation;
+
+      if (resolvedInvitation.email !== data.email) {
         return apiError(
           "L'email saisi ne correspond pas à l'invitation.",
           403,
@@ -70,17 +74,17 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      const expectedRole = mapInvitationRoleToUserRole(invitation.role as InvitationRole);
-      if (expectedRole !== data.role) {
+      if (resolvedInvitation.applicativeRole !== data.role) {
         console.warn("[register] role override forced by invitation", {
           email: data.email,
           requested: data.role,
-          forced: expectedRole,
-          invitation_role: invitation.role,
+          forced: resolvedInvitation.applicativeRole,
+          invitation_role: resolvedInvitation.invitationRole,
+          source: resolvedInvitation.source,
         });
         // Verrouillage strict : on force le rôle au lieu d'accepter celui du
         // client, qui peut avoir été manipulé via l'URL `?role=...`.
-        data.role = expectedRole;
+        data.role = resolvedInvitation.applicativeRole;
       }
     }
 
@@ -187,18 +191,36 @@ export async function POST(request: NextRequest) {
       }
 
       // B18: Résolution automatique des invitations pending.
-      // Le vrai travail est fait par le trigger DB
+      // Pour la table `invitations` (bail), le trigger DB
       // `auto_link_lease_signers_on_profile_created()` (migration
-      // 20260225100000) qui se déclenche à l'INSERT sur profiles et :
+      // 20260225100000) gère :
       //   1. Lie les lease_signers orphelins (invited_email = user email)
       //   2. Backfill invoices.tenant_id
       //   3. Marque les invitations comme used_at = NOW()
       //
-      // Ce trigger se déclenche AVANT ce code (le handle_new_user trigger
-      // insère le profil, puis auto_link_lease_signers_on_profile_created
-      // s'exécute). Aucune action supplémentaire côté API n'est nécessaire.
-      //
-      // On log simplement pour le monitoring.
+      // Pour `guarantor_invitations` (garant standalone), aucun trigger
+      // équivalent n'existe : on marque manuellement l'invitation acceptée
+      // ici, en utilisant la résolution déjà faite avant le signUp.
+      if (resolvedInvitation && resolvedInvitation.source === "guarantor") {
+        try {
+          await adminClient
+            .from("guarantor_invitations")
+            .update({
+              status: "accepted",
+              accepted_at: new Date().toISOString(),
+              guarantor_profile_id: profile.id,
+            })
+            .eq("id", resolvedInvitation.id)
+            .eq("status", "pending");
+        } catch (guarantorLinkError) {
+          console.error("[register] guarantor_invitation accept failed:", {
+            invitation_id: resolvedInvitation.id,
+            error: guarantorLinkError,
+          });
+          // Non bloquant : un endpoint d'acceptation post-login peut rejouer
+          // l'opération.
+        }
+      }
 
       // NOTE: l'email de confirmation est envoyé par Supabase (SMTP Resend configuré
       // au niveau du projet). Pas d'envoi manuel supplémentaire ici pour éviter le

--- a/app/api/v1/auth/register/route.ts
+++ b/app/api/v1/auth/register/route.ts
@@ -222,6 +222,46 @@ export async function POST(request: NextRequest) {
         }
       }
 
+      // Pour les invitations agence, créer la liaison agency_managers et
+      // marquer l'invitation acceptée. Le rôle granulaire (directeur,
+      // gestionnaire, etc.) est porté par agency_managers.role_agence,
+      // pas par profile.role qui reste 'agency'.
+      if (resolvedInvitation && resolvedInvitation.source === "agency") {
+        try {
+          const { data: manager } = await adminClient
+            .from("agency_managers")
+            .upsert(
+              {
+                agency_profile_id: resolvedInvitation.agency_profile_id!,
+                user_profile_id: profile.id,
+                role_agence: resolvedInvitation.agency_role ?? "gestionnaire",
+                can_sign_documents: resolvedInvitation.can_sign_documents ?? false,
+                is_active: true,
+              },
+              { onConflict: "agency_profile_id,user_profile_id" }
+            )
+            .select("id")
+            .maybeSingle();
+
+          await adminClient
+            .from("agency_invitations")
+            .update({
+              status: "accepted",
+              accepted_at: new Date().toISOString(),
+              accepted_profile_id: profile.id,
+              agency_manager_id: manager?.id ?? null,
+            })
+            .eq("id", resolvedInvitation.id)
+            .eq("status", "pending");
+        } catch (agencyLinkError) {
+          console.error("[register] agency_invitation accept failed:", {
+            invitation_id: resolvedInvitation.id,
+            error: agencyLinkError,
+          });
+          // Non bloquant : un endpoint d'acceptation post-login peut rejouer.
+        }
+      }
+
       // NOTE: l'email de confirmation est envoyé par Supabase (SMTP Resend configuré
       // au niveau du projet). Pas d'envoi manuel supplémentaire ici pour éviter le
       // double email à l'inscription. L'email de bienvenue/onboarding guidé peut être

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -7,32 +7,16 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
 import { Mail, AlertCircle, ArrowRight, RefreshCw } from "lucide-react";
 import Link from "next/link";
+import {
+  getInvitationRoleLabel,
+  mapInvitationRoleToUserRole,
+  type InvitationRole,
+} from "@/lib/invitations/role-mapper";
 
-// FIX P1-E12: Suppression de @ts-nocheck — types explicites
 interface InvitationData {
   id: string;
   email: string;
-  role: "locataire_principal" | "colocataire" | "garant";
-}
-
-/**
- * Mappe les rôles d'invitation (table `invitations`) vers les UserRole
- * attendus par le signup flow (/signup/role → /signup/account).
- *
- * Bug audit comptes : le signup validait `role IN ['owner','tenant',
- * 'provider','guarantor','syndic','agency']` mais recevait
- * `locataire_principal|colocataire|garant` → boucle de redirection.
- */
-function mapInvitationRoleToUserRole(
-  invitationRole: InvitationData["role"]
-): "tenant" | "guarantor" {
-  switch (invitationRole) {
-    case "locataire_principal":
-    case "colocataire":
-      return "tenant";
-    case "garant":
-      return "guarantor";
-  }
+  role: InvitationRole;
 }
 
 export default function InvitePage() {
@@ -170,11 +154,7 @@ export default function InvitePage() {
           <CardTitle className="text-2xl">Invitation reçue</CardTitle>
           <CardDescription>
             Vous avez été invité à rejoindre un logement en tant que{" "}
-            <span className="font-semibold">
-              {invitation.role === "locataire_principal" && "Locataire principal"}
-              {invitation.role === "colocataire" && "Colocataire"}
-              {invitation.role === "garant" && "Garant"}
-            </span>
+            <span className="font-semibold">{getInvitationRoleLabel(invitation.role)}</span>
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/app/signup/account/page.tsx
+++ b/app/signup/account/page.tsx
@@ -12,6 +12,7 @@ import { authService } from "@/features/auth/services/auth.service";
 import { onboardingService } from "@/features/onboarding/services/onboarding.service";
 import { accountCreationSchema, consentsSchema, minimalProfileSchema } from "@/lib/validations/onboarding";
 import type { UserRole } from "@/lib/types";
+import { getInvitationRoleLabel, type InvitationRole } from "@/lib/invitations/role-mapper";
 import {
   Mail,
   Lock,
@@ -103,12 +104,38 @@ function AccountCreationContent() {
   const propertyCode = searchParams?.get("code") ?? null;
 
   const [draft, setDraft] = useState<AccountDraft>(INITIAL_DRAFT);
+  const [inviteInfo, setInviteInfo] = useState<{ email: string; role: InvitationRole } | null>(null);
 
   useEffect(() => {
     if (!role || !["owner", "tenant", "provider", "guarantor", "syndic", "agency"].includes(role)) {
       router.push("/signup/role");
     }
   }, [role, router]);
+
+  // Si un token d'invitation est présent, on charge l'invitation côté serveur
+  // pour : (1) afficher la bannière "rôle verrouillé", (2) pré-remplir l'email
+  // et le rendre non modifiable. La validation finale est faite côté API par
+  // /api/v1/auth/register qui force le rôle d'après la table `invitations`.
+  useEffect(() => {
+    if (!inviteToken) return;
+    let cancelled = false;
+    fetch(`/api/invitations/validate?token=${encodeURIComponent(inviteToken)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data?.valid && data.invitation?.email && data.invitation?.role) {
+          setInviteInfo({ email: data.invitation.email, role: data.invitation.role });
+          setDraft((prev) => ({
+            ...prev,
+            formData: { ...prev.formData, email: String(data.invitation.email).toLowerCase() },
+          }));
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [inviteToken]);
 
   useEffect(() => {
     onboardingService.getDraft().then((saved) => {
@@ -292,6 +319,7 @@ function AccountCreationContent() {
           nom: minimalValidated.nom,
           telephone: minimalValidated.telephone || undefined,
           turnstileToken: turnstileToken || undefined,
+          inviteToken: inviteToken || undefined,
         });
 
         await autosave({
@@ -371,6 +399,36 @@ function AccountCreationContent() {
       }
     >
       <form onSubmit={handleSubmit} className="space-y-8 text-white">
+        {inviteInfo && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ type: "spring", stiffness: 160 }}
+            className="rounded-2xl border border-blue-400/30 bg-blue-500/10 p-4 text-sm text-slate-100"
+            role="status"
+            aria-live="polite"
+          >
+            <div className="flex items-start gap-3">
+              <Lock className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-300" aria-hidden="true" />
+              <div className="space-y-1">
+                <p className="font-semibold text-white">
+                  Inscription par invitation
+                </p>
+                <p className="text-slate-200">
+                  Vous rejoignez Talok en tant que{" "}
+                  <span className="font-semibold text-white">
+                    {getInvitationRoleLabel(inviteInfo.role)}
+                  </span>
+                  . Le rôle et l'adresse email sont verrouillés par votre invitation.
+                </p>
+                <p className="text-xs text-slate-300">
+                  Email invité : <span className="font-mono text-slate-100">{inviteInfo.email}</span>
+                </p>
+              </div>
+            </div>
+          </motion.div>
+        )}
+
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -483,7 +541,15 @@ function AccountCreationContent() {
               </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
+              <Label htmlFor="email">
+                Email
+                {inviteInfo && (
+                  <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-blue-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-100">
+                    <Lock className="h-2.5 w-2.5" aria-hidden="true" />
+                    Verrouillé
+                  </span>
+                )}
+              </Label>
               <div className="relative">
                 <Mail className="absolute left-3 top-3 h-4 w-4 text-slate-400" />
                 <Input
@@ -495,6 +561,8 @@ function AccountCreationContent() {
                   onChange={(e) => updateForm("email", e.target.value)}
                   required
                   disabled={loading}
+                  readOnly={!!inviteInfo}
+                  aria-readonly={!!inviteInfo}
                   className="bg-white pl-10 text-slate-900"
                 />
               </div>

--- a/app/signup/account/page.tsx
+++ b/app/signup/account/page.tsx
@@ -114,7 +114,9 @@ function AccountCreationContent() {
 
   // Si un token d'invitation est présent, on charge l'invitation côté serveur
   // pour : (1) afficher la bannière "rôle verrouillé", (2) pré-remplir l'email
-  // et le rendre non modifiable. La validation finale est faite côté API par
+  // et le rendre non modifiable, (3) forcer le mode mot de passe car la voie
+  // magic-link ne crée pas de compte (shouldCreateUser=false côté API
+  // /api/v1/auth/magic-link). La validation finale est faite côté API par
   // /api/v1/auth/register qui force le rôle d'après la table `invitations`.
   useEffect(() => {
     if (!inviteToken) return;
@@ -127,6 +129,7 @@ function AccountCreationContent() {
           setInviteInfo({ email: data.invitation.email, role: data.invitation.role });
           setDraft((prev) => ({
             ...prev,
+            useMagicLink: false,
             formData: { ...prev.formData, email: String(data.invitation.email).toLowerCase() },
           }));
         }
@@ -280,6 +283,17 @@ function AccountCreationContent() {
         accept_cgu: validatedConsents.terms_accepted,
         accept_privacy: validatedConsents.privacy_accepted,
       });
+
+      if (inviteInfo && draft.useMagicLink) {
+        toast({
+          title: "Mode non disponible",
+          description:
+            "Le lien magique ne crée pas de compte. Définissez un mot de passe pour accepter votre invitation.",
+          variant: "destructive",
+        });
+        setLoading(false);
+        return;
+      }
 
       if (!draft.useMagicLink && draft.formData.password !== draft.formData.confirmPassword) {
         toast({
@@ -586,10 +600,20 @@ function AccountCreationContent() {
                 <Label htmlFor="useMagicLink" className="font-medium cursor-pointer">
                   Utiliser un lien magique
                 </Label>
-                <p className="text-xs text-slate-300">Connexion sans mot de passe via email sécurisé.</p>
+                <p className="text-xs text-slate-300">
+                  {inviteInfo
+                    ? "Indisponible pour les inscriptions par invitation. Définissez un mot de passe pour finaliser."
+                    : "Connexion sans mot de passe via email sécurisé."}
+                </p>
               </div>
               <div className="flex items-center gap-2 sm:flex-shrink-0">
-                <label htmlFor="useMagicLink" className="flex items-center gap-2 cursor-pointer">
+                <label
+                  htmlFor="useMagicLink"
+                  className={cn(
+                    "flex items-center gap-2",
+                    inviteInfo ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+                  )}
+                >
                   <span className="text-xs text-slate-300">
                     {draft.useMagicLink ? "Sans mot de passe" : "Mot de passe requis"}
                   </span>
@@ -598,8 +622,9 @@ function AccountCreationContent() {
                     id="useMagicLink"
                     checked={draft.useMagicLink}
                     onChange={(e) => void autosave({ useMagicLink: e.target.checked })}
-                    disabled={loading}
-                    className="h-5 w-5 rounded border-white/30 bg-transparent cursor-pointer"
+                    disabled={loading || !!inviteInfo}
+                    aria-disabled={!!inviteInfo}
+                    className="h-5 w-5 rounded border-white/30 bg-transparent cursor-pointer disabled:cursor-not-allowed"
                   />
                 </label>
               </div>

--- a/app/signup/role/page.tsx
+++ b/app/signup/role/page.tsx
@@ -47,7 +47,8 @@ function RoleChoiceContent() {
 
   // Vérifier si on a un token d'invitation (rôle verrouillé)
   // Guard: useSearchParams() peut retourner null pendant le SSR sans Suspense boundary
-  const inviteToken = searchParams?.get("invite") ?? null;
+  // Compat : les anciennes invitations garant utilisaient ?token= au lieu de ?invite=
+  const inviteToken = searchParams?.get("invite") ?? searchParams?.get("token") ?? null;
   const lockedRole = searchParams?.get("role") ?? null;
 
   // Pré-remplir le code logement si transmis depuis /rejoindre-logement

--- a/features/auth/services/auth.service.ts
+++ b/features/auth/services/auth.service.ts
@@ -10,6 +10,7 @@ export interface SignUpData {
   nom: string;
   telephone?: string;
   turnstileToken?: string;
+  inviteToken?: string;
 }
 
 export interface SignInData {
@@ -39,6 +40,7 @@ export class AuthService {
         nom: data.nom,
         telephone: data.telephone,
         turnstileToken: data.turnstileToken,
+        inviteToken: data.inviteToken,
       }),
     });
 

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -31,6 +31,12 @@ export const RegisterSchema = z.object({
     ])
     .optional()
     .transform((val) => (val === "" || val === null ? undefined : val)),
+  inviteToken: z
+    .string()
+    .min(10, "Token d'invitation invalide")
+    .optional()
+    .nullable()
+    .transform((val) => (val ?? undefined)),
 });
 
 export const LoginSchema = z.object({

--- a/lib/invitations/role-mapper.ts
+++ b/lib/invitations/role-mapper.ts
@@ -1,0 +1,39 @@
+import type { UserRole } from "@/lib/types";
+
+/**
+ * Rôles stockés dans la table `invitations` (français, hérité du modèle bail).
+ */
+export type InvitationRole = "locataire_principal" | "colocataire" | "garant";
+
+/**
+ * Source de vérité unique pour la conversion FR → EN entre la taxonomie
+ * `invitations.role` et la taxonomie applicative `profiles.role` (UserRole).
+ *
+ * Doit être appelée côté serveur à chaque fois qu'un flow signup ou
+ * acceptation consomme une invitation, pour empêcher un rôle d'invitation
+ * d'être détourné vers un rôle applicatif différent.
+ */
+export function mapInvitationRoleToUserRole(role: InvitationRole): Extract<UserRole, "tenant" | "guarantor"> {
+  switch (role) {
+    case "locataire_principal":
+    case "colocataire":
+      return "tenant";
+    case "garant":
+      return "guarantor";
+  }
+}
+
+/**
+ * Libellé UI court pour afficher le rôle d'une invitation (bannière signup,
+ * page acceptation, emails).
+ */
+export function getInvitationRoleLabel(role: InvitationRole): string {
+  switch (role) {
+    case "locataire_principal":
+      return "Locataire principal";
+    case "colocataire":
+      return "Colocataire";
+    case "garant":
+      return "Garant";
+  }
+}

--- a/lib/invitations/server-resolver.ts
+++ b/lib/invitations/server-resolver.ts
@@ -4,15 +4,21 @@ import {
   type InvitationRole,
 } from "@/lib/invitations/role-mapper";
 
-export type ResolvedInvitationSource = "lease" | "guarantor";
+export type ResolvedInvitationSource = "lease" | "guarantor" | "agency";
+
+export type AgencyRole = "directeur" | "gestionnaire" | "assistant" | "comptable";
 
 export type ResolvedInvitation = {
   source: ResolvedInvitationSource;
   id: string;
   email: string;
-  applicativeRole: "tenant" | "guarantor";
-  invitationRole: InvitationRole;
+  applicativeRole: "tenant" | "guarantor" | "agency";
+  invitationRole: InvitationRole | "agency";
   lease_id: string | null;
+  // Méta-données spécifiques au flow agence (présent uniquement quand source='agency')
+  agency_profile_id?: string;
+  agency_role?: AgencyRole;
+  can_sign_documents?: boolean;
 };
 
 export type ResolveInvitationError =
@@ -73,18 +79,53 @@ export async function resolveInvitationByToken(
     .eq("invitation_token", token)
     .maybeSingle();
 
-  if (!garInv) {
+  if (garInv) {
+    if (garInv.status === "accepted" || garInv.accepted_at) {
+      return { ok: false, error: { kind: "already_used" } };
+    }
+    if (garInv.status === "declined" || garInv.declined_at) {
+      return { ok: false, error: { kind: "declined" } };
+    }
+    if (
+      garInv.status === "expired" ||
+      (garInv.expires_at && new Date(garInv.expires_at as string) < new Date())
+    ) {
+      return { ok: false, error: { kind: "expired" } };
+    }
+
+    return {
+      ok: true,
+      invitation: {
+        source: "guarantor",
+        id: String(garInv.id),
+        email: String(garInv.guarantor_email).toLowerCase().trim(),
+        applicativeRole: "guarantor",
+        invitationRole: "garant",
+        lease_id: (garInv.lease_id as string | null) ?? null,
+      },
+    };
+  }
+
+  // Fallback : agency_invitations (collaborateurs d'agence)
+  const { data: agencyInv } = await adminClient
+    .from("agency_invitations")
+    .select("id, email, status, expires_at, accepted_at, declined_at, agency_profile_id, role_agence, can_sign_documents")
+    .eq("invitation_token", token)
+    .maybeSingle();
+
+  if (!agencyInv) {
     return { ok: false, error: { kind: "not_found" } };
   }
-  if (garInv.status === "accepted" || garInv.accepted_at) {
+  if (agencyInv.status === "accepted" || agencyInv.accepted_at) {
     return { ok: false, error: { kind: "already_used" } };
   }
-  if (garInv.status === "declined" || garInv.declined_at) {
+  if (agencyInv.status === "declined" || agencyInv.declined_at) {
     return { ok: false, error: { kind: "declined" } };
   }
   if (
-    garInv.status === "expired" ||
-    (garInv.expires_at && new Date(garInv.expires_at as string) < new Date())
+    agencyInv.status === "expired" ||
+    agencyInv.status === "cancelled" ||
+    (agencyInv.expires_at && new Date(agencyInv.expires_at as string) < new Date())
   ) {
     return { ok: false, error: { kind: "expired" } };
   }
@@ -92,12 +133,15 @@ export async function resolveInvitationByToken(
   return {
     ok: true,
     invitation: {
-      source: "guarantor",
-      id: String(garInv.id),
-      email: String(garInv.guarantor_email).toLowerCase().trim(),
-      applicativeRole: "guarantor",
-      invitationRole: "garant",
-      lease_id: (garInv.lease_id as string | null) ?? null,
+      source: "agency",
+      id: String(agencyInv.id),
+      email: String(agencyInv.email).toLowerCase().trim(),
+      applicativeRole: "agency",
+      invitationRole: "agency",
+      lease_id: null,
+      agency_profile_id: String(agencyInv.agency_profile_id),
+      agency_role: agencyInv.role_agence as AgencyRole,
+      can_sign_documents: !!agencyInv.can_sign_documents,
     },
   };
 }

--- a/lib/invitations/server-resolver.ts
+++ b/lib/invitations/server-resolver.ts
@@ -1,0 +1,103 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  mapInvitationRoleToUserRole,
+  type InvitationRole,
+} from "@/lib/invitations/role-mapper";
+
+export type ResolvedInvitationSource = "lease" | "guarantor";
+
+export type ResolvedInvitation = {
+  source: ResolvedInvitationSource;
+  id: string;
+  email: string;
+  applicativeRole: "tenant" | "guarantor";
+  invitationRole: InvitationRole;
+  lease_id: string | null;
+};
+
+export type ResolveInvitationError =
+  | { kind: "not_found" }
+  | { kind: "expired" }
+  | { kind: "already_used" }
+  | { kind: "declined" };
+
+export type ResolveInvitationResult =
+  | { ok: true; invitation: ResolvedInvitation }
+  | { ok: false; error: ResolveInvitationError };
+
+/**
+ * Résout un token d'invitation côté serveur en interrogeant successivement
+ * la table `invitations` (bail) puis `guarantor_invitations` (garant
+ * standalone). Garantit que les deux pipelines partagent la même logique
+ * de validation (expiration, single-use, mapping FR→EN du rôle).
+ *
+ * Utilise un client admin (service_role) — RLS bypassée volontairement,
+ * cette résolution est appelée depuis des endpoints publics (signup,
+ * validate) qui ne peuvent pas s'authentifier en tant que destinataire
+ * de l'invitation.
+ */
+export async function resolveInvitationByToken(
+  adminClient: SupabaseClient<any, any, any>,
+  token: string
+): Promise<ResolveInvitationResult> {
+  const { data: leaseInv } = await adminClient
+    .from("invitations")
+    .select("id, email, role, expires_at, used_at, lease_id")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (leaseInv) {
+    if (leaseInv.used_at) {
+      return { ok: false, error: { kind: "already_used" } };
+    }
+    if (new Date(leaseInv.expires_at as string) < new Date()) {
+      return { ok: false, error: { kind: "expired" } };
+    }
+    const invitationRole = leaseInv.role as InvitationRole;
+    return {
+      ok: true,
+      invitation: {
+        source: "lease",
+        id: String(leaseInv.id),
+        email: String(leaseInv.email).toLowerCase().trim(),
+        applicativeRole: mapInvitationRoleToUserRole(invitationRole),
+        invitationRole,
+        lease_id: (leaseInv.lease_id as string | null) ?? null,
+      },
+    };
+  }
+
+  const { data: garInv } = await adminClient
+    .from("guarantor_invitations")
+    .select("id, guarantor_email, status, expires_at, accepted_at, declined_at, lease_id")
+    .eq("invitation_token", token)
+    .maybeSingle();
+
+  if (!garInv) {
+    return { ok: false, error: { kind: "not_found" } };
+  }
+  if (garInv.status === "accepted" || garInv.accepted_at) {
+    return { ok: false, error: { kind: "already_used" } };
+  }
+  if (garInv.status === "declined" || garInv.declined_at) {
+    return { ok: false, error: { kind: "declined" } };
+  }
+  if (
+    garInv.status === "expired" ||
+    (garInv.expires_at && new Date(garInv.expires_at as string) < new Date())
+  ) {
+    return { ok: false, error: { kind: "expired" } };
+  }
+
+  return {
+    ok: true,
+    invitation: {
+      source: "guarantor",
+      id: String(garInv.id),
+      email: String(garInv.guarantor_email).toLowerCase().trim(),
+      applicativeRole: "guarantor",
+      invitationRole: "garant",
+      lease_id: (garInv.lease_id as string | null) ?? null,
+    },
+  };
+}

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -55,6 +55,21 @@ export const rateLimitPresets = {
     windowMs: 60 * 60 * 1000,
     maxRequests: 10,
   },
+  // Limite pour les invitations copropriété (syndic peut setup 50 lots en série)
+  coproInvite: {
+    windowMs: 60 * 60 * 1000,
+    maxRequests: 50,
+  },
+  // Limite pour les invitations collaborateur agence
+  agencyInvite: {
+    windowMs: 60 * 60 * 1000,
+    maxRequests: 20,
+  },
+  // Limite pour l'acceptation d'une invitation (anti-bruteforce de token)
+  inviteAccept: {
+    windowMs: 5 * 60 * 1000,
+    maxRequests: 10,
+  },
   // Limite pour les signatures
   signature: {
     windowMs: 60 * 1000,

--- a/supabase/migrations/20260428200000_harden_auto_link_lease_signers_role_check.sql
+++ b/supabase/migrations/20260428200000_harden_auto_link_lease_signers_role_check.sql
@@ -1,0 +1,95 @@
+-- =====================================================
+-- MIGRATION: Durcissement du trigger auto_link_lease_signers
+-- Date: 2026-04-28
+--
+-- PROBLÈME CORRIGÉ:
+-- Le trigger précédent (20260216200000) liait tous les lease_signers
+-- orphelins matchant l'email du profil créé, sans vérifier la cohérence
+-- de rôle. Risque : un user qui crée un compte `tenant` était lié
+-- automatiquement à un lease_signers.role = 'garant' s'il en existait
+-- un avec le même email (cas rare mais possible).
+--
+-- SOLUTION:
+-- - Ne lier que les lease_signers dont le rôle FR est cohérent avec
+--   le rôle applicatif EN du profil créé (mapping côté DB :
+--   tenant → locataire_principal/colocataire, guarantor → garant,
+--   owner → proprietaire).
+-- - Idem pour la consommation des `invitations` (même mapping).
+-- - Logger en WARNING les emails matchés mais aux rôles incohérents
+--   pour identifier les invitations mal configurées.
+-- =====================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.auto_link_lease_signers_on_profile_created()
+RETURNS TRIGGER AS $$
+DECLARE
+  user_email TEXT;
+  linked_count INT;
+  mismatch_count INT;
+BEGIN
+  SELECT email INTO user_email
+  FROM auth.users
+  WHERE id = NEW.user_id;
+
+  IF user_email IS NULL OR user_email = '' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Lier les lease_signers orphelins en exigeant la cohérence de rôle.
+  UPDATE public.lease_signers ls
+  SET profile_id = NEW.id
+  WHERE LOWER(ls.invited_email) = LOWER(user_email)
+    AND ls.profile_id IS NULL
+    AND (
+      (NEW.role = 'tenant'    AND ls.role IN ('locataire_principal', 'colocataire'))
+      OR (NEW.role = 'guarantor' AND ls.role = 'garant')
+      OR (NEW.role = 'owner'     AND ls.role = 'proprietaire')
+    );
+
+  GET DIAGNOSTICS linked_count = ROW_COUNT;
+
+  -- Compter les lease_signers dont l'email matche mais dont le rôle est
+  -- incohérent : log warning pour traçabilité (invitation mal configurée,
+  -- ou tentative de détournement bloquée).
+  SELECT COUNT(*) INTO mismatch_count
+  FROM public.lease_signers ls
+  WHERE LOWER(ls.invited_email) = LOWER(user_email)
+    AND ls.profile_id IS NULL
+    AND NOT (
+      (NEW.role = 'tenant'    AND ls.role IN ('locataire_principal', 'colocataire'))
+      OR (NEW.role = 'guarantor' AND ls.role = 'garant')
+      OR (NEW.role = 'owner'     AND ls.role = 'proprietaire')
+    );
+
+  IF mismatch_count > 0 THEN
+    RAISE WARNING '[auto_link] % lease_signers non liés (email: %, profile.role: %) — rôles incohérents',
+      mismatch_count, user_email, NEW.role;
+  END IF;
+
+  IF linked_count > 0 THEN
+    RAISE NOTICE '[auto_link] % lease_signers liés au profil % (email: %, role: %)',
+      linked_count, NEW.id, user_email, NEW.role;
+  END IF;
+
+  -- Consommation des invitations bail avec la même règle de cohérence.
+  -- (La table invitations.role utilise les libellés FR : locataire_principal,
+  -- colocataire, garant.)
+  UPDATE public.invitations
+  SET used_by = NEW.id,
+      used_at = NOW()
+  WHERE LOWER(email) = LOWER(user_email)
+    AND used_at IS NULL
+    AND (
+      (NEW.role = 'tenant'    AND role IN ('locataire_principal', 'colocataire'))
+      OR (NEW.role = 'guarantor' AND role = 'garant')
+    );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.auto_link_lease_signers_on_profile_created() IS
+  'Lie les lease_signers orphelins à un profil nouvellement créé, en exigeant la cohérence entre profile.role (EN) et lease_signers.role / invitations.role (FR). Cf. migration 20260428200000.';
+
+COMMIT;

--- a/supabase/migrations/20260428210000_copro_invites_table_and_rpcs.sql
+++ b/supabase/migrations/20260428210000_copro_invites_table_and_rpcs.sql
@@ -1,0 +1,384 @@
+-- =====================================================
+-- MIGRATION: Module invitations copropriété
+-- Date: 2026-04-28
+--
+-- Crée la table `copro_invites` et les RPC associées
+-- (`validate_copro_invite`, `accept_copro_invite`) référencées par :
+--   - app/api/copro/invites/route.ts (POST/GET, INSERT direct)
+--   - app/api/copro/invites/[token]/route.ts (GET via RPC, POST via RPC, DELETE/PATCH)
+--   - features/copro/services/invites.service.ts (CRUD client)
+--   - app/syndic/invites/page.tsx, app/invite/copro/page.tsx (UI)
+--
+-- Contrats :
+--   - lib/types/copro.ts : CoproInvite, InviteValidationResult, InviteAcceptResult
+--   - InviteTargetRole : 10 valeurs (syndic, conseil_syndical, president_cs,
+--     coproprietaire_occupant/bailleur/nu, usufruitier, locataire, gardien,
+--     prestataire)
+--
+-- Mapping target_role → user_site_roles.role_code (CHECK existant restrictif) :
+--   syndic                     → syndic
+--   conseil_syndical/president → conseil_syndical
+--   coproprietaire_occupant    → coproprietaire
+--   coproprietaire_nu          → coproprietaire
+--   usufruitier                → coproprietaire
+--   coproprietaire_bailleur    → coproprietaire_bailleur
+--   locataire                  → locataire_copro
+--   gardien / prestataire      → pas de role dans user_site_roles
+--
+-- L'ownership est porté par copro_units.owner_profile_id (single owner) ;
+-- pour les rôles coproprietaire_* avec unit_id, on update ce champ. La
+-- gestion fine de l'indivision n'est pas dans ce périmètre.
+-- =====================================================
+
+BEGIN;
+
+-- ============================================
+-- 1. TABLE copro_invites
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS public.copro_invites (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+  -- Destinataire
+  email TEXT NOT NULL,
+  first_name TEXT,
+  last_name TEXT,
+  phone TEXT,
+
+  -- Cible
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+  unit_id UUID REFERENCES public.copro_units(id) ON DELETE SET NULL,
+  target_role TEXT NOT NULL DEFAULT 'coproprietaire_occupant'
+    CHECK (target_role IN (
+      'syndic', 'conseil_syndical', 'president_cs',
+      'coproprietaire_occupant', 'coproprietaire_bailleur',
+      'coproprietaire_nu', 'usufruitier',
+      'locataire', 'gardien', 'prestataire'
+    )),
+  ownership_type TEXT
+    CHECK (ownership_type IS NULL OR ownership_type IN (
+      'pleine_propriete', 'nue_propriete', 'usufruit', 'indivision', 'sci', 'autre'
+    )),
+  ownership_share NUMERIC(5,4) NOT NULL DEFAULT 1.0
+    CHECK (ownership_share >= 0 AND ownership_share <= 1),
+
+  personal_message TEXT,
+
+  -- Émetteur (auth user du syndic / admin)
+  invited_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+
+  -- Statut
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'sent', 'accepted', 'expired', 'cancelled')),
+  sent_at TIMESTAMPTZ,
+  accepted_at TIMESTAMPTZ,
+  accepted_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '30 days'),
+  reminder_count INTEGER NOT NULL DEFAULT 0,
+  last_reminder_at TIMESTAMPTZ,
+
+  metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Une seule invitation pending/sent par couple (site, email)
+  UNIQUE (site_id, email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_invites_site ON public.copro_invites(site_id);
+CREATE INDEX IF NOT EXISTS idx_copro_invites_email ON public.copro_invites(email);
+CREATE INDEX IF NOT EXISTS idx_copro_invites_status ON public.copro_invites(status);
+CREATE INDEX IF NOT EXISTS idx_copro_invites_token ON public.copro_invites(token);
+CREATE INDEX IF NOT EXISTS idx_copro_invites_expires_at ON public.copro_invites(expires_at);
+
+COMMENT ON TABLE public.copro_invites IS 'Invitations envoyées par les syndics aux copropriétaires/locataires/prestataires';
+COMMENT ON COLUMN public.copro_invites.token IS 'UUID utilisé dans l''URL /invite/copro?token=...';
+COMMENT ON COLUMN public.copro_invites.target_role IS 'Rôle cible (taxonomie copro fine) — mappé à user_site_roles.role_code à l''acceptation';
+
+-- Trigger updated_at (la fonction update_updated_at_column existe déjà)
+DROP TRIGGER IF EXISTS update_copro_invites_updated_at ON public.copro_invites;
+CREATE TRIGGER update_copro_invites_updated_at
+  BEFORE UPDATE ON public.copro_invites
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ============================================
+-- 2. RLS — copro_invites
+-- ============================================
+
+ALTER TABLE public.copro_invites ENABLE ROW LEVEL SECURITY;
+
+-- Le syndic du site peut tout faire sur ses invitations
+CREATE POLICY "copro_invites_syndic_all" ON public.copro_invites
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.sites s
+      WHERE s.id = copro_invites.site_id
+      AND s.syndic_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    )
+  );
+
+-- L'utilisateur invité peut voir son invitation (par email match)
+CREATE POLICY "copro_invites_invited_select" ON public.copro_invites
+  FOR SELECT USING (
+    LOWER(email) = LOWER(COALESCE((SELECT email FROM auth.users WHERE id = auth.uid()), ''))
+  );
+
+-- Admin
+CREATE POLICY "copro_invites_admin_all" ON public.copro_invites
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE user_id = auth.uid() AND role = 'admin')
+  );
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.copro_invites TO authenticated;
+
+-- ============================================
+-- 3. RPC validate_copro_invite
+-- ============================================
+-- Publique (SECURITY DEFINER) car appelée par /api/copro/invites/[token]
+-- avant authentification utilisateur. Retourne les infos enrichies
+-- (site_name + lot_number) pour l'affichage de la page d'acceptation.
+
+CREATE OR REPLACE FUNCTION public.validate_copro_invite(p_token UUID)
+RETURNS TABLE (
+  is_valid BOOLEAN,
+  invite_id UUID,
+  email TEXT,
+  first_name TEXT,
+  last_name TEXT,
+  site_id UUID,
+  site_name TEXT,
+  unit_id UUID,
+  lot_number TEXT,
+  target_role TEXT,
+  ownership_type TEXT,
+  ownership_share NUMERIC,
+  error_message TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_invite RECORD;
+  v_site_name TEXT;
+  v_lot_number TEXT;
+BEGIN
+  SELECT *
+  INTO v_invite
+  FROM public.copro_invites ci
+  WHERE ci.token = p_token
+  LIMIT 1;
+
+  IF v_invite IS NULL THEN
+    RETURN QUERY SELECT
+      FALSE, NULL::UUID, NULL::TEXT, NULL::TEXT, NULL::TEXT,
+      NULL::UUID, NULL::TEXT, NULL::UUID, NULL::TEXT,
+      NULL::TEXT, NULL::TEXT, NULL::NUMERIC,
+      'Invitation introuvable'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.status = 'cancelled' THEN
+    RETURN QUERY SELECT
+      FALSE, v_invite.id, v_invite.email, v_invite.first_name, v_invite.last_name,
+      v_invite.site_id, NULL::TEXT, v_invite.unit_id, NULL::TEXT,
+      v_invite.target_role, v_invite.ownership_type, v_invite.ownership_share,
+      'Cette invitation a été annulée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.status = 'accepted' THEN
+    RETURN QUERY SELECT
+      FALSE, v_invite.id, v_invite.email, v_invite.first_name, v_invite.last_name,
+      v_invite.site_id, NULL::TEXT, v_invite.unit_id, NULL::TEXT,
+      v_invite.target_role, v_invite.ownership_type, v_invite.ownership_share,
+      'Cette invitation a déjà été acceptée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.expires_at < NOW() THEN
+    -- Marquer expired pour le tableau de bord syndic (effet de bord acceptable
+    -- via SECURITY DEFINER : la validation publique est aussi un point de
+    -- garbage collection naturel pour les invitations périmées).
+    UPDATE public.copro_invites
+    SET status = 'expired'
+    WHERE id = v_invite.id AND status IN ('pending', 'sent');
+
+    RETURN QUERY SELECT
+      FALSE, v_invite.id, v_invite.email, v_invite.first_name, v_invite.last_name,
+      v_invite.site_id, NULL::TEXT, v_invite.unit_id, NULL::TEXT,
+      v_invite.target_role, v_invite.ownership_type, v_invite.ownership_share,
+      'Cette invitation a expiré. Demandez un nouveau lien au syndic.'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Enrichir avec site_name et lot_number
+  SELECT s.name INTO v_site_name FROM public.sites s WHERE s.id = v_invite.site_id;
+  IF v_invite.unit_id IS NOT NULL THEN
+    SELECT cu.lot_number INTO v_lot_number
+    FROM public.copro_units cu
+    WHERE cu.id = v_invite.unit_id;
+  END IF;
+
+  RETURN QUERY SELECT
+    TRUE, v_invite.id, v_invite.email, v_invite.first_name, v_invite.last_name,
+    v_invite.site_id, v_site_name, v_invite.unit_id, v_lot_number,
+    v_invite.target_role, v_invite.ownership_type, v_invite.ownership_share,
+    NULL::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.validate_copro_invite(UUID) IS
+  'Valide un token d''invitation copro et retourne les infos enrichies pour la page d''acceptation. Marque les invitations expirées au passage.';
+
+GRANT EXECUTE ON FUNCTION public.validate_copro_invite(UUID) TO anon, authenticated;
+
+-- ============================================
+-- 4. RPC accept_copro_invite
+-- ============================================
+-- Atomique : utilise un UPDATE conditionné sur status pour éviter les race
+-- conditions. Vérifie l'email match côté serveur (defense-in-depth en plus
+-- du check côté API route).
+
+CREATE OR REPLACE FUNCTION public.accept_copro_invite(
+  p_token UUID,
+  p_user_id UUID
+)
+RETURNS TABLE (
+  success BOOLEAN,
+  invite_id UUID,
+  role_assigned TEXT,
+  ownership_created BOOLEAN,
+  error_message TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_invite RECORD;
+  v_user_email TEXT;
+  v_invite_email TEXT;
+  v_role_code TEXT;
+  v_profile_id UUID;
+  v_ownership_created BOOLEAN := FALSE;
+  v_updated_count INTEGER;
+BEGIN
+  -- 1. Charger l'invitation
+  SELECT * INTO v_invite
+  FROM public.copro_invites ci
+  WHERE ci.token = p_token
+  LIMIT 1;
+
+  IF v_invite IS NULL THEN
+    RETURN QUERY SELECT FALSE, NULL::UUID, NULL::TEXT, FALSE, 'Invitation introuvable'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.status = 'cancelled' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE, 'Cette invitation a été annulée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.status = 'accepted' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE, 'Cette invitation a déjà été acceptée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.expires_at < NOW() OR v_invite.status = 'expired' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE, 'Cette invitation a expiré'::TEXT;
+    RETURN;
+  END IF;
+
+  -- 2. Vérifier l'email match (defense-in-depth)
+  SELECT LOWER(TRIM(email)) INTO v_user_email FROM auth.users WHERE id = p_user_id;
+  v_invite_email := LOWER(TRIM(v_invite.email));
+
+  IF v_user_email IS NULL OR v_user_email <> v_invite_email THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE,
+      'L''email du compte ne correspond pas à l''invitation'::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3. Acceptation atomique (race-condition-safe)
+  UPDATE public.copro_invites
+  SET status = 'accepted',
+      accepted_at = NOW(),
+      accepted_by = p_user_id
+  WHERE id = v_invite.id
+    AND status IN ('pending', 'sent');
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  IF v_updated_count = 0 THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE,
+      'Cette invitation a déjà été utilisée'::TEXT;
+    RETURN;
+  END IF;
+
+  -- 4. Mapper target_role → user_site_roles.role_code (CHECK restrictif)
+  v_role_code := CASE v_invite.target_role
+    WHEN 'syndic' THEN 'syndic'
+    WHEN 'conseil_syndical' THEN 'conseil_syndical'
+    WHEN 'president_cs' THEN 'conseil_syndical'
+    WHEN 'coproprietaire_occupant' THEN 'coproprietaire'
+    WHEN 'coproprietaire_nu' THEN 'coproprietaire'
+    WHEN 'usufruitier' THEN 'coproprietaire'
+    WHEN 'coproprietaire_bailleur' THEN 'coproprietaire_bailleur'
+    WHEN 'locataire' THEN 'locataire_copro'
+    ELSE NULL  -- gardien, prestataire : pas de rôle site (gérés par le module prestataire)
+  END;
+
+  -- 5. Insérer dans user_site_roles si rôle mappable
+  IF v_role_code IS NOT NULL THEN
+    INSERT INTO public.user_site_roles (user_id, site_id, role_code, unit_ids, granted_by)
+    VALUES (
+      p_user_id,
+      v_invite.site_id,
+      v_role_code,
+      CASE WHEN v_invite.unit_id IS NOT NULL THEN ARRAY[v_invite.unit_id] ELSE ARRAY[]::UUID[] END,
+      v_invite.invited_by
+    )
+    ON CONFLICT (user_id, site_id, role_code) DO UPDATE
+      SET unit_ids = (
+        SELECT ARRAY(
+          SELECT DISTINCT u FROM unnest(
+            COALESCE(user_site_roles.unit_ids, ARRAY[]::UUID[]) ||
+            CASE WHEN v_invite.unit_id IS NOT NULL THEN ARRAY[v_invite.unit_id] ELSE ARRAY[]::UUID[] END
+          ) AS t(u)
+        )
+      );
+  END IF;
+
+  -- 6. Si rôle de propriétaire avec unit_id : porter l'ownership sur le lot
+  IF v_invite.unit_id IS NOT NULL
+     AND v_invite.target_role IN (
+       'coproprietaire_occupant', 'coproprietaire_bailleur',
+       'coproprietaire_nu', 'usufruitier'
+     )
+  THEN
+    SELECT id INTO v_profile_id FROM public.profiles WHERE user_id = p_user_id LIMIT 1;
+    IF v_profile_id IS NOT NULL THEN
+      UPDATE public.copro_units
+      SET owner_profile_id = v_profile_id
+      WHERE id = v_invite.unit_id;
+      v_ownership_created := TRUE;
+    END IF;
+  END IF;
+
+  RETURN QUERY SELECT
+    TRUE,
+    v_invite.id,
+    COALESCE(v_role_code, v_invite.target_role)::TEXT,
+    v_ownership_created,
+    NULL::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.accept_copro_invite(UUID, UUID) IS
+  'Accepte une invitation copro de manière atomique : marque l''invitation acceptée, attribue le rôle dans user_site_roles, et porte l''ownership si applicable. Vérifie l''email match en defense-in-depth.';
+
+GRANT EXECUTE ON FUNCTION public.accept_copro_invite(UUID, UUID) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260428220000_agency_invitations.sql
+++ b/supabase/migrations/20260428220000_agency_invitations.sql
@@ -1,0 +1,121 @@
+-- =====================================================
+-- MIGRATION: Module invitations agence (collaborateurs)
+-- Date: 2026-04-28
+--
+-- Une agence (profile.role='agency') peut inviter des collaborateurs
+-- (directeur, gestionnaire, assistant, comptable) via email. Le
+-- collaborateur invité s'inscrit avec profile.role='agency' et est lié
+-- à l'agence via une nouvelle ligne dans `agency_managers`.
+--
+-- Architecture alignée avec :
+--   - guarantor_invitations (modèle d'invitation standalone)
+--   - agency_managers (table de liaison existante, role_agence :
+--     directeur | gestionnaire | assistant | comptable)
+-- =====================================================
+
+BEGIN;
+
+-- ============================================
+-- 1. TABLE agency_invitations
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS public.agency_invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invitation_token UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+  -- Agence émettrice
+  agency_profile_id UUID NOT NULL REFERENCES public.agency_profiles(profile_id) ON DELETE CASCADE,
+  invited_by UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+
+  -- Destinataire
+  email TEXT NOT NULL,
+  prenom TEXT,
+  nom TEXT,
+  telephone TEXT,
+
+  -- Rôle dans l'agence (cf. agency_managers.role_agence)
+  role_agence TEXT NOT NULL DEFAULT 'gestionnaire'
+    CHECK (role_agence IN ('directeur', 'gestionnaire', 'assistant', 'comptable')),
+  can_sign_documents BOOLEAN NOT NULL DEFAULT FALSE,
+
+  personal_message TEXT,
+
+  -- Statut
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted', 'declined', 'expired', 'cancelled')),
+  sent_at TIMESTAMPTZ DEFAULT NOW(),
+  accepted_at TIMESTAMPTZ,
+  declined_at TIMESTAMPTZ,
+  cancelled_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '30 days'),
+
+  -- Lien post-acceptation
+  accepted_profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  agency_manager_id UUID REFERENCES public.agency_managers(id) ON DELETE SET NULL,
+
+  metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (agency_profile_id, email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agency_invitations_agency ON public.agency_invitations(agency_profile_id);
+CREATE INDEX IF NOT EXISTS idx_agency_invitations_email ON public.agency_invitations(email);
+CREATE INDEX IF NOT EXISTS idx_agency_invitations_status ON public.agency_invitations(status);
+CREATE INDEX IF NOT EXISTS idx_agency_invitations_token ON public.agency_invitations(invitation_token);
+CREATE INDEX IF NOT EXISTS idx_agency_invitations_expires_at ON public.agency_invitations(expires_at);
+
+COMMENT ON TABLE public.agency_invitations IS 'Invitations envoyées par une agence à ses collaborateurs (directeur/gestionnaire/assistant/comptable)';
+COMMENT ON COLUMN public.agency_invitations.invitation_token IS 'UUID utilisé dans l''URL /signup/role?invite=...';
+
+-- Trigger updated_at
+DROP TRIGGER IF EXISTS update_agency_invitations_updated_at ON public.agency_invitations;
+CREATE TRIGGER update_agency_invitations_updated_at
+  BEFORE UPDATE ON public.agency_invitations
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ============================================
+-- 2. RLS — agency_invitations
+-- ============================================
+
+ALTER TABLE public.agency_invitations ENABLE ROW LEVEL SECURITY;
+
+-- L'agence émettrice voit/gère ses invitations
+CREATE POLICY "agency_invitations_owner_select" ON public.agency_invitations
+  FOR SELECT USING (
+    invited_by = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR agency_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+CREATE POLICY "agency_invitations_owner_insert" ON public.agency_invitations
+  FOR INSERT WITH CHECK (
+    invited_by = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+CREATE POLICY "agency_invitations_owner_update" ON public.agency_invitations
+  FOR UPDATE USING (
+    invited_by = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR agency_profile_id = (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+-- Le collaborateur invité voit son invitation (par email match)
+CREATE POLICY "agency_invitations_invited_select" ON public.agency_invitations
+  FOR SELECT USING (
+    LOWER(email) = LOWER(COALESCE((SELECT email FROM auth.users WHERE id = auth.uid()), ''))
+  );
+
+-- Admin de la plateforme : accès complet
+CREATE POLICY "agency_invitations_admin_all" ON public.agency_invitations
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE user_id = auth.uid()
+      AND role IN ('admin', 'platform_admin')
+    )
+  );
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.agency_invitations TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260428230000_align_admin_invite_policies.sql
+++ b/supabase/migrations/20260428230000_align_admin_invite_policies.sql
@@ -1,0 +1,56 @@
+-- =====================================================
+-- MIGRATION: Aligner les policies admin sur les tables d'invitation
+-- Date: 2026-04-28
+--
+-- Les policies admin existantes sur les tables d'invitation ne testent
+-- que `role='admin'`. Le rôle `platform_admin` (cf. lib/types,
+-- profiles_role_check) doit aussi avoir un accès complet pour le
+-- monitoring et le support.
+-- =====================================================
+
+BEGIN;
+
+-- ============================================
+-- guarantor_invitations
+-- ============================================
+
+DROP POLICY IF EXISTS "guarantor_invitations_admin_all" ON public.guarantor_invitations;
+CREATE POLICY "guarantor_invitations_admin_all" ON public.guarantor_invitations
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE user_id = auth.uid()
+      AND role IN ('admin', 'platform_admin')
+    )
+  );
+
+-- ============================================
+-- copro_invites (créée par 20260428210000)
+-- ============================================
+
+DROP POLICY IF EXISTS "copro_invites_admin_all" ON public.copro_invites;
+CREATE POLICY "copro_invites_admin_all" ON public.copro_invites
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE user_id = auth.uid()
+      AND role IN ('admin', 'platform_admin')
+    )
+  );
+
+-- ============================================
+-- invitations (bail) — pas de policy admin existante
+-- Ajouter pour cohérence avec les autres tables.
+-- ============================================
+
+DROP POLICY IF EXISTS "invitations_admin_all" ON public.invitations;
+CREATE POLICY "invitations_admin_all" ON public.invitations
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE user_id = auth.uid()
+      AND role IN ('admin', 'platform_admin')
+    )
+  );
+
+COMMIT;

--- a/supabase/migrations/20260428240000_harden_copro_invite_rpcs.sql
+++ b/supabase/migrations/20260428240000_harden_copro_invite_rpcs.sql
@@ -1,0 +1,241 @@
+-- =====================================================
+-- MIGRATION: Hardening des RPC d'invitations copro
+-- Date: 2026-04-28
+--
+-- Findings de l'audit sécurité des RPC SECURITY DEFINER
+-- (lib/invitations/server-resolver + audit C):
+--
+-- 1. 🔴 accept_copro_invite acceptait n'importe quel p_user_id sans
+--    vérifier qu'il correspond au caller authentifié. Un user
+--    authentifié pouvait forger l'acceptation d'une invitation au
+--    nom d'un autre user (à condition que l'email cible matche).
+--    Fix : exiger auth.uid() = p_user_id.
+--
+-- 2. ⚠️ validate_copro_invite retournait l'email/first_name/last_name
+--    même pour des invitations cancelled/accepted. Le token étant
+--    secret (UUID v4, 122 bits) le risque est limité, mais on
+--    durcit pour ne révéler que les infos minimales nécessaires.
+-- =====================================================
+
+BEGIN;
+
+-- ============================================
+-- 1. validate_copro_invite : ne pas leak email pour status non-pending
+-- ============================================
+
+CREATE OR REPLACE FUNCTION public.validate_copro_invite(p_token UUID)
+RETURNS TABLE (
+  is_valid BOOLEAN,
+  invite_id UUID,
+  email TEXT,
+  first_name TEXT,
+  last_name TEXT,
+  site_id UUID,
+  site_name TEXT,
+  unit_id UUID,
+  lot_number TEXT,
+  target_role TEXT,
+  ownership_type TEXT,
+  ownership_share NUMERIC,
+  error_message TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_invite RECORD;
+  v_site_name TEXT;
+  v_lot_number TEXT;
+BEGIN
+  SELECT * INTO v_invite FROM public.copro_invites ci WHERE ci.token = p_token LIMIT 1;
+
+  IF v_invite IS NULL THEN
+    RETURN QUERY SELECT FALSE, NULL::UUID, NULL::TEXT, NULL::TEXT, NULL::TEXT,
+      NULL::UUID, NULL::TEXT, NULL::UUID, NULL::TEXT,
+      NULL::TEXT, NULL::TEXT, NULL::NUMERIC, 'Invitation introuvable'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Pour les status non-actionnables, ne pas leak les PII
+  -- (email, prenom, nom). On retourne juste le code d'erreur.
+  IF v_invite.status = 'cancelled' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, NULL::TEXT, NULL::TEXT,
+      NULL::UUID, NULL::TEXT, NULL::UUID, NULL::TEXT,
+      NULL::TEXT, NULL::TEXT, NULL::NUMERIC,
+      'Cette invitation a été annulée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.status = 'accepted' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, NULL::TEXT, NULL::TEXT,
+      NULL::UUID, NULL::TEXT, NULL::UUID, NULL::TEXT,
+      NULL::TEXT, NULL::TEXT, NULL::NUMERIC,
+      'Cette invitation a déjà été acceptée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.expires_at < NOW() THEN
+    UPDATE public.copro_invites SET status = 'expired'
+    WHERE id = v_invite.id AND status IN ('pending', 'sent');
+
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, NULL::TEXT, NULL::TEXT,
+      NULL::UUID, NULL::TEXT, NULL::UUID, NULL::TEXT,
+      NULL::TEXT, NULL::TEXT, NULL::NUMERIC,
+      'Cette invitation a expiré. Demandez un nouveau lien au syndic.'::TEXT;
+    RETURN;
+  END IF;
+
+  -- Status pending/sent : retour enrichi pour la page d'acceptation
+  SELECT s.name INTO v_site_name FROM public.sites s WHERE s.id = v_invite.site_id;
+  IF v_invite.unit_id IS NOT NULL THEN
+    SELECT cu.lot_number INTO v_lot_number FROM public.copro_units cu WHERE cu.id = v_invite.unit_id;
+  END IF;
+
+  RETURN QUERY SELECT TRUE, v_invite.id, v_invite.email, v_invite.first_name, v_invite.last_name,
+    v_invite.site_id, v_site_name, v_invite.unit_id, v_lot_number,
+    v_invite.target_role, v_invite.ownership_type, v_invite.ownership_share, NULL::TEXT;
+END;
+$$;
+
+-- ============================================
+-- 2. accept_copro_invite : exiger auth.uid() = p_user_id
+-- ============================================
+
+CREATE OR REPLACE FUNCTION public.accept_copro_invite(
+  p_token UUID,
+  p_user_id UUID
+)
+RETURNS TABLE (
+  success BOOLEAN,
+  invite_id UUID,
+  role_assigned TEXT,
+  ownership_created BOOLEAN,
+  error_message TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_invite RECORD;
+  v_user_email TEXT;
+  v_invite_email TEXT;
+  v_role_code TEXT;
+  v_profile_id UUID;
+  v_ownership_created BOOLEAN := FALSE;
+  v_updated_count INTEGER;
+  v_caller UUID;
+BEGIN
+  -- 0. Vérifier que le caller authentifié correspond à p_user_id.
+  --    Empêche un user authentifié de forger l'acceptation d'une
+  --    invitation au nom d'un autre user (même si l'email matche).
+  v_caller := auth.uid();
+  IF v_caller IS NULL THEN
+    RETURN QUERY SELECT FALSE, NULL::UUID, NULL::TEXT, FALSE,
+      'Authentification requise'::TEXT;
+    RETURN;
+  END IF;
+  IF v_caller <> p_user_id THEN
+    RETURN QUERY SELECT FALSE, NULL::UUID, NULL::TEXT, FALSE,
+      'Le user ne correspond pas à la session authentifiée'::TEXT;
+    RETURN;
+  END IF;
+
+  -- 1. Charger l'invitation
+  SELECT * INTO v_invite FROM public.copro_invites ci WHERE ci.token = p_token LIMIT 1;
+
+  IF v_invite IS NULL THEN
+    RETURN QUERY SELECT FALSE, NULL::UUID, NULL::TEXT, FALSE, 'Invitation introuvable'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.status = 'cancelled' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE, 'Cette invitation a été annulée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.status = 'accepted' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE, 'Cette invitation a déjà été acceptée'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_invite.expires_at < NOW() OR v_invite.status = 'expired' THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE, 'Cette invitation a expiré'::TEXT;
+    RETURN;
+  END IF;
+
+  -- 2. Vérifier l'email match (defense-in-depth)
+  SELECT LOWER(TRIM(email)) INTO v_user_email FROM auth.users WHERE id = p_user_id;
+  v_invite_email := LOWER(TRIM(v_invite.email));
+
+  IF v_user_email IS NULL OR v_user_email <> v_invite_email THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE,
+      'L''email du compte ne correspond pas à l''invitation'::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3. Acceptation atomique (race-condition-safe)
+  UPDATE public.copro_invites
+  SET status = 'accepted', accepted_at = NOW(), accepted_by = p_user_id
+  WHERE id = v_invite.id AND status IN ('pending', 'sent');
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  IF v_updated_count = 0 THEN
+    RETURN QUERY SELECT FALSE, v_invite.id, NULL::TEXT, FALSE,
+      'Cette invitation a déjà été utilisée'::TEXT;
+    RETURN;
+  END IF;
+
+  -- 4. Mapper target_role → user_site_roles.role_code (CHECK restrictif)
+  v_role_code := CASE v_invite.target_role
+    WHEN 'syndic' THEN 'syndic'
+    WHEN 'conseil_syndical' THEN 'conseil_syndical'
+    WHEN 'president_cs' THEN 'conseil_syndical'
+    WHEN 'coproprietaire_occupant' THEN 'coproprietaire'
+    WHEN 'coproprietaire_nu' THEN 'coproprietaire'
+    WHEN 'usufruitier' THEN 'coproprietaire'
+    WHEN 'coproprietaire_bailleur' THEN 'coproprietaire_bailleur'
+    WHEN 'locataire' THEN 'locataire_copro'
+    ELSE NULL
+  END;
+
+  -- 5. Insérer dans user_site_roles si rôle mappable
+  IF v_role_code IS NOT NULL THEN
+    INSERT INTO public.user_site_roles (user_id, site_id, role_code, unit_ids, granted_by)
+    VALUES (
+      p_user_id, v_invite.site_id, v_role_code,
+      CASE WHEN v_invite.unit_id IS NOT NULL THEN ARRAY[v_invite.unit_id] ELSE ARRAY[]::UUID[] END,
+      v_invite.invited_by
+    )
+    ON CONFLICT (user_id, site_id, role_code) DO UPDATE
+      SET unit_ids = (
+        SELECT ARRAY(
+          SELECT DISTINCT u FROM unnest(
+            COALESCE(user_site_roles.unit_ids, ARRAY[]::UUID[]) ||
+            CASE WHEN v_invite.unit_id IS NOT NULL THEN ARRAY[v_invite.unit_id] ELSE ARRAY[]::UUID[] END
+          ) AS t(u)
+        )
+      );
+  END IF;
+
+  -- 6. Si rôle de propriétaire avec unit_id : porter l'ownership sur le lot
+  IF v_invite.unit_id IS NOT NULL
+     AND v_invite.target_role IN ('coproprietaire_occupant', 'coproprietaire_bailleur', 'coproprietaire_nu', 'usufruitier')
+  THEN
+    SELECT id INTO v_profile_id FROM public.profiles WHERE user_id = p_user_id LIMIT 1;
+    IF v_profile_id IS NOT NULL THEN
+      UPDATE public.copro_units SET owner_profile_id = v_profile_id WHERE id = v_invite.unit_id;
+      v_ownership_created := TRUE;
+    END IF;
+  END IF;
+
+  RETURN QUERY SELECT TRUE, v_invite.id, COALESCE(v_role_code, v_invite.target_role)::TEXT,
+    v_ownership_created, NULL::TEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.accept_copro_invite(UUID, UUID) IS
+  'Accepte une invitation copro de manière atomique. Vérifie auth.uid()=p_user_id (anti-forgery), email match, expiration, race conditions. Mappe target_role et porte l''ownership.';
+
+COMMIT;

--- a/tests/unit/invitations-role-mapper.test.ts
+++ b/tests/unit/invitations-role-mapper.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapInvitationRoleToUserRole,
+  getInvitationRoleLabel,
+} from "@/lib/invitations/role-mapper";
+
+describe("mapInvitationRoleToUserRole", () => {
+  it("locataire_principal et colocataire mappent vers tenant", () => {
+    expect(mapInvitationRoleToUserRole("locataire_principal")).toBe("tenant");
+    expect(mapInvitationRoleToUserRole("colocataire")).toBe("tenant");
+  });
+
+  it("garant mappe vers guarantor", () => {
+    expect(mapInvitationRoleToUserRole("garant")).toBe("guarantor");
+  });
+});
+
+describe("getInvitationRoleLabel", () => {
+  it("retourne le libellé UI français pour chaque rôle", () => {
+    expect(getInvitationRoleLabel("locataire_principal")).toBe("Locataire principal");
+    expect(getInvitationRoleLabel("colocataire")).toBe("Colocataire");
+    expect(getInvitationRoleLabel("garant")).toBe("Garant");
+  });
+});

--- a/tests/unit/invitations-server-resolver.test.ts
+++ b/tests/unit/invitations-server-resolver.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import { resolveInvitationByToken } from "@/lib/invitations/server-resolver";
+
+type FakeRow = Record<string, unknown> | null;
+
+/**
+ * Mock minimal du SupabaseClient utilisé par resolveInvitationByToken :
+ * - from(table).select(cols).eq(col, val).maybeSingle()
+ * Le mapping `byTable` permet de simuler la présence/absence d'une ligne
+ * dans chaque table (`invitations`, `guarantor_invitations`).
+ */
+function fakeClient(byTable: Record<string, FakeRow>) {
+  return {
+    from(table: string) {
+      const row = byTable[table] ?? null;
+      const builder = {
+        select() {
+          return builder;
+        },
+        eq() {
+          return builder;
+        },
+        async maybeSingle() {
+          return { data: row, error: null };
+        },
+      };
+      return builder;
+    },
+  } as any;
+}
+
+const inFuture = new Date(Date.now() + 86_400_000).toISOString();
+const inPast = new Date(Date.now() - 86_400_000).toISOString();
+
+describe("resolveInvitationByToken — table invitations (bail)", () => {
+  it("retourne ok avec mapping FR→EN pour locataire_principal", async () => {
+    const client = fakeClient({
+      invitations: {
+        id: "inv-1",
+        email: "Tenant@Example.com",
+        role: "locataire_principal",
+        expires_at: inFuture,
+        used_at: null,
+        lease_id: "lease-42",
+      },
+      guarantor_invitations: null,
+    });
+    const result = await resolveInvitationByToken(client, "tok-1");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.invitation.source).toBe("lease");
+      expect(result.invitation.applicativeRole).toBe("tenant");
+      expect(result.invitation.invitationRole).toBe("locataire_principal");
+      expect(result.invitation.email).toBe("tenant@example.com"); // normalisé
+      expect(result.invitation.lease_id).toBe("lease-42");
+    }
+  });
+
+  it("mappe garant → guarantor même quand la ligne est dans `invitations`", async () => {
+    const client = fakeClient({
+      invitations: {
+        id: "inv-2",
+        email: "g@x.fr",
+        role: "garant",
+        expires_at: inFuture,
+        used_at: null,
+        lease_id: null,
+      },
+      guarantor_invitations: null,
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.invitation.applicativeRole).toBe("guarantor");
+    }
+  });
+
+  it("rejette already_used si used_at est défini", async () => {
+    const client = fakeClient({
+      invitations: {
+        id: "inv-3",
+        email: "x@x.fr",
+        role: "colocataire",
+        expires_at: inFuture,
+        used_at: new Date().toISOString(),
+        lease_id: null,
+      },
+      guarantor_invitations: null,
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("already_used");
+  });
+
+  it("rejette expired si expires_at est passé", async () => {
+    const client = fakeClient({
+      invitations: {
+        id: "inv-4",
+        email: "x@x.fr",
+        role: "colocataire",
+        expires_at: inPast,
+        used_at: null,
+        lease_id: null,
+      },
+      guarantor_invitations: null,
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("expired");
+  });
+});
+
+describe("resolveInvitationByToken — fallback guarantor_invitations", () => {
+  it("résout une invitation garant standalone (status pending)", async () => {
+    const client = fakeClient({
+      invitations: null,
+      guarantor_invitations: {
+        id: "gi-1",
+        guarantor_email: "GUARANT@x.fr",
+        status: "pending",
+        expires_at: inFuture,
+        accepted_at: null,
+        declined_at: null,
+        lease_id: "lease-99",
+      },
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.invitation.source).toBe("guarantor");
+      expect(result.invitation.applicativeRole).toBe("guarantor");
+      expect(result.invitation.invitationRole).toBe("garant");
+      expect(result.invitation.email).toBe("guarant@x.fr"); // normalisé
+      expect(result.invitation.lease_id).toBe("lease-99");
+    }
+  });
+
+  it("rejette already_used quand status = accepted", async () => {
+    const client = fakeClient({
+      invitations: null,
+      guarantor_invitations: {
+        id: "gi-2",
+        guarantor_email: "g@x.fr",
+        status: "accepted",
+        expires_at: inFuture,
+        accepted_at: new Date().toISOString(),
+        declined_at: null,
+        lease_id: null,
+      },
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("already_used");
+  });
+
+  it("rejette declined quand status = declined", async () => {
+    const client = fakeClient({
+      invitations: null,
+      guarantor_invitations: {
+        id: "gi-3",
+        guarantor_email: "g@x.fr",
+        status: "declined",
+        expires_at: inFuture,
+        accepted_at: null,
+        declined_at: new Date().toISOString(),
+        lease_id: null,
+      },
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("declined");
+  });
+
+  it("rejette expired quand status = expired ou date passée", async () => {
+    const expiredByStatus = await resolveInvitationByToken(
+      fakeClient({
+        invitations: null,
+        guarantor_invitations: {
+          id: "gi-4",
+          guarantor_email: "g@x.fr",
+          status: "expired",
+          expires_at: inFuture,
+          accepted_at: null,
+          declined_at: null,
+          lease_id: null,
+        },
+      }),
+      "tok"
+    );
+    expect(expiredByStatus.ok).toBe(false);
+    if (!expiredByStatus.ok) expect(expiredByStatus.error.kind).toBe("expired");
+
+    const expiredByDate = await resolveInvitationByToken(
+      fakeClient({
+        invitations: null,
+        guarantor_invitations: {
+          id: "gi-5",
+          guarantor_email: "g@x.fr",
+          status: "pending",
+          expires_at: inPast,
+          accepted_at: null,
+          declined_at: null,
+          lease_id: null,
+        },
+      }),
+      "tok"
+    );
+    expect(expiredByDate.ok).toBe(false);
+    if (!expiredByDate.ok) expect(expiredByDate.error.kind).toBe("expired");
+  });
+
+  it("rejette not_found si aucune table ne contient le token", async () => {
+    const client = fakeClient({ invitations: null, guarantor_invitations: null });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("not_found");
+  });
+});
+
+describe("resolveInvitationByToken — priorité d'interrogation", () => {
+  it("préfère `invitations` (bail) si les deux tables contiennent le token", async () => {
+    const client = fakeClient({
+      invitations: {
+        id: "lease-source",
+        email: "x@x.fr",
+        role: "locataire_principal",
+        expires_at: inFuture,
+        used_at: null,
+        lease_id: "lease-1",
+      },
+      guarantor_invitations: {
+        id: "garant-source",
+        guarantor_email: "x@x.fr",
+        status: "pending",
+        expires_at: inFuture,
+        accepted_at: null,
+        declined_at: null,
+        lease_id: "lease-2",
+      },
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.invitation.source).toBe("lease");
+      expect(result.invitation.id).toBe("lease-source");
+    }
+  });
+});

--- a/tests/unit/invitations-server-resolver.test.ts
+++ b/tests/unit/invitations-server-resolver.test.ts
@@ -246,3 +246,111 @@ describe("resolveInvitationByToken — priorité d'interrogation", () => {
     }
   });
 });
+
+describe("resolveInvitationByToken — fallback agency_invitations", () => {
+  it("résout une invitation agence (status pending)", async () => {
+    const client = fakeClient({
+      invitations: null,
+      guarantor_invitations: null,
+      agency_invitations: {
+        id: "ai-1",
+        email: "Manager@Agency.fr",
+        status: "pending",
+        expires_at: inFuture,
+        accepted_at: null,
+        declined_at: null,
+        agency_profile_id: "agency-99",
+        role_agence: "gestionnaire",
+        can_sign_documents: true,
+      },
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.invitation.source).toBe("agency");
+      expect(result.invitation.applicativeRole).toBe("agency");
+      expect(result.invitation.invitationRole).toBe("agency");
+      expect(result.invitation.email).toBe("manager@agency.fr");
+      expect(result.invitation.agency_profile_id).toBe("agency-99");
+      expect(result.invitation.agency_role).toBe("gestionnaire");
+      expect(result.invitation.can_sign_documents).toBe(true);
+    }
+  });
+
+  it("rejette already_used si status accepted", async () => {
+    const result = await resolveInvitationByToken(
+      fakeClient({
+        invitations: null,
+        guarantor_invitations: null,
+        agency_invitations: {
+          id: "ai-2",
+          email: "x@x.fr",
+          status: "accepted",
+          expires_at: inFuture,
+          accepted_at: new Date().toISOString(),
+          declined_at: null,
+          agency_profile_id: "agency-1",
+          role_agence: "directeur",
+          can_sign_documents: false,
+        },
+      }),
+      "tok"
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("already_used");
+  });
+
+  it("rejette expired si status cancelled", async () => {
+    const result = await resolveInvitationByToken(
+      fakeClient({
+        invitations: null,
+        guarantor_invitations: null,
+        agency_invitations: {
+          id: "ai-3",
+          email: "x@x.fr",
+          status: "cancelled",
+          expires_at: inFuture,
+          accepted_at: null,
+          declined_at: null,
+          agency_profile_id: "agency-1",
+          role_agence: "assistant",
+          can_sign_documents: false,
+        },
+      }),
+      "tok"
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe("expired");
+  });
+
+  it("priorité guarantor_invitations > agency_invitations en cas de collision", async () => {
+    const client = fakeClient({
+      invitations: null,
+      guarantor_invitations: {
+        id: "gar",
+        guarantor_email: "x@x.fr",
+        status: "pending",
+        expires_at: inFuture,
+        accepted_at: null,
+        declined_at: null,
+        lease_id: null,
+      },
+      agency_invitations: {
+        id: "ag",
+        email: "x@x.fr",
+        status: "pending",
+        expires_at: inFuture,
+        accepted_at: null,
+        declined_at: null,
+        agency_profile_id: "agency-x",
+        role_agence: "comptable",
+        can_sign_documents: false,
+      },
+    });
+    const result = await resolveInvitationByToken(client, "tok");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.invitation.source).toBe("guarantor");
+    }
+  });
+});


### PR DESCRIPTION
## Contexte

Audit complet du flux d'inscription et des invitations (bail / garant / copro / agency) suivi des fixes prioritaires. Détails dans la conversation.

## 10 commits

```
70d8422  fix(security): rate-limit aussi les endpoints d'invitation existants
d449309  fix(security): hardening RPC SECURITY DEFINER copro
78cf5a8  fix(security): rate-limit sur les endpoints d'invitation
ea6f101  feat(agency): module d'invitations collaborateurs + admin RLS aligné
e7327a7  feat(copro): livrer la table copro_invites et les RPC manquantes
af103c7  test(invitations): couvrir mapper et résolveur unifié
5c3cd0b  fix(db): trigger auto_link exige la cohérence de rôle
fc9756c  feat(invitations): unifier flux bail + garant standalone
a6b8ff9  fix(signup): désactiver magic-link en présence d'invitation
fd3659d  feat(signup): verrouiller le rôle par invitation côté serveur
```

## Changements par axe

### 🔒 Sécurité (vecteurs réels corrigés)

- **Verrouillage rôle au signup** : `/api/v1/auth/register` accepte un `inviteToken`, lookup l'invitation côté serveur (3 tables : `invitations`, `guarantor_invitations`, `agency_invitations` via résolveur unifié), valide expiration/email/usage et **force le rôle final** d'après la table. Empêche le détournement `garant` → signup `owner`.
- **Magic-link bypass** : la voie magic-link est désactivée en présence d'une invitation (UX + garde-fou submit).
- **Trigger DB cohérence rôle** : `auto_link_lease_signers_on_profile_created` exige désormais que `profile.role` matche `lease_signers.role` / `invitations.role`. Empêche un compte `tenant` d'être auto-lié à un `lease_signers.role='garant'`.
- **Hardening RPC SECURITY DEFINER copro** :
  - 🔴 `accept_copro_invite` exige `auth.uid() = p_user_id` (anti-forgery sur acceptation au nom d'un autre user)
  - ⚠️ `validate_copro_invite` ne leak plus les PII (email/prenom/nom) pour les status `cancelled`/`accepted`
- **Rate-limits** sur 7 endpoints d'invitation (création + acceptation) avec 3 nouveaux presets (`coproInvite`, `agencyInvite`, `inviteAccept`).

### 📦 Modules livrés

- **Copro** : table `copro_invites` + RPC `validate_copro_invite` / `accept_copro_invite` qui étaient référencées par 4 endpoints/UI mais **n'existaient dans aucune migration** (pipeline cassé en prod).
- **Agency** : module complet d'invitations collaborateurs (table `agency_invitations`, endpoints POST/GET/accept, email HTML, branchement `agency_managers` post-signUp).
- **Garant standalone** : workflow finalisé (endpoint d'acceptation post-login + marquage atomique post-signUp). Auparavant le statut restait figé à `pending` à vie.

### 🛠️ Architecture

- `lib/invitations/role-mapper.ts` — source unique du mapping FR↔EN (`locataire_principal` → `tenant`, `garant` → `guarantor`).
- `lib/invitations/server-resolver.ts` — résolveur serveur unifié pour les 3 tables d'invitation.
- Compat URL : `/signup/role` accepte aussi `?token=` en fallback pour les invitations garant déjà envoyées avec l'ancien format.

### 🧪 Tests

18 cas unitaires Vitest sur le mapper et le résolveur (mocks Supabase, pas de réseau).

## Migrations SQL (5)

Toutes idempotentes, transactionnelles. **Déjà appliquées en prod par l'utilisateur durant la session.**

1. `20260428200000_harden_auto_link_lease_signers_role_check.sql`
2. `20260428210000_copro_invites_table_and_rpcs.sql`
3. `20260428220000_agency_invitations.sql`
4. `20260428230000_align_admin_invite_policies.sql` (admin + platform_admin sur toutes les tables d'invitation)
5. `20260428240000_harden_copro_invite_rpcs.sql`

## Test plan

- [ ] Signup propriétaire / locataire / garant / syndic / agency standard sans invitation
- [ ] Signup avec `?invite=TOKEN` valide → rôle verrouillé, email pré-rempli, bannière affichée
- [ ] Signup avec invitation à email mismatch → 403 `INVITE_EMAIL_MISMATCH`
- [ ] Signup avec invitation expirée → 410 `INVITE_EXPIRED`
- [ ] Signup avec invitation déjà utilisée → 409 `INVITE_ALREADY_USED`
- [ ] Magic-link désactivé visuellement en présence d'invitation
- [ ] Création invitation copro par syndic → email envoyé
- [ ] Acceptation invitation copro post-login → role `coproprietaire` créé dans `user_site_roles`, ownership porté sur `copro_units`
- [ ] Création invitation agence collaborateur → ligne `agency_managers` créée à l'acceptation
- [ ] Rate-limit 429 après dépassement (50/h copro, 20/h agency, 10/h leaseInvite, 10/5min accept)
- [ ] Admin et platform_admin voient toutes les invitations (RLS)

https://claude.ai/code/session_01HuXisWqRescnoJkepRLTkj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuXisWqRescnoJkepRLTkj)_