### PR TITLE
Add copropriété (co-ownership) module for property owners

### DIFF
--- a/app/api/owner/copro/route.ts
+++ b/app/api/owner/copro/route.ts
@@ -1,0 +1,295 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/owner/copro
+ *
+ * Liste les copropriétés rattachées au propriétaire connecté via
+ * `user_site_roles` (rôle `coproprietaire`, `coproprietaire_bailleur`,
+ * `coproprietaire_nu`, `usufruitier`). Retourne pour chaque site les
+ * lots possédés, les appels de fonds en attente, les AG à venir et les
+ * documents distribués.
+ *
+ * Lecture seule. Aucune écriture, aucune migration : on consomme
+ * uniquement l'existant via RLS. Si la RLS bloque, ajouter une policy
+ * SELECT additionnelle sur sites/copro_units/copro_fund_calls/copro_assemblies
+ * scopée par user_site_roles.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+const COPRO_ROLE_CODES = [
+  "coproprietaire",
+  "coproprietaire_bailleur",
+  "coproprietaire_nu",
+  "usufruitier",
+];
+
+interface CoproSite {
+  site: {
+    id: string;
+    name: string;
+    address: string;
+    syndic_name: string | null;
+    syndic_email: string | null;
+  };
+  lots: Array<{
+    id: string;
+    number: string;
+    tantiemes: number;
+    tantiemes_total: number;
+    surface_m2: number | null;
+    type: string | null;
+    floor: number | null;
+    property_id: string | null;
+    property_address: string | null;
+  }>;
+  fund_calls: Array<{
+    id: string;
+    period_label: string;
+    amount_cents: number;
+    paid_cents: number;
+    status: "pending" | "partial" | "paid" | "overdue";
+    due_date: string | null;
+  }>;
+  assemblies_upcoming: Array<{
+    id: string;
+    title: string;
+    date: string | null;
+    status: string;
+  }>;
+  balance_cents: number;
+  documents: Array<{
+    id: string;
+    title: string;
+    type: string;
+    url: string | null;
+    distributed_at: string;
+  }>;
+}
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .single();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+    }
+
+    const { data: roles } = await (supabase as any)
+      .from("user_site_roles")
+      .select("site_id, role_code")
+      .eq("user_id", user.id)
+      .in("role_code", COPRO_ROLE_CODES);
+
+    const siteIds = Array.from(
+      new Set(((roles ?? []) as Array<{ site_id: string }>).map((r) => r.site_id)),
+    );
+
+    if (siteIds.length === 0) {
+      return NextResponse.json({ copros: [] });
+    }
+
+    const { data: sites } = await (supabase as any)
+      .from("sites")
+      .select(
+        "id, name, address_line1, address_line2, postal_code, city, syndic_company_name, syndic_email, total_tantiemes_general",
+      )
+      .in("id", siteIds);
+
+    const sitesById = new Map<string, any>();
+    for (const s of (sites ?? []) as any[]) sitesById.set(s.id, s);
+
+    const { data: lots } = await (supabase as any)
+      .from("copro_units")
+      .select(
+        "id, site_id, lot_number, tantieme_general, type, floor, surface, property_id",
+      )
+      .in("site_id", siteIds)
+      .eq("owner_profile_id", profile.id);
+
+    const lotsBySite = new Map<string, any[]>();
+    const propertyIds = new Set<string>();
+    for (const lot of (lots ?? []) as Array<{
+      site_id: string;
+      property_id: string | null;
+    }>) {
+      const arr = lotsBySite.get(lot.site_id) ?? [];
+      arr.push(lot);
+      lotsBySite.set(lot.site_id, arr);
+      if (lot.property_id) propertyIds.add(lot.property_id);
+    }
+
+    const propertyAddressById = new Map<string, string>();
+    if (propertyIds.size > 0) {
+      const { data: properties } = await supabase
+        .from("properties")
+        .select("id, adresse_complete")
+        .in("id", Array.from(propertyIds));
+      for (const p of (properties ?? []) as Array<{
+        id: string;
+        adresse_complete: string | null;
+      }>) {
+        propertyAddressById.set(p.id, p.adresse_complete ?? "");
+      }
+    }
+
+    const today = new Date().toISOString().split("T")[0];
+
+    const { data: assemblies } = await (supabase as any)
+      .from("copro_assemblies")
+      .select("id, site_id, title, scheduled_at, status")
+      .in("site_id", siteIds)
+      .gte("scheduled_at", today)
+      .order("scheduled_at", { ascending: true })
+      .limit(20);
+
+    const assembliesBySite = new Map<string, any[]>();
+    for (const a of (assemblies ?? []) as Array<{ site_id: string }>) {
+      const arr = assembliesBySite.get(a.site_id) ?? [];
+      arr.push(a);
+      assembliesBySite.set(a.site_id, arr);
+    }
+
+    const { data: fundCalls } = await (supabase as any)
+      .from("copro_fund_calls")
+      .select(
+        "id, copro_lot_id, period_label, call_amount_cents, paid_amount_cents, payment_status, due_date, created_at",
+      )
+      .in(
+        "copro_lot_id",
+        ((lots ?? []) as Array<{ id: string }>).map((l) => l.id),
+      )
+      .order("due_date", { ascending: false })
+      .limit(50);
+
+    const fundCallsByLot = new Map<string, any[]>();
+    for (const fc of (fundCalls ?? []) as Array<{ copro_lot_id: string }>) {
+      const arr = fundCallsByLot.get(fc.copro_lot_id) ?? [];
+      arr.push(fc);
+      fundCallsByLot.set(fc.copro_lot_id, arr);
+    }
+
+    const { data: documents } = await supabase
+      .from("documents")
+      .select("id, title, original_filename, type, storage_path, created_at, metadata")
+      .or(
+        siteIds
+          .map((sid) => `metadata->>site_id.eq.${sid}`)
+          .join(","),
+      )
+      .order("created_at", { ascending: false })
+      .limit(50);
+
+    const docsBySite = new Map<string, any[]>();
+    for (const doc of (documents ?? []) as Array<{
+      metadata: Record<string, unknown> | null;
+    }>) {
+      const sid =
+        doc.metadata && typeof doc.metadata === "object"
+          ? (doc.metadata as { site_id?: string }).site_id
+          : undefined;
+      if (!sid) continue;
+      const arr = docsBySite.get(sid) ?? [];
+      arr.push(doc);
+      docsBySite.set(sid, arr);
+    }
+
+    const copros: CoproSite[] = [];
+    for (const sid of siteIds) {
+      const site = sitesById.get(sid);
+      if (!site) continue;
+
+      const siteLots = lotsBySite.get(sid) ?? [];
+      const siteFundCalls: CoproSite["fund_calls"] = [];
+      let balanceCents = 0;
+
+      for (const lot of siteLots) {
+        const lotCalls = fundCallsByLot.get(lot.id) ?? [];
+        for (const fc of lotCalls) {
+          const amount = fc.call_amount_cents ?? 0;
+          const paid = fc.paid_amount_cents ?? 0;
+          balanceCents += amount - paid;
+          siteFundCalls.push({
+            id: fc.id,
+            period_label: fc.period_label ?? "—",
+            amount_cents: amount,
+            paid_cents: paid,
+            status: fc.payment_status,
+            due_date: fc.due_date,
+          });
+        }
+      }
+
+      const address = [
+        site.address_line1,
+        site.address_line2,
+        site.postal_code,
+        site.city,
+      ]
+        .filter(Boolean)
+        .join(", ");
+
+      copros.push({
+        site: {
+          id: site.id,
+          name: site.name,
+          address,
+          syndic_name: site.syndic_company_name,
+          syndic_email: site.syndic_email,
+        },
+        lots: siteLots.map((l: any) => ({
+          id: l.id,
+          number: l.lot_number,
+          tantiemes: l.tantieme_general ?? 0,
+          tantiemes_total: site.total_tantiemes_general ?? 10000,
+          surface_m2: l.surface ?? null,
+          type: l.type,
+          floor: l.floor,
+          property_id: l.property_id,
+          property_address: l.property_id
+            ? propertyAddressById.get(l.property_id) ?? null
+            : null,
+        })),
+        fund_calls: siteFundCalls,
+        assemblies_upcoming: (assembliesBySite.get(sid) ?? []).map((a: any) => ({
+          id: a.id,
+          title: a.title ?? "Assemblée générale",
+          date: a.scheduled_at,
+          status: a.status ?? "scheduled",
+        })),
+        balance_cents: balanceCents,
+        documents: (docsBySite.get(sid) ?? []).map((d: any) => ({
+          id: d.id,
+          title: (d.title?.trim() || d.original_filename || `Document ${d.type}`) as string,
+          type: d.type,
+          url: d.storage_path
+            ? `/api/documents/file?path=${encodeURIComponent(d.storage_path)}&disposition=inline`
+            : null,
+          distributed_at: d.created_at,
+        })),
+      });
+    }
+
+    return NextResponse.json({ copros });
+  } catch (error) {
+    console.error("[api/owner/copro] error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/owner/buildings/[id]/BuildingDetailClient.tsx
+++ b/app/owner/buildings/[id]/BuildingDetailClient.tsx
@@ -797,9 +797,17 @@ export function BuildingDetailClient({
                 Propriété complète
               </Badge>
             ) : (
-              <Badge className="bg-amber-600 text-white shrink-0">
-                Copropriété &bull; {totalUnits} lot(s) sur {totalLotsInBuilding || "?"}
-              </Badge>
+              <>
+                <Badge className="bg-amber-600 text-white shrink-0">
+                  Copropriété &bull; {totalUnits} lot(s) sur {totalLotsInBuilding || "?"}
+                </Badge>
+                <Link
+                  href="/owner/copro"
+                  className="inline-flex items-center gap-1 text-xs text-white/90 hover:text-white underline underline-offset-2 shrink-0"
+                >
+                  Voir ma copropriété &rarr;
+                </Link>
+              </>
             )}
           </div>
           <div className="flex items-center gap-4 text-white/80 flex-wrap">

--- a/app/owner/copro/CoproOwnerClient.tsx
+++ b/app/owner/copro/CoproOwnerClient.tsx
@@ -1,11 +1,19 @@
 "use client";
 // @ts-nocheck — TODO: remove once database.types.ts is regenerated
 
+import { useMemo, useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { formatCents } from "@/lib/utils/format-cents";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Building2,
   MapPin,
@@ -15,7 +23,8 @@ import {
   FileText,
   Download,
   CreditCard,
-  ArrowLeft,
+  Calendar,
+  Home,
 } from "lucide-react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
@@ -24,59 +33,91 @@ import { useAuth } from "@/lib/hooks/use-auth";
 
 // -- Types -------------------------------------------------------------------
 
-interface CoproOwnerData {
-  copro: {
-    name: string;
-    address: string;
-    syndic_name: string;
-    syndic_email: string;
-  };
-  lot: {
-    number: string;
-    tantiemes: number;
-    tantiemes_total: number;
-    surface_m2: number | null;
-    type: string;
-    floor: string | null;
-  };
-  fund_calls: FundCallRow[];
-  balance_cents: number;
-  annexes: AnnexeDoc[];
-}
-
 interface FundCallRow {
   id: string;
   period_label: string;
   amount_cents: number;
   paid_cents: number;
-  status: "paye" | "en_attente" | "en_retard";
+  status: "pending" | "partial" | "paid" | "overdue";
+  due_date: string | null;
 }
 
-interface AnnexeDoc {
-  number: number;
+interface AssemblyRow {
+  id: string;
   title: string;
-  exercise_label: string;
-  download_url: string;
+  date: string | null;
+  status: string;
+}
+
+interface DocumentRow {
+  id: string;
+  title: string;
+  type: string;
+  url: string | null;
+  distributed_at: string;
+}
+
+interface LotRow {
+  id: string;
+  number: string;
+  tantiemes: number;
+  tantiemes_total: number;
+  surface_m2: number | null;
+  type: string | null;
+  floor: number | null;
+  property_id: string | null;
+  property_address: string | null;
+}
+
+interface CoproSite {
+  site: {
+    id: string;
+    name: string;
+    address: string;
+    syndic_name: string | null;
+    syndic_email: string | null;
+  };
+  lots: LotRow[];
+  fund_calls: FundCallRow[];
+  assemblies_upcoming: AssemblyRow[];
+  balance_cents: number;
+  documents: DocumentRow[];
+}
+
+interface CoproApiResponse {
+  copros: CoproSite[];
 }
 
 const CALL_STATUS_MAP: Record<
   FundCallRow["status"],
   { label: string; className: string }
 > = {
-  paye: {
-    label: "Paye",
+  paid: {
+    label: "Payé",
     className:
       "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400",
   },
-  en_attente: {
+  partial: {
+    label: "Partiel",
+    className:
+      "bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-400",
+  },
+  pending: {
     label: "En attente",
     className:
       "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400",
   },
-  en_retard: {
+  overdue: {
     label: "En retard",
     className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400",
   },
+};
+
+const formatDate = (iso: string | null): string => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("fr-FR", { day: "2-digit", month: "long", year: "numeric" });
 };
 
 export default function CoproOwnerClient() {
@@ -89,12 +130,13 @@ export default function CoproOwnerClient() {
 
 function CoproOwnerContent() {
   const { profile } = useAuth();
+  const [selectedSiteId, setSelectedSiteId] = useState<string | null>(null);
 
-  const { data, isLoading, error } = useQuery<any>({
+  const { data, isLoading, error } = useQuery<CoproApiResponse | null>({
     queryKey: ["owner", "copro"],
-    queryFn: async (): Promise<CoproOwnerData | null> => {
+    queryFn: async () => {
       try {
-        return await apiClient.get<CoproOwnerData>("/owner/copro");
+        return await apiClient.get<CoproApiResponse>("/owner/copro");
       } catch {
         return null;
       }
@@ -103,15 +145,25 @@ function CoproOwnerContent() {
     staleTime: 5 * 60 * 1000,
   });
 
+  const copros = data?.copros ?? [];
+
+  const selected = useMemo(() => {
+    if (copros.length === 0) return null;
+    if (selectedSiteId) {
+      return copros.find((c) => c.site.id === selectedSiteId) ?? copros[0];
+    }
+    return copros[0];
+  }, [copros, selectedSiteId]);
+
   if (isLoading) {
     return <CoproOwnerLoadingSkeleton />;
   }
 
-  if (error || !data) {
+  if (error || copros.length === 0) {
     return (
       <div className="space-y-6">
         <h1 className="text-2xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
-          Ma copropriete
+          Ma copropriété
         </h1>
         <Card>
           <CardContent className="py-12 text-center">
@@ -119,12 +171,19 @@ function CoproOwnerContent() {
               <Building2 className="w-7 h-7 text-muted-foreground" />
             </div>
             <h3 className="text-lg font-semibold text-foreground">
-              Aucune copropriete associee
+              Aucune copropriété rattachée à votre compte
             </h3>
-            <p className="text-sm text-muted-foreground mt-1">
-              Vous n&apos;etes pas rattache a une copropriete pour le moment.
-              Contactez votre syndic si vous pensez qu&apos;il s&apos;agit
-              d&apos;une erreur.
+            <p className="text-sm text-muted-foreground mt-1 max-w-md mx-auto">
+              Si l'un de vos biens est en copropriété, demandez à votre syndic de
+              vous inviter. Si votre syndic n'utilise pas Talok, contactez-nous
+              à{" "}
+              <a
+                href="mailto:support@talok.fr"
+                className="text-cyan-600 hover:underline"
+              >
+                support@talok.fr
+              </a>
+              .
             </p>
           </CardContent>
         </Card>
@@ -132,155 +191,103 @@ function CoproOwnerContent() {
     );
   }
 
-  const { copro, lot, fund_calls, balance_cents, annexes } = data as any;
+  if (!selected) return null;
+
+  const { site, lots, fund_calls, balance_cents, documents, assemblies_upcoming } = selected;
+  const totalAmountCents = fund_calls.reduce((sum, c) => sum + c.amount_cents, 0);
+  const totalPaidCents = fund_calls.reduce((sum, c) => sum + c.paid_cents, 0);
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
-          Ma copropriete
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">{copro.name}</p>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
+            Ma copropriété
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">{site.name}</p>
+        </div>
+        {copros.length > 1 && (
+          <Select
+            value={selected.site.id}
+            onValueChange={(v) => setSelectedSiteId(v)}
+          >
+            <SelectTrigger className="w-full sm:w-[280px]">
+              <SelectValue placeholder="Choisir une copropriété" />
+            </SelectTrigger>
+            <SelectContent>
+              {copros.map((c) => (
+                <SelectItem key={c.site.id} value={c.site.id}>
+                  {c.site.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </div>
 
-      {/* Copro info + Lot info */}
+      {/* Copro info + lots */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {/* Copro info */}
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-base flex items-center gap-2">
               <Building2 className="w-4 h-4 text-cyan-600" />
-              Informations copropriete
+              Informations copropriété
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <InfoRow
-              icon={<Building2 className="w-4 h-4" />}
-              label="Nom"
-              value={copro.name}
-            />
-            <InfoRow
-              icon={<MapPin className="w-4 h-4" />}
-              label="Adresse"
-              value={copro.address}
-            />
-            <InfoRow
-              icon={<User className="w-4 h-4" />}
-              label="Syndic"
-              value={copro.syndic_name}
-            />
-            <p className="text-xs text-muted-foreground pl-8">
-              {copro.syndic_email}
-            </p>
+            <InfoRow icon={<Building2 className="w-4 h-4" />} label="Nom" value={site.name} />
+            <InfoRow icon={<MapPin className="w-4 h-4" />} label="Adresse" value={site.address || "—"} />
+            <InfoRow icon={<User className="w-4 h-4" />} label="Syndic" value={site.syndic_name || "—"} />
+            {site.syndic_email && (
+              <p className="text-xs text-muted-foreground pl-8">{site.syndic_email}</p>
+            )}
           </CardContent>
         </Card>
 
-        {/* Lot info */}
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-base flex items-center gap-2">
               <Hash className="w-4 h-4 text-cyan-600" />
-              Mon lot
+              Mes lots ({lots.length})
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <InfoRow
-              icon={<Hash className="w-4 h-4" />}
-              label="Numero"
-              value={`Lot ${lot.number}`}
-            />
-            <InfoRow
-              icon={<CreditCard className="w-4 h-4" />}
-              label="Tantiemes"
-              value={`${lot.tantiemes}/${lot.tantiemes_total}`}
-            />
-            {lot.surface_m2 && (
-              <InfoRow
-                icon={<Ruler className="w-4 h-4" />}
-                label="Surface"
-                value={`${lot.surface_m2} m2`}
-              />
+            {lots.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Aucun lot rattaché.</p>
+            ) : (
+              lots.map((lot) => (
+                <div
+                  key={lot.id}
+                  className="flex items-start justify-between py-2 border-b last:border-0 border-border/50"
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">Lot {lot.number}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {lot.tantiemes}/{lot.tantiemes_total} tantièmes
+                      {lot.surface_m2 ? ` · ${lot.surface_m2} m²` : ""}
+                      {lot.floor != null ? ` · Étage ${lot.floor}` : ""}
+                    </p>
+                    {lot.property_id && lot.property_address && (
+                      <Link
+                        href={`/owner/properties/${lot.property_id}`}
+                        className="text-xs text-cyan-600 hover:underline inline-flex items-center gap-1"
+                      >
+                        <Home className="w-3 h-3" />
+                        {lot.property_address}
+                      </Link>
+                    )}
+                  </div>
+                  {lot.type && (
+                    <Badge variant="outline" className="text-xs">
+                      {lot.type}
+                    </Badge>
+                  )}
+                </div>
+              ))
             )}
-            {lot.floor && (
-              <InfoRow
-                icon={<Building2 className="w-4 h-4" />}
-                label="Etage"
-                value={lot.floor}
-              />
-            )}
-            <InfoRow
-              icon={<FileText className="w-4 h-4" />}
-              label="Type"
-              value={lot.type.charAt(0).toUpperCase() + lot.type.slice(1)}
-            />
           </CardContent>
         </Card>
       </div>
-
-      {/* Fund calls table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center gap-2">
-            <CreditCard className="w-4 h-4 text-cyan-600" />
-            Mes appels de fonds
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {fund_calls.length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-6">
-              Aucun appel de fonds
-            </p>
-          ) : (
-            <div className="overflow-x-auto -mx-4 sm:-mx-6">
-              <table className="w-full text-sm min-w-[450px]">
-                <thead>
-                  <tr className="border-b border-border">
-                    <th className="text-left py-2 px-4 sm:px-6 text-muted-foreground font-medium">
-                      Periode
-                    </th>
-                    <th className="text-right py-2 px-4 sm:px-6 text-muted-foreground font-medium">
-                      Montant
-                    </th>
-                    <th className="text-right py-2 px-4 sm:px-6 text-muted-foreground font-medium">
-                      Paye
-                    </th>
-                    <th className="text-center py-2 px-4 sm:px-6 text-muted-foreground font-medium">
-                      Statut
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {fund_calls.map((call: any) => {
-                    const statusCfg = (CALL_STATUS_MAP as any)[call.status];
-                    return (
-                      <tr
-                        key={call.id}
-                        className="border-b border-border/50 last:border-0"
-                      >
-                        <td className="py-3 px-4 sm:px-6 font-medium text-foreground">
-                          {call.period_label}
-                        </td>
-                        <td className="py-3 px-4 sm:px-6 text-right text-foreground">
-                          {formatCents(call.amount_cents)}
-                        </td>
-                        <td className="py-3 px-4 sm:px-6 text-right text-foreground">
-                          {formatCents(call.paid_cents)}
-                        </td>
-                        <td className="py-3 px-4 sm:px-6 text-center">
-                          <Badge className={`${statusCfg.className} border-0`}>
-                            {statusCfg.label}
-                          </Badge>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
 
       {/* Balance */}
       <Card>
@@ -301,65 +308,131 @@ function CoproOwnerContent() {
               </p>
               <p className="text-xs text-muted-foreground mt-1">
                 {balance_cents > 0
-                  ? "Solde debiteur - vous devez cette somme"
+                  ? "Solde débiteur — somme due à la copropriété"
                   : balance_cents < 0
-                    ? "Solde crediteur - trop-percu en votre faveur"
-                    : "Solde equilibre"}
+                    ? "Solde créditeur — trop-perçu en votre faveur"
+                    : "Solde équilibré"}
               </p>
             </div>
-            {balance_cents > 0 && (
-              <Button className="bg-cyan-600 hover:bg-cyan-700" size="sm">
-                <CreditCard className="w-4 h-4 mr-2" />
-                Regulariser
-              </Button>
-            )}
+            <div className="text-right text-xs text-muted-foreground space-y-1">
+              <div>
+                Total appelé : <span className="font-medium text-foreground">{formatCents(totalAmountCents)}</span>
+              </div>
+              <div>
+                Total payé : <span className="font-medium text-foreground">{formatCents(totalPaidCents)}</span>
+              </div>
+            </div>
           </div>
         </CardContent>
       </Card>
 
-      {/* AG Documents - Annexes */}
-      {annexes.length > 0 && (
+      {/* Fund calls */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <CreditCard className="w-4 h-4 text-cyan-600" />
+            Mes appels de fonds
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {fund_calls.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-6">Aucun appel de fonds.</p>
+          ) : (
+            <div className="overflow-x-auto -mx-4 sm:-mx-6">
+              <table className="w-full text-sm min-w-[520px]">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left py-2 px-4 sm:px-6 text-muted-foreground font-medium">Période</th>
+                    <th className="text-left py-2 px-4 sm:px-6 text-muted-foreground font-medium">Échéance</th>
+                    <th className="text-right py-2 px-4 sm:px-6 text-muted-foreground font-medium">Montant</th>
+                    <th className="text-right py-2 px-4 sm:px-6 text-muted-foreground font-medium">Payé</th>
+                    <th className="text-center py-2 px-4 sm:px-6 text-muted-foreground font-medium">Statut</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {fund_calls.map((call) => {
+                    const cfg = CALL_STATUS_MAP[call.status] ?? CALL_STATUS_MAP.pending;
+                    return (
+                      <tr key={call.id} className="border-b border-border/50 last:border-0">
+                        <td className="py-3 px-4 sm:px-6 font-medium text-foreground">{call.period_label}</td>
+                        <td className="py-3 px-4 sm:px-6 text-muted-foreground">{formatDate(call.due_date)}</td>
+                        <td className="py-3 px-4 sm:px-6 text-right text-foreground">{formatCents(call.amount_cents)}</td>
+                        <td className="py-3 px-4 sm:px-6 text-right text-foreground">{formatCents(call.paid_cents)}</td>
+                        <td className="py-3 px-4 sm:px-6 text-center">
+                          <Badge className={`${cfg.className} border-0`}>{cfg.label}</Badge>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Upcoming assemblies */}
+      {assemblies_upcoming.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle className="text-base flex items-center gap-2">
-              <FileText className="w-4 h-4 text-cyan-600" />
-              Documents AG - Annexes du dernier exercice cloture
+              <Calendar className="w-4 h-4 text-cyan-600" />
+              Assemblées à venir
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
-              {annexes.map((annexe: any) => (
+              {assemblies_upcoming.map((a) => (
                 <div
-                  key={annexe.number}
+                  key={a.id}
+                  className="flex items-center justify-between py-2.5 px-3 rounded-lg bg-muted/50"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{a.title}</p>
+                    <p className="text-xs text-muted-foreground">{formatDate(a.date)}</p>
+                  </div>
+                  <Badge variant="outline" className="text-xs">
+                    {a.status}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Documents */}
+      {documents.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <FileText className="w-4 h-4 text-cyan-600" />
+              Documents distribués par le syndic
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {documents.map((doc) => (
+                <div
+                  key={doc.id}
                   className="flex items-center justify-between py-2.5 px-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors"
                 >
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-lg bg-cyan-100 dark:bg-cyan-900/40 flex items-center justify-center text-xs font-bold text-cyan-600 dark:text-cyan-400">
-                      {annexe.number}
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="w-8 h-8 rounded-lg bg-cyan-100 dark:bg-cyan-900/40 flex items-center justify-center text-cyan-600 dark:text-cyan-400 flex-shrink-0">
+                      <FileText className="w-4 h-4" />
                     </div>
-                    <div>
-                      <p className="text-sm font-medium text-foreground">
-                        {annexe.title}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {annexe.exercise_label}
-                      </p>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-foreground truncate">{doc.title}</p>
+                      <p className="text-xs text-muted-foreground">{formatDate(doc.distributed_at)}</p>
                     </div>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    className="text-cyan-600 hover:text-cyan-700"
-                    asChild
-                  >
-                    <a
-                      href={annexe.download_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Download className="w-4 h-4" />
-                    </a>
-                  </Button>
+                  {doc.url && (
+                    <Button variant="ghost" size="sm" className="text-cyan-600 hover:text-cyan-700" asChild>
+                      <a href={doc.url} target="_blank" rel="noopener noreferrer">
+                        <Download className="w-4 h-4" />
+                      </a>
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>
@@ -369,8 +442,6 @@ function CoproOwnerContent() {
     </div>
   );
 }
-
-// -- Info Row -----------------------------------------------------------------
 
 function InfoRow({
   icon,
@@ -392,8 +463,6 @@ function InfoRow({
   );
 }
 
-// -- Loading skeleton --------------------------------------------------------
-
 function CoproOwnerLoadingSkeleton() {
   return (
     <div className="space-y-6 animate-pulse">
@@ -402,8 +471,8 @@ function CoproOwnerLoadingSkeleton() {
         <div className="h-44 bg-muted rounded-xl" />
         <div className="h-44 bg-muted rounded-xl" />
       </div>
-      <div className="h-64 bg-muted rounded-xl" />
       <div className="h-32 bg-muted rounded-xl" />
+      <div className="h-64 bg-muted rounded-xl" />
     </div>
   );
 }

--- a/components/layout/owner-app-layout.tsx
+++ b/components/layout/owner-app-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import { ProtectedRoute } from "@/components/protected-route";
@@ -23,6 +23,7 @@ import {
   MessageSquare,
   Settings,
   Receipt,
+  Users,
 } from "lucide-react";
 import { OWNER_ROUTES } from "@/lib/config/owner-routes";
 import { SharedBottomNav } from "./shared-bottom-nav";
@@ -68,7 +69,14 @@ interface NavGroup {
  * Prestataires, Entités) restent accessibles depuis les pages contextuelles
  * et via la Command Palette (⌘K).
  */
-const navigationGroups: NavGroup[] = [
+const COPRO_NAV_ITEM: NavItem = {
+  name: "Ma copropriété",
+  href: "/owner/copro",
+  icon: Users,
+  tourId: "nav-copro",
+};
+
+const buildNavigationGroups = ({ showCopro }: { showCopro: boolean }): NavGroup[] => [
   {
     items: [
       { name: "Tableau de bord", href: OWNER_ROUTES.dashboard.path, icon: LayoutDashboard, tourId: "nav-dashboard" },
@@ -81,6 +89,7 @@ const navigationGroups: NavGroup[] = [
       { name: "Mes baux", href: OWNER_ROUTES.contracts.path, icon: FileText, tourId: "nav-leases" },
       { name: "Finances", href: OWNER_ROUTES.money.path, icon: Euro, tourId: "nav-money" },
       { name: "Comptabilité", href: OWNER_ROUTES.accounting.path, icon: Landmark, tourId: "nav-accounting" },
+      ...(showCopro ? [COPRO_NAV_ITEM] : []),
     ],
   },
   {
@@ -93,9 +102,6 @@ const navigationGroups: NavGroup[] = [
     ],
   },
 ];
-
-// Flat list for page title lookup and bottom nav
-const allNavItems = navigationGroups.flatMap((g) => g.items);
 
 interface OwnerAppLayoutProps {
   children: React.ReactNode;
@@ -119,6 +125,42 @@ export function OwnerAppLayout({ children, profile: serverProfile }: OwnerAppLay
 
   // Utiliser le profil du serveur si disponible, sinon celui du client
   const profile = serverProfile || clientProfile;
+
+  // Le lien "Ma copropriété" n'apparaît que si l'utilisateur a au moins
+  // une copropriété rattachée via user_site_roles. Probe léger qui retourne
+  // { copros: [] } sinon. Si l'utilisateur navigue déjà sur /owner/copro
+  // (ex. lien direct), on affiche sans attendre.
+  const [hasCopro, setHasCopro] = useState<boolean>(
+    pathname?.startsWith("/owner/copro") ?? false,
+  );
+  useEffect(() => {
+    if (!profile || profile.role !== "owner") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch("/api/owner/copro", { credentials: "include" });
+        if (!response.ok) return;
+        const data = (await response.json()) as { copros?: unknown[] };
+        if (!cancelled && Array.isArray(data.copros) && data.copros.length > 0) {
+          setHasCopro(true);
+        }
+      } catch {
+        // Silent — feature non bloquante.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [profile]);
+
+  const navigationGroups = useMemo(
+    () => buildNavigationGroups({ showCopro: hasCopro }),
+    [hasCopro],
+  );
+  const allNavItems = useMemo(
+    () => navigationGroups.flatMap((g) => g.items),
+    [navigationGroups],
+  );
 
   // Rediriger si pas propriétaire (seulement côté client si pas de profil serveur)
   useEffect(() => {


### PR DESCRIPTION
## Summary
Introduces a new copropriété (co-ownership) management module for property owners, allowing them to view their co-owned properties, fund calls, assemblies, and related documents. Includes a new API endpoint and updated navigation to conditionally display the feature.

## Key Changes

- **New API endpoint** (`/api/owner/copro`): Fetches co-ownership data for the authenticated user, including:
  - Sites (copropriétés) linked via `user_site_roles` with copro-related role codes
  - Lots (units) owned by the user within each site
  - Fund calls (appels de fonds) with payment status and due dates
  - Upcoming assemblies (assemblées générales)
  - Distributed documents with download URLs
  - Balance calculation (amount owed or credited)

- **Updated CoproOwnerClient component**:
  - Refactored data types to match new API response structure (multiple sites support)
  - Added site selector dropdown for users with multiple copropriétés
  - Enhanced lot display to show multiple lots per site with property links
  - Added "Upcoming Assemblies" section with dates and status
  - Improved "Documents" section with better formatting and metadata
  - Added `formatDate()` utility for French date formatting
  - Updated fund call status mapping (`pending`, `partial`, `paid`, `overdue`)
  - Reorganized balance display with clearer messaging
  - Better empty state messaging with support contact information

- **Navigation updates** (`owner-app-layout.tsx`):
  - Conditionally show "Ma copropriété" nav item only if user has linked copropriétés
  - Light probe on mount to check for copro access without blocking navigation
  - Maintains nav item visibility if user navigates directly to `/owner/copro`

- **Building detail page**: Added quick link to copropriété module from co-owned property view

## Implementation Details

- Uses `useMemo` and `useState` for efficient site selection and navigation state management
- API uses RLS (Row Level Security) to scope data by user permissions
- Supports multiple ownership roles: `coproprietaire`, `coproprietaire_bailleur`, `coproprietaire_nu`, `usufruitier`
- Gracefully handles missing data (null syndic info, missing documents, etc.)
- Responsive design with proper mobile/desktop layout handling

https://claude.ai/code/session_01Q46fUzye4CFcpzL6o4Xmzv