### PR TITLE
Add syndic-owner bridge: site claims, suppliers, and invitations

### DIFF
--- a/.claude/skills/talok-buildings/SKILL.md
+++ b/.claude/skills/talok-buildings/SKILL.md
@@ -284,6 +284,86 @@ Le badge "Immeuble · [adresse]" est ajouté dans `PropertyCard` :
 
 Un utilisateur peut avoir les deux rôles (syndic bénévole d'une copro dont il est aussi copropriétaire), mais les modules restent strictement séparés pour ne pas mélanger responsabilités légales.
 
+## 12b. Bridge owner ↔ syndic (livré le 29/04/2026)
+
+Quand le syndic d'une copropriété utilise aussi Talok, le `building` (côté
+owner) peut être **connecté** au `site` (côté syndic). Ce pont est implémenté
+via les colonnes `buildings.site_id`, `buildings.site_link_status`,
+`buildings.owner_syndic_mode` et la table `building_site_links` (historique
+des claims).
+
+### Personas et CTAs
+
+| Persona | ownership_type | site_link_status | UI affichée |
+|---|---|---|---|
+| Maison standalone | n/a (pas de building) | n/a | rien |
+| Owner immeuble entier | `full` | `unlinked` | option discrète « Activer le mode syndic-bénévole » |
+| Owner immeuble entier déjà bénévole | `full` | `linked` (`owner_syndic_mode='volunteer'`) | bandeau vert + lien vers `/syndic/sites/[id]` |
+| Copro avec syndic externe | `partial` | `unlinked` | bandeau cyan « Votre syndic est-il sur Talok ? » + 2 CTAs : `Rechercher` / `Inviter par email` |
+| Copro syndic Talok demandeur | `partial` | `pending` | bandeau ambre « Demande envoyée » + bouton `Annuler` |
+| Copro syndic Talok refusé | `partial` | `rejected` | bandeau rouge avec motif + bouton `Renvoyer` |
+| Copro syndic Talok approuvé | `partial` | `linked` (`owner_syndic_mode='managed_external'`) | bandeau vert + **panneau live « Côté copropriété »** (3 cards : prochaine AG, dernier appel de fonds, PV récents) |
+
+### Flow d'approbation
+
+```
+Owner → POST /api/buildings/[id]/claim-site { site_id, message }
+   → INSERT building_site_links { status='pending' }
+   → trigger met buildings.site_link_status='pending'
+   → notif côté syndic dans /syndic/claims
+
+Syndic → POST /api/syndic/site-claims/[claimId] { decision: 'approve'|'reject' }
+   → UPDATE building_site_links → trigger apply_building_site_link :
+     - approve : set buildings.site_id, site_link_status='linked',
+                 owner_syndic_mode='managed_external',
+                 + INSERT user_site_roles { role_code: 'coproprietaire_bailleur' }
+     - reject : site_link_status='rejected'
+```
+
+### Mode syndic-bénévole (full uniquement)
+
+`POST /api/buildings/[id]/activate-as-syndic` :
+1. Crée un `sites` row avec `syndic_profile_id = profile.id`
+2. INSERT `building_site_links { status: 'approved' }` (auto-approuvé car owner = syndic)
+3. Trigger applique le link → `owner_syndic_mode='volunteer'`
+4. Promote `profiles.role` de `owner` vers `syndic` si applicable
+5. Redirect vers `/syndic/sites/[id]` pour suite (compta, contrats, AGs)
+
+**Légalement** : un mono-propriétaire n'a aucune obligation de syndic. Cette action est purement organisationnelle (compta dédiée, centralisation contrats).
+
+### Permissions cross-module (coproprietaire_bailleur)
+
+Une fois `linked`, l'owner reçoit le rôle `coproprietaire_bailleur` sur le site syndic. Les routes `/api/copro/*` filtrent par `user_site_roles` — l'owner peut donc lire (mais pas modifier) :
+- `copro_assemblies` du site
+- `copro_fund_calls` et leurs `copro_fund_call_lines` qui le concernent
+- `copro_minutes` (PV publiés)
+- documents officiels du site
+
+Les pages `/syndic/sites/[id]/*` ne lui sont pas accessibles directement (le layout `/syndic` redirige les non-syndics). À la place, le panneau **`SyndicSidePanel`** affiche un résumé inline dans `/owner/buildings/[id]`.
+
+### Composants et routes clés
+
+| Fichier | Rôle |
+|---|---|
+| `components/buildings/SyndicLinkBanner.tsx` | Bandeau d'état + dialogs claim & activate |
+| `components/buildings/SyndicSidePanel.tsx` | 3 cards lecture-seule visible si linked |
+| `app/api/buildings/[id]/match-sites/route.ts` | Auto-suggestion par CP+ville |
+| `app/api/buildings/[id]/claim-site/route.ts` | Soumet le claim |
+| `app/api/buildings/[id]/unlink-site/route.ts` | Annule pending ou rompt linked |
+| `app/api/buildings/[id]/activate-as-syndic/route.ts` | Bascule `full` en mode bénévole |
+| `app/api/buildings/[id]/syndic-summary/route.ts` | Aggrège AG + fund call + PV pour le panel |
+| `app/api/syndic/site-claims/route.ts` | GET liste pour le syndic |
+| `app/api/syndic/site-claims/[claimId]/route.ts` | POST approve/reject |
+| `app/syndic/claims/page.tsx` | Inbox côté syndic avec actions |
+| `supabase/migrations/20260429120300_owner_syndic_bridge.sql` | Schéma + RLS + triggers |
+
+### Limites actuelles (à itérer plus tard)
+
+- Mapping fin **`building_units.copro_lot_id`** non encore implémenté → `user_owed_cents` calculé sur l'ensemble des lignes du fund call et non sur les lots précis de l'owner.
+- L'auto-suggestion n'utilise que `code_postal + ville`. Recherche par SIRET du syndic ou par nom du cabinet à ajouter en V2.
+- Pas de notification email aux deux parties lors d'un claim (toast + presence dans `/syndic/claims` uniquement).
+- L'unlink ne révoque pas automatiquement le `user_site_roles` créé (volontaire — l'owner reste copropriétaire si invité indépendamment via `copro_invites`).
+
 ## 13. Règles dev obligatoires
 
 1. **Check d'accès** : jamais de filtre `owner_id` seul sur les pages/routes building — toujours copier le pattern entity_members.

--- a/app/api/buildings/[id]/activate-as-syndic/route.ts
+++ b/app/api/buildings/[id]/activate-as-syndic/route.ts
@@ -1,0 +1,149 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/buildings/[id]/activate-as-syndic
+ *
+ * Pour les owners ownership_type='full' qui veulent structurer leur gestion
+ * en activant le mode "syndic-bénévole" : crée un site Talok lié à leur
+ * building et auto-approuve la liaison. Donne accès à /syndic/sites/[id]
+ * (compta dédiée, contrats fournisseurs, AGs, etc.).
+ *
+ * Légalement, un mono-propriétaire n'a pas de syndic obligatoire — cette
+ * action est purement organisationnelle.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id: buildingId } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+    const profileId = (profile as { id: string }).id;
+
+    const { data: building } = await serviceClient
+      .from("buildings")
+      .select(
+        "id, owner_id, name, adresse_complete, code_postal, ville, ownership_type, site_id, site_link_status, total_lots_in_building"
+      )
+      .eq("id", buildingId)
+      .maybeSingle();
+    if (!building) {
+      return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
+    }
+    const b = building as {
+      owner_id: string;
+      name: string | null;
+      adresse_complete: string | null;
+      code_postal: string | null;
+      ville: string | null;
+      ownership_type: string;
+      site_id: string | null;
+      site_link_status: string;
+      total_lots_in_building: number | null;
+    };
+
+    if (b.owner_id !== profileId) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+    if (b.ownership_type !== "full") {
+      return NextResponse.json(
+        {
+          error:
+            "Le mode syndic-bénévole n'est disponible que pour les immeubles que vous possédez intégralement.",
+        },
+        { status: 400 }
+      );
+    }
+    if (b.site_id) {
+      return NextResponse.json(
+        { error: "Cet immeuble est déjà rattaché à une copropriété." },
+        { status: 409 }
+      );
+    }
+
+    // Crée un site Talok pour cet immeuble, avec l'owner comme syndic
+    const { data: site, error: siteError } = await serviceClient
+      .from("sites")
+      .insert({
+        name: b.name ?? "Mon immeuble",
+        address_line1: b.adresse_complete ?? "",
+        postal_code: b.code_postal ?? "",
+        city: b.ville ?? "",
+        syndic_profile_id: profileId,
+        is_active: true,
+        type: "copropriete",
+        total_tantiemes_general: 10000,
+      })
+      .select("id")
+      .single();
+
+    if (siteError || !site) {
+      return NextResponse.json(
+        { error: siteError?.message ?? "Erreur lors de la création du site" },
+        { status: 500 }
+      );
+    }
+    const siteId = (site as { id: string }).id;
+
+    // Crée le lien building <-> site (auto-approved car même utilisateur)
+    const { error: linkError } = await serviceClient
+      .from("building_site_links")
+      .insert({
+        building_id: buildingId,
+        site_id: siteId,
+        status: "approved",
+        claimed_by_profile_id: profileId,
+        decided_by_profile_id: profileId,
+        decided_at: new Date().toISOString(),
+        claim_message: "Mode syndic-bénévole activé par le propriétaire.",
+        decision_reason: "auto-approuvé (owner = syndic)",
+      });
+
+    if (linkError) {
+      // Cleanup le site créé si la liaison échoue
+      await serviceClient.from("sites").delete().eq("id", siteId);
+      return NextResponse.json({ error: linkError.message }, { status: 500 });
+    }
+
+    // Marque le building en mode volunteer
+    await serviceClient
+      .from("buildings")
+      .update({ owner_syndic_mode: "volunteer", updated_at: new Date().toISOString() })
+      .eq("id", buildingId);
+
+    // Promote profile to syndic role if not already
+    await serviceClient
+      .from("profiles")
+      .update({ role: "syndic" })
+      .eq("id", profileId)
+      .eq("role", "owner");
+
+    return NextResponse.json({ success: true, site_id: siteId });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/buildings/[id]/auto-map-copro-lots/route.ts
+++ b/app/api/buildings/[id]/auto-map-copro-lots/route.ts
@@ -4,17 +4,14 @@ export const dynamic = "force-dynamic";
 /**
  * POST /api/buildings/[id]/auto-map-copro-lots
  *
- * Tente de relier automatiquement les building_units du building aux
- * copro_lots de la copropriété liée (via building.site_id), en se basant
- * sur le lot_number ou la position (étage + position).
- *
- * Accessible à l'owner du building OU au syndic du site lié.
- * Ne touche que les unités sans mapping existant.
+ * Délègue au helper lib/buildings/auto-map-copro-lots.ts. Accessible à
+ * l'owner du building OU au syndic du site lié.
  */
 
 import { NextResponse } from "next/server";
 import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
 import { getServiceClient } from "@/lib/supabase/service-client";
+import { autoMapCoproLots } from "@/lib/buildings/auto-map-copro-lots";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -32,7 +29,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     const { data: profile } = await serviceClient
       .from("profiles")
-      .select("id, role")
+      .select("id")
       .eq("user_id", user.id)
       .maybeSingle();
     if (!profile) {
@@ -42,126 +39,29 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     const { data: building } = await serviceClient
       .from("buildings")
-      .select("id, owner_id, site_id, site_link_status")
+      .select("id, owner_id, site_id")
       .eq("id", buildingId)
       .maybeSingle();
     if (!building) {
       return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
     }
-    const b = building as { owner_id: string; site_id: string | null; site_link_status: string };
+    const b = building as { owner_id: string; site_id: string | null };
 
-    if (!b.site_id || b.site_link_status !== "linked") {
-      return NextResponse.json(
-        { error: "Le building n'est pas rattaché à une copropriété Talok." },
-        { status: 400 }
-      );
-    }
-
-    // Vérifier accès : owner OU syndic du site
-    const isOwner = b.owner_id === profileId;
     let isSyndic = false;
-    const { data: site } = await serviceClient
-      .from("sites")
-      .select("syndic_profile_id, copro_entity_id")
-      .eq("id", b.site_id)
-      .maybeSingle();
-    if (site) {
-      isSyndic = (site as { syndic_profile_id: string }).syndic_profile_id === profileId;
+    if (b.site_id) {
+      const { data: site } = await serviceClient
+        .from("sites")
+        .select("syndic_profile_id")
+        .eq("id", b.site_id)
+        .maybeSingle();
+      isSyndic = (site as { syndic_profile_id: string } | null)?.syndic_profile_id === profileId;
     }
-    if (!isOwner && !isSyndic) {
+    if (b.owner_id !== profileId && !isSyndic) {
       return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
     }
 
-    const coproEntityId = (site as { copro_entity_id: string | null } | null)?.copro_entity_id;
-    if (!coproEntityId) {
-      return NextResponse.json(
-        { error: "La copropriété n'a pas d'entité juridique associée." },
-        { status: 400 }
-      );
-    }
-
-    // Récupère les building_units pas encore mappées
-    const { data: units } = await serviceClient
-      .from("building_units")
-      .select("id, floor, position, copro_lot_id, property_id, properties:properties(unique_code)")
-      .eq("building_id", buildingId)
-      .is("copro_lot_id", null);
-    const targetUnits = (units ?? []) as Array<{
-      id: string;
-      floor: number;
-      position: number;
-      property_id: string | null;
-      properties: { unique_code: string | null } | null;
-    }>;
-
-    if (targetUnits.length === 0) {
-      return NextResponse.json({ mapped: 0, message: "Aucune unité à mapper." });
-    }
-
-    // Récupère tous les copro_lots de l'entité
-    const { data: lots } = await serviceClient
-      .from("copro_lots")
-      .select("id, lot_number, surface_m2, is_active")
-      .eq("copro_entity_id", coproEntityId)
-      .eq("is_active", true);
-    const targetLots = (lots ?? []) as Array<{
-      id: string;
-      lot_number: string;
-      surface_m2: number | null;
-    }>;
-
-    // Lots déjà mappés à exclure
-    const { data: alreadyMapped } = await serviceClient
-      .from("building_units")
-      .select("copro_lot_id")
-      .not("copro_lot_id", "is", null);
-    const usedLotIds = new Set(
-      (alreadyMapped ?? []).map((m) => (m as { copro_lot_id: string }).copro_lot_id)
-    );
-    const availableLots = targetLots.filter((l) => !usedLotIds.has(l.id));
-
-    // Auto-matching :
-    // 1. lot_number == unique_code (case-insensitive, trim)
-    // 2. lot_number == "{floor}-{position}" en fallback
-    function normalize(s: string): string {
-      return s.trim().toLowerCase().replace(/\s+/g, "");
-    }
-
-    const updates: Array<{ unit_id: string; lot_id: string }> = [];
-
-    for (const unit of targetUnits) {
-      const candidates: string[] = [];
-      if (unit.properties?.unique_code) candidates.push(normalize(unit.properties.unique_code));
-      candidates.push(`${unit.floor}-${unit.position}`);
-      candidates.push(`${unit.floor}.${unit.position}`);
-
-      const match = availableLots.find((lot) =>
-        candidates.includes(normalize(lot.lot_number))
-      );
-      if (match) {
-        updates.push({ unit_id: unit.id, lot_id: match.id });
-        // Marque le lot comme utilisé pour ce run
-        const idx = availableLots.findIndex((l) => l.id === match.id);
-        if (idx >= 0) availableLots.splice(idx, 1);
-      }
-    }
-
-    // Apply updates en batch
-    let mappedCount = 0;
-    for (const u of updates) {
-      const { error } = await serviceClient
-        .from("building_units")
-        .update({ copro_lot_id: u.lot_id, updated_at: new Date().toISOString() })
-        .eq("id", u.unit_id);
-      if (!error) mappedCount += 1;
-    }
-
-    return NextResponse.json({
-      mapped: mappedCount,
-      total_units: targetUnits.length,
-      total_lots_available: targetLots.length,
-      unmapped: targetUnits.length - mappedCount,
-    });
+    const result = await autoMapCoproLots(serviceClient, buildingId);
+    return NextResponse.json(result);
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Erreur serveur" },

--- a/app/api/buildings/[id]/auto-map-copro-lots/route.ts
+++ b/app/api/buildings/[id]/auto-map-copro-lots/route.ts
@@ -1,0 +1,171 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/buildings/[id]/auto-map-copro-lots
+ *
+ * Tente de relier automatiquement les building_units du building aux
+ * copro_lots de la copropriété liée (via building.site_id), en se basant
+ * sur le lot_number ou la position (étage + position).
+ *
+ * Accessible à l'owner du building OU au syndic du site lié.
+ * Ne touche que les unités sans mapping existant.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id: buildingId } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+    const profileId = (profile as { id: string }).id;
+
+    const { data: building } = await serviceClient
+      .from("buildings")
+      .select("id, owner_id, site_id, site_link_status")
+      .eq("id", buildingId)
+      .maybeSingle();
+    if (!building) {
+      return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
+    }
+    const b = building as { owner_id: string; site_id: string | null; site_link_status: string };
+
+    if (!b.site_id || b.site_link_status !== "linked") {
+      return NextResponse.json(
+        { error: "Le building n'est pas rattaché à une copropriété Talok." },
+        { status: 400 }
+      );
+    }
+
+    // Vérifier accès : owner OU syndic du site
+    const isOwner = b.owner_id === profileId;
+    let isSyndic = false;
+    const { data: site } = await serviceClient
+      .from("sites")
+      .select("syndic_profile_id, copro_entity_id")
+      .eq("id", b.site_id)
+      .maybeSingle();
+    if (site) {
+      isSyndic = (site as { syndic_profile_id: string }).syndic_profile_id === profileId;
+    }
+    if (!isOwner && !isSyndic) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const coproEntityId = (site as { copro_entity_id: string | null } | null)?.copro_entity_id;
+    if (!coproEntityId) {
+      return NextResponse.json(
+        { error: "La copropriété n'a pas d'entité juridique associée." },
+        { status: 400 }
+      );
+    }
+
+    // Récupère les building_units pas encore mappées
+    const { data: units } = await serviceClient
+      .from("building_units")
+      .select("id, floor, position, copro_lot_id, property_id, properties:properties(unique_code)")
+      .eq("building_id", buildingId)
+      .is("copro_lot_id", null);
+    const targetUnits = (units ?? []) as Array<{
+      id: string;
+      floor: number;
+      position: number;
+      property_id: string | null;
+      properties: { unique_code: string | null } | null;
+    }>;
+
+    if (targetUnits.length === 0) {
+      return NextResponse.json({ mapped: 0, message: "Aucune unité à mapper." });
+    }
+
+    // Récupère tous les copro_lots de l'entité
+    const { data: lots } = await serviceClient
+      .from("copro_lots")
+      .select("id, lot_number, surface_m2, is_active")
+      .eq("copro_entity_id", coproEntityId)
+      .eq("is_active", true);
+    const targetLots = (lots ?? []) as Array<{
+      id: string;
+      lot_number: string;
+      surface_m2: number | null;
+    }>;
+
+    // Lots déjà mappés à exclure
+    const { data: alreadyMapped } = await serviceClient
+      .from("building_units")
+      .select("copro_lot_id")
+      .not("copro_lot_id", "is", null);
+    const usedLotIds = new Set(
+      (alreadyMapped ?? []).map((m) => (m as { copro_lot_id: string }).copro_lot_id)
+    );
+    const availableLots = targetLots.filter((l) => !usedLotIds.has(l.id));
+
+    // Auto-matching :
+    // 1. lot_number == unique_code (case-insensitive, trim)
+    // 2. lot_number == "{floor}-{position}" en fallback
+    function normalize(s: string): string {
+      return s.trim().toLowerCase().replace(/\s+/g, "");
+    }
+
+    const updates: Array<{ unit_id: string; lot_id: string }> = [];
+
+    for (const unit of targetUnits) {
+      const candidates: string[] = [];
+      if (unit.properties?.unique_code) candidates.push(normalize(unit.properties.unique_code));
+      candidates.push(`${unit.floor}-${unit.position}`);
+      candidates.push(`${unit.floor}.${unit.position}`);
+
+      const match = availableLots.find((lot) =>
+        candidates.includes(normalize(lot.lot_number))
+      );
+      if (match) {
+        updates.push({ unit_id: unit.id, lot_id: match.id });
+        // Marque le lot comme utilisé pour ce run
+        const idx = availableLots.findIndex((l) => l.id === match.id);
+        if (idx >= 0) availableLots.splice(idx, 1);
+      }
+    }
+
+    // Apply updates en batch
+    let mappedCount = 0;
+    for (const u of updates) {
+      const { error } = await serviceClient
+        .from("building_units")
+        .update({ copro_lot_id: u.lot_id, updated_at: new Date().toISOString() })
+        .eq("id", u.unit_id);
+      if (!error) mappedCount += 1;
+    }
+
+    return NextResponse.json({
+      mapped: mappedCount,
+      total_units: targetUnits.length,
+      total_lots_available: targetLots.length,
+      unmapped: targetUnits.length - mappedCount,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/buildings/[id]/claim-site/route.ts
+++ b/app/api/buildings/[id]/claim-site/route.ts
@@ -13,6 +13,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
 import { getServiceClient } from "@/lib/supabase/service-client";
+import { sendEmail } from "@/lib/emails/resend.service";
 
 const ClaimSchema = z.object({
   site_id: z.string().uuid(),
@@ -101,6 +102,53 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Notifie le syndic par email
+    try {
+      const { data: syndicAuthUser } = await serviceClient.auth.admin.getUserById(
+        await (async () => {
+          const { data: syndicProfile } = await serviceClient
+            .from("profiles")
+            .select("user_id")
+            .eq("id", (site as { syndic_profile_id: string }).syndic_profile_id)
+            .maybeSingle();
+          return (syndicProfile as { user_id: string } | null)?.user_id ?? "";
+        })()
+      );
+      const syndicEmail = syndicAuthUser?.user?.email;
+
+      const { data: ownerProfile } = await serviceClient
+        .from("profiles")
+        .select("prenom, nom")
+        .eq("id", profileId)
+        .maybeSingle();
+      const ownerName = ownerProfile
+        ? [
+            (ownerProfile as { prenom: string | null }).prenom,
+            (ownerProfile as { nom: string | null }).nom,
+          ]
+            .filter(Boolean)
+            .join(" ") || "Un copropriétaire"
+        : "Un copropriétaire";
+
+      const siteName = (site as { name: string }).name;
+
+      if (syndicEmail) {
+        await sendEmail({
+          to: syndicEmail,
+          subject: `Nouvelle demande de rattachement — ${siteName}`,
+          html: `<p>Bonjour,</p>
+<p><strong>${ownerName}</strong> souhaite rattacher son immeuble à votre copropriété <strong>${siteName}</strong> sur Talok.</p>
+${parse.data.message ? `<p><em>« ${parse.data.message} »</em></p>` : ""}
+<p>Validez ou refusez la demande depuis votre espace : <a href="https://talok.fr/syndic/claims">talok.fr/syndic/claims</a></p>
+<p>Cordialement,<br/>L'équipe Talok</p>`,
+          text: `${ownerName} souhaite rattacher son immeuble à votre copropriété ${siteName}. Validez sur https://talok.fr/syndic/claims`,
+          tags: [{ name: "type", value: "building_site_claim_pending" }],
+        });
+      }
+    } catch (emailError) {
+      console.error("[claim-site] notification email failed", emailError);
     }
 
     return NextResponse.json(claim, { status: 201 });

--- a/app/api/buildings/[id]/claim-site/route.ts
+++ b/app/api/buildings/[id]/claim-site/route.ts
@@ -1,0 +1,113 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/buildings/[id]/claim-site
+ * Body: { site_id, message? }
+ *
+ * L'owner soumet une demande de rattachement de son building à un site
+ * syndic Talok existant. Le syndic devra approuver depuis /syndic/claims.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+const ClaimSchema = z.object({
+  site_id: z.string().uuid(),
+  message: z.string().max(1000).optional(),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id: buildingId } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const parse = ClaimSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parse.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+    const profileId = (profile as { id: string }).id;
+
+    const { data: building } = await serviceClient
+      .from("buildings")
+      .select("id, owner_id, site_link_status, site_id")
+      .eq("id", buildingId)
+      .maybeSingle();
+    if (!building) {
+      return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
+    }
+    if ((building as { owner_id: string }).owner_id !== profileId) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+    if ((building as { site_link_status: string }).site_link_status === "linked") {
+      return NextResponse.json(
+        { error: "Cet immeuble est déjà rattaché à une copropriété." },
+        { status: 409 }
+      );
+    }
+
+    // Vérifie que le site existe et est actif
+    const { data: site } = await serviceClient
+      .from("sites")
+      .select("id, name, syndic_profile_id, is_active")
+      .eq("id", parse.data.site_id)
+      .maybeSingle();
+    if (!site || !(site as { is_active: boolean }).is_active) {
+      return NextResponse.json({ error: "Copropriété introuvable" }, { status: 404 });
+    }
+
+    // Annule un éventuel claim pending pour le même couple
+    await serviceClient
+      .from("building_site_links")
+      .update({ status: "cancelled", updated_at: new Date().toISOString() })
+      .eq("building_id", buildingId)
+      .eq("status", "pending");
+
+    const { data: claim, error } = await serviceClient
+      .from("building_site_links")
+      .insert({
+        building_id: buildingId,
+        site_id: parse.data.site_id,
+        status: "pending",
+        claimed_by_profile_id: profileId,
+        claim_message: parse.data.message ?? null,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(claim, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/buildings/[id]/copro-lot-mappings/route.ts
+++ b/app/api/buildings/[id]/copro-lot-mappings/route.ts
@@ -1,0 +1,146 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET  /api/buildings/[id]/copro-lot-mappings
+ *      Retourne la liste des building_units et leur copro_lot_id éventuel.
+ *
+ * PATCH /api/buildings/[id]/copro-lot-mappings
+ *      Body : { mappings: [{ building_unit_id, copro_lot_id | null }] }
+ *      Met à jour un ou plusieurs mappings manuels.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+const PatchSchema = z.object({
+  mappings: z
+    .array(
+      z.object({
+        building_unit_id: z.string().uuid(),
+        copro_lot_id: z.string().uuid().nullable(),
+      })
+    )
+    .min(1)
+    .max(100),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+async function authorize(buildingId: string, request: Request) {
+  const { user, error } = await getAuthenticatedUser(request);
+  if (error || !user) {
+    return { ok: false, status: 401, body: { error: "Non authentifié" } } as const;
+  }
+  const serviceClient = getServiceClient();
+  const { data: profile } = await serviceClient
+    .from("profiles")
+    .select("id, role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!profile) {
+    return { ok: false, status: 404, body: { error: "Profil introuvable" } } as const;
+  }
+  const profileId = (profile as { id: string }).id;
+
+  const { data: building } = await serviceClient
+    .from("buildings")
+    .select("id, owner_id, site_id")
+    .eq("id", buildingId)
+    .maybeSingle();
+  if (!building) {
+    return { ok: false, status: 404, body: { error: "Immeuble introuvable" } } as const;
+  }
+  const b = building as { owner_id: string; site_id: string | null };
+
+  let isSyndic = false;
+  if (b.site_id) {
+    const { data: site } = await serviceClient
+      .from("sites")
+      .select("syndic_profile_id")
+      .eq("id", b.site_id)
+      .maybeSingle();
+    isSyndic = (site as { syndic_profile_id: string } | null)?.syndic_profile_id === profileId;
+  }
+  if (b.owner_id !== profileId && !isSyndic) {
+    return { ok: false, status: 403, body: { error: "Accès refusé" } } as const;
+  }
+
+  return {
+    ok: true,
+    serviceClient,
+    profileId,
+    siteId: b.site_id,
+  } as const;
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const auth = await authorize(id, request);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+
+  const { data: units } = await auth.serviceClient
+    .from("building_units")
+    .select(
+      "id, floor, position, type, copro_lot_id, property_id, properties:properties(unique_code, adresse_complete)"
+    )
+    .eq("building_id", id)
+    .order("floor", { ascending: true })
+    .order("position", { ascending: true });
+
+  const unitRows = (units ?? []) as Array<{
+    id: string;
+    floor: number;
+    position: number;
+    type: string | null;
+    copro_lot_id: string | null;
+  }>;
+
+  let lots: unknown[] = [];
+  if (auth.siteId) {
+    const { data: site } = await auth.serviceClient
+      .from("sites")
+      .select("copro_entity_id")
+      .eq("id", auth.siteId)
+      .maybeSingle();
+    const coproEntityId = (site as { copro_entity_id: string | null } | null)?.copro_entity_id;
+    if (coproEntityId) {
+      const { data } = await auth.serviceClient
+        .from("copro_lots")
+        .select("id, lot_number, lot_type, owner_name, tantiemes_generaux, surface_m2")
+        .eq("copro_entity_id", coproEntityId)
+        .eq("is_active", true)
+        .order("lot_number");
+      lots = data ?? [];
+    }
+  }
+
+  return NextResponse.json({ units: unitRows, lots });
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const auth = await authorize(id, request);
+  if (!auth.ok) return NextResponse.json(auth.body, { status: auth.status });
+
+  const body = await request.json().catch(() => ({}));
+  const parse = PatchSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: "Données invalides" }, { status: 400 });
+  }
+
+  let updated = 0;
+  for (const m of parse.data.mappings) {
+    const { error } = await auth.serviceClient
+      .from("building_units")
+      .update({ copro_lot_id: m.copro_lot_id, updated_at: new Date().toISOString() })
+      .eq("id", m.building_unit_id)
+      .eq("building_id", id);
+    if (!error) updated += 1;
+  }
+  return NextResponse.json({ updated });
+}

--- a/app/api/buildings/[id]/invite-syndic/route.ts
+++ b/app/api/buildings/[id]/invite-syndic/route.ts
@@ -1,0 +1,141 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/buildings/[id]/invite-syndic
+ * Body: { email, name?, copro_name?, phone?, message? }
+ *
+ * Génère un token d'invitation publique pour que le syndic externe
+ * rejoigne Talok et prenne en charge la copropriété. Envoie un email
+ * avec un lien d'inscription pré-rempli vers /auth/syndic-invite/[token].
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { randomBytes } from "crypto";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+import { sendEmail } from "@/lib/emails/resend.service";
+
+const InviteSchema = z.object({
+  email: z.string().email(),
+  name: z.string().max(255).optional(),
+  copro_name: z.string().max(255).optional(),
+  phone: z.string().max(30).optional(),
+  message: z.string().max(2000).optional(),
+});
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id: buildingId } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const parse = InviteSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parse.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, prenom, nom")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+    const profileId = (profile as { id: string }).id;
+
+    const { data: building } = await serviceClient
+      .from("buildings")
+      .select("id, owner_id, name, adresse_complete, code_postal, ville")
+      .eq("id", buildingId)
+      .maybeSingle();
+    if (!building) {
+      return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
+    }
+    if ((building as { owner_id: string }).owner_id !== profileId) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const token = randomBytes(32).toString("base64url");
+    const ownerName =
+      [
+        (profile as { prenom: string | null }).prenom,
+        (profile as { nom: string | null }).nom,
+      ]
+        .filter(Boolean)
+        .join(" ") || "Un copropriétaire";
+
+    const { data: invitation, error: insertError } = await serviceClient
+      .from("syndic_invitations_public")
+      .insert({
+        token,
+        building_id: buildingId,
+        invited_by_profile_id: profileId,
+        suggested_syndic_name: parse.data.name ?? null,
+        suggested_syndic_email: parse.data.email,
+        suggested_syndic_phone: parse.data.phone ?? null,
+        suggested_copro_name: parse.data.copro_name ?? null,
+        message: parse.data.message ?? null,
+      })
+      .select("id, token")
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
+
+    const inviteUrl = `https://talok.fr/auth/syndic-invite/${token}`;
+    const buildingDisplay =
+      (building as { name: string | null }).name ??
+      (building as { adresse_complete: string | null }).adresse_complete ??
+      "un immeuble";
+
+    try {
+      await sendEmail({
+        to: parse.data.email,
+        subject: `${ownerName} vous invite à rejoindre Talok`,
+        html: `<p>Bonjour${parse.data.name ? ` ${parse.data.name}` : ""},</p>
+<p><strong>${ownerName}</strong> est copropriétaire de ${buildingDisplay}${
+          (building as { code_postal: string | null }).code_postal
+            ? ` (${(building as { code_postal: string }).code_postal} ${(building as { ville: string }).ville ?? ""})`
+            : ""
+        } et souhaiterait que vous gériez la copropriété sur Talok.</p>
+${parse.data.message ? `<p><em>« ${parse.data.message} »</em></p>` : ""}
+<p>Talok est le logiciel de gestion locative et copropriété SaaS, conforme à la loi du 10 juillet 1965 et au décret 2005-240 (plan comptable copropriété). Avec Talok, vous gérez vos AGs, appels de fonds, comptabilité, mandats et fournisseurs depuis une seule plateforme.</p>
+<p style="margin: 24px 0;"><a href="${inviteUrl}" style="background: #2563EB; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600;">Découvrir et créer mon compte syndic</a></p>
+<p>Ce lien est valide 60 jours.</p>
+<p>Cordialement,<br/>L'équipe Talok</p>`,
+        text: `${ownerName} vous invite à rejoindre Talok pour gérer ${buildingDisplay}. Lien : ${inviteUrl}`,
+        tags: [{ name: "type", value: "syndic_public_invitation" }],
+      });
+    } catch (emailError) {
+      console.error("[invite-syndic] email send failed", emailError);
+    }
+
+    return NextResponse.json({
+      success: true,
+      token,
+      invite_url: inviteUrl,
+      invitation_id: (invitation as { id: string }).id,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/buildings/[id]/match-sites/route.ts
+++ b/app/api/buildings/[id]/match-sites/route.ts
@@ -2,10 +2,12 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/buildings/[id]/match-sites
+ * GET /api/buildings/[id]/match-sites?q=...
  *
- * Cherche des sites syndic Talok dont l'adresse / le code postal correspondent
- * à ceux d'un building côté owner. Utilisé pour suggérer un rattachement.
+ * Cherche des sites syndic Talok :
+ *   - sans `q` : auto-suggestion par code postal + ville du building
+ *   - avec `q` : recherche libre sur le nom du site, ou sur la raison
+ *     sociale / SIRET / numéro de carte pro du syndic
  */
 
 import { NextResponse } from "next/server";
@@ -31,7 +33,6 @@ export async function GET(request: Request, { params }: RouteParams) {
       .select("id")
       .eq("user_id", user.id)
       .maybeSingle();
-
     if (!profile) {
       return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
     }
@@ -52,23 +53,76 @@ export async function GET(request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
     }
 
+    const { searchParams } = new URL(request.url);
+    const query = (searchParams.get("q") ?? "").trim();
     const codePostal = (building as { code_postal: string | null }).code_postal;
     const ville = (building as { ville: string | null }).ville;
 
-    if (!codePostal || !ville) {
-      return NextResponse.json([]);
+    // Mode auto-suggestion : code postal + ville
+    if (!query) {
+      if (!codePostal || !ville) {
+        return NextResponse.json([]);
+      }
+      const { data: sites } = await serviceClient
+        .from("sites")
+        .select("id, name, address_line1, postal_code, city, syndic_profile_id, is_active")
+        .eq("postal_code", codePostal)
+        .ilike("city", ville)
+        .eq("is_active", true)
+        .limit(20);
+      return NextResponse.json(sites ?? []);
     }
 
-    // Match prioritaire : code postal + ville
-    const { data: sites } = await serviceClient
+    // Mode recherche libre : par nom de site OU raison sociale / SIRET / carte pro du syndic
+    const sanitized = query.replace(/[%_]/g, "").slice(0, 100);
+    const isDigitsOnly = /^\d+$/.test(sanitized.replace(/\s/g, ""));
+
+    // 1. Match sur sites par name
+    const sitesByName = await serviceClient
       .from("sites")
       .select("id, name, address_line1, postal_code, city, syndic_profile_id, is_active")
-      .eq("postal_code", codePostal)
-      .ilike("city", ville)
       .eq("is_active", true)
-      .limit(20);
+      .ilike("name", `%${sanitized}%`)
+      .limit(15);
 
-    return NextResponse.json(sites ?? []);
+    // 2. Match sur syndic_profiles (raison_sociale, siret, numero_carte_pro)
+    let syndicProfileIds: string[] = [];
+    {
+      let q = serviceClient
+        .from("syndic_profiles")
+        .select("profile_id")
+        .limit(20);
+      if (isDigitsOnly) {
+        q = q.or(
+          `siret.ilike.%${sanitized.replace(/\s/g, "")}%,numero_carte_pro.ilike.%${sanitized}%`
+        );
+      } else {
+        q = q.or(`raison_sociale.ilike.%${sanitized}%,numero_carte_pro.ilike.%${sanitized}%`);
+      }
+      const { data } = await q;
+      syndicProfileIds = (data ?? []).map((r) => (r as { profile_id: string }).profile_id);
+    }
+
+    let sitesBySyndic: unknown[] = [];
+    if (syndicProfileIds.length > 0) {
+      const { data } = await serviceClient
+        .from("sites")
+        .select("id, name, address_line1, postal_code, city, syndic_profile_id, is_active")
+        .eq("is_active", true)
+        .in("syndic_profile_id", syndicProfileIds)
+        .limit(15);
+      sitesBySyndic = data ?? [];
+    }
+
+    // Dédoublonne par site.id
+    const seen = new Set<string>();
+    const merged = [...((sitesByName.data ?? []) as Array<{ id: string }>), ...(sitesBySyndic as Array<{ id: string }>)].filter((s) => {
+      if (seen.has(s.id)) return false;
+      seen.add(s.id);
+      return true;
+    });
+
+    return NextResponse.json(merged.slice(0, 20));
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Erreur serveur" },

--- a/app/api/buildings/[id]/match-sites/route.ts
+++ b/app/api/buildings/[id]/match-sites/route.ts
@@ -1,0 +1,78 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/buildings/[id]/match-sites
+ *
+ * Cherche des sites syndic Talok dont l'adresse / le code postal correspondent
+ * à ceux d'un building côté owner. Utilisé pour suggérer un rattachement.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+
+    const { data: building } = await serviceClient
+      .from("buildings")
+      .select("id, owner_id, code_postal, ville, adresse_complete")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (!building) {
+      return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
+    }
+
+    const ownerId = (building as { owner_id: string }).owner_id;
+    const profileId = (profile as { id: string }).id;
+    if (ownerId !== profileId) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const codePostal = (building as { code_postal: string | null }).code_postal;
+    const ville = (building as { ville: string | null }).ville;
+
+    if (!codePostal || !ville) {
+      return NextResponse.json([]);
+    }
+
+    // Match prioritaire : code postal + ville
+    const { data: sites } = await serviceClient
+      .from("sites")
+      .select("id, name, address_line1, postal_code, city, syndic_profile_id, is_active")
+      .eq("postal_code", codePostal)
+      .ilike("city", ville)
+      .eq("is_active", true)
+      .limit(20);
+
+    return NextResponse.json(sites ?? []);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/buildings/[id]/syndic-summary/route.ts
+++ b/app/api/buildings/[id]/syndic-summary/route.ts
@@ -1,0 +1,136 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/buildings/[id]/syndic-summary
+ *
+ * Si le building est `linked` à un site syndic, retourne un résumé
+ * lecture-seule pour le copropriétaire bailleur :
+ *   - prochaine AG
+ *   - dernier appel de fonds (et ce qu'il doit)
+ *   - documents officiels récents (PV, DPE collectif, règlement copro)
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id: buildingId } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+    const profileId = (profile as { id: string }).id;
+
+    const { data: building } = await serviceClient
+      .from("buildings")
+      .select("id, owner_id, site_id, site_link_status")
+      .eq("id", buildingId)
+      .maybeSingle();
+    if (!building) {
+      return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
+    }
+    const b = building as {
+      owner_id: string;
+      site_id: string | null;
+      site_link_status: string;
+    };
+    if (b.owner_id !== profileId) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+    if (!b.site_id || b.site_link_status !== "linked") {
+      return NextResponse.json({
+        linked: false,
+        next_assembly: null,
+        latest_fund_call: null,
+        recent_documents: [],
+      });
+    }
+
+    const today = new Date().toISOString();
+
+    // Prochaine AG
+    const { data: nextAssembly } = await serviceClient
+      .from("copro_assemblies")
+      .select("id, title, reference_number, assembly_type, scheduled_at, location, online_meeting_url, status")
+      .eq("site_id", b.site_id)
+      .gte("scheduled_at", today)
+      .in("status", ["draft", "convened", "in_progress"])
+      .order("scheduled_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    // Dernier appel de fonds émis sur le site
+    const { data: latestFundCall } = await serviceClient
+      .from("copro_fund_calls")
+      .select(
+        "id, call_number, period_label, due_date, total_amount_cents, total_amount, status"
+      )
+      .eq("site_id", b.site_id)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    // Statistiques sur les lignes de l'appel de fonds qui concernent les
+    // copropriétaires (l'utilisateur peut avoir des lignes via ses lots,
+    // mais le mapping fin building_units → copro_lots n'est pas encore en
+    // place — on retourne les totaux globaux du site pour info).
+    let userOwedCents: number | null = null;
+    if (latestFundCall) {
+      const { data: lines } = await serviceClient
+        .from("copro_fund_call_lines")
+        .select("amount_cents, paid_cents, lot_id")
+        .eq("call_id", (latestFundCall as { id: string }).id);
+      if (lines && lines.length > 0) {
+        userOwedCents = (lines as Array<{ amount_cents: number; paid_cents: number }>).reduce(
+          (sum, l) => sum + Math.max(0, (l.amount_cents ?? 0) - (l.paid_cents ?? 0)),
+          0
+        );
+      }
+    }
+
+    // Derniers PV de copro (3 plus récents)
+    const { data: minutes } = await serviceClient
+      .from("copro_minutes")
+      .select(
+        "id, version, status, signed_by_president_at, distributed_at, assembly_id, assembly:copro_assemblies(title, scheduled_at)"
+      )
+      .order("distributed_at", { ascending: false, nullsFirst: false })
+      .limit(3);
+
+    return NextResponse.json({
+      linked: true,
+      site_id: b.site_id,
+      next_assembly: nextAssembly ?? null,
+      latest_fund_call: latestFundCall
+        ? {
+            ...(latestFundCall as Record<string, unknown>),
+            user_owed_cents: userOwedCents,
+          }
+        : null,
+      recent_documents: minutes ?? [],
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/buildings/[id]/syndic-summary/route.ts
+++ b/app/api/buildings/[id]/syndic-summary/route.ts
@@ -88,19 +88,37 @@ export async function GET(request: Request, { params }: RouteParams) {
       .limit(1)
       .maybeSingle();
 
-    // Statistiques sur les lignes de l'appel de fonds qui concernent les
-    // copropriétaires (l'utilisateur peut avoir des lignes via ses lots,
-    // mais le mapping fin building_units → copro_lots n'est pas encore en
-    // place — on retourne les totaux globaux du site pour info).
+    // Calcul du solde exact :
+    //   - on récupère les copro_lot_id mappés sur les building_units du building
+    //   - on filtre les lignes du fund call sur ces lot_id
+    //   - si aucun mapping, on retourne null (solde non calculable précisément)
     let userOwedCents: number | null = null;
+    let mappingUsed = false;
     if (latestFundCall) {
-      const { data: lines } = await serviceClient
-        .from("copro_fund_call_lines")
-        .select("amount_cents, paid_cents, lot_id")
-        .eq("call_id", (latestFundCall as { id: string }).id);
-      if (lines && lines.length > 0) {
-        userOwedCents = (lines as Array<{ amount_cents: number; paid_cents: number }>).reduce(
-          (sum, l) => sum + Math.max(0, (l.amount_cents ?? 0) - (l.paid_cents ?? 0)),
+      const { data: mappedUnits } = await serviceClient
+        .from("building_units")
+        .select("copro_lot_id")
+        .eq("building_id", buildingId)
+        .not("copro_lot_id", "is", null);
+      const mappedLotIds = (mappedUnits ?? [])
+        .map((u) => (u as { copro_lot_id: string | null }).copro_lot_id)
+        .filter((v): v is string => v !== null);
+
+      if (mappedLotIds.length > 0) {
+        mappingUsed = true;
+        const { data: lines } = await serviceClient
+          .from("copro_fund_call_lines")
+          .select("amount_cents, paid_cents, lot_id")
+          .eq("call_id", (latestFundCall as { id: string }).id)
+          .in("lot_id", mappedLotIds);
+        userOwedCents = (lines ?? []).reduce(
+          (sum, l) =>
+            sum +
+            Math.max(
+              0,
+              ((l as { amount_cents: number }).amount_cents ?? 0) -
+                ((l as { paid_cents: number }).paid_cents ?? 0)
+            ),
           0
         );
       }
@@ -123,6 +141,7 @@ export async function GET(request: Request, { params }: RouteParams) {
         ? {
             ...(latestFundCall as Record<string, unknown>),
             user_owed_cents: userOwedCents,
+            mapping_used: mappingUsed,
           }
         : null,
       recent_documents: minutes ?? [],

--- a/app/api/buildings/[id]/unlink-site/route.ts
+++ b/app/api/buildings/[id]/unlink-site/route.ts
@@ -1,0 +1,98 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/buildings/[id]/unlink-site
+ *
+ * Annule le lien entre un building et un site syndic. Possible :
+ * - par l'owner si statut pending (annulation de sa demande)
+ * - par l'owner ou le syndic si statut linked (rupture du lien)
+ *
+ * Note : ne supprime pas user_site_roles existants — à faire manuellement
+ * côté syndic si besoin (l'owner reste copropriétaire si invité indépendamment).
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id: buildingId } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: profile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil introuvable" }, { status: 404 });
+    }
+    const profileId = (profile as { id: string }).id;
+    const role = (profile as { role: string }).role;
+
+    const { data: building } = await serviceClient
+      .from("buildings")
+      .select("id, owner_id, site_id, site_link_status")
+      .eq("id", buildingId)
+      .maybeSingle();
+    if (!building) {
+      return NextResponse.json({ error: "Immeuble introuvable" }, { status: 404 });
+    }
+
+    const isOwner = (building as { owner_id: string }).owner_id === profileId;
+    const siteId = (building as { site_id: string | null }).site_id;
+    let isSyndicOfSite = false;
+    if (siteId) {
+      const { data: site } = await serviceClient
+        .from("sites")
+        .select("syndic_profile_id")
+        .eq("id", siteId)
+        .maybeSingle();
+      isSyndicOfSite = (site as { syndic_profile_id: string } | null)?.syndic_profile_id === profileId;
+    }
+
+    if (!isOwner && !isSyndicOfSite && role !== "admin" && role !== "platform_admin") {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    // Annule le pending ou rompt le linked
+    await serviceClient
+      .from("building_site_links")
+      .update({
+        status: "cancelled",
+        decided_by_profile_id: profileId,
+        decided_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("building_id", buildingId)
+      .in("status", ["pending"]);
+
+    await serviceClient
+      .from("buildings")
+      .update({
+        site_id: null,
+        site_link_status: "unlinked",
+        site_linked_at: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", buildingId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/councils/route.ts
+++ b/app/api/copro/councils/route.ts
@@ -23,7 +23,9 @@ export async function GET(request: NextRequest) {
   try {
     let query = auth.serviceClient
       .from("copro_councils")
-      .select("*")
+      .select(
+        "*, president:profiles!copro_councils_president_profile_id_fkey(id, prenom, nom), vice_president:profiles!copro_councils_vice_president_profile_id_fkey(id, prenom, nom)"
+      )
       .order("mandate_start", { ascending: false });
 
     if (siteId) {

--- a/app/api/copro/fonds-travaux/movements/route.ts
+++ b/app/api/copro/fonds-travaux/movements/route.ts
@@ -1,0 +1,116 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET  /api/copro/fonds-travaux/movements?site_id=...   Liste les mouvements
+ * POST /api/copro/fonds-travaux/movements                Crée un mouvement
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+const MovementSchema = z.object({
+  site_id: z.string().uuid(),
+  fonds_id: z.string().uuid().optional(),
+  movement_type: z.enum(["cotisation", "travaux", "interets", "remboursement", "autre"]),
+  direction: z.enum(["credit", "debit"]),
+  amount_cents: z.number().int().positive(),
+  movement_date: z.string().optional(),
+  description: z.string().max(500).optional(),
+  reference: z.string().max(100).optional(),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const siteId = searchParams.get("site_id");
+    if (!siteId) {
+      return NextResponse.json({ error: "site_id requis" }, { status: 400 });
+    }
+
+    const auth = await requireSyndic(request, { siteId });
+    if (auth instanceof NextResponse) return auth;
+
+    const { data, error } = await auth.serviceClient
+      .from("copro_fonds_travaux_movements")
+      .select("*")
+      .eq("site_id", siteId)
+      .order("movement_date", { ascending: false })
+      .limit(100);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data ?? []);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parse = MovementSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parse.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const input = parse.data;
+    const auth = await requireSyndic(request, { siteId: input.site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    let fondsId = input.fonds_id;
+    if (!fondsId) {
+      const { data: fonds } = await auth.serviceClient
+        .from("copro_fonds_travaux")
+        .select("id")
+        .eq("site_id", input.site_id)
+        .eq("status", "active")
+        .order("fiscal_year", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (!fonds) {
+        return NextResponse.json(
+          { error: "Aucun fonds de travaux actif. Créez-en un d'abord." },
+          { status: 400 }
+        );
+      }
+      fondsId = (fonds as { id: string }).id;
+    }
+
+    const { data: inserted, error: insertError } = await auth.serviceClient
+      .from("copro_fonds_travaux_movements")
+      .insert({
+        fonds_id: fondsId,
+        site_id: input.site_id,
+        movement_type: input.movement_type,
+        direction: input.direction,
+        amount_cents: input.amount_cents,
+        movement_date: input.movement_date ?? new Date().toISOString().split("T")[0],
+        description: input.description ?? null,
+        reference: input.reference ?? null,
+        created_by_profile_id: auth.profile.id,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
+
+    return NextResponse.json(inserted, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/fund-calls/[id]/pdf/route.ts
+++ b/app/api/copro/fund-calls/[id]/pdf/route.ts
@@ -1,0 +1,108 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/copro/fund-calls/[id]/pdf?line_id=...
+ * Retourne le HTML imprimable d'un appel de fonds (pour conversion en PDF côté navigateur).
+ * Si line_id absent, retourne un récapitulatif global de l'appel.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import {
+  generateCallForFundsHtml,
+  type CallForFundsPdfData,
+} from "@/lib/pdf/templates";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: callId } = await params;
+
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { searchParams } = new URL(request.url);
+    const lineId = searchParams.get("line_id");
+
+    const { data: call, error: callError } = await auth.serviceClient
+      .from("copro_fund_calls")
+      .select("id, site_id, call_number, period_label, due_date, total_amount_cents, total_amount, type, description")
+      .eq("id", callId)
+      .maybeSingle();
+
+    if (callError || !call) {
+      return NextResponse.json({ error: "Appel introuvable" }, { status: 404 });
+    }
+
+    const siteCheck = await requireSyndic(request, { siteId: (call as { site_id: string }).site_id });
+    if (siteCheck instanceof NextResponse) return siteCheck;
+
+    const { data: site } = await auth.serviceClient
+      .from("sites")
+      .select("name, address_line1, postal_code, city")
+      .eq("id", (call as { site_id: string }).site_id)
+      .maybeSingle();
+
+    let lineRow: Record<string, unknown> | null = null;
+    if (lineId) {
+      const { data } = await auth.serviceClient
+        .from("copro_fund_call_lines")
+        .select("id, lot_id, owner_name, tantiemes, amount_cents")
+        .eq("id", lineId)
+        .maybeSingle();
+      lineRow = (data as Record<string, unknown>) ?? null;
+    }
+
+    const totalAmount =
+      (call as { total_amount_cents?: number | null; total_amount?: number | null }).total_amount_cents != null
+        ? ((call as { total_amount_cents: number }).total_amount_cents) / 100
+        : (call as { total_amount?: number }).total_amount ?? 0;
+
+    const data: CallForFundsPdfData = {
+      site_name: (site as { name?: string } | null)?.name ?? "Copropriété",
+      site_address: site
+        ? `${(site as { address_line1?: string }).address_line1 ?? ""} ${(site as { postal_code?: string }).postal_code ?? ""} ${(site as { city?: string }).city ?? ""}`.trim()
+        : "",
+      owner: {
+        name: (lineRow?.owner_name as string) ?? "Copropriétaire",
+        address: "",
+      },
+      unit: {
+        lot_number: lineRow ? `Lot ${lineRow.lot_id ?? ""}` : "Tous les lots",
+        description: "",
+        tantiemes: (lineRow?.tantiemes as number) ?? 0,
+        total_tantiemes: 10000,
+      },
+      call_number: (call as { call_number?: string }).call_number ?? `AF-${callId.slice(0, 8)}`,
+      period_label: (call as { period_label?: string }).period_label ?? "",
+      due_date: (call as { due_date?: string }).due_date ?? "",
+      items: [
+        {
+          label: (call as { description?: string }).description ?? "Appel de fonds",
+          amount:
+            lineRow != null
+              ? Math.max(0, ((lineRow.amount_cents as number) ?? 0)) / 100
+              : totalAmount,
+        },
+      ],
+      total_amount:
+        lineRow != null
+          ? Math.max(0, ((lineRow.amount_cents as number) ?? 0)) / 100
+          : totalAmount,
+      generated_at: new Date().toISOString(),
+    };
+
+    const html = generateCallForFundsHtml(data);
+    return new NextResponse(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/fund-calls/[id]/remind/route.ts
+++ b/app/api/copro/fund-calls/[id]/remind/route.ts
@@ -1,0 +1,154 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/copro/fund-calls/[id]/remind
+ * Envoie une relance email pour un appel de fonds non payé
+ * et enregistre la relance dans copro_overdue_notices.
+ *
+ * Body (optionnel) :
+ *   { line_id?: string, recipient_email?: string }
+ *   Si line_id absent : relance toutes les lignes en retard de l'appel.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { sendEmail } from "@/lib/emails/resend.service";
+
+interface FundCallLine {
+  id: string;
+  lot_id: string;
+  owner_name: string | null;
+  amount_cents: number;
+  paid_cents: number;
+  payment_status: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: callId } = await params;
+
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const body = await request.json().catch(() => ({}));
+    const targetLineId: string | undefined = body.line_id;
+    const overrideEmail: string | undefined = body.recipient_email;
+
+    const { data: call, error: callError } = await auth.serviceClient
+      .from("copro_fund_calls")
+      .select("id, site_id, period_label, due_date, total_amount_cents, total_amount, status")
+      .eq("id", callId)
+      .maybeSingle();
+
+    if (callError || !call) {
+      return NextResponse.json({ error: "Appel de fonds introuvable" }, { status: 404 });
+    }
+
+    // Vérification accès au site
+    const siteCheck = await requireSyndic(request, { siteId: (call as { site_id: string }).site_id });
+    if (siteCheck instanceof NextResponse) return siteCheck;
+
+    let linesQuery = auth.serviceClient
+      .from("copro_fund_call_lines")
+      .select("id, lot_id, owner_name, amount_cents, paid_cents, payment_status")
+      .eq("call_id", callId);
+
+    if (targetLineId) {
+      linesQuery = linesQuery.eq("id", targetLineId);
+    } else {
+      linesQuery = linesQuery.in("payment_status", ["pending", "partial", "overdue"]);
+    }
+
+    const { data: lines, error: linesError } = await linesQuery;
+    if (linesError) {
+      return NextResponse.json({ error: linesError.message }, { status: 500 });
+    }
+
+    const overdueLines = (lines ?? []) as unknown as FundCallLine[];
+    if (overdueLines.length === 0) {
+      return NextResponse.json({ sent: 0, message: "Aucune ligne à relancer" });
+    }
+
+    const dueDate = (call as { due_date: string | null }).due_date;
+    const periodLabel = (call as { period_label: string | null }).period_label ?? "—";
+    const daysLate = dueDate
+      ? Math.max(0, Math.floor((Date.now() - new Date(dueDate).getTime()) / (1000 * 60 * 60 * 24)))
+      : 0;
+
+    let sentCount = 0;
+    const noticesToInsert: Array<Record<string, unknown>> = [];
+
+    for (const line of overdueLines) {
+      const remaining = Math.max(0, line.amount_cents - line.paid_cents);
+      if (remaining === 0) continue;
+
+      const recipient = overrideEmail || `lot-${line.lot_id}@example.invalid`;
+      try {
+        if (overrideEmail) {
+          await sendEmail({
+            to: overrideEmail,
+            subject: `Relance — Appel de fonds ${periodLabel}`,
+            html: `<p>Bonjour ${line.owner_name ?? "Madame, Monsieur"},</p>
+                   <p>Nous vous rappelons que l'appel de fonds <strong>${periodLabel}</strong> reste impayé pour un montant de
+                   <strong>${(remaining / 100).toFixed(2)} €</strong>${dueDate ? ` (échéance du ${new Date(dueDate).toLocaleDateString("fr-FR")})` : ""}.</p>
+                   <p>Merci de procéder au règlement dans les meilleurs délais.</p>
+                   <p>Cordialement,<br/>Votre syndic</p>`,
+            text: `Relance amiable — Appel de fonds ${periodLabel} — Montant dû : ${(remaining / 100).toFixed(2)} €`,
+            tags: [{ name: "type", value: "copro_overdue_reminder" }],
+          });
+        }
+        sentCount += 1;
+      } catch (err) {
+        console.error("[fund-calls/remind] email error", err);
+      }
+
+      noticesToInsert.push({
+        site_id: (call as { site_id: string }).site_id,
+        fund_call_id: callId,
+        fund_call_line_id: line.id,
+        lot_id: line.lot_id,
+        notice_type: "reminder",
+        channel: overrideEmail ? "email" : "in_app",
+        recipient_name: line.owner_name,
+        recipient_email: overrideEmail ?? null,
+        amount_due_cents: remaining,
+        days_late: daysLate,
+        message: `Relance amiable pour l'appel ${periodLabel}`,
+        sent_by_user_id: auth.user.id,
+        sent_by_profile_id: auth.profile.id,
+      });
+
+      // Met à jour les compteurs sur la ligne
+      await auth.serviceClient
+        .from("copro_fund_call_lines")
+        .update({
+          last_reminder_at: new Date().toISOString(),
+        })
+        .eq("id", line.id);
+    }
+
+    if (noticesToInsert.length) {
+      const { error: insertError } = await auth.serviceClient
+        .from("copro_overdue_notices")
+        .insert(noticesToInsert);
+      if (insertError) {
+        console.error("[fund-calls/remind] insert error", insertError);
+      }
+    }
+
+    return NextResponse.json({
+      sent: sentCount,
+      logged: noticesToInsert.length,
+    });
+  } catch (error) {
+    console.error("[fund-calls/remind:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/fund-calls/[id]/sepa-xml/route.ts
+++ b/app/api/copro/fund-calls/[id]/sepa-xml/route.ts
@@ -1,0 +1,117 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/copro/fund-calls/[id]/sepa-xml
+ * Génère un fichier SEPA pain.008.001.02 (Direct Debit) pour prélever les
+ * lignes impayées d'un appel de fonds.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: callId } = await params;
+
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { data: call } = await auth.serviceClient
+      .from("copro_fund_calls")
+      .select("id, site_id, call_number, period_label, due_date")
+      .eq("id", callId)
+      .maybeSingle();
+
+    if (!call) {
+      return NextResponse.json({ error: "Appel introuvable" }, { status: 404 });
+    }
+
+    const siteCheck = await requireSyndic(request, { siteId: (call as { site_id: string }).site_id });
+    if (siteCheck instanceof NextResponse) return siteCheck;
+
+    const { data: lines } = await auth.serviceClient
+      .from("copro_fund_call_lines")
+      .select("id, lot_id, owner_name, amount_cents, paid_cents, payment_status")
+      .eq("call_id", callId)
+      .in("payment_status", ["pending", "partial", "overdue"]);
+
+    type DueLine = { id: string; owner_name: string | null; amount_cents: number; paid_cents: number };
+    const dueLines = (lines ?? [])
+      .map((l: unknown) => l as DueLine)
+      .filter((l: DueLine) => l.amount_cents - l.paid_cents > 0);
+
+    const totalCents = dueLines.reduce(
+      (sum: number, l: DueLine) => sum + (l.amount_cents - l.paid_cents),
+      0
+    );
+    const messageId = `TALOK-${callId.slice(0, 8)}-${Date.now()}`;
+    const creationDate = new Date().toISOString();
+    const dueDate = (call as { due_date?: string }).due_date ?? new Date().toISOString().split("T")[0];
+
+    const txns = dueLines
+      .map((line: DueLine, idx: number) => {
+        const amount = ((line.amount_cents - line.paid_cents) / 100).toFixed(2);
+        const endToEndId = `${messageId}-${idx + 1}`.slice(0, 35);
+        return `      <DrctDbtTxInf>
+        <PmtId><EndToEndId>${escapeXml(endToEndId)}</EndToEndId></PmtId>
+        <InstdAmt Ccy="EUR">${amount}</InstdAmt>
+        <DrctDbtTx><MndtRltdInf><MndtId>MNDT-${escapeXml(line.id.slice(0, 8))}</MndtId><DtOfSgntr>${dueDate}</DtOfSgntr></MndtRltdInf></DrctDbtTx>
+        <DbtrAgt><FinInstnId><BIC>NOTPROVIDED</BIC></FinInstnId></DbtrAgt>
+        <Dbtr><Nm>${escapeXml(line.owner_name ?? "Copropriétaire")}</Nm></Dbtr>
+        <DbtrAcct><Id><IBAN>FR0000000000000000000000000</IBAN></Id></DbtrAcct>
+        <RmtInf><Ustrd>Appel ${escapeXml((call as { call_number?: string }).call_number ?? "")} ${escapeXml((call as { period_label?: string }).period_label ?? "")}</Ustrd></RmtInf>
+      </DrctDbtTxInf>`;
+      })
+      .join("\n");
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.02">
+  <CstmrDrctDbtInitn>
+    <GrpHdr>
+      <MsgId>${escapeXml(messageId)}</MsgId>
+      <CreDtTm>${creationDate}</CreDtTm>
+      <NbOfTxs>${dueLines.length}</NbOfTxs>
+      <CtrlSum>${(totalCents / 100).toFixed(2)}</CtrlSum>
+      <InitgPty><Nm>Talok Syndic</Nm></InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>${escapeXml(messageId)}</PmtInfId>
+      <PmtMtd>DD</PmtMtd>
+      <NbOfTxs>${dueLines.length}</NbOfTxs>
+      <CtrlSum>${(totalCents / 100).toFixed(2)}</CtrlSum>
+      <PmtTpInf><SvcLvl><Cd>SEPA</Cd></SvcLvl><LclInstrm><Cd>CORE</Cd></LclInstrm><SeqTp>RCUR</SeqTp></PmtTpInf>
+      <ReqdColltnDt>${dueDate}</ReqdColltnDt>
+      <Cdtr><Nm>Syndic Talok</Nm></Cdtr>
+      <CdtrAcct><Id><IBAN>FR0000000000000000000000000</IBAN></Id></CdtrAcct>
+      <CdtrAgt><FinInstnId><BIC>NOTPROVIDED</BIC></FinInstnId></CdtrAgt>
+${txns}
+    </PmtInf>
+  </CstmrDrctDbtInitn>
+</Document>`;
+
+    return new NextResponse(xml, {
+      headers: {
+        "Content-Type": "application/xml; charset=utf-8",
+        "Content-Disposition": `attachment; filename="sepa-${callId.slice(0, 8)}.xml"`,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/overdue/formal-notice/route.ts
+++ b/app/api/copro/overdue/formal-notice/route.ts
@@ -1,0 +1,110 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/copro/overdue/formal-notice
+ * Envoie une mise en demeure (recommandé numérique) à un copropriétaire en retard.
+ *
+ * Body :
+ *   { site_id: string, lot_id: string, fund_call_id?: string, recipient_email?: string }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { sendEmail } from "@/lib/emails/resend.service";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const { site_id, lot_id, fund_call_id, recipient_email } = body as {
+      site_id?: string;
+      lot_id?: string;
+      fund_call_id?: string;
+      recipient_email?: string;
+    };
+
+    if (!site_id || !lot_id) {
+      return NextResponse.json(
+        { error: "site_id et lot_id requis" },
+        { status: 400 }
+      );
+    }
+
+    const auth = await requireSyndic(request, { siteId: site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    // Récupère les lignes impayées du lot (sur tous les appels ou sur l'appel cible)
+    let linesQuery = auth.serviceClient
+      .from("copro_fund_call_lines")
+      .select("id, call_id, lot_id, owner_name, amount_cents, paid_cents, payment_status")
+      .eq("lot_id", lot_id)
+      .in("payment_status", ["pending", "partial", "overdue"]);
+
+    if (fund_call_id) {
+      linesQuery = linesQuery.eq("call_id", fund_call_id);
+    }
+
+    const { data: lines } = await linesQuery;
+    const remainingCents = (lines ?? []).reduce(
+      (sum: number, l: unknown) =>
+        sum +
+        Math.max(0, ((l as { amount_cents?: number }).amount_cents ?? 0) - ((l as { paid_cents?: number }).paid_cents ?? 0)),
+      0
+    );
+
+    const ownerName = (lines?.[0] as { owner_name?: string } | undefined)?.owner_name ?? "Copropriétaire";
+
+    if (recipient_email) {
+      try {
+        await sendEmail({
+          to: recipient_email,
+          subject: "Mise en demeure de payer — Charges de copropriété",
+          html: `<p>Madame, Monsieur ${ownerName},</p>
+                 <p>Malgré nos précédentes relances, nous constatons que la somme de
+                 <strong>${(remainingCents / 100).toFixed(2)} €</strong> reste due au titre des charges de copropriété.</p>
+                 <p>Nous vous mettons en demeure de procéder au règlement intégral de cette somme dans un délai de
+                 <strong>30 jours</strong> à compter de la réception du présent courrier.</p>
+                 <p>À défaut, nous serons contraints d'engager une procédure judiciaire conformément à l'article 19-2
+                 de la loi du 10 juillet 1965, sans nouvelle relance préalable.</p>
+                 <p>Veuillez agréer, Madame, Monsieur, l'expression de nos salutations distinguées.</p>
+                 <p>Le syndic</p>`,
+          text: `Mise en demeure — Montant dû : ${(remainingCents / 100).toFixed(2)} €`,
+          tags: [{ name: "type", value: "copro_formal_notice" }],
+        });
+      } catch (err) {
+        console.error("[overdue/formal-notice] email error", err);
+      }
+    }
+
+    const { data: inserted, error: insertError } = await auth.serviceClient
+      .from("copro_overdue_notices")
+      .insert({
+        site_id,
+        fund_call_id: fund_call_id ?? null,
+        lot_id,
+        notice_type: "formal_notice",
+        channel: recipient_email ? "email" : "postal",
+        recipient_name: ownerName,
+        recipient_email: recipient_email ?? null,
+        amount_due_cents: remainingCents,
+        days_late: 0,
+        message: "Mise en demeure de payer",
+        sent_by_user_id: auth.user.id,
+        sent_by_profile_id: auth.profile.id,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, notice: inserted });
+  } catch (error) {
+    console.error("[overdue/formal-notice:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/overdue/remind-all/route.ts
+++ b/app/api/copro/overdue/remind-all/route.ts
@@ -1,0 +1,115 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/copro/overdue/remind-all
+ * Relance en masse tous les copropriétaires en retard d'un site.
+ *
+ * Body :
+ *   { site_id: string }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const siteId: string | undefined = body.site_id;
+    if (!siteId) {
+      return NextResponse.json({ error: "site_id requis" }, { status: 400 });
+    }
+
+    const auth = await requireSyndic(request, { siteId });
+    if (auth instanceof NextResponse) return auth;
+
+    // Récupère tous les appels du site
+    const { data: calls } = await auth.serviceClient
+      .from("copro_fund_calls")
+      .select("id, site_id, period_label, due_date")
+      .eq("site_id", siteId);
+
+    const callIds = (calls ?? []).map((c: unknown) => (c as { id: string }).id);
+    if (callIds.length === 0) {
+      return NextResponse.json({ sent: 0, message: "Aucun appel de fonds" });
+    }
+
+    const { data: lines } = await auth.serviceClient
+      .from("copro_fund_call_lines")
+      .select("id, call_id, lot_id, owner_name, amount_cents, paid_cents, payment_status")
+      .in("call_id", callIds)
+      .in("payment_status", ["pending", "partial", "overdue"]);
+
+    const overdueLines = lines ?? [];
+    if (overdueLines.length === 0) {
+      return NextResponse.json({ sent: 0, message: "Aucun impayé à relancer" });
+    }
+
+    const callMap = new Map(
+      (calls ?? []).map((c: unknown) => [(c as { id: string }).id, c])
+    );
+
+    const noticesToInsert = overdueLines
+      .map((line: unknown) => {
+        const l = line as {
+          id: string;
+          call_id: string;
+          lot_id: string;
+          owner_name: string | null;
+          amount_cents: number;
+          paid_cents: number;
+        };
+        const remaining = Math.max(0, l.amount_cents - l.paid_cents);
+        if (remaining === 0) return null;
+        const call = callMap.get(l.call_id) as { due_date: string | null; period_label: string | null } | undefined;
+        const daysLate = call?.due_date
+          ? Math.max(0, Math.floor((Date.now() - new Date(call.due_date).getTime()) / (1000 * 60 * 60 * 24)))
+          : 0;
+        return {
+          site_id: siteId,
+          fund_call_id: l.call_id,
+          fund_call_line_id: l.id,
+          lot_id: l.lot_id,
+          notice_type: "reminder",
+          channel: "in_app",
+          recipient_name: l.owner_name,
+          amount_due_cents: remaining,
+          days_late: daysLate,
+          message: `Relance groupée pour l'appel ${call?.period_label ?? ""}`,
+          sent_by_user_id: auth.user.id,
+          sent_by_profile_id: auth.profile.id,
+        };
+      })
+      .filter((n: unknown): n is NonNullable<typeof n> => n !== null);
+
+    if (noticesToInsert.length) {
+      const { error: insertError } = await auth.serviceClient
+        .from("copro_overdue_notices")
+        .insert(noticesToInsert);
+      if (insertError) {
+        return NextResponse.json({ error: insertError.message }, { status: 500 });
+      }
+
+      // Met à jour les last_reminder_at
+      const lineIds = noticesToInsert.map((n: { fund_call_line_id: string }) => n.fund_call_line_id);
+      await auth.serviceClient
+        .from("copro_fund_call_lines")
+        .update({ last_reminder_at: new Date().toISOString() })
+        .in("id", lineIds);
+    }
+
+    return NextResponse.json({
+      sent: noticesToInsert.length,
+      total_amount_cents: noticesToInsert.reduce(
+        (sum: number, n: { amount_due_cents: number }) => sum + n.amount_due_cents,
+        0
+      ),
+    });
+  } catch (error) {
+    console.error("[overdue/remind-all:POST]", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/suppliers/[id]/contracts/route.ts
+++ b/app/api/copro/suppliers/[id]/contracts/route.ts
@@ -1,0 +1,106 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+const ContractSchema = z.object({
+  site_id: z.string().uuid(),
+  contract_number: z.string().max(100).nullable().optional(),
+  title: z.string().min(1).max(255),
+  category: z
+    .enum([
+      "entretien",
+      "ascenseur",
+      "chauffage",
+      "plomberie",
+      "electricite",
+      "espaces_verts",
+      "nettoyage",
+      "gardiennage",
+      "securite",
+      "assurance_immeuble",
+      "expert_comptable",
+      "avocat",
+      "autre",
+    ])
+    .default("entretien"),
+  start_date: z.string(),
+  end_date: z.string().nullable().optional(),
+  duration_months: z.number().int().min(1).max(120).nullable().optional(),
+  tacit_renewal: z.boolean().default(false),
+  notice_period_months: z.number().int().min(0).max(12).default(3),
+  payment_frequency: z.enum(["monthly", "quarterly", "annual", "on_demand"]).default("monthly"),
+  amount_cents: z.number().int().nonnegative().nullable().optional(),
+  vat_rate_pct: z.number().min(0).max(100).nullable().optional(),
+  contract_pdf_url: z.string().url().nullable().optional(),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: supplierId } = await params;
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { data, error } = await auth.serviceClient
+      .from("copro_supplier_contracts")
+      .select("*")
+      .eq("supplier_id", supplierId)
+      .order("start_date", { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: supplierId } = await params;
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parse = ContractSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parse.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const auth = await requireSyndic(request, { siteId: parse.data.site_id });
+    if (auth instanceof NextResponse) return auth;
+
+    const { data, error } = await auth.serviceClient
+      .from("copro_supplier_contracts")
+      .insert({
+        supplier_id: supplierId,
+        ...parse.data,
+        status: "active",
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/suppliers/[id]/route.ts
+++ b/app/api/copro/suppliers/[id]/route.ts
@@ -1,0 +1,137 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+const PatchSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  category: z.string().optional(),
+  contact_name: z.string().nullable().optional(),
+  contact_email: z.string().email().nullable().optional(),
+  contact_phone: z.string().nullable().optional(),
+  address_line1: z.string().nullable().optional(),
+  postal_code: z.string().nullable().optional(),
+  city: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+  rating: z.number().int().min(1).max(5).nullable().optional(),
+  status: z.enum(["active", "archived"]).optional(),
+});
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { data, error } = await auth.serviceClient
+      .from("copro_suppliers")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+    if (error || !data) {
+      return NextResponse.json({ error: "Fournisseur introuvable" }, { status: 404 });
+    }
+    if (!auth.isAdmin && (data as { syndic_profile_id: string }).syndic_profile_id !== auth.profile.id) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const body = await request.json().catch(() => ({}));
+    const parse = PatchSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parse.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { data: current } = await auth.serviceClient
+      .from("copro_suppliers")
+      .select("syndic_profile_id")
+      .eq("id", id)
+      .maybeSingle();
+    if (!current) {
+      return NextResponse.json({ error: "Fournisseur introuvable" }, { status: 404 });
+    }
+    if (!auth.isAdmin && (current as { syndic_profile_id: string }).syndic_profile_id !== auth.profile.id) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const { data, error } = await auth.serviceClient
+      .from("copro_suppliers")
+      .update({ ...parse.data, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { data: current } = await auth.serviceClient
+      .from("copro_suppliers")
+      .select("syndic_profile_id")
+      .eq("id", id)
+      .maybeSingle();
+    if (!current) {
+      return NextResponse.json({ error: "Fournisseur introuvable" }, { status: 404 });
+    }
+    if (!auth.isAdmin && (current as { syndic_profile_id: string }).syndic_profile_id !== auth.profile.id) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    // Soft archive plutôt que delete pour préserver l'historique des contrats
+    const { error } = await auth.serviceClient
+      .from("copro_suppliers")
+      .update({ status: "archived", updated_at: new Date().toISOString() })
+      .eq("id", id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/copro/suppliers/route.ts
+++ b/app/api/copro/suppliers/route.ts
@@ -1,0 +1,118 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * /api/copro/suppliers
+ * GET  — liste les fournisseurs du syndic connecté
+ * POST — crée un fournisseur
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+const SUPPLIER_CATEGORIES = [
+  "entretien",
+  "ascenseur",
+  "chauffage",
+  "plomberie",
+  "electricite",
+  "espaces_verts",
+  "nettoyage",
+  "gardiennage",
+  "securite",
+  "assurance",
+  "expert_comptable",
+  "avocat",
+  "architecte",
+  "travaux_batiment",
+  "autre",
+] as const;
+
+const SupplierSchema = z.object({
+  name: z.string().min(1).max(255),
+  legal_form: z.string().max(50).nullable().optional(),
+  siret: z.string().regex(/^\d{14}$/).nullable().optional(),
+  vat_number: z.string().max(30).nullable().optional(),
+  category: z.enum(SUPPLIER_CATEGORIES).default("autre"),
+  contact_name: z.string().max(255).nullable().optional(),
+  contact_email: z.string().email().nullable().optional(),
+  contact_phone: z.string().max(30).nullable().optional(),
+  address_line1: z.string().max(500).nullable().optional(),
+  postal_code: z.string().max(10).nullable().optional(),
+  city: z.string().max(100).nullable().optional(),
+  country: z.string().length(2).default("FR"),
+  notes: z.string().max(2000).nullable().optional(),
+  rating: z.number().int().min(1).max(5).nullable().optional(),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status") ?? "active";
+    const category = searchParams.get("category");
+
+    let query = auth.serviceClient
+      .from("copro_suppliers")
+      .select("*")
+      .eq("status", status)
+      .order("name", { ascending: true });
+
+    if (!auth.isAdmin) {
+      query = query.eq("syndic_profile_id", auth.profile.id);
+    }
+    if (category) {
+      query = query.eq("category", category);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const body = await request.json().catch(() => ({}));
+    const parse = SupplierSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parse.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await auth.serviceClient
+      .from("copro_suppliers")
+      .insert({
+        ...parse.data,
+        syndic_profile_id: auth.profile.id,
+        status: "active",
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/syndic-invite/[token]/route.ts
+++ b/app/api/syndic-invite/[token]/route.ts
@@ -1,0 +1,193 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/syndic-invite/[token]
+ * Endpoint public (pas d'auth requise) qui retourne les infos pré-remplies
+ * de l'invitation à partir du token. Utilisé par /auth/syndic-invite/[token].
+ *
+ * POST /api/syndic-invite/[token]
+ * Endpoint authentifié appelé après l'inscription du syndic. Crée le site,
+ * rattache le building, et marque l'invitation comme redeemed.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/helpers/auth-helper";
+import { getServiceClient } from "@/lib/supabase/service-client";
+
+interface RouteParams {
+  params: Promise<{ token: string }>;
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const { token } = await params;
+    if (!token || token.length < 16) {
+      return NextResponse.json({ error: "Token invalide" }, { status: 400 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: invitation } = await serviceClient
+      .from("syndic_invitations_public")
+      .select(
+        "id, status, expires_at, suggested_syndic_name, suggested_syndic_email, suggested_syndic_phone, suggested_copro_name, message, building:buildings(name, adresse_complete, code_postal, ville, total_lots_in_building), invited_by:profiles!syndic_invitations_public_invited_by_profile_id_fkey(prenom, nom)"
+      )
+      .eq("token", token)
+      .maybeSingle();
+
+    if (!invitation) {
+      return NextResponse.json({ error: "Invitation introuvable" }, { status: 404 });
+    }
+    const inv = invitation as {
+      status: string;
+      expires_at: string;
+      suggested_syndic_email: string;
+    };
+
+    if (inv.status !== "pending") {
+      return NextResponse.json(
+        { error: "Cette invitation a déjà été utilisée ou annulée." },
+        { status: 410 }
+      );
+    }
+    if (new Date(inv.expires_at) < new Date()) {
+      return NextResponse.json({ error: "Cette invitation a expiré." }, { status: 410 });
+    }
+
+    return NextResponse.json(invitation);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { token } = await params;
+    const { user, error: authError } = await getAuthenticatedUser(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const serviceClient = getServiceClient();
+
+    const { data: invitation } = await serviceClient
+      .from("syndic_invitations_public")
+      .select(
+        "id, status, expires_at, building_id, suggested_copro_name, building:buildings(name, adresse_complete, code_postal, ville, total_lots_in_building)"
+      )
+      .eq("token", token)
+      .maybeSingle();
+
+    if (!invitation) {
+      return NextResponse.json({ error: "Invitation introuvable" }, { status: 404 });
+    }
+    const inv = invitation as {
+      id: string;
+      status: string;
+      expires_at: string;
+      building_id: string;
+      suggested_copro_name: string | null;
+      building: {
+        name: string | null;
+        adresse_complete: string | null;
+        code_postal: string | null;
+        ville: string | null;
+        total_lots_in_building: number | null;
+      };
+    };
+
+    if (inv.status !== "pending") {
+      return NextResponse.json(
+        { error: "Invitation déjà utilisée ou annulée." },
+        { status: 410 }
+      );
+    }
+    if (new Date(inv.expires_at) < new Date()) {
+      return NextResponse.json({ error: "Invitation expirée." }, { status: 410 });
+    }
+
+    // Récupère le profile du syndic fraîchement inscrit
+    const { data: syndicProfile } = await serviceClient
+      .from("profiles")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!syndicProfile) {
+      return NextResponse.json(
+        { error: "Inscrivez-vous d'abord sur Talok puis revenez sur ce lien." },
+        { status: 400 }
+      );
+    }
+    const syndicProfileId = (syndicProfile as { id: string }).id;
+
+    // Promote vers syndic si encore owner
+    await serviceClient
+      .from("profiles")
+      .update({ role: "syndic" })
+      .eq("id", syndicProfileId)
+      .eq("role", "owner");
+
+    // Crée le site avec le syndic comme gestionnaire
+    const { data: site, error: siteError } = await serviceClient
+      .from("sites")
+      .insert({
+        name:
+          inv.suggested_copro_name ??
+          inv.building.name ??
+          inv.building.adresse_complete ??
+          "Copropriété",
+        address_line1: inv.building.adresse_complete ?? "",
+        postal_code: inv.building.code_postal ?? "",
+        city: inv.building.ville ?? "",
+        syndic_profile_id: syndicProfileId,
+        is_active: true,
+        type: "copropriete",
+        total_tantiemes_general: 10000,
+      })
+      .select("id")
+      .single();
+
+    if (siteError || !site) {
+      return NextResponse.json(
+        { error: siteError?.message ?? "Erreur lors de la création du site" },
+        { status: 500 }
+      );
+    }
+    const siteId = (site as { id: string }).id;
+
+    // Crée la liaison building ↔ site (auto-approuvée car invitation explicite)
+    await serviceClient.from("building_site_links").insert({
+      building_id: inv.building_id,
+      site_id: siteId,
+      status: "approved",
+      claimed_by_profile_id: syndicProfileId,
+      decided_by_profile_id: syndicProfileId,
+      decided_at: new Date().toISOString(),
+      claim_message: "Rattachement automatique via invitation publique d'un copropriétaire.",
+      decision_reason: "auto-approuvé (invitation publique)",
+    });
+
+    // Marque l'invitation comme redeemed
+    await serviceClient
+      .from("syndic_invitations_public")
+      .update({
+        status: "redeemed",
+        redeemed_at: new Date().toISOString(),
+        redeemed_by_user_id: user.id,
+        resulting_site_id: siteId,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", inv.id);
+
+    return NextResponse.json({ success: true, site_id: siteId });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/syndic/dashboard/route.ts
+++ b/app/api/syndic/dashboard/route.ts
@@ -1,52 +1,188 @@
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 /**
- * API Route pour le dashboard syndic
  * GET /api/syndic/dashboard
+ * - sans ?site_id : retourne le récapitulatif global (RPC syndic_dashboard)
+ * - avec ?site_id : retourne la shape SyndicDashboardData consommée par
+ *   useSyndicDashboard (KPIs, budget vs réalisé, prochain appel, impayés,
+ *   fonds travaux) construite à partir des tables copro_*
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 
-export async function GET() {
+interface FundCallLineRow {
+  id: string;
+  call_id: string;
+  lot_id: string;
+  owner_name: string | null;
+  amount_cents: number;
+  paid_cents: number;
+  payment_status: string;
+}
+
+interface FundCallRow {
+  id: string;
+  site_id: string;
+  period_label: string | null;
+  due_date: string | null;
+  total_amount_cents: number | null;
+  total_amount: number | null;
+  status: string | null;
+  created_at: string;
+}
+
+export async function GET(request: NextRequest) {
   try {
     const supabase = await createRouteHandlerClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
 
     if (authError || !user) {
       return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
     }
 
-    // Appeler la fonction RPC
-    const { data, error } = await supabase.rpc("syndic_dashboard", {
-      p_user_id: user.id,
+    const siteId = new URL(request.url).searchParams.get("site_id");
+
+    if (!siteId) {
+      const { data, error } = await supabase.rpc("syndic_dashboard", {
+        p_user_id: user.id,
+      });
+      if (error) {
+        return NextResponse.json(
+          { error: error.message ?? "Erreur RPC" },
+          { status: 500 }
+        );
+      }
+      return NextResponse.json(data ?? {});
+    }
+
+    // Mode site_id : agrège les données pour la shape SyndicDashboardData.
+    // RLS garantit qu'on ne lit que les sites accessibles à l'utilisateur.
+
+    const [budgetsRes, fundCallsRes, fondsTravauxRes] = await Promise.all([
+      supabase
+        .from("copro_budgets")
+        .select("id, fiscal_year, total_budget_cents, status")
+        .eq("site_id", siteId)
+        .order("fiscal_year", { ascending: false })
+        .limit(1),
+      supabase
+        .from("copro_fund_calls")
+        .select("id, site_id, period_label, due_date, total_amount_cents, total_amount, status, created_at")
+        .eq("site_id", siteId)
+        .order("due_date", { ascending: true, nullsFirst: false })
+        .limit(20),
+      supabase
+        .from("copro_fonds_travaux")
+        .select(
+          "solde_actuel_cents, cotisation_taux_percent, total_collected_cents, total_spent_cents"
+        )
+        .eq("site_id", siteId)
+        .eq("status", "active")
+        .order("fiscal_year", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+    const fundCalls = (fundCallsRes.data ?? []) as unknown as FundCallRow[];
+    const callIds = fundCalls.map((c) => c.id);
+
+    const linesRes = callIds.length
+      ? await supabase
+          .from("copro_fund_call_lines")
+          .select("id, call_id, lot_id, owner_name, amount_cents, paid_cents, payment_status")
+          .in("call_id", callIds)
+      : { data: [] as FundCallLineRow[] };
+
+    const lines = (linesRes.data ?? []) as unknown as FundCallLineRow[];
+
+    // KPIs
+    const lastBudgetCents = budgetsRes.data?.[0]?.total_budget_cents ?? 0;
+    const totalCalled = fundCalls.reduce(
+      (sum, c) => sum + (c.total_amount_cents ?? Math.round((c.total_amount ?? 0) * 100)),
+      0
+    );
+    const totalPaid = lines.reduce((sum, l) => sum + (l.paid_cents ?? 0), 0);
+    const totalDue = lines.reduce((sum, l) => sum + (l.amount_cents ?? 0), 0);
+    const impayesCents = Math.max(0, totalDue - totalPaid);
+    const overdueLines = lines.filter(
+      (l) => l.payment_status === "overdue" || l.payment_status === "partial" || (l.paid_cents ?? 0) < (l.amount_cents ?? 0)
+    );
+
+    const kpis = {
+      budget_execution_pct: lastBudgetCents > 0 ? Math.min(100, Math.round((totalCalled / lastBudgetCents) * 100)) : 0,
+      tresorerie_cents: Math.max(0, totalPaid),
+      taux_recouvrement_pct: totalDue > 0 ? Math.round((totalPaid / totalDue) * 100) : 100,
+      impayes_cents: impayesCents,
+      impayes_count: overdueLines.length,
+    };
+
+    // Prochain appel : premier non-payé futur, sinon le plus récent
+    const today = new Date().toISOString().split("T")[0];
+    const upcoming = fundCalls.find((c) => c.due_date && c.due_date >= today);
+    const nextFundCall = upcoming
+      ? {
+          id: upcoming.id,
+          period_label: upcoming.period_label ?? "—",
+          due_date: upcoming.due_date ?? "",
+          total_cents: upcoming.total_amount_cents ?? Math.round((upcoming.total_amount ?? 0) * 100),
+          is_sent: upcoming.status === "sent" || upcoming.status === "paid" || upcoming.status === "partial",
+        }
+      : null;
+
+    // Budget vs Réalisé : agrège par poste — placeholder vide tant que la table copro_expense_categories n'est pas branchée
+    const budgetVsRealise: Array<{ poste: string; budget_cents: number; realise_cents: number }> = [];
+
+    // Impayés détaillés (top 10)
+    const overdueByLot = new Map<string, { lot_id: string; owner_name: string; amount_cents: number; days_late: number }>();
+    for (const line of overdueLines) {
+      const call = fundCalls.find((c) => c.id === line.call_id);
+      const dueDate = call?.due_date;
+      const daysLate = dueDate
+        ? Math.max(0, Math.floor((Date.now() - new Date(dueDate).getTime()) / (1000 * 60 * 60 * 24)))
+        : 0;
+      const remaining = Math.max(0, (line.amount_cents ?? 0) - (line.paid_cents ?? 0));
+      const existing = overdueByLot.get(line.lot_id);
+      overdueByLot.set(line.lot_id, {
+        lot_id: line.lot_id,
+        owner_name: line.owner_name ?? existing?.owner_name ?? "Copropriétaire",
+        amount_cents: (existing?.amount_cents ?? 0) + remaining,
+        days_late: Math.max(existing?.days_late ?? 0, daysLate),
+      });
+    }
+    const overdueCopros = Array.from(overdueByLot.values())
+      .sort((a, b) => b.amount_cents - a.amount_cents)
+      .slice(0, 10)
+      .map((e) => ({
+        lot_id: e.lot_id,
+        lot_number: "", // résolu côté UI si besoin
+        owner_name: e.owner_name,
+        amount_cents: e.amount_cents,
+        days_late: e.days_late,
+      }));
+
+    const fonds = fondsTravauxRes.data;
+    const worksFund = {
+      balance_cents: fonds?.solde_actuel_cents ?? 0,
+      rate_pct: Number(fonds?.cotisation_taux_percent ?? 0),
+      evolution_cents: (fonds?.total_collected_cents ?? 0) - (fonds?.total_spent_cents ?? 0),
+    };
+
+    return NextResponse.json({
+      kpis,
+      budget_vs_realise: budgetVsRealise,
+      next_fund_call: nextFundCall,
+      overdue_copros: overdueCopros,
+      works_fund: worksFund,
     });
-
-    if (error) {
-      console.error("Erreur dashboard syndic:", error);
-      return NextResponse.json({ error: error instanceof Error ? error.message : "Une erreur est survenue" }, { status: 500 });
-    }
-
-    if (!data) {
-      return NextResponse.json(
-        { error: "Aucune copropriété trouvée" },
-        { status: 404 }
-      );
-    }
-
-    return NextResponse.json(data);
   } catch (error: unknown) {
-    console.error("Erreur API syndic dashboard:", error);
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Erreur serveur" },
       { status: 500 }
     );
   }
 }
-
-
-
-
-
-
-

--- a/app/api/syndic/site-claims/[claimId]/route.ts
+++ b/app/api/syndic/site-claims/[claimId]/route.ts
@@ -13,6 +13,7 @@ export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireSyndic } from "@/lib/helpers/syndic-auth";
+import { sendEmail } from "@/lib/emails/resend.service";
 
 const DecisionSchema = z.object({
   decision: z.enum(["approve", "reject"]),
@@ -85,6 +86,72 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
+    // Notifie le copropriétaire par email
+    try {
+      const { data: claimFull } = await auth.serviceClient
+        .from("building_site_links")
+        .select(
+          "claimed_by_profile_id, building:buildings(name, adresse_complete), site:sites(name)"
+        )
+        .eq("id", claimId)
+        .maybeSingle();
+
+      const ownerProfileId = (claimFull as { claimed_by_profile_id: string } | null)
+        ?.claimed_by_profile_id;
+      const buildingName =
+        (claimFull as { building: { name: string | null; adresse_complete: string | null } } | null)
+          ?.building?.name ??
+        (claimFull as { building: { adresse_complete: string | null } } | null)?.building
+          ?.adresse_complete ??
+        "votre immeuble";
+      const siteName =
+        (claimFull as { site: { name: string } } | null)?.site?.name ?? "la copropriété";
+
+      let ownerEmail: string | undefined;
+      if (ownerProfileId) {
+        const { data: ownerProfile } = await auth.serviceClient
+          .from("profiles")
+          .select("user_id")
+          .eq("id", ownerProfileId)
+          .maybeSingle();
+        const ownerUserId = (ownerProfile as { user_id: string } | null)?.user_id;
+        if (ownerUserId) {
+          const { data: ownerAuth } = await auth.serviceClient.auth.admin.getUserById(ownerUserId);
+          ownerEmail = ownerAuth?.user?.email ?? undefined;
+        }
+      }
+
+      if (ownerEmail) {
+        if (parse.data.decision === "approve") {
+          await sendEmail({
+            to: ownerEmail,
+            subject: `Rattachement validé — ${siteName}`,
+            html: `<p>Bonne nouvelle !</p>
+<p>Votre demande de rattachement de <strong>${buildingName}</strong> à la copropriété <strong>${siteName}</strong> a été validée par le syndic.</p>
+<p>Vous accédez désormais en lecture seule aux assemblées générales, appels de fonds et procès-verbaux depuis votre espace : <a href="https://talok.fr/owner/properties?tab=immeubles">votre fiche immeuble</a>.</p>
+<p>Cordialement,<br/>L'équipe Talok</p>`,
+            text: `Votre demande de rattachement de ${buildingName} à ${siteName} a été validée. Voir https://talok.fr/owner/properties?tab=immeubles`,
+            tags: [{ name: "type", value: "building_site_claim_approved" }],
+          });
+        } else {
+          await sendEmail({
+            to: ownerEmail,
+            subject: `Demande de rattachement refusée — ${siteName}`,
+            html: `<p>Bonjour,</p>
+<p>Votre demande de rattachement de <strong>${buildingName}</strong> à la copropriété <strong>${siteName}</strong> a été refusée par le syndic.</p>
+${parse.data.reason ? `<p><strong>Motif :</strong> ${parse.data.reason}</p>` : ""}
+<p>Vous pouvez renvoyer une nouvelle demande depuis la fiche de votre immeuble.</p>
+<p>Cordialement,<br/>L'équipe Talok</p>`,
+            text: `Votre demande de rattachement à ${siteName} a été refusée${parse.data.reason ? `. Motif : ${parse.data.reason}` : "."}.`,
+            tags: [{ name: "type", value: "building_site_claim_rejected" }],
+          });
+        }
+      }
+    } catch (emailError) {
+      console.error("[site-claims] notification email failed", emailError);
+    }
+
     return NextResponse.json(updated);
   } catch (error) {
     return NextResponse.json(

--- a/app/api/syndic/site-claims/[claimId]/route.ts
+++ b/app/api/syndic/site-claims/[claimId]/route.ts
@@ -14,6 +14,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireSyndic } from "@/lib/helpers/syndic-auth";
 import { sendEmail } from "@/lib/emails/resend.service";
+import { autoMapCoproLots } from "@/lib/buildings/auto-map-copro-lots";
 
 const DecisionSchema = z.object({
   decision: z.enum(["approve", "reject"]),
@@ -39,7 +40,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Récupérer le claim et vérifier qu'il vise bien un site du syndic
     const { data: claim } = await auth.serviceClient
       .from("building_site_links")
-      .select("id, site_id, status")
+      .select("id, building_id, site_id, status")
       .eq("id", claimId)
       .maybeSingle();
     if (!claim) {
@@ -85,6 +86,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Auto-mapping building_units → copro_lots après approve.
+    // Best effort : si l'auto-map échoue, on log mais le claim reste approved.
+    let autoMapResult: Awaited<ReturnType<typeof autoMapCoproLots>> | null = null;
+    if (parse.data.decision === "approve") {
+      try {
+        const buildingId = (claim as { building_id: string }).building_id;
+        autoMapResult = await autoMapCoproLots(auth.serviceClient, buildingId);
+      } catch (mapError) {
+        console.error("[site-claims] auto-map failed", mapError);
+      }
     }
 
     // Notifie le copropriétaire par email
@@ -152,7 +165,10 @@ ${parse.data.reason ? `<p><strong>Motif :</strong> ${parse.data.reason}</p>` : "
       console.error("[site-claims] notification email failed", emailError);
     }
 
-    return NextResponse.json(updated);
+    return NextResponse.json({
+      ...(updated as Record<string, unknown>),
+      auto_mapping: autoMapResult,
+    });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Erreur serveur" },

--- a/app/api/syndic/site-claims/[claimId]/route.ts
+++ b/app/api/syndic/site-claims/[claimId]/route.ts
@@ -1,0 +1,95 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/syndic/site-claims/[claimId]
+ * Body: { decision: 'approve' | 'reject', reason? }
+ *
+ * Le syndic approuve ou refuse une demande de rattachement.
+ * Le trigger SQL apply_building_site_link met à jour buildings.site_id
+ * et crée user_site_roles automatiquement.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+const DecisionSchema = z.object({
+  decision: z.enum(["approve", "reject"]),
+  reason: z.string().max(500).optional(),
+});
+
+interface RouteParams {
+  params: Promise<{ claimId: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { claimId } = await params;
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const body = await request.json().catch(() => ({}));
+    const parse = DecisionSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json({ error: "Données invalides" }, { status: 400 });
+    }
+
+    // Récupérer le claim et vérifier qu'il vise bien un site du syndic
+    const { data: claim } = await auth.serviceClient
+      .from("building_site_links")
+      .select("id, site_id, status")
+      .eq("id", claimId)
+      .maybeSingle();
+    if (!claim) {
+      return NextResponse.json({ error: "Demande introuvable" }, { status: 404 });
+    }
+    if ((claim as { status: string }).status !== "pending") {
+      return NextResponse.json(
+        { error: "Cette demande a déjà été traitée." },
+        { status: 409 }
+      );
+    }
+
+    // Vérifie que le syndic est bien gestionnaire du site
+    const { data: site } = await auth.serviceClient
+      .from("sites")
+      .select("id, syndic_profile_id")
+      .eq("id", (claim as { site_id: string }).site_id)
+      .maybeSingle();
+    if (!site) {
+      return NextResponse.json({ error: "Copropriété introuvable" }, { status: 404 });
+    }
+    if (
+      !auth.isAdmin &&
+      (site as { syndic_profile_id: string }).syndic_profile_id !== auth.profile.id
+    ) {
+      return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+    }
+
+    const newStatus = parse.data.decision === "approve" ? "approved" : "rejected";
+
+    const { data: updated, error } = await auth.serviceClient
+      .from("building_site_links")
+      .update({
+        status: newStatus,
+        decided_by_profile_id: auth.profile.id,
+        decided_at: new Date().toISOString(),
+        decision_reason: parse.data.reason ?? null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", claimId)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(updated);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/syndic/site-claims/route.ts
+++ b/app/api/syndic/site-claims/route.ts
@@ -1,0 +1,54 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/syndic/site-claims
+ *
+ * Liste toutes les demandes de rattachement (building → site) en attente
+ * adressées aux sites gérés par le syndic connecté.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireSyndic } from "@/lib/helpers/syndic-auth";
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireSyndic(request);
+    if (auth instanceof NextResponse) return auth;
+
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status") ?? "pending";
+
+    let query = auth.serviceClient
+      .from("building_site_links")
+      .select(
+        "*, building:buildings(id, name, adresse_complete, code_postal, ville, ownership_type, total_lots_in_building, owner:profiles!buildings_owner_id_fkey(id, prenom, nom, email_contact)), site:sites(id, name)"
+      )
+      .order("created_at", { ascending: false });
+
+    if (status !== "all") {
+      query = query.eq("status", status);
+    }
+
+    if (!auth.isAdmin) {
+      const { data: mySites } = await auth.serviceClient
+        .from("sites")
+        .select("id")
+        .eq("syndic_profile_id", auth.profile.id);
+      const siteIds = (mySites ?? []).map((s) => (s as { id: string }).id);
+      if (siteIds.length === 0) return NextResponse.json([]);
+      query = query.in("site_id", siteIds);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Erreur serveur" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/auth/syndic-invite/[token]/page.tsx
+++ b/app/auth/syndic-invite/[token]/page.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Building2,
+  CheckCircle2,
+  Mail,
+  Phone,
+  MapPin,
+  User,
+  Sparkles,
+  ArrowRight,
+  Loader2,
+} from "lucide-react";
+
+interface InvitationData {
+  id: string;
+  status: string;
+  expires_at: string;
+  suggested_syndic_name: string | null;
+  suggested_syndic_email: string | null;
+  suggested_syndic_phone: string | null;
+  suggested_copro_name: string | null;
+  message: string | null;
+  building: {
+    name: string | null;
+    adresse_complete: string | null;
+    code_postal: string | null;
+    ville: string | null;
+    total_lots_in_building: number | null;
+  };
+  invited_by: {
+    prenom: string | null;
+    nom: string | null;
+  } | null;
+}
+
+export default function SyndicInvitePage() {
+  const params = useParams();
+  const router = useRouter();
+  const { toast } = useToast();
+  const token = params?.token as string;
+
+  const [invitation, setInvitation] = useState<InvitationData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [claiming, setClaiming] = useState(false);
+  const [authed, setAuthed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(`/api/syndic-invite/${token}`);
+        const data = await res.json();
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(data.error ?? "Invitation invalide");
+        } else {
+          setInvitation(data);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  // Vérifie si l'utilisateur est connecté pour adapter le CTA
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/me/profile")
+      .then((res) => {
+        if (cancelled) return;
+        setAuthed(res.ok);
+      })
+      .catch(() => !cancelled && setAuthed(false));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleAcceptAfterAuth() {
+    setClaiming(true);
+    try {
+      const res = await fetch(`/api/syndic-invite/${token}`, { method: "POST" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Erreur");
+      toast({ title: "Copropriété créée", description: "Vous êtes redirigé vers votre espace." });
+      router.push(`/syndic/sites/${data.site_id}`);
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    } finally {
+      setClaiming(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-cyan-50/30 to-slate-50 p-6">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <Skeleton className="h-16" />
+          <Skeleton className="h-72" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !invitation) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-cyan-50/30 to-slate-50 p-6 flex items-center justify-center">
+        <Card className="max-w-md w-full">
+          <CardContent className="py-10 text-center">
+            <p className="text-foreground font-semibold">Invitation invalide</p>
+            <p className="text-muted-foreground text-sm mt-2">
+              {error ?? "Ce lien d'invitation n'est pas valide ou a expiré."}
+            </p>
+            <Link href="/">
+              <Button variant="outline" className="mt-6">
+                Retour à l'accueil
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const inviterName = invitation.invited_by
+    ? [invitation.invited_by.prenom, invitation.invited_by.nom]
+        .filter(Boolean)
+        .join(" ") || "Un copropriétaire"
+    : "Un copropriétaire";
+
+  const buildingDisplay =
+    invitation.building.name ?? invitation.building.adresse_complete ?? "un immeuble";
+
+  const signupUrl = invitation.suggested_syndic_email
+    ? `/auth/signup?role=syndic&email=${encodeURIComponent(invitation.suggested_syndic_email)}&invite_token=${token}`
+    : `/auth/signup?role=syndic&invite_token=${token}`;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-cyan-50/30 to-slate-50 py-12 px-4">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="text-center">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-600 to-cyan-500 mb-4">
+            <Building2 className="w-8 h-8 text-white" />
+          </div>
+          <h1 className="text-3xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
+            Vous êtes invité sur Talok
+          </h1>
+          <p className="text-muted-foreground mt-2">
+            <strong>{inviterName}</strong> vous propose de gérer sa copropriété sur Talok.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="w-5 h-5 text-violet-600" />
+              La copropriété concernée
+            </CardTitle>
+            <CardDescription>
+              Une fois votre compte créé, cette copropriété sera automatiquement initialisée.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">Immeuble</p>
+                <p className="text-foreground font-medium">{buildingDisplay}</p>
+                {invitation.building.code_postal && invitation.building.ville && (
+                  <p className="text-muted-foreground inline-flex items-center gap-1 text-xs mt-1">
+                    <MapPin className="w-3 h-3" />
+                    {invitation.building.code_postal} {invitation.building.ville}
+                  </p>
+                )}
+              </div>
+              {invitation.building.total_lots_in_building && (
+                <div>
+                  <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                    Nombre de lots
+                  </p>
+                  <p className="text-foreground font-medium">
+                    {invitation.building.total_lots_in_building} lot(s)
+                  </p>
+                </div>
+              )}
+              {invitation.suggested_copro_name && (
+                <div className="sm:col-span-2">
+                  <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                    Nom suggéré
+                  </p>
+                  <p className="text-foreground">{invitation.suggested_copro_name}</p>
+                </div>
+              )}
+            </div>
+
+            {invitation.message && (
+              <div className="rounded-lg bg-muted/40 p-3">
+                <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                  Message du copropriétaire
+                </p>
+                <p className="text-foreground italic">« {invitation.message} »</p>
+              </div>
+            )}
+
+            {(invitation.suggested_syndic_name || invitation.suggested_syndic_email) && (
+              <div className="rounded-lg border border-border p-3 space-y-2">
+                <p className="text-xs uppercase text-muted-foreground tracking-wide">
+                  Coordonnées pré-remplies
+                </p>
+                {invitation.suggested_syndic_name && (
+                  <p className="text-foreground inline-flex items-center gap-2">
+                    <User className="w-3.5 h-3.5 text-muted-foreground" />
+                    {invitation.suggested_syndic_name}
+                  </p>
+                )}
+                {invitation.suggested_syndic_email && (
+                  <p className="text-foreground inline-flex items-center gap-2">
+                    <Mail className="w-3.5 h-3.5 text-muted-foreground" />
+                    {invitation.suggested_syndic_email}
+                  </p>
+                )}
+                {invitation.suggested_syndic_phone && (
+                  <p className="text-foreground inline-flex items-center gap-2">
+                    <Phone className="w-3.5 h-3.5 text-muted-foreground" />
+                    {invitation.suggested_syndic_phone}
+                  </p>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border-cyan-200 bg-cyan-50/40">
+          <CardContent className="p-6 space-y-4">
+            <div className="flex items-start gap-3">
+              <CheckCircle2 className="w-5 h-5 text-cyan-600 mt-0.5 shrink-0" />
+              <div>
+                <p className="font-semibold text-foreground">Avec Talok, vous pourrez :</p>
+                <ul className="text-sm text-muted-foreground space-y-1 mt-2">
+                  <li>• Convoquer et tenir vos AG (vote en ligne par tantièmes, PV PDF auto)</li>
+                  <li>• Émettre les appels de fonds, exporter le SEPA, suivre les impayés</li>
+                  <li>• Tenir une comptabilité copropriété (décret 2005-240) et exporter le FEC</li>
+                  <li>• Gérer mandats, conseils syndicaux, contrats fournisseurs</li>
+                  <li>• Mettre à disposition l'extranet aux copropriétaires</li>
+                </ul>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex flex-col gap-2">
+          {authed ? (
+            <Button
+              size="lg"
+              onClick={handleAcceptAfterAuth}
+              disabled={claiming}
+              className="bg-gradient-to-r from-blue-600 to-cyan-500 hover:from-blue-700 hover:to-cyan-600"
+            >
+              {claiming ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}
+              Initialiser cette copropriété sur mon compte
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </Button>
+          ) : (
+            <>
+              <Link href={signupUrl}>
+                <Button
+                  size="lg"
+                  className="w-full bg-gradient-to-r from-blue-600 to-cyan-500 hover:from-blue-700 hover:to-cyan-600"
+                >
+                  Créer mon compte syndic
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Button>
+              </Link>
+              <Link href={`/auth/signin?redirect=/auth/syndic-invite/${token}`}>
+                <Button size="lg" variant="outline" className="w-full">
+                  J'ai déjà un compte
+                </Button>
+              </Link>
+            </>
+          )}
+          <p className="text-center text-xs text-muted-foreground mt-2">
+            Lien valide jusqu'au{" "}
+            {new Date(invitation.expires_at).toLocaleDateString("fr-FR", {
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            })}
+            .
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/owner/buildings/[id]/BuildingDetailClient.tsx
+++ b/app/owner/buildings/[id]/BuildingDetailClient.tsx
@@ -81,6 +81,7 @@ import { TYPE_TO_LABEL, type DocumentType } from "@/lib/documents/constants";
 import { SmartImageCard } from "@/components/ui/smart-image-card";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { formatCurrency, formatDateShort } from "@/lib/helpers/format";
+import { SyndicLinkBanner } from "@/components/buildings/SyndicLinkBanner";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -127,6 +128,8 @@ interface BuildingDetailClientProps {
   leases?: UnitLease[];
   tenants?: UnitTenant[];
   documents?: BuildingDocument[];
+  linkedSite?: { id: string; name: string } | null;
+  rejectedReason?: string | null;
 }
 
 interface BuildingDocument {
@@ -294,6 +297,8 @@ export function BuildingDetailClient({
   leases = [],
   tenants = [],
   documents: initialDocuments,
+  linkedSite = null,
+  rejectedReason = null,
 }: BuildingDetailClientProps) {
   const { toast } = useToast();
 
@@ -728,6 +733,25 @@ export function BuildingDetailClient({
           Retour aux immeubles
         </Link>
       </Button>
+
+      {/* Bridge owner ↔ syndic — bandeau de statut adapté au mode de possession */}
+      {buildingId && (
+        <div className="mb-6">
+          <SyndicLinkBanner
+            buildingId={buildingId}
+            ownershipType={ownershipType}
+            initialStatus={
+              ((buildingMeta as any)?.site_link_status as
+                | "unlinked"
+                | "pending"
+                | "linked"
+                | "rejected") ?? "unlinked"
+            }
+            linkedSite={linkedSite}
+            rejectedReason={rejectedReason}
+          />
+        </div>
+      )}
 
       {/* Header */}
       <div className="relative h-56 md:h-64 rounded-xl overflow-hidden mb-8 bg-card group">

--- a/app/owner/buildings/[id]/BuildingDetailClient.tsx
+++ b/app/owner/buildings/[id]/BuildingDetailClient.tsx
@@ -82,6 +82,7 @@ import { SmartImageCard } from "@/components/ui/smart-image-card";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { formatCurrency, formatDateShort } from "@/lib/helpers/format";
 import { SyndicLinkBanner } from "@/components/buildings/SyndicLinkBanner";
+import { SyndicSidePanel } from "@/components/buildings/SyndicSidePanel";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -736,7 +737,7 @@ export function BuildingDetailClient({
 
       {/* Bridge owner ↔ syndic — bandeau de statut adapté au mode de possession */}
       {buildingId && (
-        <div className="mb-6">
+        <div className="mb-6 space-y-4">
           <SyndicLinkBanner
             buildingId={buildingId}
             ownershipType={ownershipType}
@@ -750,6 +751,9 @@ export function BuildingDetailClient({
             linkedSite={linkedSite}
             rejectedReason={rejectedReason}
           />
+          {(buildingMeta as any)?.site_link_status === "linked" && (
+            <SyndicSidePanel buildingId={buildingId} />
+          )}
         </div>
       )}
 

--- a/app/owner/buildings/[id]/page.tsx
+++ b/app/owner/buildings/[id]/page.tsx
@@ -314,6 +314,35 @@ export default async function BuildingDetailPage({ params }: PageProps) {
     last_name: string | null;
   }>;
 
+  // Bridge owner ↔ syndic : récupère le site lié + raison du dernier rejet si besoin
+  const buildingMetaAny = buildingMeta as
+    | { id: string; site_id: string | null; site_link_status: string | null }
+    | null;
+  let linkedSite: { id: string; name: string } | null = null;
+  if (buildingMetaAny?.site_id) {
+    const { data: siteRow } = await serviceClient
+      .from("sites")
+      .select("id, name")
+      .eq("id", buildingMetaAny.site_id)
+      .maybeSingle();
+    if (siteRow) {
+      linkedSite = { id: (siteRow as { id: string }).id, name: (siteRow as { name: string }).name };
+    }
+  }
+
+  let rejectedReason: string | null = null;
+  if (buildingMetaAny?.id && buildingMetaAny.site_link_status === "rejected") {
+    const { data: lastClaim } = await serviceClient
+      .from("building_site_links")
+      .select("decision_reason")
+      .eq("building_id", buildingMetaAny.id)
+      .eq("status", "rejected")
+      .order("decided_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    rejectedReason = (lastClaim as { decision_reason: string | null } | null)?.decision_reason ?? null;
+  }
+
   return (
     <BuildingDetailClient
       propertyId={propertyId}
@@ -329,6 +358,8 @@ export default async function BuildingDetailPage({ params }: PageProps) {
       leases={leases}
       tenants={tenants}
       documents={(documentsResult.data as any[]) || []}
+      linkedSite={linkedSite}
+      rejectedReason={rejectedReason}
     />
   );
 }

--- a/app/syndic/accounting/SyndicDashboardClient.tsx
+++ b/app/syndic/accounting/SyndicDashboardClient.tsx
@@ -99,10 +99,10 @@ function SyndicDashboardContent() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
-            Comptabilite Syndic
+            Comptabilité Syndic
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Tableau de bord copropriete
+            Tableau de bord copropriété
           </p>
         </div>
 
@@ -111,7 +111,7 @@ function SyndicDashboardContent() {
           <Select value={activeSiteId} onValueChange={setSelectedSiteId}>
             <SelectTrigger className="w-full sm:w-64">
               <Building2 className="w-4 h-4 mr-2 text-cyan-600" />
-              <SelectValue placeholder="Selectionner une copropriete" />
+              <SelectValue placeholder="Sélectionner une copropriété" />
             </SelectTrigger>
             <SelectContent>
               {sites.map((site) => (
@@ -122,6 +122,37 @@ function SyndicDashboardContent() {
             </SelectContent>
           </Select>
         )}
+      </div>
+
+      {/* Navigation interne comptabilité */}
+      <div className="flex gap-1 sm:gap-2 overflow-x-auto -mx-4 sm:mx-0 px-4 sm:px-0 pb-1">
+        <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300 whitespace-nowrap">
+          Vue générale
+        </span>
+        <Link
+          href="/syndic/accounting/budget"
+          className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted whitespace-nowrap"
+        >
+          Budget
+        </Link>
+        <Link
+          href="/syndic/accounting/entries"
+          className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted whitespace-nowrap"
+        >
+          Journal / Grand-livre
+        </Link>
+        <Link
+          href="/syndic/accounting/appels"
+          className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted whitespace-nowrap"
+        >
+          Appels de fonds
+        </Link>
+        <Link
+          href="/syndic/accounting/close"
+          className="inline-flex items-center px-3 py-1.5 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted whitespace-nowrap"
+        >
+          Clôture / Annexes
+        </Link>
       </div>
 
       {/* KPI Cards */}

--- a/app/syndic/assemblies/[id]/edit/page.tsx
+++ b/app/syndic/assemblies/[id]/edit/page.tsx
@@ -180,17 +180,17 @@ export default function EditAssemblyPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="p-0">
         <div className="max-w-3xl mx-auto space-y-4">
-          <Skeleton className="h-12 w-96 bg-white/10" />
-          <Skeleton className="h-64 bg-white/10" />
+          <Skeleton className="h-12 w-96 bg-muted" />
+          <Skeleton className="h-64 bg-muted" />
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+    <div className="p-0">
       <div className="max-w-3xl mx-auto space-y-6">
         <motion.div
           initial={{ opacity: 0, y: -20 }}
@@ -198,34 +198,34 @@ export default function EditAssemblyPage() {
           className="flex items-center gap-4"
         >
           <Link href={`/syndic/assemblies/${assemblyId}`}>
-            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
+            <Button variant="ghost" size="sm" className="text-foreground hover:text-foreground hover:bg-muted">
               <ArrowLeft className="h-4 w-4 mr-2" />
               Retour
             </Button>
           </Link>
           <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <CalendarIcon className="h-6 w-6 text-violet-400" />
+            <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+              <CalendarIcon className="h-6 w-6 text-violet-600" />
               Modifier l'assemblée
             </h1>
-            <p className="text-slate-400">Statut actuel : {status === "draft" ? "Brouillon" : "Convoquée"}</p>
+            <p className="text-muted-foreground">Statut actuel : {status === "draft" ? "Brouillon" : "Convoquée"}</p>
           </div>
         </motion.div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white">Informations</CardTitle>
+              <CardTitle className="text-foreground">Informations</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label className="text-slate-300">Type *</Label>
+                <Label className="text-foreground">Type *</Label>
                 <Select
                   value={form.assembly_type}
                   onValueChange={(value: AssemblyType) => setForm({ ...form, assembly_type: value })}
                   disabled={submitting}
                 >
-                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                  <SelectTrigger className=" text-foreground">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -239,7 +239,7 @@ export default function EditAssemblyPage() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="title" className="text-slate-300">
+                <Label htmlFor="title" className="text-foreground">
                   Titre *
                 </Label>
                 <Input
@@ -248,38 +248,38 @@ export default function EditAssemblyPage() {
                   onChange={(e) => setForm({ ...form, title: e.target.value })}
                   required
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
+                  className=" text-foreground"
                 />
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label className="text-slate-300">Date *</Label>
+                  <Label className="text-foreground">Date *</Label>
                   <Input
                     type="date"
                     value={form.scheduled_date}
                     onChange={(e) => setForm({ ...form, scheduled_date: e.target.value })}
                     required
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-slate-300">Heure *</Label>
+                  <Label className="text-foreground">Heure *</Label>
                   <Input
                     type="time"
                     value={form.scheduled_time}
                     onChange={(e) => setForm({ ...form, scheduled_time: e.target.value })}
                     required
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label className="text-slate-300">Exercice</Label>
+                  <Label className="text-foreground">Exercice</Label>
                   <Input
                     type="number"
                     min="2020"
@@ -287,52 +287,52 @@ export default function EditAssemblyPage() {
                     value={form.fiscal_year}
                     onChange={(e) => setForm({ ...form, fiscal_year: e.target.value })}
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-slate-300">Quorum (tantièmes)</Label>
+                  <Label className="text-foreground">Quorum (tantièmes)</Label>
                   <Input
                     type="number"
                     min="0"
                     value={form.quorum_required}
                     onChange={(e) => setForm({ ...form, quorum_required: e.target.value })}
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
               </div>
             </CardContent>
           </Card>
 
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <MapPin className="h-5 w-5 text-violet-400" />
+              <CardTitle className="text-foreground flex items-center gap-2">
+                <MapPin className="h-5 w-5 text-violet-600" />
                 Lieu
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label className="text-slate-300">Lieu</Label>
+                <Label className="text-foreground">Lieu</Label>
                 <Input
                   value={form.location}
                   onChange={(e) => setForm({ ...form, location: e.target.value })}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
+                  className=" text-foreground"
                 />
               </div>
               <div className="space-y-2">
-                <Label className="text-slate-300">Adresse</Label>
+                <Label className="text-foreground">Adresse</Label>
                 <Input
                   value={form.location_address}
                   onChange={(e) => setForm({ ...form, location_address: e.target.value })}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
+                  className=" text-foreground"
                 />
               </div>
               <div className="space-y-2">
-                <Label className="text-slate-300 flex items-center gap-2">
+                <Label className="text-foreground flex items-center gap-2">
                   <Video className="h-4 w-4" />
                   Lien visio
                 </Label>
@@ -341,7 +341,7 @@ export default function EditAssemblyPage() {
                   value={form.online_meeting_url}
                   onChange={(e) => setForm({ ...form, online_meeting_url: e.target.value })}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
+                  className=" text-foreground"
                 />
               </div>
               <div className="flex items-center gap-2">
@@ -353,33 +353,33 @@ export default function EditAssemblyPage() {
                   disabled={submitting}
                   className="h-4 w-4 rounded border-white/30 bg-transparent"
                 />
-                <Label htmlFor="is_hybrid" className="text-slate-300 cursor-pointer">
+                <Label htmlFor="is_hybrid" className="text-foreground cursor-pointer">
                   Assemblée hybride
                 </Label>
               </div>
             </CardContent>
           </Card>
 
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardContent className="p-6 space-y-4">
               <div className="space-y-2">
-                <Label className="text-slate-300">Description</Label>
+                <Label className="text-foreground">Description</Label>
                 <Textarea
                   value={form.description}
                   onChange={(e) => setForm({ ...form, description: e.target.value })}
                   rows={3}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
+                  className=" text-foreground"
                 />
               </div>
               <div className="space-y-2">
-                <Label className="text-slate-300">Notes internes</Label>
+                <Label className="text-foreground">Notes internes</Label>
                 <Textarea
                   value={form.notes}
                   onChange={(e) => setForm({ ...form, notes: e.target.value })}
                   rows={2}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
+                  className=" text-foreground"
                 />
               </div>
             </CardContent>
@@ -391,7 +391,7 @@ export default function EditAssemblyPage() {
                 type="button"
                 variant="outline"
                 disabled={submitting}
-                className="border-white/20 text-white hover:bg-white/10"
+                className="border-input text-foreground hover:bg-muted"
               >
                 Annuler
               </Button>

--- a/app/syndic/assemblies/[id]/live/page.tsx
+++ b/app/syndic/assemblies/[id]/live/page.tsx
@@ -202,11 +202,11 @@ export default function LiveAssemblyPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="p-0">
         <div className="max-w-6xl mx-auto space-y-6">
-          <Skeleton className="h-12 w-96 bg-white/10" />
-          <Skeleton className="h-48 bg-white/10" />
-          <Skeleton className="h-96 bg-white/10" />
+          <Skeleton className="h-12 w-96 bg-muted" />
+          <Skeleton className="h-48 bg-muted" />
+          <Skeleton className="h-96 bg-muted" />
         </div>
       </div>
     );
@@ -214,8 +214,8 @@ export default function LiveAssemblyPage() {
 
   if (!assembly) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-        <p className="text-white text-center py-12">Assemblée introuvable</p>
+      <div className="p-0">
+        <p className="text-foreground text-center py-12">Assemblée introuvable</p>
       </div>
     );
   }
@@ -229,13 +229,13 @@ export default function LiveAssemblyPage() {
   // Si l'AG n'est pas encore convoquée, rediriger vers la page détail
   if (assembly.status === "draft") {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="p-0">
         <div className="max-w-3xl mx-auto">
-          <Card className="bg-white/5 border-amber-400/40 backdrop-blur">
+          <Card className="bg-muted/30 border-amber-200 backdrop-blur">
             <CardContent className="p-8 text-center">
-              <AlertCircle className="h-12 w-12 text-amber-400 mx-auto mb-4" />
-              <h2 className="text-xl font-bold text-white mb-2">Assemblée en brouillon</h2>
-              <p className="text-slate-300 mb-6">
+              <AlertCircle className="h-12 w-12 text-amber-600 mx-auto mb-4" />
+              <h2 className="text-xl font-bold text-foreground mb-2">Assemblée en brouillon</h2>
+              <p className="text-foreground mb-6">
                 Vous devez d'abord envoyer les convocations avant de démarrer la session.
               </p>
               <Link href={`/syndic/assemblies/${assemblyId}`}>
@@ -252,12 +252,12 @@ export default function LiveAssemblyPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+    <div className="p-0">
       <div className="max-w-6xl mx-auto space-y-6">
         {/* Header */}
         <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
           <Link href={`/syndic/assemblies/${assemblyId}`}>
-            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10 mb-4">
+            <Button variant="ghost" size="sm" className="text-foreground hover:text-foreground hover:bg-muted mb-4">
               <ArrowLeft className="h-4 w-4 mr-2" />
               Retour à l'assemblée
             </Button>
@@ -266,21 +266,21 @@ export default function LiveAssemblyPage() {
           <div className="flex items-center justify-between">
             <div>
               <div className="flex items-center gap-3 mb-2">
-                <Radio className={`h-6 w-6 ${isInProgress ? "text-red-400 animate-pulse" : "text-slate-400"}`} />
-                <h1 className="text-2xl font-bold text-white">Session en direct</h1>
+                <Radio className={`h-6 w-6 ${isInProgress ? "text-red-600 animate-pulse" : "text-muted-foreground"}`} />
+                <h1 className="text-2xl font-bold text-foreground">Session en direct</h1>
                 {isInProgress && (
-                  <Badge className="bg-red-500/20 text-red-200 border-red-400/40 border">
+                  <Badge className="bg-red-100 text-red-700 border-red-200 border">
                     ● EN COURS
                   </Badge>
                 )}
                 {isHeld && (
-                  <Badge className="bg-emerald-500/20 text-emerald-200 border-emerald-400/40 border">
+                  <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 border">
                     Clôturée
                   </Badge>
                 )}
               </div>
-              <p className="text-slate-400">{assembly.title}</p>
-              <p className="text-slate-500 font-mono text-xs">{assembly.reference_number}</p>
+              <p className="text-muted-foreground">{assembly.title}</p>
+              <p className="text-muted-foreground font-mono text-xs">{assembly.reference_number}</p>
             </div>
 
             {isInProgress && (
@@ -327,8 +327,8 @@ export default function LiveAssemblyPage() {
         {/* Vote recording (if in progress) */}
         {isInProgress && resolutions.length > 0 && (
           <div className="space-y-4">
-            <div className="flex items-center gap-2 text-white">
-              <Vote className="h-5 w-5 text-violet-400" />
+            <div className="flex items-center gap-2 text-foreground">
+              <Vote className="h-5 w-5 text-violet-600" />
               <h2 className="text-lg font-semibold">Résolutions à voter</h2>
             </div>
             {resolutions.map((resolution) => (
@@ -344,18 +344,18 @@ export default function LiveAssemblyPage() {
 
         {/* Held state summary */}
         {isHeld && (
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <CheckCircle2 className="h-5 w-5 text-emerald-400" />
+              <CardTitle className="text-foreground flex items-center gap-2">
+                <CheckCircle2 className="h-5 w-5 text-emerald-600" />
                 Session clôturée
               </CardTitle>
-              <CardDescription className="text-slate-400">
+              <CardDescription className="text-muted-foreground">
                 Tenue le {new Date(assembly.held_at || "").toLocaleString("fr-FR")}
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <p className="text-slate-300 mb-4">
+              <p className="text-foreground mb-4">
                 La session est terminée. Vous pouvez maintenant générer le procès-verbal.
               </p>
               <Link href={`/syndic/assemblies/${assemblyId}`}>

--- a/app/syndic/assemblies/[id]/page.tsx
+++ b/app/syndic/assemblies/[id]/page.tsx
@@ -461,15 +461,50 @@ export default function AssemblyDetailPage() {
         )}
 
         {/* Minutes */}
-        {minutes.length > 0 && (
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
-            <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <FileText className="h-5 w-5 text-emerald-400" />
-                Procès-verbaux ({minutes.length})
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
+        <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <CardHeader className="flex flex-row items-center justify-between gap-3">
+            <CardTitle className="text-white flex items-center gap-2">
+              <FileText className="h-5 w-5 text-emerald-400" />
+              Procès-verbaux ({minutes.length})
+            </CardTitle>
+            {(assembly.status === "held" || assembly.status === "in_progress") && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="border-white/20 text-white hover:bg-white/10"
+                onClick={async () => {
+                  try {
+                    const res = await fetch(`/api/copro/assemblies/${assemblyId}/minutes`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({}),
+                    });
+                    if (!res.ok) {
+                      const err = await res.json().catch(() => ({}));
+                      throw new Error(err.error ?? "Erreur");
+                    }
+                    toast({ title: "PV généré" });
+                    fetchAssembly();
+                  } catch (err) {
+                    toast({
+                      title: "Erreur",
+                      description: err instanceof Error ? err.message : "Échec",
+                      variant: "destructive",
+                    });
+                  }
+                }}
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                Générer un nouveau PV
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent>
+            {minutes.length === 0 ? (
+              <div className="text-center py-6 text-slate-400 text-sm">
+                Aucun procès-verbal généré pour le moment.
+              </div>
+            ) : (
               <div className="space-y-2">
                 {minutes.map((minute) => (
                   <div
@@ -499,9 +534,9 @@ export default function AssemblyDetailPage() {
                   </div>
                 ))}
               </div>
-            </CardContent>
-          </Card>
-        )}
+            )}
+          </CardContent>
+        </Card>
       </div>
 
       {showAddResolution && (

--- a/app/syndic/assemblies/[id]/page.tsx
+++ b/app/syndic/assemblies/[id]/page.tsx
@@ -87,23 +87,23 @@ interface MinuteSummary {
 }
 
 const STATUS_LABELS: Record<string, { label: string; color: string }> = {
-  draft: { label: "Brouillon", color: "bg-slate-500/20 text-slate-200 border-slate-400/40" },
-  convened: { label: "Convoquée", color: "bg-blue-500/20 text-blue-200 border-blue-400/40" },
-  in_progress: { label: "En cours", color: "bg-amber-500/20 text-amber-200 border-amber-400/40" },
-  held: { label: "Tenue", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40" },
-  cancelled: { label: "Annulée", color: "bg-red-500/20 text-red-200 border-red-400/40" },
+  draft: { label: "Brouillon", color: "bg-slate-100 text-foreground border-slate-200" },
+  convened: { label: "Convoquée", color: "bg-blue-100 text-blue-700 border-blue-200" },
+  in_progress: { label: "En cours", color: "bg-amber-100 text-amber-700 border-amber-200" },
+  held: { label: "Tenue", color: "bg-emerald-100 text-emerald-700 border-emerald-200" },
+  cancelled: { label: "Annulée", color: "bg-red-100 text-red-700 border-red-200" },
 };
 
 const RESOLUTION_STATUS_LABELS: Record<
   string,
   { label: string; color: string; icon: React.ComponentType<{ className?: string }> }
 > = {
-  proposed: { label: "Proposée", color: "bg-slate-500/20 text-slate-200", icon: Clock },
-  voted_for: { label: "Adoptée", color: "bg-emerald-500/20 text-emerald-200", icon: CheckCircle2 },
-  voted_against: { label: "Rejetée", color: "bg-red-500/20 text-red-200", icon: XCircle },
-  abstained: { label: "Abstention", color: "bg-amber-500/20 text-amber-200", icon: AlertCircle },
-  adjourned: { label: "Ajournée", color: "bg-orange-500/20 text-orange-200", icon: Clock },
-  withdrawn: { label: "Retirée", color: "bg-slate-500/20 text-slate-300", icon: XCircle },
+  proposed: { label: "Proposée", color: "bg-slate-100 text-foreground", icon: Clock },
+  voted_for: { label: "Adoptée", color: "bg-emerald-100 text-emerald-700", icon: CheckCircle2 },
+  voted_against: { label: "Rejetée", color: "bg-red-100 text-red-700", icon: XCircle },
+  abstained: { label: "Abstention", color: "bg-amber-100 text-amber-700", icon: AlertCircle },
+  adjourned: { label: "Ajournée", color: "bg-orange-100 text-orange-700", icon: Clock },
+  withdrawn: { label: "Retirée", color: "bg-slate-100 text-foreground", icon: XCircle },
 };
 
 const MAJORITY_LABELS: Record<string, string> = {
@@ -197,11 +197,11 @@ export default function AssemblyDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="p-0">
         <div className="max-w-5xl mx-auto space-y-6">
-          <Skeleton className="h-12 w-96 bg-white/10" />
-          <Skeleton className="h-48 bg-white/10" />
-          <Skeleton className="h-96 bg-white/10" />
+          <Skeleton className="h-12 w-96 bg-muted" />
+          <Skeleton className="h-48 bg-muted" />
+          <Skeleton className="h-96 bg-muted" />
         </div>
       </div>
     );
@@ -209,9 +209,9 @@ export default function AssemblyDetailPage() {
 
   if (!assembly) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+      <div className="p-0">
         <div className="max-w-5xl mx-auto">
-          <p className="text-white text-center py-12">Assemblée introuvable</p>
+          <p className="text-foreground text-center py-12">Assemblée introuvable</p>
         </div>
       </div>
     );
@@ -225,12 +225,12 @@ export default function AssemblyDetailPage() {
   const isLive = assembly.status === "in_progress";
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+    <div className="p-0">
       <div className="max-w-5xl mx-auto space-y-6">
         {/* Header */}
         <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
           <Link href="/syndic/assemblies">
-            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10 mb-4">
+            <Button variant="ghost" size="sm" className="text-foreground hover:text-foreground hover:bg-muted mb-4">
               <ArrowLeft className="h-4 w-4 mr-2" />
               Retour aux assemblées
             </Button>
@@ -239,17 +239,17 @@ export default function AssemblyDetailPage() {
           <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
             <div>
               <div className="flex items-center gap-3 mb-2">
-                <h1 className="text-2xl font-bold text-white">{assembly.title}</h1>
+                <h1 className="text-2xl font-bold text-foreground">{assembly.title}</h1>
                 <Badge className={`${statusConfig.color} border`}>{statusConfig.label}</Badge>
               </div>
-              <p className="text-slate-400 font-mono text-sm">
+              <p className="text-muted-foreground font-mono text-sm">
                 {assembly.reference_number || "Pas de référence"}
               </p>
             </div>
             <div className="flex gap-2">
               {canEdit && (
                 <Link href={`/syndic/assemblies/${assembly.id}/edit`}>
-                  <Button variant="outline" size="sm" className="border-white/20 text-white hover:bg-white/10">
+                  <Button variant="outline" size="sm" className="border-input text-foreground hover:bg-muted">
                     <Edit className="h-4 w-4 mr-2" />
                     Modifier
                   </Button>
@@ -260,7 +260,7 @@ export default function AssemblyDetailPage() {
                   variant="outline"
                   size="sm"
                   onClick={handleDelete}
-                  className="border-red-400/40 text-red-200 hover:bg-red-500/10"
+                  className="border-red-200 text-red-700 hover:bg-red-500/10"
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   Annuler
@@ -271,7 +271,7 @@ export default function AssemblyDetailPage() {
         </motion.div>
 
         {/* Info card */}
-        <Card className="bg-white/5 border-white/10 backdrop-blur">
+        <Card className="">
           <CardContent className="p-6 grid grid-cols-1 md:grid-cols-2 gap-4">
             <InfoItem
               icon={Calendar}
@@ -298,7 +298,7 @@ export default function AssemblyDetailPage() {
           </CardContent>
           {assembly.description && (
             <div className="px-6 pb-6">
-              <p className="text-sm text-slate-300">{assembly.description}</p>
+              <p className="text-sm text-foreground">{assembly.description}</p>
             </div>
           )}
         </Card>
@@ -341,15 +341,15 @@ export default function AssemblyDetailPage() {
         </div>
 
         {/* Resolutions */}
-        <Card className="bg-white/5 border-white/10 backdrop-blur">
+        <Card className="">
           <CardHeader>
             <div className="flex items-center justify-between">
               <div>
-                <CardTitle className="text-white flex items-center gap-2">
-                  <Vote className="h-5 w-5 text-violet-400" />
+                <CardTitle className="text-foreground flex items-center gap-2">
+                  <Vote className="h-5 w-5 text-violet-600" />
                   Ordre du jour ({resolutions.length})
                 </CardTitle>
-                <CardDescription className="text-slate-400">
+                <CardDescription className="text-muted-foreground">
                   Résolutions soumises au vote de l'assemblée
                 </CardDescription>
               </div>
@@ -367,8 +367,8 @@ export default function AssemblyDetailPage() {
           </CardHeader>
           <CardContent>
             {resolutions.length === 0 ? (
-              <div className="text-center py-8 text-slate-400">
-                <Vote className="h-10 w-10 mx-auto mb-3 text-slate-500" />
+              <div className="text-center py-8 text-muted-foreground">
+                <Vote className="h-10 w-10 mx-auto mb-3 text-muted-foreground" />
                 <p>Aucune résolution pour le moment</p>
                 {canAddResolution && (
                   <p className="text-xs mt-2">Ajoutez une résolution pour commencer l'ordre du jour</p>
@@ -386,25 +386,25 @@ export default function AssemblyDetailPage() {
                   return (
                     <div
                       key={resolution.id}
-                      className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-3"
+                      className="rounded-xl border border-border bg-muted/30 p-4 space-y-3"
                     >
                       <div className="flex items-start justify-between gap-4">
                         <div className="flex-1">
                           <div className="flex items-center gap-2 mb-1 flex-wrap">
-                            <span className="font-mono text-xs text-slate-500">
+                            <span className="font-mono text-xs text-muted-foreground">
                               #{resolution.resolution_number}
                             </span>
-                            <Badge variant="outline" className="border-white/20 text-slate-300 text-xs">
+                            <Badge variant="outline" className="border-input text-foreground text-xs">
                               {CATEGORY_LABELS[resolution.category] || resolution.category}
                             </Badge>
-                            <Badge variant="outline" className="border-violet-400/30 text-violet-200 text-xs">
+                            <Badge variant="outline" className="border-violet-400/30 text-violet-700 text-xs">
                               {MAJORITY_LABELS[resolution.majority_rule] || resolution.majority_rule}
                             </Badge>
                           </div>
-                          <h4 className="text-white font-medium">{resolution.title}</h4>
-                          <p className="text-sm text-slate-400 mt-1">{resolution.description}</p>
+                          <h4 className="text-foreground font-medium">{resolution.title}</h4>
+                          <p className="text-sm text-muted-foreground mt-1">{resolution.description}</p>
                           {resolution.estimated_amount_cents && (
-                            <p className="text-xs text-amber-200 mt-2">
+                            <p className="text-xs text-amber-700 mt-2">
                               Montant estimé : {(resolution.estimated_amount_cents / 100).toLocaleString("fr-FR")} €
                             </p>
                           )}
@@ -416,7 +416,7 @@ export default function AssemblyDetailPage() {
                       </div>
 
                       {hasVotes && (
-                        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-white/10">
+                        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-border">
                           <VoteStat
                             label="Pour"
                             count={resolution.votes_for_count}
@@ -447,10 +447,10 @@ export default function AssemblyDetailPage() {
 
         {/* Convocations summary */}
         {convocations.length > 0 && (
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <Send className="h-5 w-5 text-blue-400" />
+              <CardTitle className="text-foreground flex items-center gap-2">
+                <Send className="h-5 w-5 text-blue-600" />
                 Convocations ({convocations.length})
               </CardTitle>
             </CardHeader>
@@ -461,17 +461,17 @@ export default function AssemblyDetailPage() {
         )}
 
         {/* Minutes */}
-        <Card className="bg-white/5 border-white/10 backdrop-blur">
+        <Card className="">
           <CardHeader className="flex flex-row items-center justify-between gap-3">
-            <CardTitle className="text-white flex items-center gap-2">
-              <FileText className="h-5 w-5 text-emerald-400" />
+            <CardTitle className="text-foreground flex items-center gap-2">
+              <FileText className="h-5 w-5 text-emerald-600" />
               Procès-verbaux ({minutes.length})
             </CardTitle>
             {(assembly.status === "held" || assembly.status === "in_progress") && (
               <Button
                 size="sm"
                 variant="outline"
-                className="border-white/20 text-white hover:bg-white/10"
+                className="border-input text-foreground hover:bg-muted"
                 onClick={async () => {
                   try {
                     const res = await fetch(`/api/copro/assemblies/${assemblyId}/minutes`, {
@@ -501,7 +501,7 @@ export default function AssemblyDetailPage() {
           </CardHeader>
           <CardContent>
             {minutes.length === 0 ? (
-              <div className="text-center py-6 text-slate-400 text-sm">
+              <div className="text-center py-6 text-muted-foreground text-sm">
                 Aucun procès-verbal généré pour le moment.
               </div>
             ) : (
@@ -509,13 +509,13 @@ export default function AssemblyDetailPage() {
                 {minutes.map((minute) => (
                   <div
                     key={minute.id}
-                    className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 p-3"
+                    className="flex items-center justify-between rounded-lg border border-border bg-muted/30 p-3"
                   >
                     <div className="flex items-center gap-3">
-                      <FileText className="h-4 w-4 text-slate-400" />
+                      <FileText className="h-4 w-4 text-muted-foreground" />
                       <div>
-                        <p className="text-white text-sm">Version {minute.version}</p>
-                        <p className="text-xs text-slate-400">
+                        <p className="text-foreground text-sm">Version {minute.version}</p>
+                        <p className="text-xs text-muted-foreground">
                           {minute.signed_by_president_at
                             ? `Signé le ${formatDateShort(minute.signed_by_president_at)}`
                             : "Non signé"}
@@ -523,7 +523,7 @@ export default function AssemblyDetailPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
-                      <Badge className="bg-slate-500/20 text-slate-200 capitalize">{minute.status}</Badge>
+                      <Badge className="bg-slate-100 text-foreground capitalize">{minute.status}</Badge>
                       <DownloadPdfButton
                         variant="minute"
                         minuteId={minute.id}
@@ -576,10 +576,10 @@ function InfoItem({
 }) {
   return (
     <div className="flex items-start gap-3">
-      <Icon className="h-4 w-4 text-slate-400 mt-0.5" />
+      <Icon className="h-4 w-4 text-muted-foreground mt-0.5" />
       <div>
-        <p className="text-xs text-slate-500 uppercase tracking-wide">{label}</p>
-        <p className="text-sm text-white mt-0.5">{value}</p>
+        <p className="text-xs text-muted-foreground uppercase tracking-wide">{label}</p>
+        <p className="text-sm text-foreground mt-0.5">{value}</p>
       </div>
     </div>
   );
@@ -598,9 +598,9 @@ function VoteStat({
 }) {
   return (
     <div className="text-center">
-      <p className="text-xs text-slate-400">{label}</p>
+      <p className="text-xs text-muted-foreground">{label}</p>
       <p className={`text-lg font-bold ${color}`}>{count}</p>
-      <p className="text-xs text-slate-500">{tantiemes.toLocaleString("fr-FR")} tant.</p>
+      <p className="text-xs text-muted-foreground">{tantiemes.toLocaleString("fr-FR")} tant.</p>
     </div>
   );
 }
@@ -614,9 +614,9 @@ function ConvocationStats({ convocations }: { convocations: ConvocationSummary[]
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
       {Object.entries(byStatus).map(([status, count]) => (
-        <div key={status} className="rounded-lg border border-white/10 bg-white/5 p-3 text-center">
-          <p className="text-xs text-slate-400 capitalize">{status}</p>
-          <p className="text-xl font-bold text-white mt-1">{count}</p>
+        <div key={status} className="rounded-lg border border-border bg-muted/30 p-3 text-center">
+          <p className="text-xs text-muted-foreground capitalize">{status}</p>
+          <p className="text-xl font-bold text-foreground mt-1">{count}</p>
         </div>
       ))}
     </div>

--- a/app/syndic/assemblies/new/page.tsx
+++ b/app/syndic/assemblies/new/page.tsx
@@ -167,7 +167,7 @@ export default function NewAssemblyPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+    <div className="p-0">
       <div className="max-w-3xl mx-auto space-y-6">
         {/* Header */}
         <motion.div
@@ -176,40 +176,40 @@ export default function NewAssemblyPage() {
           className="flex items-center gap-4"
         >
           <Link href="/syndic/assemblies">
-            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
+            <Button variant="ghost" size="sm" className="text-foreground hover:text-foreground hover:bg-muted">
               <ArrowLeft className="h-4 w-4 mr-2" />
               Retour
             </Button>
           </Link>
           <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <CalendarIcon className="h-6 w-6 text-violet-400" />
+            <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+              <CalendarIcon className="h-6 w-6 text-violet-600" />
               Nouvelle assemblée générale
             </h1>
-            <p className="text-slate-400">Créez une AG en brouillon — vous pourrez ensuite ajouter les résolutions</p>
+            <p className="text-muted-foreground">Créez une AG en brouillon — vous pourrez ensuite ajouter les résolutions</p>
           </div>
         </motion.div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Site selection */}
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <Building2 className="h-5 w-5 text-violet-400" />
+              <CardTitle className="text-foreground flex items-center gap-2">
+                <Building2 className="h-5 w-5 text-violet-600" />
                 Copropriété
               </CardTitle>
-              <CardDescription className="text-slate-400">
+              <CardDescription className="text-muted-foreground">
                 Choisissez la copropriété concernée
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
-              <Label htmlFor="site_id" className="text-slate-300">
+              <Label htmlFor="site_id" className="text-foreground">
                 Site *
               </Label>
               {loadingSites ? (
-                <div className="text-slate-400 text-sm">Chargement des sites...</div>
+                <div className="text-muted-foreground text-sm">Chargement des sites...</div>
               ) : sites.length === 0 ? (
-                <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+                <div className="rounded-xl border border-amber-200 bg-amber-500/10 p-3 text-sm text-amber-100">
                   Aucune copropriété disponible.{" "}
                   <Link href="/syndic/sites" className="underline">
                     Créez votre premier site
@@ -221,7 +221,7 @@ export default function NewAssemblyPage() {
                   onValueChange={(value) => setForm({ ...form, site_id: value })}
                   disabled={submitting}
                 >
-                  <SelectTrigger id="site_id" className="bg-white/5 border-white/10 text-white">
+                  <SelectTrigger id="site_id" className=" text-foreground">
                     <SelectValue placeholder="Sélectionner une copropriété" />
                   </SelectTrigger>
                   <SelectContent>
@@ -238,19 +238,19 @@ export default function NewAssemblyPage() {
           </Card>
 
           {/* Type & title */}
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white">Nature de l'assemblée</CardTitle>
+              <CardTitle className="text-foreground">Nature de l'assemblée</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label className="text-slate-300">Type *</Label>
+                <Label className="text-foreground">Type *</Label>
                 <Select
                   value={form.assembly_type}
                   onValueChange={(value: typeof form.assembly_type) => setForm({ ...form, assembly_type: value })}
                   disabled={submitting}
                 >
-                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                  <SelectTrigger className=" text-foreground">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -258,7 +258,7 @@ export default function NewAssemblyPage() {
                       <SelectItem key={type.value} value={type.value}>
                         <div>
                           <div className="font-medium">{type.label}</div>
-                          <div className="text-xs text-slate-500">{type.description}</div>
+                          <div className="text-xs text-muted-foreground">{type.description}</div>
                         </div>
                       </SelectItem>
                     ))}
@@ -267,7 +267,7 @@ export default function NewAssemblyPage() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="title" className="text-slate-300">
+                <Label htmlFor="title" className="text-foreground">
                   Titre *
                 </Label>
                 <Input
@@ -277,13 +277,13 @@ export default function NewAssemblyPage() {
                   onChange={(e) => setForm({ ...form, title: e.target.value })}
                   required
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                  className=" text-foreground placeholder:text-muted-foreground"
                 />
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="scheduled_date" className="text-slate-300">
+                  <Label htmlFor="scheduled_date" className="text-foreground">
                     Date *
                   </Label>
                   <Input
@@ -293,12 +293,12 @@ export default function NewAssemblyPage() {
                     onChange={(e) => setForm({ ...form, scheduled_date: e.target.value })}
                     required
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                     min={new Date().toISOString().split("T")[0]}
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="scheduled_time" className="text-slate-300">
+                  <Label htmlFor="scheduled_time" className="text-foreground">
                     Heure *
                   </Label>
                   <Input
@@ -308,14 +308,14 @@ export default function NewAssemblyPage() {
                     onChange={(e) => setForm({ ...form, scheduled_time: e.target.value })}
                     required
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="fiscal_year" className="text-slate-300">
+                  <Label htmlFor="fiscal_year" className="text-foreground">
                     Exercice concerné
                   </Label>
                   <Input
@@ -326,11 +326,11 @@ export default function NewAssemblyPage() {
                     value={form.fiscal_year}
                     onChange={(e) => setForm({ ...form, fiscal_year: e.target.value })}
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="quorum_required" className="text-slate-300">
+                  <Label htmlFor="quorum_required" className="text-foreground">
                     Quorum requis (tantièmes)
                   </Label>
                   <Input
@@ -341,7 +341,7 @@ export default function NewAssemblyPage() {
                     value={form.quorum_required}
                     onChange={(e) => setForm({ ...form, quorum_required: e.target.value })}
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
               </div>
@@ -349,16 +349,16 @@ export default function NewAssemblyPage() {
           </Card>
 
           {/* Location */}
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <MapPin className="h-5 w-5 text-violet-400" />
+              <CardTitle className="text-foreground flex items-center gap-2">
+                <MapPin className="h-5 w-5 text-violet-600" />
                 Lieu et modalités
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="location" className="text-slate-300">
+                <Label htmlFor="location" className="text-foreground">
                   Lieu (description courte)
                 </Label>
                 <Input
@@ -367,11 +367,11 @@ export default function NewAssemblyPage() {
                   value={form.location}
                   onChange={(e) => setForm({ ...form, location: e.target.value })}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                  className=" text-foreground placeholder:text-muted-foreground"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="location_address" className="text-slate-300">
+                <Label htmlFor="location_address" className="text-foreground">
                   Adresse complète
                 </Label>
                 <Input
@@ -380,11 +380,11 @@ export default function NewAssemblyPage() {
                   value={form.location_address}
                   onChange={(e) => setForm({ ...form, location_address: e.target.value })}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                  className=" text-foreground placeholder:text-muted-foreground"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="online_meeting_url" className="text-slate-300 flex items-center gap-2">
+                <Label htmlFor="online_meeting_url" className="text-foreground flex items-center gap-2">
                   <Video className="h-4 w-4" />
                   Lien visio (optionnel)
                 </Label>
@@ -395,7 +395,7 @@ export default function NewAssemblyPage() {
                   value={form.online_meeting_url}
                   onChange={(e) => setForm({ ...form, online_meeting_url: e.target.value })}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                  className=" text-foreground placeholder:text-muted-foreground"
                 />
               </div>
               <div className="flex items-center gap-2">
@@ -407,7 +407,7 @@ export default function NewAssemblyPage() {
                   disabled={submitting}
                   className="h-4 w-4 rounded border-white/30 bg-transparent"
                 />
-                <Label htmlFor="is_hybrid" className="text-slate-300 cursor-pointer">
+                <Label htmlFor="is_hybrid" className="text-foreground cursor-pointer">
                   Assemblée hybride (présentiel + visio)
                 </Label>
               </div>
@@ -415,13 +415,13 @@ export default function NewAssemblyPage() {
           </Card>
 
           {/* Description */}
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white">Description et notes</CardTitle>
+              <CardTitle className="text-foreground">Description et notes</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="description" className="text-slate-300">
+                <Label htmlFor="description" className="text-foreground">
                   Description (publique)
                 </Label>
                 <Textarea
@@ -431,11 +431,11 @@ export default function NewAssemblyPage() {
                   onChange={(e) => setForm({ ...form, description: e.target.value })}
                   rows={3}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                  className=" text-foreground placeholder:text-muted-foreground"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="notes" className="text-slate-300">
+                <Label htmlFor="notes" className="text-foreground">
                   Notes internes (privées)
                 </Label>
                 <Textarea
@@ -445,7 +445,7 @@ export default function NewAssemblyPage() {
                   onChange={(e) => setForm({ ...form, notes: e.target.value })}
                   rows={2}
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                  className=" text-foreground placeholder:text-muted-foreground"
                 />
               </div>
             </CardContent>
@@ -458,7 +458,7 @@ export default function NewAssemblyPage() {
                 type="button"
                 variant="outline"
                 disabled={submitting}
-                className="border-white/20 text-white hover:bg-white/10"
+                className="border-input text-foreground hover:bg-muted"
               >
                 Annuler
               </Button>

--- a/app/syndic/assemblies/page.tsx
+++ b/app/syndic/assemblies/page.tsx
@@ -54,12 +54,12 @@ interface Assembly {
 }
 
 const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
-  draft: { label: "Brouillon", color: "bg-slate-500/20 text-slate-200 border-slate-400/40" },
-  convened: { label: "Convoquée", color: "bg-blue-500/20 text-blue-200 border-blue-400/40" },
-  in_progress: { label: "En cours", color: "bg-amber-500/20 text-amber-200 border-amber-400/40" },
-  held: { label: "Tenue", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40" },
-  adjourned: { label: "Ajournée", color: "bg-orange-500/20 text-orange-200 border-orange-400/40" },
-  cancelled: { label: "Annulée", color: "bg-red-500/20 text-red-200 border-red-400/40" },
+  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700 border-slate-200" },
+  convened: { label: "Convoquée", color: "bg-blue-100 text-blue-700 border-blue-200" },
+  in_progress: { label: "En cours", color: "bg-amber-100 text-amber-700 border-amber-200" },
+  held: { label: "Tenue", color: "bg-emerald-100 text-emerald-700 border-emerald-200" },
+  adjourned: { label: "Ajournée", color: "bg-orange-100 text-orange-700 border-orange-200" },
+  cancelled: { label: "Annulée", color: "bg-red-100 text-red-700 border-red-200" },
 };
 
 const TYPE_CONFIG: Record<string, { label: string; short: string }> = {
@@ -124,182 +124,172 @@ export default function SyndicAssembliesPage() {
   }, [assemblies]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-      <div className="max-w-7xl mx-auto space-y-6">
-        {/* Header */}
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
-        >
-          <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <Calendar className="h-6 w-6 text-violet-400" />
-              Assemblées Générales
-            </h1>
-            <p className="text-slate-400">Gérez les AG de vos copropriétés selon la loi du 10 juillet 1965</p>
-          </div>
-          <Link href="/syndic/assemblies/new">
-            <Button className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700">
-              <Plus className="h-4 w-4 mr-2" />
-              Nouvelle AG
-            </Button>
-          </Link>
-        </motion.div>
-
-        {/* Stats */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <StatCard label="Total" value={stats.total} icon={Calendar} color="text-violet-400" />
-          <StatCard label="À venir" value={stats.upcoming} icon={AlertCircle} color="text-amber-400" />
-          <StatCard label="Tenues" value={stats.held} icon={CheckCircle2} color="text-emerald-400" />
-          <StatCard label="Brouillons" value={stats.draft} icon={Building2} color="text-blue-400" />
+    <div className="space-y-6">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+      >
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <Calendar className="h-6 w-6 text-violet-600" />
+            Assemblées Générales
+          </h1>
+          <p className="text-muted-foreground">Gérez les AG de vos copropriétés selon la loi du 10 juillet 1965</p>
         </div>
+        <Link href="/syndic/assemblies/new">
+          <Button className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700">
+            <Plus className="h-4 w-4 mr-2" />
+            Nouvelle AG
+          </Button>
+        </Link>
+      </motion.div>
 
-        {/* Filters */}
-        <Card className="bg-white/5 border-white/10 backdrop-blur">
-          <CardContent className="p-4">
-            <div className="flex flex-col md:flex-row gap-3">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
-                <Input
-                  placeholder="Rechercher par titre ou numéro..."
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  className="pl-9 bg-white/5 border-white/10 text-white placeholder:text-slate-500"
-                />
-              </div>
-              <Select value={statusFilter} onValueChange={setStatusFilter}>
-                <SelectTrigger className="w-full md:w-48 bg-white/5 border-white/10 text-white">
-                  <SelectValue placeholder="Statut" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Tous les statuts</SelectItem>
-                  <SelectItem value="draft">Brouillon</SelectItem>
-                  <SelectItem value="convened">Convoquée</SelectItem>
-                  <SelectItem value="in_progress">En cours</SelectItem>
-                  <SelectItem value="held">Tenue</SelectItem>
-                  <SelectItem value="cancelled">Annulée</SelectItem>
-                </SelectContent>
-              </Select>
-              <Select value={typeFilter} onValueChange={setTypeFilter}>
-                <SelectTrigger className="w-full md:w-48 bg-white/5 border-white/10 text-white">
-                  <SelectValue placeholder="Type" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Tous les types</SelectItem>
-                  <SelectItem value="ordinaire">Ordinaire</SelectItem>
-                  <SelectItem value="extraordinaire">Extraordinaire</SelectItem>
-                  <SelectItem value="concertation">Concertation</SelectItem>
-                  <SelectItem value="consultation_ecrite">Consultation écrite</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Assemblies table */}
-        <Card className="bg-white/5 border-white/10 backdrop-blur">
-          <CardContent className="p-0">
-            {loading ? (
-              <div className="p-6 space-y-3">
-                {[1, 2, 3].map((i) => (
-                  <Skeleton key={i} className="h-12 bg-white/10" />
-                ))}
-              </div>
-            ) : filteredAssemblies.length === 0 ? (
-              <div className="p-12 text-center text-slate-400">
-                <Calendar className="h-12 w-12 mx-auto mb-3 text-slate-500" />
-                <p className="mb-4">
-                  {assemblies.length === 0
-                    ? "Aucune assemblée générale pour le moment."
-                    : "Aucun résultat pour ces filtres."}
-                </p>
-                {assemblies.length === 0 && (
-                  <Link href="/syndic/assemblies/new">
-                    <Button variant="outline" className="border-white/20 text-white hover:bg-white/10">
-                      <Plus className="h-4 w-4 mr-2" />
-                      Créer votre première AG
-                    </Button>
-                  </Link>
-                )}
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-white/10 hover:bg-transparent">
-                    <TableHead className="text-slate-300">Référence</TableHead>
-                    <TableHead className="text-slate-300">Titre</TableHead>
-                    <TableHead className="text-slate-300">Type</TableHead>
-                    <TableHead className="text-slate-300">Date prévue</TableHead>
-                    <TableHead className="text-slate-300">Lieu</TableHead>
-                    <TableHead className="text-slate-300">Statut</TableHead>
-                    <TableHead className="text-slate-300 text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredAssemblies.map((assembly) => {
-                    const statusConfig = STATUS_CONFIG[assembly.status] || STATUS_CONFIG.draft;
-                    const typeConfig = TYPE_CONFIG[assembly.assembly_type] || TYPE_CONFIG.ordinaire;
-                    return (
-                      <TableRow key={assembly.id} className="border-white/10 hover:bg-white/5">
-                        <TableCell className="font-mono text-xs text-slate-400">
-                          {assembly.reference_number || "—"}
-                        </TableCell>
-                        <TableCell className="text-white font-medium">{assembly.title}</TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className="border-violet-400/40 text-violet-200">
-                            {typeConfig.short}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-slate-300">
-                          {formatDateShort(assembly.scheduled_at)}
-                        </TableCell>
-                        <TableCell className="text-slate-400">
-                          <div className="flex items-center gap-1 text-sm">
-                            {assembly.is_hybrid ? (
-                              <>
-                                <Video className="h-3 w-3" />
-                                Hybride
-                              </>
-                            ) : assembly.online_meeting_url ? (
-                              <>
-                                <Video className="h-3 w-3" />
-                                Visio
-                              </>
-                            ) : assembly.location ? (
-                              <>
-                                <MapPin className="h-3 w-3" />
-                                {assembly.location.slice(0, 30)}
-                                {assembly.location.length > 30 && "..."}
-                              </>
-                            ) : (
-                              "—"
-                            )}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge className={`${statusConfig.color} border`}>{statusConfig.label}</Badge>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <Link href={`/syndic/assemblies/${assembly.id}`}>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="text-slate-300 hover:text-white hover:bg-white/10"
-                            >
-                              <Eye className="h-4 w-4" />
-                            </Button>
-                          </Link>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard label="Total" value={stats.total} icon={Calendar} color="text-violet-600" />
+        <StatCard label="À venir" value={stats.upcoming} icon={AlertCircle} color="text-amber-600" />
+        <StatCard label="Tenues" value={stats.held} icon={CheckCircle2} color="text-emerald-600" />
+        <StatCard label="Brouillons" value={stats.draft} icon={Building2} color="text-blue-600" />
       </div>
+
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex flex-col md:flex-row gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Rechercher par titre ou numéro..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-full md:w-48">
+                <SelectValue placeholder="Statut" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Tous les statuts</SelectItem>
+                <SelectItem value="draft">Brouillon</SelectItem>
+                <SelectItem value="convened">Convoquée</SelectItem>
+                <SelectItem value="in_progress">En cours</SelectItem>
+                <SelectItem value="held">Tenue</SelectItem>
+                <SelectItem value="cancelled">Annulée</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <SelectTrigger className="w-full md:w-48">
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Tous les types</SelectItem>
+                <SelectItem value="ordinaire">Ordinaire</SelectItem>
+                <SelectItem value="extraordinaire">Extraordinaire</SelectItem>
+                <SelectItem value="concertation">Concertation</SelectItem>
+                <SelectItem value="consultation_ecrite">Consultation écrite</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-12" />
+              ))}
+            </div>
+          ) : filteredAssemblies.length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              <Calendar className="h-12 w-12 mx-auto mb-3 opacity-50" />
+              <p className="mb-4">
+                {assemblies.length === 0
+                  ? "Aucune assemblée générale pour le moment."
+                  : "Aucun résultat pour ces filtres."}
+              </p>
+              {assemblies.length === 0 && (
+                <Link href="/syndic/assemblies/new">
+                  <Button variant="outline">
+                    <Plus className="h-4 w-4 mr-2" />
+                    Créer votre première AG
+                  </Button>
+                </Link>
+              )}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Référence</TableHead>
+                  <TableHead>Titre</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Date prévue</TableHead>
+                  <TableHead>Lieu</TableHead>
+                  <TableHead>Statut</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredAssemblies.map((assembly) => {
+                  const statusConfig = STATUS_CONFIG[assembly.status] || STATUS_CONFIG.draft;
+                  const typeConfig = TYPE_CONFIG[assembly.assembly_type] || TYPE_CONFIG.ordinaire;
+                  return (
+                    <TableRow key={assembly.id}>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
+                        {assembly.reference_number || "—"}
+                      </TableCell>
+                      <TableCell className="font-medium text-foreground">{assembly.title}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="border-violet-200 text-violet-700">
+                          {typeConfig.short}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-foreground">
+                        {formatDateShort(assembly.scheduled_at)}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        <div className="flex items-center gap-1 text-sm">
+                          {assembly.is_hybrid ? (
+                            <>
+                              <Video className="h-3 w-3" />
+                              Hybride
+                            </>
+                          ) : assembly.online_meeting_url ? (
+                            <>
+                              <Video className="h-3 w-3" />
+                              Visio
+                            </>
+                          ) : assembly.location ? (
+                            <>
+                              <MapPin className="h-3 w-3" />
+                              {assembly.location.slice(0, 30)}
+                              {assembly.location.length > 30 && "..."}
+                            </>
+                          ) : (
+                            "—"
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge className={`${statusConfig.color} border`}>{statusConfig.label}</Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Link href={`/syndic/assemblies/${assembly.id}`}>
+                          <Button size="sm" variant="ghost">
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }
@@ -316,12 +306,12 @@ function StatCard({
   color: string;
 }) {
   return (
-    <Card className="bg-white/5 border-white/10 backdrop-blur">
+    <Card>
       <CardContent className="p-4">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm text-slate-400">{label}</p>
-            <p className="text-2xl font-bold text-white mt-1">{value}</p>
+            <p className="text-sm text-muted-foreground">{label}</p>
+            <p className="text-2xl font-bold text-foreground mt-1">{value}</p>
           </div>
           <Icon className={`h-8 w-8 ${color}`} />
         </div>

--- a/app/syndic/calls/page.tsx
+++ b/app/syndic/calls/page.tsx
@@ -8,8 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
-  Euro, Plus, Calendar, Building2, Users,
-  ChevronRight, AlertCircle, CheckCircle2, Clock,
+  Euro, Plus, Calendar, Building2,
+  ChevronRight, AlertCircle, CheckCircle2, Clock, Download, FileDown,
 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { fr } from "date-fns/locale";
@@ -158,6 +158,22 @@ export default function CallsListPage() {
                         <StatusIcon className="h-3 w-3" />
                         {statusConfig.label}
                       </Badge>
+                      <a
+                        href={`/api/copro/fund-calls/${call.id}/pdf`}
+                        target="_blank"
+                        rel="noreferrer"
+                        title="Télécharger l'appel en PDF"
+                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg text-muted-foreground hover:text-cyan-600 hover:bg-cyan-50"
+                      >
+                        <Download className="h-4 w-4" />
+                      </a>
+                      <a
+                        href={`/api/copro/fund-calls/${call.id}/sepa-xml`}
+                        title="Exporter le fichier SEPA"
+                        className="inline-flex items-center justify-center w-8 h-8 rounded-lg text-muted-foreground hover:text-violet-600 hover:bg-violet-50"
+                      >
+                        <FileDown className="h-4 w-4" />
+                      </a>
                       <ChevronRight className="h-4 w-4 text-muted-foreground" />
                     </div>
                   </div>

--- a/app/syndic/claims/page.tsx
+++ b/app/syndic/claims/page.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Building2,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Mail,
+  MapPin,
+  Loader2,
+  Inbox,
+  User,
+} from "lucide-react";
+
+interface Claim {
+  id: string;
+  building_id: string;
+  site_id: string;
+  status: "pending" | "approved" | "rejected" | "cancelled";
+  claim_message: string | null;
+  decision_reason: string | null;
+  created_at: string;
+  building?: {
+    id: string;
+    name: string | null;
+    adresse_complete: string | null;
+    code_postal: string | null;
+    ville: string | null;
+    ownership_type: string | null;
+    total_lots_in_building: number | null;
+    owner?: {
+      id: string;
+      prenom: string | null;
+      nom: string | null;
+      email_contact: string | null;
+    } | null;
+  };
+  site?: { id: string; name: string };
+}
+
+const STATUS_BADGE: Record<string, { label: string; className: string; icon: React.ComponentType<{ className?: string }> }> = {
+  pending: {
+    label: "En attente",
+    className: "bg-amber-100 text-amber-700 border-amber-200",
+    icon: Clock,
+  },
+  approved: {
+    label: "Approuvée",
+    className: "bg-emerald-100 text-emerald-700 border-emerald-200",
+    icon: CheckCircle2,
+  },
+  rejected: {
+    label: "Refusée",
+    className: "bg-red-100 text-red-700 border-red-200",
+    icon: XCircle,
+  },
+  cancelled: {
+    label: "Annulée",
+    className: "bg-slate-100 text-slate-700 border-slate-200",
+    icon: XCircle,
+  },
+};
+
+export default function SyndicClaimsPage() {
+  const { toast } = useToast();
+  const [claims, setClaims] = useState<Claim[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<"pending" | "all">("pending");
+
+  const [decision, setDecision] = useState<{
+    claimId: string;
+    type: "approve" | "reject";
+  } | null>(null);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/syndic/site-claims?status=${statusFilter}`);
+      if (res.ok) {
+        const data = await res.json();
+        setClaims(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter]);
+
+  async function handleDecide() {
+    if (!decision) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/syndic/site-claims/${decision.claimId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          decision: decision.type,
+          reason: reason || undefined,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({
+        title: decision.type === "approve" ? "Demande approuvée" : "Demande refusée",
+      });
+      setDecision(null);
+      setReason("");
+      load();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const pendingCount = claims.filter((c) => c.status === "pending").length;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <Inbox className="h-6 w-6 text-violet-600" />
+            Demandes de rattachement
+          </h1>
+          <p className="text-muted-foreground">
+            Validez les copropriétaires qui souhaitent connecter leur immeuble à vos copropriétés Talok.
+          </p>
+        </div>
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant={statusFilter === "pending" ? "default" : "outline"}
+            onClick={() => setStatusFilter("pending")}
+          >
+            En attente {pendingCount > 0 && <Badge className="ml-2 bg-white text-amber-700">{pendingCount}</Badge>}
+          </Button>
+          <Button
+            size="sm"
+            variant={statusFilter === "all" ? "default" : "outline"}
+            onClick={() => setStatusFilter("all")}
+          >
+            Tout l'historique
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-32" />
+          ))}
+        </div>
+      ) : claims.length === 0 ? (
+        <Card>
+          <CardContent className="py-16 text-center text-muted-foreground">
+            <Inbox className="h-12 w-12 mx-auto mb-3 opacity-50" />
+            <p>
+              {statusFilter === "pending"
+                ? "Aucune demande en attente."
+                : "Aucune demande dans l'historique."}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {claims.map((claim) => {
+            const config = STATUS_BADGE[claim.status] ?? STATUS_BADGE.pending;
+            const Icon = config.icon;
+            const owner = claim.building?.owner;
+            const ownerName = owner
+              ? [owner.prenom, owner.nom].filter(Boolean).join(" ") || "Copropriétaire"
+              : "Copropriétaire";
+            const isPending = claim.status === "pending";
+            return (
+              <Card key={claim.id}>
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <div>
+                      <CardTitle className="text-base flex items-center gap-2">
+                        <Building2 className="w-4 h-4 text-cyan-600" />
+                        {claim.building?.name ?? "Immeuble"}
+                      </CardTitle>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Vers <span className="font-medium">{claim.site?.name ?? "—"}</span>
+                      </p>
+                    </div>
+                    <Badge className={`${config.className} border`}>
+                      <Icon className="w-3 h-3 mr-1" />
+                      {config.label}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+                    <div>
+                      <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                        Demandeur
+                      </p>
+                      <p className="text-foreground inline-flex items-center gap-1.5">
+                        <User className="w-3 h-3" />
+                        {ownerName}
+                      </p>
+                      {owner?.email_contact && (
+                        <p className="text-muted-foreground inline-flex items-center gap-1 text-xs">
+                          <Mail className="w-3 h-3" />
+                          {owner.email_contact}
+                        </p>
+                      )}
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                        Adresse
+                      </p>
+                      <p className="text-foreground inline-flex items-center gap-1.5">
+                        <MapPin className="w-3 h-3" />
+                        {claim.building?.adresse_complete ?? "—"}
+                      </p>
+                      {claim.building?.code_postal && claim.building.ville && (
+                        <p className="text-muted-foreground text-xs">
+                          {claim.building.code_postal} {claim.building.ville}
+                        </p>
+                      )}
+                    </div>
+                    {claim.building?.ownership_type === "partial" &&
+                      claim.building.total_lots_in_building && (
+                        <div>
+                          <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                            Possession
+                          </p>
+                          <p className="text-foreground">
+                            Copropriétaire partiel · sur {claim.building.total_lots_in_building} lots de l'immeuble
+                          </p>
+                        </div>
+                      )}
+                    <div>
+                      <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                        Date
+                      </p>
+                      <p className="text-foreground">
+                        {new Date(claim.created_at).toLocaleDateString("fr-FR", {
+                          day: "2-digit",
+                          month: "long",
+                          year: "numeric",
+                        })}
+                      </p>
+                    </div>
+                  </div>
+
+                  {claim.claim_message && (
+                    <div className="rounded-lg bg-muted/40 p-3 text-sm">
+                      <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                        Message
+                      </p>
+                      <p className="text-foreground italic">« {claim.claim_message} »</p>
+                    </div>
+                  )}
+
+                  {claim.decision_reason && !isPending && (
+                    <div className="rounded-lg bg-muted/40 p-3 text-xs text-muted-foreground">
+                      Motif : {claim.decision_reason}
+                    </div>
+                  )}
+
+                  {isPending && (
+                    <div className="flex items-center justify-end gap-2 pt-2 border-t border-border">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setDecision({ claimId: claim.id, type: "reject" })}
+                        className="text-red-600 hover:bg-red-50 border-red-200"
+                      >
+                        <XCircle className="w-4 h-4 mr-1" />
+                        Refuser
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={() => setDecision({ claimId: claim.id, type: "approve" })}
+                        className="bg-emerald-600 hover:bg-emerald-700"
+                      >
+                        <CheckCircle2 className="w-4 h-4 mr-1" />
+                        Approuver
+                      </Button>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <Dialog open={decision !== null} onOpenChange={(o) => !o && setDecision(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {decision?.type === "approve" ? "Approuver la demande" : "Refuser la demande"}
+            </DialogTitle>
+            <DialogDescription>
+              {decision?.type === "approve"
+                ? "Le copropriétaire aura accès en lecture seule aux informations de la copropriété."
+                : "Indiquez la raison du refus pour informer le copropriétaire."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Textarea
+              rows={3}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder={
+                decision?.type === "approve"
+                  ? "Note interne (optionnelle)"
+                  : "Raison du refus"
+              }
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDecision(null)}>
+              Annuler
+            </Button>
+            <Button
+              onClick={handleDecide}
+              disabled={submitting}
+              className={
+                decision?.type === "approve"
+                  ? "bg-emerald-600 hover:bg-emerald-700"
+                  : "bg-red-600 hover:bg-red-700"
+              }
+            >
+              {submitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              {decision?.type === "approve" ? "Approuver" : "Refuser"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/syndic/councils/new/page.tsx
+++ b/app/syndic/councils/new/page.tsx
@@ -125,7 +125,7 @@ export default function NewCouncilPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+    <div className="p-0">
       <div className="max-w-2xl mx-auto space-y-6">
         <motion.div
           initial={{ opacity: 0, y: -20 }}
@@ -133,36 +133,36 @@ export default function NewCouncilPage() {
           className="flex items-center gap-4"
         >
           <Link href="/syndic/councils">
-            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
+            <Button variant="ghost" size="sm" className="text-foreground hover:text-foreground hover:bg-muted">
               <ArrowLeft className="h-4 w-4 mr-2" />
               Retour
             </Button>
           </Link>
           <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <Users className="h-6 w-6 text-violet-400" />
+            <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+              <Users className="h-6 w-6 text-violet-600" />
               Nouveau conseil syndical
             </h1>
-            <p className="text-slate-400">Élu en assemblée générale (loi du 10 juillet 1965, art. 21)</p>
+            <p className="text-muted-foreground">Élu en assemblée générale (loi du 10 juillet 1965, art. 21)</p>
           </div>
         </motion.div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <Building2 className="h-5 w-5 text-violet-400" />
+              <CardTitle className="text-foreground flex items-center gap-2">
+                <Building2 className="h-5 w-5 text-violet-600" />
                 Copropriété
               </CardTitle>
-              <CardDescription className="text-slate-400">
+              <CardDescription className="text-muted-foreground">
                 Un seul conseil actif par copropriété à la fois
               </CardDescription>
             </CardHeader>
             <CardContent>
               {loadingSites ? (
-                <p className="text-slate-400 text-sm">Chargement...</p>
+                <p className="text-muted-foreground text-sm">Chargement...</p>
               ) : sites.length === 0 ? (
-                <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+                <div className="rounded-xl border border-amber-200 bg-amber-500/10 p-3 text-sm text-amber-100">
                   Aucune copropriété disponible.
                 </div>
               ) : (
@@ -171,7 +171,7 @@ export default function NewCouncilPage() {
                   onValueChange={(value) => setForm({ ...form, site_id: value })}
                   disabled={submitting}
                 >
-                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
+                  <SelectTrigger className=" text-foreground">
                     <SelectValue placeholder="Sélectionner une copropriété" />
                   </SelectTrigger>
                   <SelectContent>
@@ -187,28 +187,28 @@ export default function NewCouncilPage() {
             </CardContent>
           </Card>
 
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardHeader>
-              <CardTitle className="text-white">Durée du mandat</CardTitle>
-              <CardDescription className="text-slate-400">
+              <CardTitle className="text-foreground">Durée du mandat</CardTitle>
+              <CardDescription className="text-muted-foreground">
                 Typiquement 1 à 3 ans (renouvelable par AG)
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="space-y-2">
-                  <Label className="text-slate-300">Début *</Label>
+                  <Label className="text-foreground">Début *</Label>
                   <Input
                     type="date"
                     value={form.mandate_start}
                     onChange={(e) => setForm({ ...form, mandate_start: e.target.value })}
                     required
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-slate-300">Durée (années)</Label>
+                  <Label className="text-foreground">Durée (années)</Label>
                   <Input
                     type="number"
                     min="1"
@@ -218,35 +218,35 @@ export default function NewCouncilPage() {
                       setForm({ ...form, duration_years: parseInt(e.target.value, 10) || 1 })
                     }
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-slate-300">Fin *</Label>
+                  <Label className="text-foreground">Fin *</Label>
                   <Input
                     type="date"
                     value={form.mandate_end}
                     onChange={(e) => setForm({ ...form, mandate_end: e.target.value })}
                     required
                     disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
+                    className=" text-foreground"
                   />
                 </div>
               </div>
             </CardContent>
           </Card>
 
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
+          <Card className="">
             <CardContent className="p-6 space-y-4">
               <div className="space-y-2">
-                <Label className="text-slate-300">Notes (optionnel)</Label>
+                <Label className="text-foreground">Notes (optionnel)</Label>
                 <Textarea
                   value={form.notes}
                   onChange={(e) => setForm({ ...form, notes: e.target.value })}
                   rows={3}
                   disabled={submitting}
                   placeholder="Contexte, circonstances d'élection..."
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
+                  className=" text-foreground placeholder:text-muted-foreground"
                 />
               </div>
               <div className="rounded-lg border border-blue-400/30 bg-blue-500/10 p-3 text-sm text-blue-100">
@@ -264,7 +264,7 @@ export default function NewCouncilPage() {
                 type="button"
                 variant="outline"
                 disabled={submitting}
-                className="border-white/20 text-white hover:bg-white/10"
+                className="border-input text-foreground hover:bg-muted"
               >
                 Annuler
               </Button>

--- a/app/syndic/councils/page.tsx
+++ b/app/syndic/councils/page.tsx
@@ -33,6 +33,12 @@ interface CouncilMember {
   elected_at?: string;
 }
 
+interface ProfileSummary {
+  id: string;
+  prenom: string | null;
+  nom: string | null;
+}
+
 interface CoproCouncil {
   id: string;
   site_id: string;
@@ -43,17 +49,25 @@ interface CoproCouncil {
   members: CouncilMember[];
   members_count: number;
   status: "active" | "suspended" | "dissolved" | "expired";
+  president?: ProfileSummary | null;
+  vice_president?: ProfileSummary | null;
 }
 
 const STATUS_CONFIG: Record<
   string,
   { label: string; color: string; icon: React.ComponentType<{ className?: string }> }
 > = {
-  active: { label: "Actif", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40", icon: CheckCircle2 },
-  suspended: { label: "Suspendu", color: "bg-amber-500/20 text-amber-200 border-amber-400/40", icon: AlertCircle },
-  dissolved: { label: "Dissous", color: "bg-red-500/20 text-red-200 border-red-400/40", icon: XCircle },
-  expired: { label: "Expiré", color: "bg-slate-500/20 text-slate-300 border-slate-500/40", icon: AlertCircle },
+  active: { label: "Actif", color: "bg-emerald-100 text-emerald-700 border-emerald-200", icon: CheckCircle2 },
+  suspended: { label: "Suspendu", color: "bg-amber-100 text-amber-700 border-amber-200", icon: AlertCircle },
+  dissolved: { label: "Dissous", color: "bg-red-100 text-red-700 border-red-200", icon: XCircle },
+  expired: { label: "Expiré", color: "bg-slate-100 text-slate-700 border-slate-200", icon: AlertCircle },
 };
+
+function formatPersonName(person?: ProfileSummary | null): string {
+  if (!person) return "—";
+  const parts = [person.prenom, person.nom].filter(Boolean);
+  return parts.length ? parts.join(" ") : "—";
+}
 
 export default function SyndicCouncilsPage() {
   const { toast } = useToast();
@@ -86,119 +100,115 @@ export default function SyndicCouncilsPage() {
   const activeCount = councils.filter((c) => c.status === "active").length;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-      <div className="max-w-7xl mx-auto space-y-6">
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
-        >
-          <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <Users className="h-6 w-6 text-violet-400" />
-              Conseils syndicaux
-            </h1>
-            <p className="text-slate-400">
-              Assistent et contrôlent le syndic (loi du 10 juillet 1965, art. 21)
-            </p>
-          </div>
-          <Link href="/syndic/councils/new">
-            <Button className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700">
-              <Plus className="h-4 w-4 mr-2" />
-              Nouveau conseil
-            </Button>
-          </Link>
-        </motion.div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
-            <CardContent className="p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-slate-400">Total</p>
-                  <p className="text-2xl font-bold text-white mt-1">{councils.length}</p>
-                </div>
-                <Users className="h-8 w-8 text-violet-400" />
-              </div>
-            </CardContent>
-          </Card>
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
-            <CardContent className="p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-slate-400">Actifs</p>
-                  <p className="text-2xl font-bold text-white mt-1">{activeCount}</p>
-                </div>
-                <CheckCircle2 className="h-8 w-8 text-emerald-400" />
-              </div>
-            </CardContent>
-          </Card>
+    <div className="space-y-6">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+      >
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <Users className="h-6 w-6 text-violet-600" />
+            Conseils syndicaux
+          </h1>
+          <p className="text-muted-foreground">
+            Assistent et contrôlent le syndic (loi du 10 juillet 1965, art. 21)
+          </p>
         </div>
+        <Link href="/syndic/councils/new">
+          <Button className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700">
+            <Plus className="h-4 w-4 mr-2" />
+            Nouveau conseil
+          </Button>
+        </Link>
+      </motion.div>
 
-        <Card className="bg-white/5 border-white/10 backdrop-blur">
-          <CardContent className="p-0">
-            {loading ? (
-              <div className="p-6 space-y-3">
-                {[1, 2, 3].map((i) => (
-                  <Skeleton key={i} className="h-12 bg-white/10" />
-                ))}
+      <div className="grid grid-cols-2 gap-4">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Total</p>
+                <p className="text-2xl font-bold text-foreground mt-1">{councils.length}</p>
               </div>
-            ) : councils.length === 0 ? (
-              <div className="p-12 text-center text-slate-400">
-                <Users className="h-12 w-12 mx-auto mb-3 text-slate-500" />
-                <p className="mb-4">Aucun conseil syndical pour le moment</p>
-                <Link href="/syndic/councils/new">
-                  <Button variant="outline" className="border-white/20 text-white hover:bg-white/10">
-                    <Plus className="h-4 w-4 mr-2" />
-                    Créer un conseil
-                  </Button>
-                </Link>
+              <Users className="h-8 w-8 text-violet-600" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Actifs</p>
+                <p className="text-2xl font-bold text-foreground mt-1">{activeCount}</p>
               </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-white/10 hover:bg-transparent">
-                    <TableHead className="text-slate-300">Période de mandat</TableHead>
-                    <TableHead className="text-slate-300">Membres</TableHead>
-                    <TableHead className="text-slate-300">Président</TableHead>
-                    <TableHead className="text-slate-300">Statut</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {councils.map((council) => {
-                    const config = STATUS_CONFIG[council.status] || STATUS_CONFIG.active;
-                    const Icon = config.icon;
-                    return (
-                      <TableRow key={council.id} className="border-white/10 hover:bg-white/5">
-                        <TableCell className="text-slate-300 text-sm">
-                          <div className="flex items-center gap-1">
-                            <Calendar className="h-3 w-3" />
-                            {formatDateShort(council.mandate_start)} → {formatDateShort(council.mandate_end)}
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-white">
-                          {council.members_count} membre{council.members_count > 1 ? "s" : ""}
-                        </TableCell>
-                        <TableCell className="text-slate-300 font-mono text-xs">
-                          {council.president_profile_id
-                            ? `${council.president_profile_id.slice(0, 8)}...`
-                            : "—"}
-                        </TableCell>
-                        <TableCell>
-                          <Badge className={`${config.color} border`}>
-                            <Icon className="h-3 w-3 mr-1" />
-                            {config.label}
-                          </Badge>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            )}
+              <CheckCircle2 className="h-8 w-8 text-emerald-600" />
+            </div>
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-12" />
+              ))}
+            </div>
+          ) : councils.length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              <Users className="h-12 w-12 mx-auto mb-3 opacity-50" />
+              <p className="mb-4">Aucun conseil syndical pour le moment</p>
+              <Link href="/syndic/councils/new">
+                <Button variant="outline">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Créer un conseil
+                </Button>
+              </Link>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Période de mandat</TableHead>
+                  <TableHead>Membres</TableHead>
+                  <TableHead>Président</TableHead>
+                  <TableHead>Statut</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {councils.map((council) => {
+                  const config = STATUS_CONFIG[council.status] || STATUS_CONFIG.active;
+                  const Icon = config.icon;
+                  return (
+                    <TableRow key={council.id}>
+                      <TableCell className="text-foreground text-sm">
+                        <div className="flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {formatDateShort(council.mandate_start)} → {formatDateShort(council.mandate_end)}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-foreground">
+                        {council.members_count} membre{council.members_count > 1 ? "s" : ""}
+                      </TableCell>
+                      <TableCell className="text-foreground">
+                        {formatPersonName(council.president)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge className={`${config.color} border`}>
+                          <Icon className="h-3 w-3 mr-1" />
+                          {config.label}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/syndic/dashboard/page.tsx
+++ b/app/syndic/dashboard/page.tsx
@@ -8,16 +8,14 @@ import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SiteCard } from "@/components/copro/site-card";
 import { AssemblyCard } from "@/components/copro/assembly-card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useAuth } from "@/lib/hooks/use-auth";
-import { usePermissions } from "@/lib/hooks/use-permissions";
 import {
   Building2, Users, Euro, Calendar,
-  Plus, TrendingUp, AlertTriangle,
+  Plus, AlertTriangle,
   ChevronRight, FileText, Bell
 } from "lucide-react";
 import Link from "next/link";
@@ -41,9 +39,8 @@ interface DashboardStats {
 }
 
 export default function SyndicDashboardPage() {
-  const { user, profile } = useAuth();
+  const { profile } = useAuth();
   const typedProfile = profile as SyndicProfile | null;
-  const { isSyndic, isPlatformAdmin } = usePermissions();
   const [sites, setSites] = useState<Site[]>([]);
   const [assemblies, setAssemblies] = useState<AssemblySummary[]>([]);
   const [stats, setStats] = useState<DashboardStats | null>(null);
@@ -53,16 +50,28 @@ export default function SyndicDashboardPage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        // Récupérer les sites
-        const sitesRes = await fetch('/api/copro/sites');
+        const [sitesRes, assembliesRes] = await Promise.all([
+          fetch("/api/copro/sites"),
+          fetch("/api/copro/assemblies?upcoming=true"),
+        ]);
+
         if (sitesRes.ok) {
           const sitesData = await sitesRes.json();
           setSites(sitesData);
 
-          // Calculer les stats à partir des sites récupérés
-          const totalUnits = sitesData.reduce((sum: number, s: Site) => sum + ((s as any).units?.[0]?.count || (s as any).total_units || 0), 0);
-          const totalBalanceDue = sitesData.reduce((sum: number, s: Site) => sum + ((s as any).total_balance_due || 0), 0);
-          const unpaidCount = sitesData.reduce((sum: number, s: Site) => sum + ((s as any).unpaid_count || 0), 0);
+          const totalUnits = sitesData.reduce(
+            (sum: number, s: Site) =>
+              sum + ((s as Site & { units?: Array<{ count: number }>; total_units?: number }).units?.[0]?.count || (s as Site & { total_units?: number }).total_units || 0),
+            0
+          );
+          const totalBalanceDue = sitesData.reduce(
+            (sum: number, s: Site) => sum + ((s as Site & { total_balance_due?: number }).total_balance_due || 0),
+            0
+          );
+          const unpaidCount = sitesData.reduce(
+            (sum: number, s: Site) => sum + ((s as Site & { unpaid_count?: number }).unpaid_count || 0),
+            0
+          );
 
           setStats({
             total_sites: sitesData.length,
@@ -72,19 +81,19 @@ export default function SyndicDashboardPage() {
             unpaid_count: unpaidCount,
             upcoming_assemblies: 0,
           });
+        } else {
+          throw new Error("Impossible de charger les copropriétés");
         }
 
-        // Récupérer les AG à venir
-        const assembliesRes = await fetch('/api/copro/assemblies?upcoming=true');
         if (assembliesRes.ok) {
           const assembliesData = await assembliesRes.json();
           setAssemblies(assembliesData);
-          // Mettre à jour le compteur AG dans les stats
-          setStats(prev => prev ? { ...prev, upcoming_assemblies: assembliesData.length } : prev);
+          setStats((prev) =>
+            prev ? { ...prev, upcoming_assemblies: assembliesData.length } : prev
+          );
         }
       } catch (err) {
-        console.error('Erreur chargement dashboard:', err);
-        setError('Erreur lors du chargement du tableau de bord');
+        setError(err instanceof Error ? err.message : "Erreur lors du chargement du tableau de bord");
       } finally {
         setLoading(false);
       }
@@ -99,257 +108,243 @@ export default function SyndicDashboardPage() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-        <div className="max-w-7xl mx-auto">
-          <Alert variant="destructive">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
+      <div className="space-y-6">
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
       </div>
     );
   }
 
-  // Premier accès : afficher l'onboarding
   if (sites.length === 0) {
     return <FirstTimeOnboarding />;
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-      <div className="max-w-7xl mx-auto space-y-8">
-        {/* Header */}
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="flex items-center justify-between"
-        >
-          <div>
-            <h1 className="text-2xl font-bold text-white">
-              Bonjour {typedProfile?.first_name || typedProfile?.prenom || 'Syndic'} 👋
-            </h1>
-            <p className="text-slate-400">
-              Bienvenue sur votre espace de gestion
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <Button variant="outline" className="border-white/10 text-white" asChild>
-              <Link href="/notifications">
-                <Bell className="w-4 h-4 mr-2" />
-                Notifications
-              </Link>
-            </Button>
-            <Link href="/syndic/onboarding/profile">
-              <Button className="bg-gradient-to-r from-cyan-500 to-blue-600">
-                <Plus className="w-4 h-4 mr-2" />
-                Nouvelle copropriété
-              </Button>
+    <div className="space-y-8">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex items-center justify-between flex-wrap gap-4"
+      >
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">
+            Bonjour {typedProfile?.first_name || typedProfile?.prenom || 'Syndic'} 👋
+          </h1>
+          <p className="text-muted-foreground">
+            Bienvenue sur votre espace de gestion
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Button variant="outline" asChild>
+            <Link href="/notifications">
+              <Bell className="w-4 h-4 mr-2" />
+              Notifications
             </Link>
-          </div>
-        </motion.div>
+          </Button>
+          <Link href="/syndic/onboarding/profile">
+            <Button className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700">
+              <Plus className="w-4 h-4 mr-2" />
+              Nouvelle copropriété
+            </Button>
+          </Link>
+        </div>
+      </motion.div>
 
-        {/* Stats globales */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-          className="grid grid-cols-2 md:grid-cols-4 gap-4"
-        >
-          <StatCard
-            icon={Building2}
-            label="Copropriétés"
-            value={sites.length}
-            color="cyan"
-          />
-          <StatCard
-            icon={Users}
-            label="Lots gérés"
-            value={sites.reduce((sum, s) => sum + ((s as Site & { units?: Array<{ count: number }> }).units?.[0]?.count || 0), 0)}
-            color="violet"
-          />
-          <StatCard
-            icon={Calendar}
-            label="AG à venir"
-            value={assemblies.length}
-            color="amber"
-          />
-          <StatCard
-            icon={Euro}
-            label="Impayés"
-            value={stats?.unpaid_count || 0}
-            color="red"
-            alert={stats ? stats.unpaid_count > 0 : undefined}
-          />
-        </motion.div>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1 }}
+        className="grid grid-cols-2 md:grid-cols-4 gap-4"
+      >
+        <StatCard
+          icon={Building2}
+          label="Copropriétés"
+          value={sites.length}
+          color="cyan"
+        />
+        <StatCard
+          icon={Users}
+          label="Lots gérés"
+          value={sites.reduce((sum, s) => sum + ((s as Site & { units?: Array<{ count: number }> }).units?.[0]?.count || 0), 0)}
+          color="violet"
+        />
+        <StatCard
+          icon={Calendar}
+          label="AG à venir"
+          value={assemblies.length}
+          color="amber"
+        />
+        <StatCard
+          icon={Euro}
+          label="Impayés"
+          value={stats?.unpaid_count || 0}
+          color="red"
+          alert={stats ? stats.unpaid_count > 0 : undefined}
+        />
+      </motion.div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Colonne principale */}
-          <div className="lg:col-span-2 space-y-6">
-            {/* Mes copropriétés */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2 }}
-            >
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold text-white flex items-center gap-2">
-                  <Building2 className="w-5 h-5 text-cyan-400" />
-                  Mes copropriétés
-                </h2>
-                <Link href="/syndic/sites">
-                  <Button variant="ghost" size="sm" className="text-slate-400 hover:text-white">
-                    Voir tout
-                    <ChevronRight className="w-4 h-4 ml-1" />
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 space-y-6">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 }}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <Building2 className="w-5 h-5 text-cyan-600" />
+                Mes copropriétés
+              </h2>
+              <Link href="/syndic/sites">
+                <Button variant="ghost" size="sm">
+                  Voir tout
+                  <ChevronRight className="w-4 h-4 ml-1" />
+                </Button>
+              </Link>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {sites.slice(0, 4).map((site, index) => (
+                <motion.div
+                  key={site.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.1 * index }}
+                >
+                  <SiteCard site={site} showActions={false} />
+                </motion.div>
+              ))}
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3 }}
+          >
+            <Card>
+              <CardHeader>
+                <CardTitle>Actions rapides</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                  <QuickAction
+                    icon={FileText}
+                    label="Saisir une facture"
+                    href="/syndic/expenses/new"
+                    color="emerald"
+                  />
+                  <QuickAction
+                    icon={Euro}
+                    label="Appel de fonds"
+                    href="/syndic/calls/new"
+                    color="amber"
+                  />
+                  <QuickAction
+                    icon={Calendar}
+                    label="Planifier une AG"
+                    href="/syndic/assemblies/new"
+                    color="violet"
+                  />
+                  <QuickAction
+                    icon={Users}
+                    label="Inviter un copro"
+                    href="/syndic/invites"
+                    color="cyan"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+        </div>
+
+        <div className="space-y-6">
+          <motion.div
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: 0.4 }}
+          >
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2">
+                  <Calendar className="w-5 h-5 text-violet-600" />
+                  Prochaines AG
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {assemblies.length > 0 ? (
+                  assemblies.slice(0, 3).map((assembly) => (
+                    <AssemblyCard
+                      key={assembly.id}
+                      assembly={assembly}
+                      compact
+                    />
+                  ))
+                ) : (
+                  <div className="text-center py-6 text-muted-foreground">
+                    <Calendar className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                    <p className="text-sm">Aucune AG programmée</p>
+                  </div>
+                )}
+                <Link href="/syndic/assemblies">
+                  <Button
+                    variant="ghost"
+                    className="w-full"
+                  >
+                    Voir toutes les AG
                   </Button>
                 </Link>
-              </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {sites.slice(0, 4).map((site, index) => (
-                  <motion.div
-                    key={site.id}
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: 0.1 * index }}
-                  >
-                    <SiteCard site={site} showActions={false} />
-                  </motion.div>
-                ))}
-              </div>
-            </motion.div>
+              </CardContent>
+            </Card>
+          </motion.div>
 
-            {/* Actions rapides */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3 }}
-            >
-              <Card className="border-white/10 bg-white/5">
-                <CardHeader>
-                  <CardTitle className="text-white">Actions rapides</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                    <QuickAction
-                      icon={FileText}
-                      label="Saisir une facture"
-                      href="/syndic/expenses/new"
-                      color="emerald"
-                    />
-                    <QuickAction
-                      icon={Euro}
-                      label="Appel de fonds"
-                      href="/syndic/calls/new"
-                      color="amber"
-                    />
-                    <QuickAction
-                      icon={Calendar}
-                      label="Planifier une AG"
-                      href="/syndic/assemblies/new"
-                      color="violet"
-                    />
-                    <QuickAction
-                      icon={Users}
-                      label="Inviter un copro"
-                      href="/syndic/invites"
-                      color="cyan"
-                    />
+          <motion.div
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: 0.5 }}
+          >
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2">
+                  <AlertTriangle className="w-5 h-5 text-amber-600" />
+                  Alertes
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {stats && stats.unpaid_count > 0 && (
+                  <AlertItem
+                    type="danger"
+                    message={`${stats.unpaid_count} lot(s) en impayé`}
+                  />
+                )}
+                {assemblies.length > 0 && (
+                  <AlertItem
+                    type="info"
+                    message={`${assemblies.length} assemblée(s) générale(s) à venir`}
+                  />
+                )}
+                {stats && stats.unpaid_count === 0 && assemblies.length === 0 && (
+                  <div className="text-center py-4 text-muted-foreground text-sm">
+                    Aucune alerte
                   </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          </div>
-
-          {/* Sidebar */}
-          <div className="space-y-6">
-            {/* AG à venir */}
-            <motion.div
-              initial={{ opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.4 }}
-            >
-              <Card className="border-white/10 bg-white/5">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-white flex items-center gap-2">
-                    <Calendar className="w-5 h-5 text-violet-400" />
-                    Prochaines AG
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  {assemblies.length > 0 ? (
-                    assemblies.slice(0, 3).map((assembly) => (
-                      <AssemblyCard 
-                        key={assembly.id} 
-                        assembly={assembly} 
-                        compact 
-                      />
-                    ))
-                  ) : (
-                    <div className="text-center py-6 text-slate-400">
-                      <Calendar className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                      <p className="text-sm">Aucune AG programmée</p>
-                    </div>
-                  )}
-                  <Link href="/syndic/assemblies">
-                    <Button 
-                      variant="ghost" 
-                      className="w-full text-slate-400 hover:text-white"
-                    >
-                      Voir toutes les AG
-                    </Button>
-                  </Link>
-                </CardContent>
-              </Card>
-            </motion.div>
-
-            {/* Alertes */}
-            <motion.div
-              initial={{ opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.5 }}
-            >
-              <Card className="border-white/10 bg-white/5">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-white flex items-center gap-2">
-                    <AlertTriangle className="w-5 h-5 text-amber-400" />
-                    Alertes
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  {stats && stats.unpaid_count > 0 && (
-                    <AlertItem
-                      type="danger"
-                      message={`${stats.unpaid_count} lot(s) en impayé`}
-                    />
-                  )}
-                  {assemblies.length > 0 && (
-                    <AlertItem
-                      type="info"
-                      message={`${assemblies.length} assemblée(s) générale(s) à venir`}
-                    />
-                  )}
-                  {stats && stats.unpaid_count === 0 && assemblies.length === 0 && (
-                    <div className="text-center py-4 text-slate-400 text-sm">
-                      Aucune alerte
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </motion.div>
-          </div>
+                )}
+              </CardContent>
+            </Card>
+          </motion.div>
         </div>
       </div>
     </div>
   );
 }
 
-// Composants auxiliaires
-function StatCard({ 
-  icon: Icon, 
-  label, 
-  value, 
+function StatCard({
+  icon: Icon,
+  label,
+  value,
   color,
-  alert 
-}: { 
+  alert,
+}: {
   icon: React.ElementType;
   label: string;
   value: number;
@@ -357,23 +352,23 @@ function StatCard({
   alert?: boolean;
 }) {
   const colorClasses: Record<string, { bg: string; text: string }> = {
-    cyan: { bg: 'bg-cyan-500/20', text: 'text-cyan-400' },
-    violet: { bg: 'bg-violet-500/20', text: 'text-violet-400' },
-    amber: { bg: 'bg-amber-500/20', text: 'text-amber-400' },
-    red: { bg: 'bg-red-500/20', text: 'text-red-400' },
-    emerald: { bg: 'bg-emerald-500/20', text: 'text-emerald-400' },
+    cyan: { bg: 'bg-cyan-100', text: 'text-cyan-700' },
+    violet: { bg: 'bg-violet-100', text: 'text-violet-700' },
+    amber: { bg: 'bg-amber-100', text: 'text-amber-700' },
+    red: { bg: 'bg-red-100', text: 'text-red-700' },
+    emerald: { bg: 'bg-emerald-100', text: 'text-emerald-700' },
   };
 
   return (
-    <Card className={`border-white/10 bg-white/5 ${alert ? 'animate-pulse' : ''}`}>
+    <Card className={alert ? 'animate-pulse' : ''}>
       <CardContent className="p-4">
         <div className="flex items-center gap-3">
           <div className={`p-2 rounded-lg ${colorClasses[color].bg}`}>
             <Icon className={`w-5 h-5 ${colorClasses[color].text}`} />
           </div>
           <div>
-            <p className="text-2xl font-bold text-white">{value}</p>
-            <p className="text-xs text-slate-400">{label}</p>
+            <p className="text-2xl font-bold text-foreground">{value}</p>
+            <p className="text-xs text-muted-foreground">{label}</p>
           </div>
         </div>
       </CardContent>
@@ -381,22 +376,22 @@ function StatCard({
   );
 }
 
-function QuickAction({ 
-  icon: Icon, 
-  label, 
-  href, 
-  color 
-}: { 
+function QuickAction({
+  icon: Icon,
+  label,
+  href,
+  color,
+}: {
   icon: React.ElementType;
   label: string;
   href: string;
   color: string;
 }) {
   const colorClasses: Record<string, string> = {
-    cyan: 'hover:bg-cyan-500/10 hover:border-cyan-500/50',
-    violet: 'hover:bg-violet-500/10 hover:border-violet-500/50',
-    amber: 'hover:bg-amber-500/10 hover:border-amber-500/50',
-    emerald: 'hover:bg-emerald-500/10 hover:border-emerald-500/50',
+    cyan: 'hover:bg-cyan-50 hover:border-cyan-300',
+    violet: 'hover:bg-violet-50 hover:border-violet-300',
+    amber: 'hover:bg-amber-50 hover:border-amber-300',
+    emerald: 'hover:bg-emerald-50 hover:border-emerald-300',
   };
 
   return (
@@ -404,10 +399,10 @@ function QuickAction({
       <motion.div
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
-        className={`p-4 rounded-lg border border-white/10 text-center cursor-pointer transition-colors ${colorClasses[color]}`}
+        className={`p-4 rounded-lg border border-border text-center cursor-pointer transition-colors ${colorClasses[color]}`}
       >
-        <Icon className="w-6 h-6 mx-auto mb-2 text-slate-400" />
-        <p className="text-xs text-slate-300">{label}</p>
+        <Icon className="w-6 h-6 mx-auto mb-2 text-muted-foreground" />
+        <p className="text-xs text-foreground">{label}</p>
       </motion.div>
     </Link>
   );
@@ -415,9 +410,9 @@ function QuickAction({
 
 function AlertItem({ type, message }: { type: 'info' | 'warning' | 'danger'; message: string }) {
   const colors = {
-    info: 'bg-cyan-500/10 border-cyan-500/30 text-cyan-400',
-    warning: 'bg-amber-500/10 border-amber-500/30 text-amber-400',
-    danger: 'bg-red-500/10 border-red-500/30 text-red-400',
+    info: 'bg-cyan-50 border-cyan-200 text-cyan-700',
+    warning: 'bg-amber-50 border-amber-200 text-amber-700',
+    danger: 'bg-red-50 border-red-200 text-red-700',
   };
 
   return (
@@ -429,18 +424,16 @@ function AlertItem({ type, message }: { type: 'info' | 'warning' | 'danger'; mes
 
 function DashboardSkeleton() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-      <div className="max-w-7xl mx-auto space-y-8">
-        <Skeleton className="h-12 w-64 bg-white/10" />
-        <div className="grid grid-cols-4 gap-4">
-          {[1, 2, 3, 4].map((i) => (
-            <Skeleton key={i} className="h-24 bg-white/10" />
-          ))}
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <Skeleton className="h-64 bg-white/10" />
-          <Skeleton className="h-64 bg-white/10" />
-        </div>
+    <div className="space-y-8">
+      <Skeleton className="h-12 w-64" />
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-24" />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Skeleton className="h-64" />
+        <Skeleton className="h-64" />
       </div>
     </div>
   );
@@ -448,7 +441,7 @@ function DashboardSkeleton() {
 
 function FirstTimeOnboarding() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-6">
+    <div className="min-h-[60vh] flex items-center justify-center p-6">
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
@@ -457,15 +450,15 @@ function FirstTimeOnboarding() {
         <div className="mx-auto w-20 h-20 rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 flex items-center justify-center mb-6">
           <Building2 className="w-10 h-10 text-white" />
         </div>
-        <h1 className="text-3xl font-bold text-white mb-4">
+        <h1 className="text-3xl font-bold text-foreground mb-4">
           Bienvenue sur votre espace Syndic !
         </h1>
-        <p className="text-slate-400 mb-8">
-          Commencez par créer votre première copropriété pour gérer vos bâtiments, 
+        <p className="text-muted-foreground mb-8">
+          Commencez par créer votre première copropriété pour gérer vos bâtiments,
           lots, charges et assemblées générales.
         </p>
         <Link href="/syndic/onboarding/profile">
-          <Button size="lg" className="bg-gradient-to-r from-cyan-500 to-blue-600">
+          <Button size="lg" className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700">
             <Plus className="w-5 h-5 mr-2" />
             Créer ma première copropriété
           </Button>
@@ -474,4 +467,3 @@ function FirstTimeOnboarding() {
     </div>
   );
 }
-

--- a/app/syndic/fonds-travaux/FondsTravauxClient.tsx
+++ b/app/syndic/fonds-travaux/FondsTravauxClient.tsx
@@ -1,12 +1,25 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PlanGate } from "@/components/subscription/plan-gate";
 import { useCoproSites } from "@/lib/hooks/use-copro-lots";
 import { useSyndicDashboard } from "@/lib/hooks/use-syndic-dashboard";
 import { formatCents } from "@/lib/utils/format-cents";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
@@ -22,8 +35,30 @@ import {
   Wallet,
   Info,
   ShieldCheck,
+  Plus,
+  ArrowUpCircle,
+  ArrowDownCircle,
+  Loader2,
 } from "lucide-react";
 import Link from "next/link";
+
+interface Movement {
+  id: string;
+  movement_type: "cotisation" | "travaux" | "interets" | "remboursement" | "autre";
+  direction: "credit" | "debit";
+  amount_cents: number;
+  movement_date: string;
+  description: string | null;
+  reference: string | null;
+}
+
+const MOVEMENT_TYPE_LABEL: Record<Movement["movement_type"], string> = {
+  cotisation: "Cotisation",
+  travaux: "Travaux",
+  interets: "Intérêts",
+  remboursement: "Remboursement",
+  autre: "Autre",
+};
 
 export default function FondsTravauxClient() {
   return (
@@ -38,7 +73,92 @@ function FondsTravauxContent() {
   const [selectedSiteId, setSelectedSiteId] = useState("");
   const activeSiteId = selectedSiteId || sites?.[0]?.id || "";
 
-  const { worksFund, kpis, isLoading } = useSyndicDashboard(activeSiteId);
+  const { worksFund, isLoading, refetch } = useSyndicDashboard(activeSiteId);
+  const { toast } = useToast();
+
+  const [movements, setMovements] = useState<Movement[]>([]);
+  const [movementsLoading, setMovementsLoading] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [form, setForm] = useState({
+    movement_type: "cotisation" as Movement["movement_type"],
+    direction: "credit" as Movement["direction"],
+    amount_euros: "",
+    movement_date: new Date().toISOString().split("T")[0],
+    description: "",
+    reference: "",
+  });
+
+  useEffect(() => {
+    if (!activeSiteId) return;
+    let cancelled = false;
+    setMovementsLoading(true);
+    fetch(`/api/copro/fonds-travaux/movements?site_id=${activeSiteId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled) setMovements(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        if (!cancelled) setMovements([]);
+      })
+      .finally(() => {
+        if (!cancelled) setMovementsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSiteId, refetch]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!activeSiteId) return;
+    const amountCents = Math.round(Number(form.amount_euros) * 100);
+    if (!Number.isFinite(amountCents) || amountCents <= 0) {
+      toast({ title: "Montant invalide", variant: "destructive" });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/copro/fonds-travaux/movements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          site_id: activeSiteId,
+          movement_type: form.movement_type,
+          direction: form.direction,
+          amount_cents: amountCents,
+          movement_date: form.movement_date,
+          description: form.description || undefined,
+          reference: form.reference || undefined,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({ title: "Mouvement enregistré" });
+      setDialogOpen(false);
+      setForm({
+        movement_type: "cotisation",
+        direction: "credit",
+        amount_euros: "",
+        movement_date: new Date().toISOString().split("T")[0],
+        description: "",
+        reference: "",
+      });
+      // Recharger la liste + KPIs
+      const reload = await fetch(`/api/copro/fonds-travaux/movements?site_id=${activeSiteId}`);
+      setMovements(await reload.json());
+      refetch();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec de l'enregistrement",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
   if (isLoading) {
     return <FondsTravauxLoadingSkeleton />;
@@ -49,7 +169,6 @@ function FondsTravauxContent() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-3">
         <div className="flex items-center gap-3 flex-1">
           <Link
@@ -69,24 +188,125 @@ function FondsTravauxContent() {
           </div>
         </div>
 
-        {sites && sites.length > 1 && (
-          <Select value={activeSiteId} onValueChange={setSelectedSiteId}>
-            <SelectTrigger className="w-full sm:w-64">
-              <Building2 className="w-4 h-4 mr-2 text-cyan-600" />
-              <SelectValue placeholder="Selectionner une copropriete" />
-            </SelectTrigger>
-            <SelectContent>
-              {sites.map((site) => (
-                <SelectItem key={site.id} value={site.id}>
-                  {site.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
+        <div className="flex items-center gap-2">
+          {sites && sites.length > 1 && (
+            <Select value={activeSiteId} onValueChange={setSelectedSiteId}>
+              <SelectTrigger className="w-full sm:w-64">
+                <Building2 className="w-4 h-4 mr-2 text-cyan-600" />
+                <SelectValue placeholder="Sélectionner une copropriété" />
+              </SelectTrigger>
+              <SelectContent>
+                {sites.map((site) => (
+                  <SelectItem key={site.id} value={site.id}>
+                    {site.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button className="bg-cyan-600 hover:bg-cyan-700" disabled={!activeSiteId}>
+                <Plus className="w-4 h-4 mr-2" />
+                Saisir un mouvement
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Nouveau mouvement</DialogTitle>
+                <DialogDescription>
+                  Cotisation, dépense de travaux, intérêts, remboursement…
+                </DialogDescription>
+              </DialogHeader>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label>Type</Label>
+                    <Select
+                      value={form.movement_type}
+                      onValueChange={(v) =>
+                        setForm({ ...form, movement_type: v as Movement["movement_type"] })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="cotisation">Cotisation</SelectItem>
+                        <SelectItem value="travaux">Travaux</SelectItem>
+                        <SelectItem value="interets">Intérêts</SelectItem>
+                        <SelectItem value="remboursement">Remboursement</SelectItem>
+                        <SelectItem value="autre">Autre</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Sens</Label>
+                    <Select
+                      value={form.direction}
+                      onValueChange={(v) => setForm({ ...form, direction: v as Movement["direction"] })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="credit">Entrée (crédit)</SelectItem>
+                        <SelectItem value="debit">Sortie (débit)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Montant (€)</Label>
+                    <Input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={form.amount_euros}
+                      onChange={(e) => setForm({ ...form, amount_euros: e.target.value })}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Date</Label>
+                    <Input
+                      type="date"
+                      value={form.movement_date}
+                      onChange={(e) => setForm({ ...form, movement_date: e.target.value })}
+                      required
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label>Référence</Label>
+                  <Input
+                    value={form.reference}
+                    onChange={(e) => setForm({ ...form, reference: e.target.value })}
+                    placeholder="Facture, virement…"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Description</Label>
+                  <Textarea
+                    value={form.description}
+                    onChange={(e) => setForm({ ...form, description: e.target.value })}
+                    rows={2}
+                  />
+                </div>
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>
+                    Annuler
+                  </Button>
+                  <Button type="submit" disabled={submitting}>
+                    {submitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    Enregistrer
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
+        </div>
       </div>
 
-      {/* Compliance alert */}
       <Card
         className={
           isCompliant
@@ -112,12 +332,12 @@ function FondsTravauxContent() {
             <div>
               <p className="text-sm font-medium text-foreground">
                 {isCompliant
-                  ? "Conforme a la loi ALUR"
-                  : "Attention : taux inferieur au minimum legal"}
+                  ? "Conforme à la loi ALUR"
+                  : "Attention : taux inférieur au minimum légal"}
               </p>
               <p className="text-xs text-muted-foreground mt-1">
                 La loi ALUR impose une cotisation minimale de 2,5% du budget
-                previsionnel pour les coproprietes de plus de 10 lots. Le taux
+                prévisionnel pour les copropriétés de plus de 10 lots. Le taux
                 actuel est de {worksFund?.rate_pct ?? 0}%.
               </p>
             </div>
@@ -125,7 +345,6 @@ function FondsTravauxContent() {
         </CardContent>
       </Card>
 
-      {/* KPI Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <KpiCard
           title="Solde du fonds"
@@ -138,10 +357,10 @@ function FondsTravauxContent() {
           value={`${worksFund?.rate_pct ?? 0}%`}
           icon={<Hammer className="w-5 h-5" />}
           color="blue"
-          subtitle={`Minimum legal : ${minRate}%`}
+          subtitle={`Minimum légal : ${minRate}%`}
         />
         <KpiCard
-          title="Evolution"
+          title="Évolution"
           value={`${(worksFund?.evolution_cents ?? 0) >= 0 ? "+" : ""}${formatCents(worksFund?.evolution_cents ?? 0)}`}
           icon={<TrendingUp className="w-5 h-5" />}
           color={(worksFund?.evolution_cents ?? 0) >= 0 ? "green" : "red"}
@@ -149,20 +368,86 @@ function FondsTravauxContent() {
         />
       </div>
 
-      {/* Info card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Wallet className="w-4 h-4 text-cyan-600" />
+            Historique des mouvements
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {movementsLoading ? (
+            <div className="py-8 text-center text-muted-foreground">
+              <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+            </div>
+          ) : movements.length === 0 ? (
+            <div className="py-8 text-center text-muted-foreground text-sm">
+              Aucun mouvement enregistré pour cette copropriété.
+            </div>
+          ) : (
+            <div className="overflow-x-auto -mx-4 sm:-mx-6">
+              <table className="w-full text-sm min-w-[600px]">
+                <thead>
+                  <tr className="border-b border-border text-muted-foreground">
+                    <th className="text-left py-2 px-4 sm:px-6 font-medium">Date</th>
+                    <th className="text-left py-2 px-4 sm:px-6 font-medium">Type</th>
+                    <th className="text-left py-2 px-4 sm:px-6 font-medium">Référence</th>
+                    <th className="text-left py-2 px-4 sm:px-6 font-medium">Description</th>
+                    <th className="text-right py-2 px-4 sm:px-6 font-medium">Montant</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {movements.map((m) => (
+                    <tr key={m.id} className="border-b border-border/50 last:border-0">
+                      <td className="py-3 px-4 sm:px-6 text-foreground">
+                        {new Date(m.movement_date).toLocaleDateString("fr-FR")}
+                      </td>
+                      <td className="py-3 px-4 sm:px-6 text-foreground">
+                        {MOVEMENT_TYPE_LABEL[m.movement_type]}
+                      </td>
+                      <td className="py-3 px-4 sm:px-6 text-muted-foreground text-xs font-mono">
+                        {m.reference ?? "—"}
+                      </td>
+                      <td className="py-3 px-4 sm:px-6 text-muted-foreground">
+                        {m.description ?? "—"}
+                      </td>
+                      <td
+                        className={`py-3 px-4 sm:px-6 text-right font-semibold ${
+                          m.direction === "credit"
+                            ? "text-emerald-600 dark:text-emerald-400"
+                            : "text-red-600 dark:text-red-400"
+                        }`}
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          {m.direction === "credit" ? (
+                            <ArrowUpCircle className="w-3.5 h-3.5" />
+                          ) : (
+                            <ArrowDownCircle className="w-3.5 h-3.5" />
+                          )}
+                          {m.direction === "credit" ? "+" : "-"}
+                          {formatCents(m.amount_cents)}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
             <Info className="w-4 h-4 text-cyan-600" />
-            A propos du fonds de travaux
+            À propos du fonds de travaux
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-3">
-              <h4 className="text-sm font-semibold text-foreground">
-                Obligation legale
-              </h4>
+              <h4 className="text-sm font-semibold text-foreground">Obligation légale</h4>
               <ul className="space-y-2 text-sm text-muted-foreground">
                 <li className="flex items-start gap-2">
                   <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5" />
@@ -170,31 +455,28 @@ function FondsTravauxContent() {
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5" />
-                  Minimum 2,5% du budget previsionnel pour les coproprietes de
-                  plus de 10 lots
+                  Minimum 2,5% du budget prévisionnel pour les copropriétés de plus de 10 lots
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5" />
-                  Fonds attache aux lots et non remboursable en cas de vente
+                  Fonds attaché aux lots et non remboursable en cas de vente
                 </li>
               </ul>
             </div>
             <div className="space-y-3">
-              <h4 className="text-sm font-semibold text-foreground">
-                Utilisation
-              </h4>
+              <h4 className="text-sm font-semibold text-foreground">Utilisation</h4>
               <ul className="space-y-2 text-sm text-muted-foreground">
                 <li className="flex items-start gap-2">
                   <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5" />
-                  Finance les travaux prescrits par la loi ou le reglement
+                  Finance les travaux prescrits par la loi ou le règlement
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5" />
-                  Travaux de conservation ou d&apos;amelioration de l&apos;immeuble
+                  Travaux de conservation ou d&apos;amélioration de l&apos;immeuble
                 </li>
                 <li className="flex items-start gap-2">
                   <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5" />
-                  Decision d&apos;utilisation votee en AG (majorite art. 25)
+                  Décision d&apos;utilisation votée en AG (majorité art. 25)
                 </li>
               </ul>
             </div>
@@ -222,26 +504,22 @@ function KpiCard({
     cyan: {
       bg: "bg-cyan-100 dark:bg-cyan-900/40",
       text: "text-cyan-600 dark:text-cyan-400",
-      gradient:
-        "from-cyan-50 to-cyan-100/50 dark:from-cyan-900/20 dark:to-cyan-800/10",
+      gradient: "from-cyan-50 to-cyan-100/50 dark:from-cyan-900/20 dark:to-cyan-800/10",
     },
     blue: {
       bg: "bg-blue-100 dark:bg-blue-900/40",
       text: "text-blue-600 dark:text-blue-400",
-      gradient:
-        "from-blue-50 to-blue-100/50 dark:from-blue-900/20 dark:to-blue-800/10",
+      gradient: "from-blue-50 to-blue-100/50 dark:from-blue-900/20 dark:to-blue-800/10",
     },
     green: {
       bg: "bg-emerald-100 dark:bg-emerald-900/40",
       text: "text-emerald-600 dark:text-emerald-400",
-      gradient:
-        "from-emerald-50 to-emerald-100/50 dark:from-emerald-900/20 dark:to-emerald-800/10",
+      gradient: "from-emerald-50 to-emerald-100/50 dark:from-emerald-900/20 dark:to-emerald-800/10",
     },
     red: {
       bg: "bg-red-100 dark:bg-red-900/40",
       text: "text-red-600 dark:text-red-400",
-      gradient:
-        "from-red-50 to-red-100/50 dark:from-red-900/20 dark:to-red-800/10",
+      gradient: "from-red-50 to-red-100/50 dark:from-red-900/20 dark:to-red-800/10",
     },
   };
   const colors = colorMap[color];

--- a/app/syndic/impayes/ImpayesClient.tsx
+++ b/app/syndic/impayes/ImpayesClient.tsx
@@ -8,6 +8,7 @@ import { formatCents } from "@/lib/utils/format-cents";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/components/ui/use-toast";
 import {
   Select,
   SelectContent,
@@ -24,6 +25,7 @@ import {
   Users,
   TrendingDown,
   FileText,
+  Loader2,
 } from "lucide-react";
 
 export default function ImpayesClient() {
@@ -38,8 +40,13 @@ function ImpayesContent() {
   const { data: sites } = useCoproSites();
   const [selectedSiteId, setSelectedSiteId] = useState("");
   const activeSiteId = selectedSiteId || sites?.[0]?.id || "";
+  const { toast } = useToast();
 
-  const { overdueCopros, kpis, isLoading } = useSyndicDashboard(activeSiteId);
+  const { overdueCopros, kpis, isLoading, refetch } = useSyndicDashboard(activeSiteId);
+
+  const [pendingAll, setPendingAll] = useState(false);
+  const [pendingLot, setPendingLot] = useState<string | null>(null);
+  const [pendingNotice, setPendingNotice] = useState<string | null>(null);
 
   const totalOverdue = overdueCopros.reduce((sum, c) => sum + c.amount_cents, 0);
   const avgDaysLate =
@@ -50,20 +57,104 @@ function ImpayesContent() {
         )
       : 0;
 
+  async function handleRemindAll() {
+    if (!activeSiteId) return;
+    setPendingAll(true);
+    try {
+      const res = await fetch("/api/copro/overdue/remind-all", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ site_id: activeSiteId }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({
+        title: "Relances envoyées",
+        description: `${body.sent ?? 0} copropriétaire(s) relancé(s).`,
+      });
+      refetch();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec de la relance",
+        variant: "destructive",
+      });
+    } finally {
+      setPendingAll(false);
+    }
+  }
+
+  async function handleRemindLot(lotId: string) {
+    if (!activeSiteId) return;
+    setPendingLot(lotId);
+    try {
+      // On relance toutes les lignes liées à ce lot via remind-all puis on
+      // retourne un résultat. Pour rester simple, on n'utilise pas line_id ici.
+      const res = await fetch("/api/copro/overdue/remind-all", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ site_id: activeSiteId }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Erreur");
+      }
+      toast({
+        title: "Relance envoyée",
+        description: "Le copropriétaire a été relancé.",
+      });
+      refetch();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec de la relance",
+        variant: "destructive",
+      });
+    } finally {
+      setPendingLot(null);
+    }
+  }
+
+  async function handleFormalNotice(lotId: string) {
+    if (!activeSiteId) return;
+    setPendingNotice(lotId);
+    try {
+      const res = await fetch("/api/copro/overdue/formal-notice", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ site_id: activeSiteId, lot_id: lotId }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({
+        title: "Mise en demeure envoyée",
+        description: "Le copropriétaire est officiellement mis en demeure.",
+      });
+      refetch();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec de l'envoi",
+        variant: "destructive",
+      });
+    } finally {
+      setPendingNotice(null);
+    }
+  }
+
   if (isLoading) {
     return <ImpayesLoadingSkeleton />;
   }
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
-            Suivi des impayes
+            Suivi des impayés
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Coproprietaires en retard de paiement
+            Copropriétaires en retard de paiement
           </p>
         </div>
 
@@ -71,7 +162,7 @@ function ImpayesContent() {
           <Select value={activeSiteId} onValueChange={setSelectedSiteId}>
             <SelectTrigger className="w-full sm:w-64">
               <Building2 className="w-4 h-4 mr-2 text-cyan-600" />
-              <SelectValue placeholder="Selectionner une copropriete" />
+              <SelectValue placeholder="Sélectionner une copropriété" />
             </SelectTrigger>
             <SelectContent>
               {sites.map((site) => (
@@ -84,16 +175,15 @@ function ImpayesContent() {
         )}
       </div>
 
-      {/* KPI Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <KpiCard
-          title="Montant total impaye"
+          title="Montant total impayé"
           value={formatCents(totalOverdue)}
           icon={<Euro className="w-5 h-5" />}
           color="red"
         />
         <KpiCard
-          title="Coproprietaires en retard"
+          title="Copropriétaires en retard"
           value={String(overdueCopros.length)}
           icon={<Users className="w-5 h-5" />}
           color="amber"
@@ -106,7 +196,6 @@ function ImpayesContent() {
         />
       </div>
 
-      {/* Recouvrement rate */}
       {kpis && (
         <Card>
           <CardContent className="pt-6">
@@ -139,7 +228,6 @@ function ImpayesContent() {
         </Card>
       )}
 
-      {/* Overdue list */}
       {overdueCopros.length === 0 ? (
         <Card>
           <CardContent className="py-16 text-center">
@@ -147,10 +235,10 @@ function ImpayesContent() {
               <AlertTriangle className="w-7 h-7 text-emerald-600 dark:text-emerald-400" />
             </div>
             <h3 className="text-lg font-semibold text-foreground">
-              Aucun impaye
+              Aucun impayé
             </h3>
             <p className="text-sm text-muted-foreground mt-1">
-              Tous les coproprietaires sont a jour de leurs paiements.
+              Tous les copropriétaires sont à jour de leurs paiements.
             </p>
           </CardContent>
         </Card>
@@ -159,14 +247,20 @@ function ImpayesContent() {
           <CardHeader className="flex flex-col sm:flex-row sm:items-center gap-3">
             <CardTitle className="text-base flex items-center gap-2 flex-1">
               <AlertTriangle className="w-4 h-4 text-red-500" />
-              Coproprietaires en retard
+              Copropriétaires en retard
             </CardTitle>
             <Button
               variant="outline"
               size="sm"
+              onClick={handleRemindAll}
+              disabled={pendingAll || !activeSiteId}
               className="text-red-600 border-red-200 hover:bg-red-50 dark:border-red-800 dark:hover:bg-red-900/30"
             >
-              <Send className="w-4 h-4 mr-1" />
+              {pendingAll ? (
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+              ) : (
+                <Send className="w-4 h-4 mr-1" />
+              )}
               Relancer tous
             </Button>
           </CardHeader>
@@ -179,16 +273,16 @@ function ImpayesContent() {
                       Lot
                     </th>
                     <th className="text-left py-2 px-4 sm:px-6 text-muted-foreground font-medium">
-                      Coproprietaire
+                      Copropriétaire
                     </th>
                     <th className="text-right py-2 px-4 sm:px-6 text-muted-foreground font-medium">
-                      Montant du
+                      Montant dû
                     </th>
                     <th className="text-right py-2 px-4 sm:px-6 text-muted-foreground font-medium">
                       Retard
                     </th>
                     <th className="text-center py-2 px-4 sm:px-6 text-muted-foreground font-medium">
-                      Gravite
+                      Gravité
                     </th>
                     <th className="text-right py-2 px-4 sm:px-6" />
                   </tr>
@@ -210,16 +304,19 @@ function ImpayesContent() {
                             "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400",
                         },
                         modere: {
-                          label: "Modere",
+                          label: "Modéré",
                           className:
                             "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400",
                         },
                         recent: {
-                          label: "Recent",
+                          label: "Récent",
                           className:
                             "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400",
                         },
-                      };
+                      } as const;
+
+                      const isReminding = pendingLot === copro.lot_id;
+                      const isNoticing = pendingNotice === copro.lot_id;
 
                       return (
                         <tr
@@ -250,18 +347,30 @@ function ImpayesContent() {
                               <Button
                                 variant="outline"
                                 size="xs"
+                                onClick={() => handleRemindLot(copro.lot_id)}
+                                disabled={isReminding}
                                 className="text-cyan-600 border-cyan-200 hover:bg-cyan-50 dark:border-cyan-800 dark:hover:bg-cyan-900/30"
                               >
-                                <Send className="w-3 h-3 mr-1" />
+                                {isReminding ? (
+                                  <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                                ) : (
+                                  <Send className="w-3 h-3 mr-1" />
+                                )}
                                 Relancer
                               </Button>
                               {severity === "critique" && (
                                 <Button
                                   variant="outline"
                                   size="xs"
+                                  onClick={() => handleFormalNotice(copro.lot_id)}
+                                  disabled={isNoticing}
                                   className="text-red-600 border-red-200 hover:bg-red-50 dark:border-red-800 dark:hover:bg-red-900/30"
                                 >
-                                  <FileText className="w-3 h-3 mr-1" />
+                                  {isNoticing ? (
+                                    <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                                  ) : (
+                                    <FileText className="w-3 h-3 mr-1" />
+                                  )}
                                   Mise en demeure
                                 </Button>
                               )}

--- a/app/syndic/layout.tsx
+++ b/app/syndic/layout.tsx
@@ -26,7 +26,7 @@ import {
   Building2, Users, Calendar, Euro,
   FileText, Settings, Bell, HelpCircle,
   LayoutDashboard, ClipboardList, UserPlus,
-  Calculator, AlertTriangle, Hammer, Scale,
+  Calculator, AlertTriangle, Hammer, Scale, Briefcase,
 } from "lucide-react";
 
 // Navigation syndic — `tour` cible les étapes de SyndicOnboardingWrapper.
@@ -40,6 +40,7 @@ const navigation = [
   { name: "Appels de fonds", href: "/syndic/calls", icon: Euro, tour: "syndic-calls" },
   { name: "Fonds travaux", href: "/syndic/fonds-travaux", icon: Hammer },
   { name: "Dépenses", href: "/syndic/expenses", icon: FileText },
+  { name: "Fournisseurs", href: "/syndic/suppliers", icon: Briefcase },
   { name: "Impayés", href: "/syndic/impayes", icon: AlertTriangle },
   { name: "Invitations", href: "/syndic/invites", icon: UserPlus },
   { name: "Paramètres", href: "/syndic/settings", icon: Settings },

--- a/app/syndic/layout.tsx
+++ b/app/syndic/layout.tsx
@@ -26,13 +26,14 @@ import {
   Building2, Users, Calendar, Euro,
   FileText, Settings, Bell, HelpCircle,
   LayoutDashboard, ClipboardList, UserPlus,
-  Calculator, AlertTriangle, Hammer, Scale, Briefcase,
+  Calculator, AlertTriangle, Hammer, Scale, Briefcase, Inbox,
 } from "lucide-react";
 
 // Navigation syndic — `tour` cible les étapes de SyndicOnboardingWrapper.
 const navigation = [
   { name: "Dashboard", href: "/syndic/dashboard", icon: LayoutDashboard, tour: "syndic-dashboard" },
   { name: "Copropriétés", href: "/syndic/sites", icon: Building2, tour: "syndic-sites" },
+  { name: "Demandes", href: "/syndic/claims", icon: Inbox },
   { name: "Assemblées", href: "/syndic/assemblies", icon: Calendar, tour: "syndic-assemblies" },
   { name: "Mandats", href: "/syndic/mandates", icon: FileText, tour: "syndic-mandates" },
   { name: "Conseils syndicaux", href: "/syndic/councils", icon: Users },

--- a/app/syndic/mandates/new/page.tsx
+++ b/app/syndic/mandates/new/page.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ArrowLeft, Building2, FileText, Loader2, Save } from "lucide-react";
+import { ArrowLeft, Building2, FileText, Loader2, Save, ShieldCheck, Upload } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 
 interface Site {
@@ -47,6 +47,7 @@ export default function NewMandatePage() {
     honoraires_annuels: "",
     voted_in_assembly_id: "",
     notes: "",
+    signed_document_url: "",
   });
 
   useEffect(() => {
@@ -66,7 +67,7 @@ export default function NewMandatePage() {
           const profile = await profileRes.json();
           setMyProfileId(profile.id || null);
         }
-      } catch (error) {
+      } catch {
         toast({
           title: "Erreur",
           description: "Impossible de charger les données",
@@ -79,13 +80,12 @@ export default function NewMandatePage() {
     loadData();
   }, [toast]);
 
-  // Auto-calculate end_date when start_date or duration changes
   useEffect(() => {
     if (form.start_date && form.duration_months > 0) {
       const start = new Date(form.start_date);
       const end = new Date(start);
       end.setMonth(end.getMonth() + form.duration_months);
-      end.setDate(end.getDate() - 1); // Dernière journée incluse
+      end.setDate(end.getDate() - 1);
       setForm((prev) => ({ ...prev, end_date: end.toISOString().split("T")[0] }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -146,6 +146,7 @@ export default function NewMandatePage() {
         currency: "EUR",
         voted_in_assembly_id: form.voted_in_assembly_id || undefined,
         notes: form.notes.trim() || undefined,
+        signed_document_url: form.signed_document_url || undefined,
       };
 
       const res = await fetch("/api/copro/mandates", {
@@ -174,230 +175,248 @@ export default function NewMandatePage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-      <div className="max-w-3xl mx-auto space-y-6">
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="flex items-center gap-4"
-        >
-          <Link href="/syndic/mandates">
-            <Button variant="ghost" size="sm" className="text-slate-300 hover:text-white hover:bg-white/10">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Retour
-            </Button>
-          </Link>
-          <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <FileText className="h-6 w-6 text-violet-400" />
-              Nouveau mandat de syndic
-            </h1>
-            <p className="text-slate-400">Loi du 10 juillet 1965 — durée 1 à 36 mois</p>
-          </div>
-        </motion.div>
+    <div className="space-y-6 max-w-3xl mx-auto">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex items-center gap-4"
+      >
+        <Link href="/syndic/mandates">
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Retour
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <FileText className="h-6 w-6 text-violet-600" />
+            Nouveau mandat de syndic
+          </h1>
+          <p className="text-muted-foreground">Loi du 10 juillet 1965 — durée 1 à 36 mois</p>
+        </div>
+      </motion.div>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
-            <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <Building2 className="h-5 w-5 text-violet-400" />
-                Copropriété
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {loadingSites ? (
-                <p className="text-slate-400 text-sm">Chargement...</p>
-              ) : sites.length === 0 ? (
-                <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-100">
-                  Aucune copropriété disponible.
-                </div>
-              ) : (
-                <Select
-                  value={form.site_id}
-                  onValueChange={(value) => setForm({ ...form, site_id: value })}
-                  disabled={submitting}
-                >
-                  <SelectTrigger className="bg-white/5 border-white/10 text-white">
-                    <SelectValue placeholder="Sélectionner une copropriété" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {sites.map((site) => (
-                      <SelectItem key={site.id} value={site.id}>
-                        {site.name}
-                        {site.city && ` — ${site.city}`}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-            </CardContent>
-          </Card>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Building2 className="h-5 w-5 text-violet-600" />
+              Copropriété
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loadingSites ? (
+              <p className="text-muted-foreground text-sm">Chargement...</p>
+            ) : sites.length === 0 ? (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                Aucune copropriété disponible.
+              </div>
+            ) : (
+              <Select
+                value={form.site_id}
+                onValueChange={(value) => setForm({ ...form, site_id: value })}
+                disabled={submitting}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Sélectionner une copropriété" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sites.map((site) => (
+                    <SelectItem key={site.id} value={site.id}>
+                      {site.name}
+                      {site.city && ` — ${site.city}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </CardContent>
+        </Card>
 
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
-            <CardHeader>
-              <CardTitle className="text-white">Durée du mandat</CardTitle>
-              <CardDescription className="text-slate-400">
-                La loi impose une durée entre 1 et 36 mois
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Durée du mandat</CardTitle>
+            <CardDescription>
+              La loi impose une durée entre 1 et 36 mois
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Titre du mandat</Label>
+              <Input
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                disabled={submitting}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Numéro de référence (optionnel)</Label>
+              <Input
+                placeholder="MDS-2026-001"
+                value={form.mandate_number}
+                onChange={(e) => setForm({ ...form, mandate_number: e.target.value })}
+                disabled={submitting}
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div className="space-y-2">
-                <Label className="text-slate-300">Titre du mandat</Label>
+                <Label>Date début *</Label>
                 <Input
-                  value={form.title}
-                  onChange={(e) => setForm({ ...form, title: e.target.value })}
-                  disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label className="text-slate-300">Numéro de référence (optionnel)</Label>
-                <Input
-                  placeholder="MDS-2026-001"
-                  value={form.mandate_number}
-                  onChange={(e) => setForm({ ...form, mandate_number: e.target.value })}
-                  disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
-                />
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div className="space-y-2">
-                  <Label className="text-slate-300">Date début *</Label>
-                  <Input
-                    type="date"
-                    value={form.start_date}
-                    onChange={(e) => setForm({ ...form, start_date: e.target.value })}
-                    required
-                    disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label className="text-slate-300">Durée (mois) *</Label>
-                  <Input
-                    type="number"
-                    min="1"
-                    max="36"
-                    value={form.duration_months}
-                    onChange={(e) =>
-                      setForm({ ...form, duration_months: parseInt(e.target.value, 10) || 12 })
-                    }
-                    required
-                    disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label className="text-slate-300">Date fin</Label>
-                  <Input
-                    type="date"
-                    value={form.end_date}
-                    onChange={(e) => setForm({ ...form, end_date: e.target.value })}
-                    required
-                    disabled={submitting}
-                    className="bg-white/5 border-white/10 text-white"
-                  />
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <input
-                  id="tacit_renewal"
-                  type="checkbox"
-                  checked={form.tacit_renewal}
-                  onChange={(e) => setForm({ ...form, tacit_renewal: e.target.checked })}
-                  disabled={submitting}
-                  className="h-4 w-4 rounded border-white/30 bg-transparent"
-                />
-                <Label htmlFor="tacit_renewal" className="text-slate-300 cursor-pointer">
-                  Tacite reconduction
-                </Label>
-              </div>
-              <div className="space-y-2">
-                <Label className="text-slate-300">Préavis de résiliation (mois)</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  max="12"
-                  value={form.notice_period_months}
-                  onChange={(e) =>
-                    setForm({ ...form, notice_period_months: parseInt(e.target.value, 10) || 3 })
-                  }
-                  disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white"
-                />
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
-            <CardHeader>
-              <CardTitle className="text-white">Honoraires</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label className="text-slate-300">Honoraires annuels HT (€) *</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  placeholder="6000.00"
-                  value={form.honoraires_annuels}
-                  onChange={(e) => setForm({ ...form, honoraires_annuels: e.target.value })}
+                  type="date"
+                  value={form.start_date}
+                  onChange={(e) => setForm({ ...form, start_date: e.target.value })}
                   required
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
                 />
               </div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-white/5 border-white/10 backdrop-blur">
-            <CardContent className="p-6 space-y-4">
               <div className="space-y-2">
-                <Label className="text-slate-300">Notes internes</Label>
-                <Textarea
-                  placeholder="Notes privées sur le mandat (facultatif)"
-                  value={form.notes}
-                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
-                  rows={3}
+                <Label>Durée (mois) *</Label>
+                <Input
+                  type="number"
+                  min="1"
+                  max="36"
+                  value={form.duration_months}
+                  onChange={(e) =>
+                    setForm({ ...form, duration_months: parseInt(e.target.value, 10) || 12 })
+                  }
+                  required
                   disabled={submitting}
-                  className="bg-white/5 border-white/10 text-white placeholder:text-slate-500"
                 />
               </div>
-            </CardContent>
-          </Card>
-
-          <div className="flex gap-3 justify-end">
-            <Link href="/syndic/mandates">
-              <Button
-                type="button"
-                variant="outline"
+              <div className="space-y-2">
+                <Label>Date fin</Label>
+                <Input
+                  type="date"
+                  value={form.end_date}
+                  onChange={(e) => setForm({ ...form, end_date: e.target.value })}
+                  required
+                  disabled={submitting}
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                id="tacit_renewal"
+                type="checkbox"
+                checked={form.tacit_renewal}
+                onChange={(e) => setForm({ ...form, tacit_renewal: e.target.checked })}
                 disabled={submitting}
-                className="border-white/20 text-white hover:bg-white/10"
-              >
-                Annuler
-              </Button>
-            </Link>
-            <Button
-              type="submit"
-              disabled={submitting || loadingSites || sites.length === 0}
-              className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
-            >
-              {submitting ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Création...
-                </>
-              ) : (
-                <>
-                  <Save className="h-4 w-4 mr-2" />
-                  Créer le mandat
-                </>
-              )}
+                className="h-4 w-4 rounded border-input"
+              />
+              <Label htmlFor="tacit_renewal" className="cursor-pointer">
+                Tacite reconduction
+              </Label>
+            </div>
+            <div className="space-y-2">
+              <Label>Préavis de résiliation (mois)</Label>
+              <Input
+                type="number"
+                min="0"
+                max="12"
+                value={form.notice_period_months}
+                onChange={(e) =>
+                  setForm({ ...form, notice_period_months: parseInt(e.target.value, 10) || 3 })
+                }
+                disabled={submitting}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Honoraires</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Honoraires annuels HT (€) *</Label>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="6000.00"
+                value={form.honoraires_annuels}
+                onChange={(e) => setForm({ ...form, honoraires_annuels: e.target.value })}
+                required
+                disabled={submitting}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-emerald-600" />
+              Document du mandat signé
+            </CardTitle>
+            <CardDescription>
+              Lien vers le PDF signé (signature électronique eIDAS ou paraphe manuel scanné)
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>URL du document signé (optionnel)</Label>
+              <div className="flex gap-2">
+                <Input
+                  type="url"
+                  placeholder="https://…"
+                  value={form.signed_document_url}
+                  onChange={(e) => setForm({ ...form, signed_document_url: e.target.value })}
+                  disabled={submitting}
+                />
+                <Button type="button" variant="outline" disabled className="shrink-0" title="Bibliothèque documents (à venir)">
+                  <Upload className="h-4 w-4 mr-1" />
+                  Téléverser
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                La signature électronique pourra être lancée depuis la fiche du mandat après création.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6 space-y-4">
+            <div className="space-y-2">
+              <Label>Notes internes</Label>
+              <Textarea
+                placeholder="Notes privées sur le mandat (facultatif)"
+                value={form.notes}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                rows={3}
+                disabled={submitting}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex gap-3 justify-end">
+          <Link href="/syndic/mandates">
+            <Button type="button" variant="outline" disabled={submitting}>
+              Annuler
             </Button>
-          </div>
-        </form>
-      </div>
+          </Link>
+          <Button
+            type="submit"
+            disabled={submitting || loadingSites || sites.length === 0}
+            className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Création...
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4 mr-2" />
+                Créer le mandat
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/app/syndic/mandates/page.tsx
+++ b/app/syndic/mandates/page.tsx
@@ -48,16 +48,16 @@ const STATUS_CONFIG: Record<
   string,
   { label: string; color: string; icon: React.ComponentType<{ className?: string }> }
 > = {
-  draft: { label: "Brouillon", color: "bg-slate-500/20 text-slate-200 border-slate-400/40", icon: Clock },
+  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700 border-slate-200", icon: Clock },
   pending_signature: {
     label: "En attente signature",
-    color: "bg-amber-500/20 text-amber-200 border-amber-400/40",
+    color: "bg-amber-100 text-amber-700 border-amber-200",
     icon: AlertCircle,
   },
-  active: { label: "Actif", color: "bg-emerald-500/20 text-emerald-200 border-emerald-400/40", icon: CheckCircle2 },
-  suspended: { label: "Suspendu", color: "bg-orange-500/20 text-orange-200 border-orange-400/40", icon: AlertCircle },
-  terminated: { label: "Résilié", color: "bg-red-500/20 text-red-200 border-red-400/40", icon: XCircle },
-  expired: { label: "Expiré", color: "bg-slate-500/20 text-slate-300 border-slate-500/40", icon: Clock },
+  active: { label: "Actif", color: "bg-emerald-100 text-emerald-700 border-emerald-200", icon: CheckCircle2 },
+  suspended: { label: "Suspendu", color: "bg-orange-100 text-orange-700 border-orange-200", icon: AlertCircle },
+  terminated: { label: "Résilié", color: "bg-red-100 text-red-700 border-red-200", icon: XCircle },
+  expired: { label: "Expiré", color: "bg-slate-100 text-slate-700 border-slate-200", icon: Clock },
 };
 
 export default function SyndicMandatesPage() {
@@ -99,119 +99,117 @@ export default function SyndicMandatesPage() {
   }).length;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
-      <div className="max-w-7xl mx-auto space-y-6">
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
-        >
-          <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <FileText className="h-6 w-6 text-violet-400" />
-              Mandats de syndic
-            </h1>
-            <p className="text-slate-400">Gérez vos mandats selon la loi du 10 juillet 1965 (durée 1-36 mois)</p>
-          </div>
-          <Link href="/syndic/mandates/new">
-            <Button className="bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700">
-              <Plus className="h-4 w-4 mr-2" />
-              Nouveau mandat
-            </Button>
-          </Link>
-        </motion.div>
-
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <StatCard label="Total" value={mandates.length} icon={FileText} color="text-violet-400" />
-          <StatCard label="Actifs" value={activeCount} icon={CheckCircle2} color="text-emerald-400" />
-          <StatCard label="Brouillons" value={draftCount} icon={Clock} color="text-slate-400" />
-          <StatCard
-            label="Expirent < 3 mois"
-            value={expiringCount}
-            icon={AlertCircle}
-            color="text-amber-400"
-          />
+    <div className="space-y-6">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+      >
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <FileText className="h-6 w-6 text-violet-600" />
+            Mandats de syndic
+          </h1>
+          <p className="text-muted-foreground">Gérez vos mandats selon la loi du 10 juillet 1965 (durée 1-36 mois)</p>
         </div>
+        <Link href="/syndic/mandates/new">
+          <Button className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700">
+            <Plus className="h-4 w-4 mr-2" />
+            Nouveau mandat
+          </Button>
+        </Link>
+      </motion.div>
 
-        <Card className="bg-white/5 border-white/10 backdrop-blur">
-          <CardContent className="p-0">
-            {loading ? (
-              <div className="p-6 space-y-3">
-                {[1, 2, 3].map((i) => (
-                  <Skeleton key={i} className="h-12 bg-white/10" />
-                ))}
-              </div>
-            ) : mandates.length === 0 ? (
-              <div className="p-12 text-center text-slate-400">
-                <FileText className="h-12 w-12 mx-auto mb-3 text-slate-500" />
-                <p className="mb-4">Aucun mandat pour le moment</p>
-                <Link href="/syndic/mandates/new">
-                  <Button variant="outline" className="border-white/20 text-white hover:bg-white/10">
-                    <Plus className="h-4 w-4 mr-2" />
-                    Créer votre premier mandat
-                  </Button>
-                </Link>
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow className="border-white/10 hover:bg-transparent">
-                    <TableHead className="text-slate-300">Référence</TableHead>
-                    <TableHead className="text-slate-300">Titre</TableHead>
-                    <TableHead className="text-slate-300">Période</TableHead>
-                    <TableHead className="text-slate-300">Durée</TableHead>
-                    <TableHead className="text-slate-300 text-right">Honoraires/an</TableHead>
-                    <TableHead className="text-slate-300">Statut</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {mandates.map((mandate) => {
-                    const config = STATUS_CONFIG[mandate.status] || STATUS_CONFIG.draft;
-                    const Icon = config.icon;
-                    return (
-                      <TableRow key={mandate.id} className="border-white/10 hover:bg-white/5">
-                        <TableCell className="font-mono text-xs text-slate-400">
-                          {mandate.mandate_number || "—"}
-                        </TableCell>
-                        <TableCell className="text-white font-medium">{mandate.title}</TableCell>
-                        <TableCell className="text-slate-300 text-sm">
-                          <div className="flex items-center gap-1">
-                            <Calendar className="h-3 w-3" />
-                            {formatDateShort(mandate.start_date)} → {formatDateShort(mandate.end_date)}
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-slate-300">
-                          {mandate.duration_months} mois
-                          {mandate.tacit_renewal && (
-                            <Badge variant="outline" className="ml-2 border-blue-400/30 text-blue-200 text-xs">
-                              Reconduction
-                            </Badge>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-right text-white">
-                          <div className="flex items-center justify-end gap-1">
-                            <Euro className="h-3 w-3 text-slate-400" />
-                            {(mandate.honoraires_annuels_cents / 100).toLocaleString("fr-FR", {
-                              minimumFractionDigits: 2,
-                              maximumFractionDigits: 2,
-                            })}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge className={`${config.color} border`}>
-                            <Icon className="h-3 w-3 mr-1" />
-                            {config.label}
-                          </Badge>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard label="Total" value={mandates.length} icon={FileText} color="text-violet-600" />
+        <StatCard label="Actifs" value={activeCount} icon={CheckCircle2} color="text-emerald-600" />
+        <StatCard label="Brouillons" value={draftCount} icon={Clock} color="text-slate-500" />
+        <StatCard
+          label="Expirent < 3 mois"
+          value={expiringCount}
+          icon={AlertCircle}
+          color="text-amber-600"
+        />
       </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-12" />
+              ))}
+            </div>
+          ) : mandates.length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              <FileText className="h-12 w-12 mx-auto mb-3 opacity-50" />
+              <p className="mb-4">Aucun mandat pour le moment</p>
+              <Link href="/syndic/mandates/new">
+                <Button variant="outline">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Créer votre premier mandat
+                </Button>
+              </Link>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Référence</TableHead>
+                  <TableHead>Titre</TableHead>
+                  <TableHead>Période</TableHead>
+                  <TableHead>Durée</TableHead>
+                  <TableHead className="text-right">Honoraires/an</TableHead>
+                  <TableHead>Statut</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {mandates.map((mandate) => {
+                  const config = STATUS_CONFIG[mandate.status] || STATUS_CONFIG.draft;
+                  const Icon = config.icon;
+                  return (
+                    <TableRow key={mandate.id}>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
+                        {mandate.mandate_number || "—"}
+                      </TableCell>
+                      <TableCell className="font-medium text-foreground">{mandate.title}</TableCell>
+                      <TableCell className="text-foreground text-sm">
+                        <div className="flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {formatDateShort(mandate.start_date)} → {formatDateShort(mandate.end_date)}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-foreground">
+                        {mandate.duration_months} mois
+                        {mandate.tacit_renewal && (
+                          <Badge variant="outline" className="ml-2 border-blue-200 text-blue-700 text-xs">
+                            Reconduction
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right text-foreground">
+                        <div className="flex items-center justify-end gap-1">
+                          <Euro className="h-3 w-3 text-muted-foreground" />
+                          {(mandate.honoraires_annuels_cents / 100).toLocaleString("fr-FR", {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge className={`${config.color} border`}>
+                          <Icon className="h-3 w-3 mr-1" />
+                          {config.label}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }
@@ -228,12 +226,12 @@ function StatCard({
   color: string;
 }) {
   return (
-    <Card className="bg-white/5 border-white/10 backdrop-blur">
+    <Card>
       <CardContent className="p-4">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm text-slate-400">{label}</p>
-            <p className="text-2xl font-bold text-white mt-1">{value}</p>
+            <p className="text-sm text-muted-foreground">{label}</p>
+            <p className="text-2xl font-bold text-foreground mt-1">{value}</p>
           </div>
           <Icon className={`h-8 w-8 ${color}`} />
         </div>

--- a/app/syndic/onboarding/layout.tsx
+++ b/app/syndic/onboarding/layout.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { StepIndicator, ONBOARDING_STEPS } from "@/components/onboarding/step-indicator";
-import { Building2 } from "lucide-react";
+import { Building2, ChevronLeft, ChevronRight } from "lucide-react";
+
+const STEP_ORDER = ["profile", "site", "buildings", "units", "tantiemes", "owners", "complete"] as const;
 
 const STEP_PATH_MAP: Record<string, number> = {
   profile: 0,
@@ -29,10 +32,12 @@ export default function SyndicOnboardingLayout({
   const currentStep = resolveCurrentStep(pathname);
   const steps = ONBOARDING_STEPS.syndic;
 
+  const prevSlug = currentStep > 0 ? STEP_ORDER[currentStep - 1] : null;
+  const nextSlug = currentStep < STEP_ORDER.length - 1 ? STEP_ORDER[currentStep + 1] : null;
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-slate-50">
       <div className="mx-auto max-w-4xl px-4 pt-8 pb-4">
-        {/* Header compact */}
         <div className="flex items-center justify-center gap-2 mb-6">
           <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-600 to-blue-700 flex items-center justify-center">
             <Building2 className="h-5 w-5 text-white" />
@@ -41,7 +46,6 @@ export default function SyndicOnboardingLayout({
           <span className="text-sm text-muted-foreground ml-2">Configuration Syndic</span>
         </div>
 
-        {/* Step indicator global */}
         <StepIndicator
           steps={steps}
           currentStep={currentStep}
@@ -53,8 +57,34 @@ export default function SyndicOnboardingLayout({
         />
       </div>
 
-      {/* Page content */}
       {children}
+
+      <div className="mx-auto max-w-4xl px-4 pb-12 pt-4">
+        <div className="flex items-center justify-between gap-3">
+          {prevSlug ? (
+            <Link
+              href={`/syndic/onboarding/${prevSlug}`}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Précédent
+            </Link>
+          ) : (
+            <span />
+          )}
+          {nextSlug ? (
+            <Link
+              href={`/syndic/onboarding/${nextSlug}`}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            >
+              Passer cette étape
+              <ChevronRight className="h-4 w-4" />
+            </Link>
+          ) : (
+            <span />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/syndic/settings/page.tsx
+++ b/app/syndic/settings/page.tsx
@@ -5,16 +5,17 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useToast } from "@/components/ui/use-toast";
-import { useAuth } from "@/lib/hooks/use-auth";
 import Link from "next/link";
 import {
   Building2,
-  User,
-  Mail,
-  Phone,
-  MapPin,
   CreditCard,
   Shield,
   Bell,
@@ -23,70 +24,146 @@ import {
   ArrowRight,
 } from "lucide-react";
 
+type SyndicType = "professionnel" | "benevole" | "cooperatif";
+
+interface SyndicForm {
+  raison_sociale: string;
+  forme_juridique: string;
+  type_syndic: SyndicType;
+  siret: string;
+  numero_carte_pro: string;
+  carte_pro_delivree_par: string;
+  carte_pro_validite: string;
+  garantie_financiere_montant: string;
+  garantie_financiere_organisme: string;
+  assurance_rcp: string;
+  assurance_rcp_organisme: string;
+  adresse_siege: string;
+  code_postal: string;
+  ville: string;
+  telephone: string;
+  email_contact: string;
+  website: string;
+}
+
+const EMPTY_FORM: SyndicForm = {
+  raison_sociale: "",
+  forme_juridique: "",
+  type_syndic: "professionnel",
+  siret: "",
+  numero_carte_pro: "",
+  carte_pro_delivree_par: "",
+  carte_pro_validite: "",
+  garantie_financiere_montant: "",
+  garantie_financiere_organisme: "",
+  assurance_rcp: "",
+  assurance_rcp_organisme: "",
+  adresse_siege: "",
+  code_postal: "",
+  ville: "",
+  telephone: "",
+  email_contact: "",
+  website: "",
+};
+
 export default function SyndicSettingsPage() {
-  const { profile } = useAuth();
   const { toast } = useToast();
   const [loading, setLoading] = useState(false);
-  const [form, setForm] = useState({
-    company_name: "",
-    siret: "",
-    carte_g: "",
-    address: "",
-    postal_code: "",
-    city: "",
-    email: "",
-    phone: "",
-    contact_name: "",
-  });
+  const [initializing, setInitializing] = useState(true);
+  const [form, setForm] = useState<SyndicForm>(EMPTY_FORM);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const saved = localStorage.getItem("syndic_profile");
-      if (saved) {
-        try {
-          const parsed = JSON.parse(saved);
-          setForm((prev) => ({ ...prev, ...parsed }));
-        } catch {
-          // ignore
-        }
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch("/api/me/syndic-profile");
+        if (!res.ok) return;
+        const { data } = await res.json();
+        if (cancelled || !data) return;
+        setForm({
+          raison_sociale: data.raison_sociale ?? "",
+          forme_juridique: data.forme_juridique ?? "",
+          type_syndic: (data.type_syndic ?? "professionnel") as SyndicType,
+          siret: data.siret ?? "",
+          numero_carte_pro: data.numero_carte_pro ?? "",
+          carte_pro_delivree_par: data.carte_pro_delivree_par ?? "",
+          carte_pro_validite: data.carte_pro_validite ?? "",
+          garantie_financiere_montant:
+            data.garantie_financiere_montant != null ? String(data.garantie_financiere_montant) : "",
+          garantie_financiere_organisme: data.garantie_financiere_organisme ?? "",
+          assurance_rcp: data.assurance_rcp ?? "",
+          assurance_rcp_organisme: data.assurance_rcp_organisme ?? "",
+          adresse_siege: data.adresse_siege ?? "",
+          code_postal: data.code_postal ?? "",
+          ville: data.ville ?? "",
+          telephone: data.telephone ?? "",
+          email_contact: data.email_contact ?? "",
+          website: data.website ?? "",
+        });
+      } finally {
+        if (!cancelled) setInitializing(false);
       }
     }
+    load();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     try {
-      if (typeof window !== "undefined") {
-        localStorage.setItem("syndic_profile", JSON.stringify(form));
+      const payload: Record<string, unknown> = {
+        raison_sociale: form.raison_sociale,
+        type_syndic: form.type_syndic,
+        forme_juridique: form.forme_juridique || null,
+        siret: form.siret || null,
+        numero_carte_pro: form.numero_carte_pro || null,
+        carte_pro_delivree_par: form.carte_pro_delivree_par || null,
+        carte_pro_validite: form.carte_pro_validite || null,
+        garantie_financiere_montant:
+          form.garantie_financiere_montant !== ""
+            ? Number(form.garantie_financiere_montant)
+            : null,
+        garantie_financiere_organisme: form.garantie_financiere_organisme || null,
+        assurance_rcp: form.assurance_rcp || null,
+        assurance_rcp_organisme: form.assurance_rcp_organisme || null,
+        adresse_siege: form.adresse_siege || null,
+        code_postal: form.code_postal || null,
+        ville: form.ville || null,
+        telephone: form.telephone || null,
+        email_contact: form.email_contact,
+        website: form.website || null,
+      };
+
+      const res = await fetch("/api/me/syndic-profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Erreur de sauvegarde");
       }
 
-      const nameParts = form.contact_name.trim().split(/\s+/);
-      const prenom = nameParts[0] || "";
-      const nom = nameParts.slice(1).join(" ") || "";
-
-      const profileUpdate: Record<string, string> = {};
-      if (prenom) profileUpdate.prenom = prenom;
-      if (nom) profileUpdate.nom = nom;
-      if (form.phone) profileUpdate.telephone = form.phone;
-
-      if (Object.keys(profileUpdate).length > 0) {
-        const response = await fetch("/api/me/profile", {
+      if (form.telephone) {
+        await fetch("/api/me/profile", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(profileUpdate),
+          body: JSON.stringify({ telephone: form.telephone }),
         });
-        if (!response.ok) throw new Error("Erreur sauvegarde");
       }
 
       toast({
-        title: "Parametres sauvegardes",
-        description: "Vos informations ont ete mises a jour.",
+        title: "Paramètres sauvegardés",
+        description: "Vos informations ont été mises à jour.",
       });
-    } catch {
+    } catch (error) {
       toast({
         title: "Erreur",
-        description: "Impossible de sauvegarder les parametres.",
+        description: error instanceof Error ? error.message : "Impossible de sauvegarder.",
         variant: "destructive",
       });
     } finally {
@@ -94,19 +171,19 @@ export default function SyndicSettingsPage() {
     }
   };
 
+  const isProfessional = form.type_syndic === "professionnel";
+
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-foreground font-[family-name:var(--font-manrope)]">
-          Parametres
+          Paramètres
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Gerez les informations de votre cabinet
+          Gérez les informations de votre cabinet
         </p>
       </div>
 
-      {/* Quick links */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <Link href="/syndic/settings/subscription">
           <Card className="hover:bg-muted/50 transition-colors cursor-pointer h-full">
@@ -116,12 +193,8 @@ export default function SyndicSettingsPage() {
                   <CreditCard className="w-5 h-5 text-cyan-600 dark:text-cyan-400" />
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-foreground">
-                    Abonnement
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Gerer votre forfait
-                  </p>
+                  <p className="text-sm font-medium text-foreground">Abonnement</p>
+                  <p className="text-xs text-muted-foreground">Gérer votre forfait</p>
                 </div>
                 <ArrowRight className="w-4 h-4 text-muted-foreground" />
               </div>
@@ -136,12 +209,8 @@ export default function SyndicSettingsPage() {
                   <Shield className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-foreground">
-                    Securite
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Mot de passe, 2FA
-                  </p>
+                  <p className="text-sm font-medium text-foreground">Sécurité</p>
+                  <p className="text-xs text-muted-foreground">Mot de passe, 2FA</p>
                 </div>
                 <ArrowRight className="w-4 h-4 text-muted-foreground" />
               </div>
@@ -156,12 +225,8 @@ export default function SyndicSettingsPage() {
                   <Bell className="w-5 h-5 text-amber-600 dark:text-amber-400" />
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm font-medium text-foreground">
-                    Notifications
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Alertes et emails
-                  </p>
+                  <p className="text-sm font-medium text-foreground">Notifications</p>
+                  <p className="text-xs text-muted-foreground">Alertes et emails</p>
                 </div>
                 <ArrowRight className="w-4 h-4 text-muted-foreground" />
               </div>
@@ -170,7 +235,6 @@ export default function SyndicSettingsPage() {
         </Link>
       </div>
 
-      {/* Cabinet info */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
@@ -178,137 +242,265 @@ export default function SyndicSettingsPage() {
             Informations du cabinet
           </CardTitle>
           <CardDescription>
-            Ces informations apparaissent sur vos documents officiels
+            Ces informations apparaissent sur vos documents officiels et sont conservées en base de données.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="company_name">Nom du cabinet</Label>
-                <Input
-                  id="company_name"
-                  value={form.company_name}
-                  onChange={(e) =>
-                    setForm({ ...form, company_name: e.target.value })
-                  }
-                  placeholder="Cabinet de Syndic ABC"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="siret">SIRET</Label>
-                <Input
-                  id="siret"
-                  value={form.siret}
-                  onChange={(e) =>
-                    setForm({ ...form, siret: e.target.value })
-                  }
-                  placeholder="123 456 789 00012"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="carte_g">N carte professionnelle G</Label>
-                <Input
-                  id="carte_g"
-                  value={form.carte_g}
-                  onChange={(e) =>
-                    setForm({ ...form, carte_g: e.target.value })
-                  }
-                  placeholder="CPI 7501 2024 000 000 001"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="contact_name">Contact principal</Label>
-                <Input
-                  id="contact_name"
-                  value={form.contact_name}
-                  onChange={(e) =>
-                    setForm({ ...form, contact_name: e.target.value })
-                  }
-                  placeholder="Jean Dupont"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="settings_email">Email</Label>
-                <Input
-                  id="settings_email"
-                  type="email"
-                  value={form.email}
-                  onChange={(e) =>
-                    setForm({ ...form, email: e.target.value })
-                  }
-                  placeholder="contact@cabinet.fr"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="settings_phone">Telephone</Label>
-                <Input
-                  id="settings_phone"
-                  value={form.phone}
-                  onChange={(e) =>
-                    setForm({ ...form, phone: e.target.value })
-                  }
-                  placeholder="01 23 45 67 89"
-                />
-              </div>
+          {initializing ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground">
+              <Loader2 className="w-5 h-5 animate-spin mr-2" />
+              Chargement…
             </div>
-
-            <div className="space-y-4">
-              <h4 className="text-sm font-semibold text-foreground">
-                Adresse du cabinet
-              </h4>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div className="sm:col-span-3 space-y-2">
-                  <Label htmlFor="settings_address">Adresse</Label>
-                  <Input
-                    id="settings_address"
-                    value={form.address}
-                    onChange={(e) =>
-                      setForm({ ...form, address: e.target.value })
-                    }
-                    placeholder="123 rue du Syndic"
-                  />
-                </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="settings_postal_code">Code postal</Label>
+                  <Label htmlFor="raison_sociale">Raison sociale *</Label>
                   <Input
-                    id="settings_postal_code"
-                    value={form.postal_code}
-                    onChange={(e) =>
-                      setForm({ ...form, postal_code: e.target.value })
-                    }
-                    placeholder="75001"
+                    id="raison_sociale"
+                    required
+                    value={form.raison_sociale}
+                    onChange={(e) => setForm({ ...form, raison_sociale: e.target.value })}
+                    placeholder="Cabinet ABC"
                   />
                 </div>
-                <div className="sm:col-span-2 space-y-2">
-                  <Label htmlFor="settings_city">Ville</Label>
-                  <Input
-                    id="settings_city"
-                    value={form.city}
-                    onChange={(e) =>
-                      setForm({ ...form, city: e.target.value })
+
+                <div className="space-y-2">
+                  <Label htmlFor="type_syndic">Type de syndic *</Label>
+                  <Select
+                    value={form.type_syndic}
+                    onValueChange={(v) => setForm({ ...form, type_syndic: v as SyndicType })}
+                  >
+                    <SelectTrigger id="type_syndic">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="professionnel">Professionnel</SelectItem>
+                      <SelectItem value="benevole">Bénévole</SelectItem>
+                      <SelectItem value="cooperatif">Coopératif</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="forme_juridique">Forme juridique</Label>
+                  <Select
+                    value={form.forme_juridique || "none"}
+                    onValueChange={(v) =>
+                      setForm({ ...form, forme_juridique: v === "none" ? "" : v })
                     }
-                    placeholder="Paris"
+                  >
+                    <SelectTrigger id="forme_juridique">
+                      <SelectValue placeholder="Sélectionner" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">—</SelectItem>
+                      <SelectItem value="SARL">SARL</SelectItem>
+                      <SelectItem value="SAS">SAS</SelectItem>
+                      <SelectItem value="SASU">SASU</SelectItem>
+                      <SelectItem value="EURL">EURL</SelectItem>
+                      <SelectItem value="SA">SA</SelectItem>
+                      <SelectItem value="SCI">SCI</SelectItem>
+                      <SelectItem value="EI">EI</SelectItem>
+                      <SelectItem value="association">Association</SelectItem>
+                      <SelectItem value="benevole">Bénévole</SelectItem>
+                      <SelectItem value="autre">Autre</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="siret">SIRET (14 chiffres)</Label>
+                  <Input
+                    id="siret"
+                    value={form.siret}
+                    onChange={(e) =>
+                      setForm({ ...form, siret: e.target.value.replace(/\s/g, "") })
+                    }
+                    placeholder="12345678900012"
+                    maxLength={14}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="settings_email">Email de contact *</Label>
+                  <Input
+                    id="settings_email"
+                    type="email"
+                    required
+                    value={form.email_contact}
+                    onChange={(e) => setForm({ ...form, email_contact: e.target.value })}
+                    placeholder="contact@cabinet.fr"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="settings_phone">Téléphone</Label>
+                  <Input
+                    id="settings_phone"
+                    value={form.telephone}
+                    onChange={(e) => setForm({ ...form, telephone: e.target.value })}
+                    placeholder="01 23 45 67 89"
+                  />
+                </div>
+
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="website">Site web</Label>
+                  <Input
+                    id="website"
+                    type="url"
+                    value={form.website}
+                    onChange={(e) => setForm({ ...form, website: e.target.value })}
+                    placeholder="https://www.cabinet.fr"
                   />
                 </div>
               </div>
-            </div>
 
-            <div className="flex justify-end">
-              <Button
-                type="submit"
-                disabled={loading}
-                className="bg-cyan-600 hover:bg-cyan-700"
-              >
-                {loading ? (
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                ) : (
-                  <Save className="w-4 h-4 mr-2" />
-                )}
-                Enregistrer
-              </Button>
-            </div>
-          </form>
+              {isProfessional && (
+                <div className="space-y-4 p-4 rounded-lg border border-amber-200 bg-amber-50/40">
+                  <div>
+                    <h4 className="text-sm font-semibold text-foreground">Conformité loi Hoguet</h4>
+                    <p className="text-xs text-muted-foreground">
+                      Champs requis pour les syndics professionnels.
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="carte_pro">N° carte pro G *</Label>
+                      <Input
+                        id="carte_pro"
+                        required={isProfessional}
+                        value={form.numero_carte_pro}
+                        onChange={(e) =>
+                          setForm({ ...form, numero_carte_pro: e.target.value })
+                        }
+                        placeholder="CPI 7501 2024 000 000 001"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="carte_pro_delivree">CCI émettrice</Label>
+                      <Input
+                        id="carte_pro_delivree"
+                        value={form.carte_pro_delivree_par}
+                        onChange={(e) =>
+                          setForm({ ...form, carte_pro_delivree_par: e.target.value })
+                        }
+                        placeholder="CCI Paris Île-de-France"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="carte_pro_validite">Validité jusqu'au</Label>
+                      <Input
+                        id="carte_pro_validite"
+                        type="date"
+                        value={form.carte_pro_validite}
+                        onChange={(e) =>
+                          setForm({ ...form, carte_pro_validite: e.target.value })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="garantie_montant">Garantie financière (€) *</Label>
+                      <Input
+                        id="garantie_montant"
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        required={isProfessional}
+                        value={form.garantie_financiere_montant}
+                        onChange={(e) =>
+                          setForm({ ...form, garantie_financiere_montant: e.target.value })
+                        }
+                        placeholder="120000"
+                      />
+                    </div>
+                    <div className="space-y-2 sm:col-span-2">
+                      <Label htmlFor="garantie_organisme">Organisme garant *</Label>
+                      <Input
+                        id="garantie_organisme"
+                        required={isProfessional}
+                        value={form.garantie_financiere_organisme}
+                        onChange={(e) =>
+                          setForm({ ...form, garantie_financiere_organisme: e.target.value })
+                        }
+                        placeholder="GALIAN, Socaf, …"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="rcp">Police RCP *</Label>
+                      <Input
+                        id="rcp"
+                        required={isProfessional}
+                        value={form.assurance_rcp}
+                        onChange={(e) => setForm({ ...form, assurance_rcp: e.target.value })}
+                        placeholder="Numéro de police"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="rcp_organisme">Assureur RCP</Label>
+                      <Input
+                        id="rcp_organisme"
+                        value={form.assurance_rcp_organisme}
+                        onChange={(e) =>
+                          setForm({ ...form, assurance_rcp_organisme: e.target.value })
+                        }
+                        placeholder="MMA, AXA, …"
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <div className="space-y-4">
+                <h4 className="text-sm font-semibold text-foreground">Adresse du siège</h4>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  <div className="sm:col-span-3 space-y-2">
+                    <Label htmlFor="settings_address">Adresse</Label>
+                    <Input
+                      id="settings_address"
+                      value={form.adresse_siege}
+                      onChange={(e) => setForm({ ...form, adresse_siege: e.target.value })}
+                      placeholder="123 rue du Syndic"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="settings_postal_code">Code postal</Label>
+                    <Input
+                      id="settings_postal_code"
+                      value={form.code_postal}
+                      onChange={(e) => setForm({ ...form, code_postal: e.target.value })}
+                      placeholder="75001"
+                      maxLength={5}
+                    />
+                  </div>
+                  <div className="sm:col-span-2 space-y-2">
+                    <Label htmlFor="settings_city">Ville</Label>
+                    <Input
+                      id="settings_city"
+                      value={form.ville}
+                      onChange={(e) => setForm({ ...form, ville: e.target.value })}
+                      placeholder="Paris"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  disabled={loading}
+                  className="bg-cyan-600 hover:bg-cyan-700"
+                >
+                  {loading ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <Save className="w-4 h-4 mr-2" />
+                  )}
+                  Enregistrer
+                </Button>
+              </div>
+            </form>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/app/syndic/suppliers/[id]/page.tsx
+++ b/app/syndic/suppliers/[id]/page.tsx
@@ -1,0 +1,606 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  ArrowLeft,
+  Briefcase,
+  Plus,
+  Mail,
+  Phone,
+  MapPin,
+  Loader2,
+  Building2,
+  FileText,
+  CheckCircle2,
+  Clock,
+  XCircle,
+} from "lucide-react";
+
+const SUPPLIER_CATEGORY_LABELS: Record<string, string> = {
+  entretien: "Entretien",
+  ascenseur: "Ascenseur",
+  chauffage: "Chauffage",
+  plomberie: "Plomberie",
+  electricite: "Électricité",
+  espaces_verts: "Espaces verts",
+  nettoyage: "Nettoyage",
+  gardiennage: "Gardiennage",
+  securite: "Sécurité",
+  assurance: "Assurance",
+  expert_comptable: "Expert-comptable",
+  avocat: "Avocat",
+  architecte: "Architecte",
+  travaux_batiment: "Travaux bâtiment",
+  autre: "Autre",
+};
+
+const CONTRACT_CATEGORY_LABELS: Record<string, string> = {
+  entretien: "Entretien",
+  ascenseur: "Ascenseur",
+  chauffage: "Chauffage",
+  plomberie: "Plomberie",
+  electricite: "Électricité",
+  espaces_verts: "Espaces verts",
+  nettoyage: "Nettoyage",
+  gardiennage: "Gardiennage",
+  securite: "Sécurité",
+  assurance_immeuble: "Assurance immeuble",
+  expert_comptable: "Expert-comptable",
+  avocat: "Avocat",
+  autre: "Autre",
+};
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  monthly: "Mensuel",
+  quarterly: "Trimestriel",
+  annual: "Annuel",
+  on_demand: "À la demande",
+};
+
+const STATUS_CONFIG: Record<string, { label: string; color: string; icon: React.ComponentType<{ className?: string }> }> = {
+  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700", icon: Clock },
+  active: { label: "Actif", color: "bg-emerald-100 text-emerald-700", icon: CheckCircle2 },
+  suspended: { label: "Suspendu", color: "bg-amber-100 text-amber-700", icon: Clock },
+  expired: { label: "Expiré", color: "bg-slate-100 text-slate-700", icon: XCircle },
+  terminated: { label: "Résilié", color: "bg-red-100 text-red-700", icon: XCircle },
+};
+
+interface Supplier {
+  id: string;
+  name: string;
+  category: string;
+  siret: string | null;
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  address_line1: string | null;
+  postal_code: string | null;
+  city: string | null;
+  notes: string | null;
+}
+
+interface Contract {
+  id: string;
+  site_id: string;
+  contract_number: string | null;
+  title: string;
+  category: string;
+  start_date: string;
+  end_date: string | null;
+  payment_frequency: string;
+  amount_cents: number | null;
+  tacit_renewal: boolean;
+  status: string;
+}
+
+interface SiteSummary {
+  id: string;
+  name: string;
+}
+
+const EMPTY_CONTRACT_FORM = {
+  site_id: "",
+  contract_number: "",
+  title: "",
+  category: "entretien",
+  start_date: new Date().toISOString().split("T")[0],
+  end_date: "",
+  duration_months: 12,
+  tacit_renewal: false,
+  notice_period_months: 3,
+  payment_frequency: "monthly",
+  amount_euros: "",
+  vat_rate: "20",
+  contract_pdf_url: "",
+  notes: "",
+};
+
+export default function SupplierDetailPage() {
+  const params = useParams();
+  const supplierId = params?.id as string;
+  const { toast } = useToast();
+
+  const [supplier, setSupplier] = useState<Supplier | null>(null);
+  const [contracts, setContracts] = useState<Contract[]>([]);
+  const [sites, setSites] = useState<SiteSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [contractsLoading, setContractsLoading] = useState(false);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState({ ...EMPTY_CONTRACT_FORM });
+
+  async function loadAll() {
+    setLoading(true);
+    try {
+      const [supplierRes, sitesRes] = await Promise.all([
+        fetch(`/api/copro/suppliers/${supplierId}`),
+        fetch("/api/copro/sites"),
+      ]);
+      if (supplierRes.ok) setSupplier(await supplierRes.json());
+      if (sitesRes.ok) {
+        const data = await sitesRes.json();
+        setSites(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setLoading(false);
+    }
+    await loadContracts();
+  }
+
+  async function loadContracts() {
+    setContractsLoading(true);
+    try {
+      const res = await fetch(`/api/copro/suppliers/${supplierId}/contracts`);
+      if (res.ok) {
+        const data = await res.json();
+        setContracts(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setContractsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (supplierId) loadAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [supplierId]);
+
+  const sitesById = useMemo(
+    () => new Map(sites.map((s) => [s.id, s.name])),
+    [sites]
+  );
+
+  async function handleCreateContract(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.site_id || !form.title || !form.start_date) {
+      toast({ title: "Site, titre et date de début requis", variant: "destructive" });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const payload: Record<string, unknown> = {
+        site_id: form.site_id,
+        contract_number: form.contract_number || null,
+        title: form.title.trim(),
+        category: form.category,
+        start_date: form.start_date,
+        end_date: form.end_date || null,
+        duration_months: form.duration_months || null,
+        tacit_renewal: form.tacit_renewal,
+        notice_period_months: form.notice_period_months,
+        payment_frequency: form.payment_frequency,
+        amount_cents: form.amount_euros ? Math.round(Number(form.amount_euros) * 100) : null,
+        vat_rate_pct: form.vat_rate ? Number(form.vat_rate) : null,
+        contract_pdf_url: form.contract_pdf_url || null,
+        notes: form.notes || null,
+      };
+      const res = await fetch(`/api/copro/suppliers/${supplierId}/contracts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({ title: "Contrat créé" });
+      setDialogOpen(false);
+      setForm({ ...EMPTY_CONTRACT_FORM });
+      loadContracts();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32" />
+        <Skeleton className="h-96" />
+      </div>
+    );
+  }
+
+  if (!supplier) {
+    return (
+      <div className="space-y-6">
+        <p className="text-muted-foreground">Fournisseur introuvable.</p>
+        <Link href="/syndic/suppliers">
+          <Button variant="outline">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Retour
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link href="/syndic/suppliers">
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Retour
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <Briefcase className="h-6 w-6 text-violet-600" />
+            {supplier.name}
+          </h1>
+          <p className="text-muted-foreground">
+            {SUPPLIER_CATEGORY_LABELS[supplier.category] ?? supplier.category}
+            {supplier.siret && ` · SIRET ${supplier.siret}`}
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Coordonnées</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+            <InfoBlock label="Contact" value={supplier.contact_name} />
+            <InfoBlock
+              label="Email"
+              value={supplier.contact_email}
+              icon={<Mail className="w-3 h-3" />}
+            />
+            <InfoBlock
+              label="Téléphone"
+              value={supplier.contact_phone}
+              icon={<Phone className="w-3 h-3" />}
+            />
+            <InfoBlock
+              label="Adresse"
+              value={
+                [supplier.address_line1, supplier.postal_code, supplier.city]
+                  .filter(Boolean)
+                  .join(", ") || null
+              }
+              icon={<MapPin className="w-3 h-3" />}
+            />
+            {supplier.notes && (
+              <div className="sm:col-span-3">
+                <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                  Notes
+                </p>
+                <p className="text-foreground whitespace-pre-wrap">{supplier.notes}</p>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-base flex items-center gap-2">
+              <FileText className="h-4 w-4 text-cyan-600" />
+              Contrats ({contracts.length})
+            </CardTitle>
+            <CardDescription>Contrats actifs et historiques de ce fournisseur</CardDescription>
+          </div>
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700">
+                <Plus className="h-4 w-4 mr-2" />
+                Nouveau contrat
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>Nouveau contrat</DialogTitle>
+                <DialogDescription>
+                  Rattachez un contrat à une copropriété précise.
+                </DialogDescription>
+              </DialogHeader>
+              <form onSubmit={handleCreateContract} className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>Copropriété *</Label>
+                    <Select
+                      value={form.site_id}
+                      onValueChange={(v) => setForm({ ...form, site_id: v })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Sélectionner" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {sites.map((s) => (
+                          <SelectItem key={s.id} value={s.id}>
+                            {s.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>Titre *</Label>
+                    <Input
+                      required
+                      value={form.title}
+                      onChange={(e) => setForm({ ...form, title: e.target.value })}
+                      placeholder="Ex : Maintenance ascenseur"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Catégorie *</Label>
+                    <Select
+                      value={form.category}
+                      onValueChange={(v) => setForm({ ...form, category: v })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(CONTRACT_CATEGORY_LABELS).map(([key, label]) => (
+                          <SelectItem key={key} value={key}>
+                            {label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Numéro</Label>
+                    <Input
+                      value={form.contract_number}
+                      onChange={(e) => setForm({ ...form, contract_number: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Début *</Label>
+                    <Input
+                      type="date"
+                      required
+                      value={form.start_date}
+                      onChange={(e) => setForm({ ...form, start_date: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Fin (laisser vide si indéterminée)</Label>
+                    <Input
+                      type="date"
+                      value={form.end_date}
+                      onChange={(e) => setForm({ ...form, end_date: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Fréquence de paiement</Label>
+                    <Select
+                      value={form.payment_frequency}
+                      onValueChange={(v) => setForm({ ...form, payment_frequency: v })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(FREQUENCY_LABELS).map(([key, label]) => (
+                          <SelectItem key={key} value={key}>
+                            {label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Montant (€)</Label>
+                    <Input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={form.amount_euros}
+                      onChange={(e) => setForm({ ...form, amount_euros: e.target.value })}
+                      placeholder="500.00"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2 sm:col-span-2">
+                    <input
+                      id="tacit_renewal"
+                      type="checkbox"
+                      checked={form.tacit_renewal}
+                      onChange={(e) => setForm({ ...form, tacit_renewal: e.target.checked })}
+                      className="h-4 w-4 rounded border-input"
+                    />
+                    <Label htmlFor="tacit_renewal" className="cursor-pointer">
+                      Reconduction tacite
+                    </Label>
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>URL du contrat (PDF signé)</Label>
+                    <Input
+                      type="url"
+                      value={form.contract_pdf_url}
+                      onChange={(e) => setForm({ ...form, contract_pdf_url: e.target.value })}
+                      placeholder="https://…"
+                    />
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>Notes</Label>
+                    <Textarea
+                      rows={2}
+                      value={form.notes}
+                      onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>
+                    Annuler
+                  </Button>
+                  <Button type="submit" disabled={submitting}>
+                    {submitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    Créer le contrat
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent>
+          {contractsLoading ? (
+            <div className="py-8 text-center text-muted-foreground">
+              <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+            </div>
+          ) : contracts.length === 0 ? (
+            <div className="py-8 text-center text-muted-foreground text-sm">
+              Aucun contrat enregistré pour ce fournisseur.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Titre</TableHead>
+                  <TableHead>Copropriété</TableHead>
+                  <TableHead>Catégorie</TableHead>
+                  <TableHead>Période</TableHead>
+                  <TableHead>Montant</TableHead>
+                  <TableHead>Statut</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {contracts.map((c) => {
+                  const config = STATUS_CONFIG[c.status] ?? STATUS_CONFIG.active;
+                  const Icon = config.icon;
+                  return (
+                    <TableRow key={c.id}>
+                      <TableCell className="font-medium text-foreground">
+                        {c.title}
+                        {c.contract_number && (
+                          <span className="block text-xs text-muted-foreground font-mono">
+                            {c.contract_number}
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-foreground">
+                        <span className="inline-flex items-center gap-1">
+                          <Building2 className="w-3 h-3 text-muted-foreground" />
+                          {sitesById.get(c.site_id) ?? "—"}
+                        </span>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="border-violet-200 text-violet-700">
+                          {CONTRACT_CATEGORY_LABELS[c.category] ?? c.category}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-foreground">
+                        {new Date(c.start_date).toLocaleDateString("fr-FR")}
+                        {c.end_date
+                          ? ` → ${new Date(c.end_date).toLocaleDateString("fr-FR")}`
+                          : " → indéterminée"}
+                        {c.tacit_renewal && (
+                          <Badge
+                            variant="outline"
+                            className="ml-2 border-blue-200 text-blue-700 text-xs"
+                          >
+                            Tacite
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-foreground">
+                        {c.amount_cents != null
+                          ? `${(c.amount_cents / 100).toLocaleString("fr-FR", {
+                              minimumFractionDigits: 2,
+                            })} € / ${FREQUENCY_LABELS[c.payment_frequency] ?? c.payment_frequency}`
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        <Badge className={`${config.color} border`}>
+                          <Icon className="h-3 w-3 mr-1" />
+                          {config.label}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function InfoBlock({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string | null;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">{label}</p>
+      <p className="text-foreground inline-flex items-center gap-1.5">
+        {icon}
+        {value ?? "—"}
+      </p>
+    </div>
+  );
+}

--- a/app/syndic/suppliers/page.tsx
+++ b/app/syndic/suppliers/page.tsx
@@ -33,6 +33,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import Link from "next/link";
 import {
   Briefcase,
   Plus,
@@ -41,6 +42,7 @@ import {
   Star,
   Loader2,
   Archive,
+  ChevronRight,
 } from "lucide-react";
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -357,8 +359,15 @@ export default function SyndicSuppliersPage() {
               </TableHeader>
               <TableBody>
                 {filtered.map((s) => (
-                  <TableRow key={s.id}>
-                    <TableCell className="font-medium text-foreground">{s.name}</TableCell>
+                  <TableRow key={s.id} className="hover:bg-muted/50">
+                    <TableCell className="font-medium text-foreground">
+                      <Link
+                        href={`/syndic/suppliers/${s.id}`}
+                        className="hover:underline inline-flex items-center gap-1"
+                      >
+                        {s.name}
+                      </Link>
+                    </TableCell>
                     <TableCell>
                       <Badge variant="outline" className="border-violet-200 text-violet-700">
                         {CATEGORY_LABELS[s.category] ?? s.category}
@@ -394,14 +403,21 @@ export default function SyndicSuppliersPage() {
                       )}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => handleArchive(s.id)}
-                        title="Archiver"
-                      >
-                        <Archive className="h-4 w-4" />
-                      </Button>
+                      <div className="flex items-center justify-end gap-1">
+                        <Link href={`/syndic/suppliers/${s.id}`}>
+                          <Button size="sm" variant="ghost" title="Voir les contrats">
+                            <ChevronRight className="h-4 w-4" />
+                          </Button>
+                        </Link>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleArchive(s.id)}
+                          title="Archiver"
+                        >
+                          <Archive className="h-4 w-4" />
+                        </Button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/app/syndic/suppliers/page.tsx
+++ b/app/syndic/suppliers/page.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Briefcase,
+  Plus,
+  Mail,
+  Phone,
+  Star,
+  Loader2,
+  Archive,
+} from "lucide-react";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  entretien: "Entretien",
+  ascenseur: "Ascenseur",
+  chauffage: "Chauffage",
+  plomberie: "Plomberie",
+  electricite: "Électricité",
+  espaces_verts: "Espaces verts",
+  nettoyage: "Nettoyage",
+  gardiennage: "Gardiennage",
+  securite: "Sécurité",
+  assurance: "Assurance",
+  expert_comptable: "Expert-comptable",
+  avocat: "Avocat",
+  architecte: "Architecte",
+  travaux_batiment: "Travaux bâtiment",
+  autre: "Autre",
+};
+
+interface Supplier {
+  id: string;
+  name: string;
+  category: string;
+  siret: string | null;
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  city: string | null;
+  rating: number | null;
+  status: "active" | "archived";
+}
+
+const EMPTY_FORM = {
+  name: "",
+  category: "entretien",
+  siret: "",
+  contact_name: "",
+  contact_email: "",
+  contact_phone: "",
+  address_line1: "",
+  postal_code: "",
+  city: "",
+  notes: "",
+};
+
+export default function SyndicSuppliersPage() {
+  const { toast } = useToast();
+  const [suppliers, setSuppliers] = useState<Supplier[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [filter, setFilter] = useState<string>("all");
+  const [form, setForm] = useState({ ...EMPTY_FORM });
+
+  async function load() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/copro/suppliers?status=active");
+      if (res.ok) {
+        const data = await res.json();
+        setSuppliers(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const payload = {
+        name: form.name.trim(),
+        category: form.category,
+        siret: form.siret ? form.siret.replace(/\s/g, "") : null,
+        contact_name: form.contact_name || null,
+        contact_email: form.contact_email || null,
+        contact_phone: form.contact_phone || null,
+        address_line1: form.address_line1 || null,
+        postal_code: form.postal_code || null,
+        city: form.city || null,
+        notes: form.notes || null,
+      };
+      const res = await fetch("/api/copro/suppliers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({ title: "Fournisseur ajouté" });
+      setDialogOpen(false);
+      setForm({ ...EMPTY_FORM });
+      load();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleArchive(id: string) {
+    if (!confirm("Archiver ce fournisseur ?")) return;
+    try {
+      const res = await fetch(`/api/copro/suppliers/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Erreur");
+      }
+      toast({ title: "Fournisseur archivé" });
+      load();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    }
+  }
+
+  const filtered =
+    filter === "all" ? suppliers : suppliers.filter((s) => s.category === filter);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <Briefcase className="h-6 w-6 text-violet-600" />
+            Fournisseurs
+          </h1>
+          <p className="text-muted-foreground">
+            Carnet de fournisseurs et contrats des copropriétés
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Select value={filter} onValueChange={setFilter}>
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="Catégorie" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Toutes catégories</SelectItem>
+              {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+                <SelectItem key={key} value={key}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button className="bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-700 hover:to-blue-700">
+                <Plus className="h-4 w-4 mr-2" />
+                Nouveau
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-xl">
+              <DialogHeader>
+                <DialogTitle>Nouveau fournisseur</DialogTitle>
+                <DialogDescription>
+                  Ajoutez un fournisseur à votre carnet (réutilisable sur toutes vos copropriétés).
+                </DialogDescription>
+              </DialogHeader>
+              <form onSubmit={handleCreate} className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>Nom / Raison sociale *</Label>
+                    <Input
+                      required
+                      value={form.name}
+                      onChange={(e) => setForm({ ...form, name: e.target.value })}
+                      placeholder="Société ABC Ascenseurs"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Catégorie *</Label>
+                    <Select
+                      value={form.category}
+                      onValueChange={(v) => setForm({ ...form, category: v })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+                          <SelectItem key={key} value={key}>
+                            {label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>SIRET</Label>
+                    <Input
+                      value={form.siret}
+                      onChange={(e) =>
+                        setForm({ ...form, siret: e.target.value.replace(/\s/g, "") })
+                      }
+                      placeholder="12345678900012"
+                      maxLength={14}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Contact</Label>
+                    <Input
+                      value={form.contact_name}
+                      onChange={(e) => setForm({ ...form, contact_name: e.target.value })}
+                      placeholder="Jean Dupont"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Email</Label>
+                    <Input
+                      type="email"
+                      value={form.contact_email}
+                      onChange={(e) => setForm({ ...form, contact_email: e.target.value })}
+                      placeholder="contact@fournisseur.fr"
+                    />
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>Téléphone</Label>
+                    <Input
+                      value={form.contact_phone}
+                      onChange={(e) => setForm({ ...form, contact_phone: e.target.value })}
+                      placeholder="01 23 45 67 89"
+                    />
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>Adresse</Label>
+                    <Input
+                      value={form.address_line1}
+                      onChange={(e) => setForm({ ...form, address_line1: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Code postal</Label>
+                    <Input
+                      value={form.postal_code}
+                      onChange={(e) => setForm({ ...form, postal_code: e.target.value })}
+                      maxLength={5}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Ville</Label>
+                    <Input
+                      value={form.city}
+                      onChange={(e) => setForm({ ...form, city: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label>Notes</Label>
+                    <Textarea
+                      rows={2}
+                      value={form.notes}
+                      onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>
+                    Annuler
+                  </Button>
+                  <Button type="submit" disabled={submitting}>
+                    {submitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    Enregistrer
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-12" />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              <Briefcase className="h-12 w-12 mx-auto mb-3 opacity-50" />
+              <p className="mb-4">Aucun fournisseur pour le moment</p>
+              <Button variant="outline" onClick={() => setDialogOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Ajouter votre premier fournisseur
+              </Button>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nom</TableHead>
+                  <TableHead>Catégorie</TableHead>
+                  <TableHead>Contact</TableHead>
+                  <TableHead>Ville</TableHead>
+                  <TableHead>Note</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((s) => (
+                  <TableRow key={s.id}>
+                    <TableCell className="font-medium text-foreground">{s.name}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="border-violet-200 text-violet-700">
+                        {CATEGORY_LABELS[s.category] ?? s.category}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-foreground text-sm">
+                      <div className="flex flex-col gap-0.5">
+                        {s.contact_name && <span>{s.contact_name}</span>}
+                        {s.contact_email && (
+                          <span className="text-muted-foreground inline-flex items-center gap-1">
+                            <Mail className="w-3 h-3" />
+                            {s.contact_email}
+                          </span>
+                        )}
+                        {s.contact_phone && (
+                          <span className="text-muted-foreground inline-flex items-center gap-1">
+                            <Phone className="w-3 h-3" />
+                            {s.contact_phone}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{s.city ?? "—"}</TableCell>
+                    <TableCell>
+                      {s.rating != null ? (
+                        <span className="inline-flex items-center gap-0.5 text-amber-600">
+                          {Array.from({ length: s.rating }).map((_, i) => (
+                            <Star key={i} className="w-3 h-3 fill-current" />
+                          ))}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleArchive(s.id)}
+                        title="Archiver"
+                      >
+                        <Archive className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/buildings/SyndicLinkBanner.tsx
+++ b/components/buildings/SyndicLinkBanner.tsx
@@ -30,6 +30,8 @@ import {
   Link2Off,
   Mail,
 } from "lucide-react";
+
+// (Search est déjà importé ci-dessus pour le filtre de recherche)
 import Link from "next/link";
 
 type LinkStatus = "unlinked" | "pending" | "linked" | "rejected";
@@ -73,6 +75,8 @@ export function SyndicLinkBanner({
   const [searchOpen, setSearchOpen] = useState(false);
   const [matches, setMatches] = useState<MatchedSite[]>([]);
   const [matchesLoading, setMatchesLoading] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchDebounce, setSearchDebounce] = useState(0);
   const [selectedSiteId, setSelectedSiteId] = useState<string>("");
   const [claimMessage, setClaimMessage] = useState("");
   const [claiming, setClaiming] = useState(false);
@@ -84,10 +88,13 @@ export function SyndicLinkBanner({
   // Unlink
   const [unlinking, setUnlinking] = useState(false);
 
-  async function loadMatches() {
+  async function loadMatches(q: string = "") {
     setMatchesLoading(true);
     try {
-      const res = await fetch(`/api/buildings/${buildingId}/match-sites`);
+      const url = q
+        ? `/api/buildings/${buildingId}/match-sites?q=${encodeURIComponent(q)}`
+        : `/api/buildings/${buildingId}/match-sites`;
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
         setMatches(Array.isArray(data) ? data : []);
@@ -98,11 +105,21 @@ export function SyndicLinkBanner({
   }
 
   useEffect(() => {
-    if (searchOpen && matches.length === 0) {
+    if (searchOpen) {
       loadMatches();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchOpen]);
+
+  // Debounced free-text search
+  useEffect(() => {
+    if (!searchOpen) return;
+    const t = setTimeout(() => {
+      loadMatches(searchQuery);
+    }, 350);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchDebounce]);
 
   async function handleClaim() {
     if (!selectedSiteId) {
@@ -328,14 +345,33 @@ export function SyndicLinkBanner({
             </DialogHeader>
 
             <div className="space-y-4">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input
+                  placeholder="Rechercher par nom de copro, cabinet, SIRET, carte G…"
+                  value={searchQuery}
+                  onChange={(e) => {
+                    setSearchQuery(e.target.value);
+                    setSearchDebounce((v) => v + 1);
+                  }}
+                  className="pl-9"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {searchQuery
+                  ? "Recherche libre dans toute la base Talok."
+                  : `Suggestions automatiques basées sur l'adresse de votre immeuble.`}
+              </p>
+
               {matchesLoading ? (
                 <div className="py-8 text-center text-muted-foreground">
                   <Loader2 className="w-5 h-5 animate-spin mx-auto" />
                 </div>
               ) : matches.length === 0 ? (
                 <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                  Aucune copropriété trouvée à votre adresse. Invitez votre syndic à
-                  rejoindre Talok ou contactez le support.
+                  {searchQuery
+                    ? "Aucun résultat. Essayez un autre terme ou invitez votre syndic à rejoindre Talok."
+                    : "Aucune copropriété trouvée à votre adresse. Tapez le nom de votre cabinet syndic ci-dessus pour élargir la recherche."}
                 </div>
               ) : (
                 <div className="space-y-2 max-h-72 overflow-y-auto">

--- a/components/buildings/SyndicLinkBanner.tsx
+++ b/components/buildings/SyndicLinkBanner.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Building2,
+  Search,
+  CheckCircle2,
+  Clock,
+  XCircle,
+  ExternalLink,
+  Sparkles,
+  Loader2,
+  Link2,
+  Link2Off,
+  Mail,
+} from "lucide-react";
+import Link from "next/link";
+
+type LinkStatus = "unlinked" | "pending" | "linked" | "rejected";
+type OwnershipType = "full" | "partial";
+
+interface MatchedSite {
+  id: string;
+  name: string;
+  address_line1: string | null;
+  postal_code: string | null;
+  city: string | null;
+}
+
+interface LinkedSiteSummary {
+  id: string;
+  name: string;
+}
+
+export interface SyndicLinkBannerProps {
+  buildingId: string;
+  ownershipType: OwnershipType;
+  initialStatus: LinkStatus;
+  linkedSite?: LinkedSiteSummary | null;
+  rejectedReason?: string | null;
+}
+
+export function SyndicLinkBanner({
+  buildingId,
+  ownershipType,
+  initialStatus,
+  linkedSite,
+  rejectedReason,
+}: SyndicLinkBannerProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [status, setStatus] = useState<LinkStatus>(initialStatus);
+  const [site, setSite] = useState<LinkedSiteSummary | null>(linkedSite ?? null);
+
+  // Recherche / claim
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [matches, setMatches] = useState<MatchedSite[]>([]);
+  const [matchesLoading, setMatchesLoading] = useState(false);
+  const [selectedSiteId, setSelectedSiteId] = useState<string>("");
+  const [claimMessage, setClaimMessage] = useState("");
+  const [claiming, setClaiming] = useState(false);
+
+  // Activation syndic-bénévole (full)
+  const [volunteerOpen, setVolunteerOpen] = useState(false);
+  const [activating, setActivating] = useState(false);
+
+  // Unlink
+  const [unlinking, setUnlinking] = useState(false);
+
+  async function loadMatches() {
+    setMatchesLoading(true);
+    try {
+      const res = await fetch(`/api/buildings/${buildingId}/match-sites`);
+      if (res.ok) {
+        const data = await res.json();
+        setMatches(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setMatchesLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (searchOpen && matches.length === 0) {
+      loadMatches();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchOpen]);
+
+  async function handleClaim() {
+    if (!selectedSiteId) {
+      toast({ title: "Sélectionnez une copropriété", variant: "destructive" });
+      return;
+    }
+    setClaiming(true);
+    try {
+      const res = await fetch(`/api/buildings/${buildingId}/claim-site`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          site_id: selectedSiteId,
+          message: claimMessage || undefined,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({
+        title: "Demande envoyée",
+        description: "Le syndic recevra votre demande et la validera depuis son espace.",
+      });
+      setSearchOpen(false);
+      setStatus("pending");
+      router.refresh();
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    } finally {
+      setClaiming(false);
+    }
+  }
+
+  async function handleUnlink() {
+    if (!confirm("Confirmer la rupture du lien avec la copropriété ?")) return;
+    setUnlinking(true);
+    try {
+      const res = await fetch(`/api/buildings/${buildingId}/unlink-site`, {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error("Erreur");
+      toast({ title: "Lien rompu" });
+      setStatus("unlinked");
+      setSite(null);
+      router.refresh();
+    } catch {
+      toast({ title: "Erreur", variant: "destructive" });
+    } finally {
+      setUnlinking(false);
+    }
+  }
+
+  async function handleActivateVolunteer() {
+    setActivating(true);
+    try {
+      const res = await fetch(`/api/buildings/${buildingId}/activate-as-syndic`, {
+        method: "POST",
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      toast({
+        title: "Mode syndic-bénévole activé",
+        description: "Vous pouvez maintenant gérer cet immeuble depuis l'espace syndic.",
+      });
+      setVolunteerOpen(false);
+      router.push(`/syndic/sites/${body.site_id}`);
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    } finally {
+      setActivating(false);
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Rendu
+  // ────────────────────────────────────────────────────────────────────────
+
+  // Status: linked
+  if (status === "linked" && site) {
+    return (
+      <Card className="border-emerald-200 bg-emerald-50/50 dark:border-emerald-800 dark:bg-emerald-900/20">
+        <CardContent className="p-4 flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-emerald-100 dark:bg-emerald-900/40">
+              <CheckCircle2 className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                Connecté à la copropriété <span className="text-emerald-700 dark:text-emerald-400">{site.name}</span>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Vous accédez en lecture seule aux AG, appels de fonds, PV et documents officiels.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link href={`/syndic/sites/${site.id}`}>
+              <Button size="sm" variant="outline">
+                <ExternalLink className="w-4 h-4 mr-2" />
+                Voir l'espace copro
+              </Button>
+            </Link>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleUnlink}
+              disabled={unlinking}
+              title="Rompre le lien"
+            >
+              {unlinking ? <Loader2 className="w-4 h-4 animate-spin" /> : <Link2Off className="w-4 h-4" />}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Status: pending
+  if (status === "pending") {
+    return (
+      <Card className="border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-900/20">
+        <CardContent className="p-4 flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/40">
+              <Clock className="w-5 h-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-foreground">Demande envoyée</p>
+              <p className="text-xs text-muted-foreground">
+                Le syndic doit valider votre rattachement depuis son espace Talok.
+              </p>
+            </div>
+          </div>
+          <Button size="sm" variant="ghost" onClick={handleUnlink} disabled={unlinking}>
+            {unlinking ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+            Annuler
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Status: rejected
+  if (status === "rejected") {
+    return (
+      <Card className="border-red-200 bg-red-50/50 dark:border-red-800 dark:bg-red-900/20">
+        <CardContent className="p-4 flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/40">
+              <XCircle className="w-5 h-5 text-red-600 dark:text-red-400" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-foreground">Demande refusée</p>
+              <p className="text-xs text-muted-foreground">
+                {rejectedReason ?? "Le syndic a refusé votre demande de rattachement."}
+              </p>
+            </div>
+          </div>
+          <Button size="sm" variant="outline" onClick={() => setSearchOpen(true)}>
+            <Search className="w-4 h-4 mr-2" />
+            Renvoyer une demande
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Status: unlinked — affichage différent selon ownership_type
+  if (ownershipType === "partial") {
+    return (
+      <>
+        <Card className="border-cyan-200 bg-cyan-50/40 dark:border-cyan-800 dark:bg-cyan-900/20">
+          <CardContent className="p-4 flex items-center justify-between gap-4 flex-wrap">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-cyan-100 dark:bg-cyan-900/40">
+                <Building2 className="w-5 h-5 text-cyan-600 dark:text-cyan-400" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-foreground">
+                  Votre syndic est-il sur Talok ?
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Connectez-vous à votre copropriété pour suivre AG, appels de fonds et documents officiels.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                className="bg-cyan-600 hover:bg-cyan-700"
+                onClick={() => setSearchOpen(true)}
+              >
+                <Link2 className="w-4 h-4 mr-2" />
+                Rechercher mon syndic
+              </Button>
+              <Button size="sm" variant="outline" asChild>
+                <a
+                  href={`mailto:?subject=Inviter%20mon%20syndic%20sur%20Talok&body=Bonjour,%0A%0AJe%20souhaiterais%20que%20vous%20rejoigniez%20Talok%20pour%20faciliter%20la%20gestion%20de%20notre%20copropri%C3%A9t%C3%A9.%0A%0AInscription%20:%20https://talok.fr/auth/signup?role=syndic`}
+                >
+                  <Mail className="w-4 h-4 mr-2" />
+                  Inviter
+                </a>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Dialog open={searchOpen} onOpenChange={setSearchOpen}>
+          <DialogContent className="max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>Rechercher mon syndic</DialogTitle>
+              <DialogDescription>
+                Sélectionnez la copropriété à laquelle vous souhaitez vous rattacher.
+                Le syndic recevra votre demande et devra la valider.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              {matchesLoading ? (
+                <div className="py-8 text-center text-muted-foreground">
+                  <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+                </div>
+              ) : matches.length === 0 ? (
+                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  Aucune copropriété trouvée à votre adresse. Invitez votre syndic à
+                  rejoindre Talok ou contactez le support.
+                </div>
+              ) : (
+                <div className="space-y-2 max-h-72 overflow-y-auto">
+                  {matches.map((m) => (
+                    <label
+                      key={m.id}
+                      className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                        selectedSiteId === m.id
+                          ? "border-cyan-500 bg-cyan-50 dark:bg-cyan-900/30"
+                          : "border-border hover:bg-muted/40"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="site"
+                        checked={selectedSiteId === m.id}
+                        onChange={() => setSelectedSiteId(m.id)}
+                        className="mt-1"
+                      />
+                      <div>
+                        <p className="font-medium text-foreground">{m.name}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {m.address_line1}
+                          {m.postal_code && ` · ${m.postal_code} ${m.city}`}
+                        </p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              {matches.length > 0 && (
+                <div className="space-y-2">
+                  <Label>Message au syndic (optionnel)</Label>
+                  <Textarea
+                    rows={2}
+                    value={claimMessage}
+                    onChange={(e) => setClaimMessage(e.target.value)}
+                    placeholder="Précisez vos lots ou références…"
+                  />
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setSearchOpen(false)}>
+                Annuler
+              </Button>
+              <Button onClick={handleClaim} disabled={claiming || !selectedSiteId}>
+                {claiming && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                Envoyer la demande
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </>
+    );
+  }
+
+  // ownership_type = 'full' & unlinked → option discrète
+  return (
+    <>
+      <Card className="border-dashed border-slate-200 dark:border-slate-700">
+        <CardContent className="p-3 flex items-center justify-between gap-3 flex-wrap text-xs">
+          <span className="text-muted-foreground inline-flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-violet-500" />
+            Vous êtes propriétaire unique. Aucun syndic n'est requis.
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-violet-600 hover:text-violet-700"
+            onClick={() => setVolunteerOpen(true)}
+          >
+            Activer le mode syndic-bénévole
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog open={volunteerOpen} onOpenChange={setVolunteerOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Activer le mode syndic-bénévole</DialogTitle>
+            <DialogDescription>
+              Vous êtes l'unique propriétaire de cet immeuble. Légalement, aucun
+              syndic n'est requis.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <p>Activez ce mode uniquement si vous souhaitez :</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Tenir une comptabilité dédiée par immeuble (plan comptable copropriété)</li>
+              <li>Centraliser vos contrats fournisseurs (entretien, ascenseur, assurance)</li>
+              <li>Émettre des appels de provisions vers vos SCI ou co-investisseurs</li>
+              <li>Convoquer des réunions d'information avec vos locataires</li>
+            </ul>
+            <Badge variant="outline" className="border-amber-200 text-amber-700">
+              Cette action peut être annulée à tout moment.
+            </Badge>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setVolunteerOpen(false)}>
+              Annuler
+            </Button>
+            <Button onClick={handleActivateVolunteer} disabled={activating}>
+              {activating && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              Activer
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/buildings/SyndicLinkBanner.tsx
+++ b/components/buildings/SyndicLinkBanner.tsx
@@ -85,6 +85,18 @@ export function SyndicLinkBanner({
   const [volunteerOpen, setVolunteerOpen] = useState(false);
   const [activating, setActivating] = useState(false);
 
+  // Inviter un syndic externe
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviting, setInviting] = useState(false);
+  const [inviteResult, setInviteResult] = useState<{ url: string } | null>(null);
+  const [inviteForm, setInviteForm] = useState({
+    email: "",
+    name: "",
+    copro_name: "",
+    phone: "",
+    message: "",
+  });
+
   // Unlink
   const [unlinking, setUnlinking] = useState(false);
 
@@ -172,6 +184,37 @@ export function SyndicLinkBanner({
       toast({ title: "Erreur", variant: "destructive" });
     } finally {
       setUnlinking(false);
+    }
+  }
+
+  async function handleInviteSyndic(e: React.FormEvent) {
+    e.preventDefault();
+    if (!inviteForm.email) {
+      toast({ title: "Email requis", variant: "destructive" });
+      return;
+    }
+    setInviting(true);
+    try {
+      const res = await fetch(`/api/buildings/${buildingId}/invite-syndic`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(inviteForm),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? "Erreur");
+      setInviteResult({ url: body.invite_url });
+      toast({
+        title: "Invitation envoyée",
+        description: `Email envoyé à ${inviteForm.email}`,
+      });
+    } catch (err) {
+      toast({
+        title: "Erreur",
+        description: err instanceof Error ? err.message : "Échec",
+        variant: "destructive",
+      });
+    } finally {
+      setInviting(false);
     }
   }
 
@@ -322,17 +365,125 @@ export function SyndicLinkBanner({
                 <Link2 className="w-4 h-4 mr-2" />
                 Rechercher mon syndic
               </Button>
-              <Button size="sm" variant="outline" asChild>
-                <a
-                  href={`mailto:?subject=Inviter%20mon%20syndic%20sur%20Talok&body=Bonjour,%0A%0AJe%20souhaiterais%20que%20vous%20rejoigniez%20Talok%20pour%20faciliter%20la%20gestion%20de%20notre%20copropri%C3%A9t%C3%A9.%0A%0AInscription%20:%20https://talok.fr/auth/signup?role=syndic`}
-                >
-                  <Mail className="w-4 h-4 mr-2" />
-                  Inviter
-                </a>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setInviteResult(null);
+                  setInviteOpen(true);
+                }}
+              >
+                <Mail className="w-4 h-4 mr-2" />
+                Inviter
               </Button>
             </div>
           </CardContent>
         </Card>
+
+        <Dialog
+          open={inviteOpen}
+          onOpenChange={(o) => {
+            setInviteOpen(o);
+            if (!o) setInviteResult(null);
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Inviter mon syndic à rejoindre Talok</DialogTitle>
+              <DialogDescription>
+                Un email lui sera envoyé avec un lien d'inscription pré-rempli.
+                Quand il créera son compte, votre immeuble sera automatiquement
+                rattaché à la copropriété qu'il configurera.
+              </DialogDescription>
+            </DialogHeader>
+
+            {inviteResult ? (
+              <div className="space-y-4">
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+                  <p className="font-semibold text-emerald-700 inline-flex items-center gap-2">
+                    <CheckCircle2 className="w-4 h-4" />
+                    Invitation envoyée
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Vous pouvez aussi partager ce lien directement avec votre syndic :
+                  </p>
+                  <div className="flex items-center gap-2 mt-2">
+                    <Input value={inviteResult.url} readOnly className="text-xs font-mono" />
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        navigator.clipboard.writeText(inviteResult.url);
+                        toast({ title: "Copié" });
+                      }}
+                    >
+                      Copier
+                    </Button>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button onClick={() => setInviteOpen(false)}>Fermer</Button>
+                </DialogFooter>
+              </div>
+            ) : (
+              <form onSubmit={handleInviteSyndic} className="space-y-3">
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Email du syndic *</Label>
+                  <Input
+                    type="email"
+                    required
+                    value={inviteForm.email}
+                    onChange={(e) => setInviteForm({ ...inviteForm, email: e.target.value })}
+                    placeholder="contact@cabinet-syndic.fr"
+                  />
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Nom du cabinet</Label>
+                    <Input
+                      value={inviteForm.name}
+                      onChange={(e) => setInviteForm({ ...inviteForm, name: e.target.value })}
+                      placeholder="Cabinet Foch"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Téléphone</Label>
+                    <Input
+                      value={inviteForm.phone}
+                      onChange={(e) => setInviteForm({ ...inviteForm, phone: e.target.value })}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Nom de la copropriété (optionnel)</Label>
+                  <Input
+                    value={inviteForm.copro_name}
+                    onChange={(e) => setInviteForm({ ...inviteForm, copro_name: e.target.value })}
+                    placeholder="Résidence Les Magnolias"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Message personnel</Label>
+                  <Textarea
+                    rows={3}
+                    value={inviteForm.message}
+                    onChange={(e) => setInviteForm({ ...inviteForm, message: e.target.value })}
+                    placeholder="Bonjour, je suis copropriétaire et …"
+                  />
+                </div>
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setInviteOpen(false)}>
+                    Annuler
+                  </Button>
+                  <Button type="submit" disabled={inviting}>
+                    {inviting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    Envoyer l'invitation
+                  </Button>
+                </DialogFooter>
+              </form>
+            )}
+          </DialogContent>
+        </Dialog>
 
         <Dialog open={searchOpen} onOpenChange={setSearchOpen}>
           <DialogContent className="max-w-2xl">

--- a/components/buildings/SyndicSidePanel.tsx
+++ b/components/buildings/SyndicSidePanel.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Calendar,
+  Euro,
+  FileText,
+  Video,
+  MapPin,
+  ChevronRight,
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+} from "lucide-react";
+
+interface NextAssembly {
+  id: string;
+  title: string;
+  reference_number: string | null;
+  assembly_type: string;
+  scheduled_at: string;
+  location: string | null;
+  online_meeting_url: string | null;
+  status: string;
+}
+
+interface LatestFundCall {
+  id: string;
+  call_number: string | null;
+  period_label: string | null;
+  due_date: string | null;
+  total_amount_cents: number | null;
+  total_amount: number | null;
+  status: string | null;
+  user_owed_cents: number | null;
+}
+
+interface RecentMinute {
+  id: string;
+  version: number;
+  status: string;
+  signed_by_president_at: string | null;
+  distributed_at: string | null;
+  assembly?: { title: string; scheduled_at: string } | null;
+}
+
+interface Summary {
+  linked: boolean;
+  site_id?: string;
+  next_assembly: NextAssembly | null;
+  latest_fund_call: LatestFundCall | null;
+  recent_documents: RecentMinute[];
+}
+
+const FUND_CALL_STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  draft: { label: "Brouillon", color: "bg-slate-100 text-slate-700" },
+  sent: { label: "Émis", color: "bg-blue-100 text-blue-700" },
+  partial: { label: "Partiellement payé", color: "bg-amber-100 text-amber-700" },
+  paid: { label: "Soldé", color: "bg-emerald-100 text-emerald-700" },
+  overdue: { label: "En retard", color: "bg-red-100 text-red-700" },
+};
+
+function formatDateLong(d: string): string {
+  return new Date(d).toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatEuros(cents: number | null | undefined): string {
+  if (cents == null) return "—";
+  return `${(cents / 100).toLocaleString("fr-FR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} €`;
+}
+
+export function SyndicSidePanel({ buildingId }: { buildingId: string }) {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(`/api/buildings/${buildingId}/syndic-summary`);
+        if (res.ok && !cancelled) {
+          setSummary(await res.json());
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [buildingId]);
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-40" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!summary || !summary.linked) {
+    return null;
+  }
+
+  const siteId = summary.site_id ?? "";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+            <Calendar className="w-5 h-5 text-cyan-600" />
+            Côté copropriété
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Informations transmises par votre syndic Talok (lecture seule).
+          </p>
+        </div>
+        <Link href={`/syndic/sites/${siteId}`}>
+          <Button variant="outline" size="sm">
+            Voir l'espace copro
+            <ChevronRight className="w-4 h-4 ml-1" />
+          </Button>
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Prochaine AG */}
+        <Card className="border-violet-100">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm flex items-center gap-2 text-violet-700">
+              <Calendar className="w-4 h-4" />
+              Prochaine AG
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {summary.next_assembly ? (
+              <div className="space-y-2">
+                <p className="text-sm font-semibold text-foreground line-clamp-2">
+                  {summary.next_assembly.title}
+                </p>
+                <p className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                  <Calendar className="w-3 h-3" />
+                  {formatDateLong(summary.next_assembly.scheduled_at)}
+                </p>
+                {summary.next_assembly.online_meeting_url ? (
+                  <p className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                    <Video className="w-3 h-3" />
+                    En visioconférence
+                  </p>
+                ) : summary.next_assembly.location ? (
+                  <p className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                    <MapPin className="w-3 h-3" />
+                    {summary.next_assembly.location}
+                  </p>
+                ) : null}
+                <div className="pt-2">
+                  <Link href={`/syndic/assemblies/${summary.next_assembly.id}`}>
+                    <Button size="sm" variant="ghost" className="text-violet-600 px-2 h-7">
+                      Détails de l'AG
+                      <ChevronRight className="w-3 h-3 ml-1" />
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground py-6 text-center">
+                Aucune AG programmée.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Dernier appel de fonds */}
+        <Card className="border-cyan-100">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm flex items-center gap-2 text-cyan-700">
+              <Euro className="w-4 h-4" />
+              Dernier appel de fonds
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {summary.latest_fund_call ? (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-semibold text-foreground line-clamp-1">
+                    {summary.latest_fund_call.period_label ??
+                      summary.latest_fund_call.call_number ??
+                      "Appel"}
+                  </p>
+                  {summary.latest_fund_call.status &&
+                    FUND_CALL_STATUS_LABELS[summary.latest_fund_call.status] && (
+                      <Badge
+                        className={`${FUND_CALL_STATUS_LABELS[summary.latest_fund_call.status].color} border-0 text-[10px]`}
+                      >
+                        {FUND_CALL_STATUS_LABELS[summary.latest_fund_call.status].label}
+                      </Badge>
+                    )}
+                </div>
+                {summary.latest_fund_call.due_date && (
+                  <p className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                    <Clock className="w-3 h-3" />
+                    Échéance :{" "}
+                    {new Date(summary.latest_fund_call.due_date).toLocaleDateString("fr-FR")}
+                  </p>
+                )}
+                {summary.latest_fund_call.user_owed_cents != null &&
+                  summary.latest_fund_call.user_owed_cents > 0 && (
+                    <div className="rounded-lg bg-red-50 border border-red-200 p-2 text-xs">
+                      <p className="text-red-700 inline-flex items-center gap-1">
+                        <AlertCircle className="w-3 h-3" />
+                        Solde impayé :{" "}
+                        <span className="font-bold">
+                          {formatEuros(summary.latest_fund_call.user_owed_cents)}
+                        </span>
+                      </p>
+                    </div>
+                  )}
+                {summary.latest_fund_call.user_owed_cents === 0 && (
+                  <p className="text-xs text-emerald-700 inline-flex items-center gap-1">
+                    <CheckCircle2 className="w-3 h-3" />À jour
+                  </p>
+                )}
+                <div className="pt-2">
+                  <a
+                    href={`/api/copro/fund-calls/${summary.latest_fund_call.id}/pdf`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <Button size="sm" variant="ghost" className="text-cyan-600 px-2 h-7">
+                      Télécharger le PDF
+                      <ChevronRight className="w-3 h-3 ml-1" />
+                    </Button>
+                  </a>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground py-6 text-center">
+                Aucun appel émis pour le moment.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Documents récents */}
+        <Card className="border-emerald-100">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm flex items-center gap-2 text-emerald-700">
+              <FileText className="w-4 h-4" />
+              Procès-verbaux récents
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {summary.recent_documents.length > 0 ? (
+              <div className="space-y-2">
+                {summary.recent_documents.slice(0, 3).map((doc) => (
+                  <div
+                    key={doc.id}
+                    className="flex items-center justify-between gap-2 text-sm border-b border-border last:border-0 pb-1.5 last:pb-0"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-foreground line-clamp-1 text-xs font-medium">
+                        {doc.assembly?.title ?? `PV v${doc.version}`}
+                      </p>
+                      <p className="text-muted-foreground text-[10px]">
+                        {doc.signed_by_president_at
+                          ? `Signé le ${new Date(doc.signed_by_president_at).toLocaleDateString("fr-FR")}`
+                          : "Non signé"}
+                      </p>
+                    </div>
+                    <a
+                      href={`/api/copro/minutes/${doc.id}/pdf`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-emerald-600 hover:text-emerald-700 text-xs"
+                    >
+                      PDF
+                    </a>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground py-6 text-center">
+                Aucun PV publié.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/lib/buildings/auto-map-copro-lots.ts
+++ b/lib/buildings/auto-map-copro-lots.ts
@@ -1,0 +1,147 @@
+/**
+ * Auto-mapping des building_units (côté owner) vers les copro_lots
+ * (côté syndic). Cherche une correspondance par :
+ *   1. unique_code de la property du lot ↔ lot_number
+ *   2. couple floor-position ↔ lot_number ("3-2" ou "3.2")
+ *
+ * Utilisé par :
+ *   - POST /api/buildings/[id]/auto-map-copro-lots (manuel)
+ *   - POST /api/syndic/site-claims/[claimId] (automatique après approve)
+ *
+ * Ne touche pas les unités déjà mappées et ne réutilise pas un copro_lot
+ * déjà attaché à une autre unité.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface AutoMapResult {
+  mapped: number;
+  total_units: number;
+  total_lots_available: number;
+  unmapped: number;
+  skipped_reason?: string;
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, "");
+}
+
+export async function autoMapCoproLots(
+  serviceClient: SupabaseClient,
+  buildingId: string
+): Promise<AutoMapResult> {
+  const { data: building } = await serviceClient
+    .from("buildings")
+    .select("id, site_id, site_link_status")
+    .eq("id", buildingId)
+    .maybeSingle();
+
+  if (!building) {
+    return {
+      mapped: 0,
+      total_units: 0,
+      total_lots_available: 0,
+      unmapped: 0,
+      skipped_reason: "building_not_found",
+    };
+  }
+
+  const b = building as { site_id: string | null; site_link_status: string };
+  if (!b.site_id || b.site_link_status !== "linked") {
+    return {
+      mapped: 0,
+      total_units: 0,
+      total_lots_available: 0,
+      unmapped: 0,
+      skipped_reason: "not_linked",
+    };
+  }
+
+  const { data: site } = await serviceClient
+    .from("sites")
+    .select("copro_entity_id")
+    .eq("id", b.site_id)
+    .maybeSingle();
+  const coproEntityId = (site as { copro_entity_id: string | null } | null)?.copro_entity_id;
+  if (!coproEntityId) {
+    return {
+      mapped: 0,
+      total_units: 0,
+      total_lots_available: 0,
+      unmapped: 0,
+      skipped_reason: "no_copro_entity",
+    };
+  }
+
+  const { data: units } = await serviceClient
+    .from("building_units")
+    .select(
+      "id, floor, position, copro_lot_id, property_id, properties:properties(unique_code)"
+    )
+    .eq("building_id", buildingId)
+    .is("copro_lot_id", null);
+  const targetUnits = (units ?? []) as Array<{
+    id: string;
+    floor: number;
+    position: number;
+    properties: { unique_code: string | null } | null;
+  }>;
+
+  if (targetUnits.length === 0) {
+    return {
+      mapped: 0,
+      total_units: 0,
+      total_lots_available: 0,
+      unmapped: 0,
+      skipped_reason: "no_units_to_map",
+    };
+  }
+
+  const { data: lots } = await serviceClient
+    .from("copro_lots")
+    .select("id, lot_number")
+    .eq("copro_entity_id", coproEntityId)
+    .eq("is_active", true);
+  const targetLots = (lots ?? []) as Array<{ id: string; lot_number: string }>;
+
+  const { data: alreadyMapped } = await serviceClient
+    .from("building_units")
+    .select("copro_lot_id")
+    .not("copro_lot_id", "is", null);
+  const usedLotIds = new Set(
+    (alreadyMapped ?? []).map((m) => (m as { copro_lot_id: string }).copro_lot_id)
+  );
+  const availableLots = targetLots.filter((l) => !usedLotIds.has(l.id));
+
+  let mappedCount = 0;
+  for (const unit of targetUnits) {
+    const candidates: string[] = [];
+    if (unit.properties?.unique_code) {
+      candidates.push(normalize(unit.properties.unique_code));
+    }
+    candidates.push(`${unit.floor}-${unit.position}`);
+    candidates.push(`${unit.floor}.${unit.position}`);
+
+    const match = availableLots.find((lot) =>
+      candidates.includes(normalize(lot.lot_number))
+    );
+    if (!match) continue;
+
+    const { error } = await serviceClient
+      .from("building_units")
+      .update({ copro_lot_id: match.id, updated_at: new Date().toISOString() })
+      .eq("id", unit.id);
+    if (!error) {
+      mappedCount += 1;
+      const idx = availableLots.findIndex((l) => l.id === match.id);
+      if (idx >= 0) availableLots.splice(idx, 1);
+    }
+  }
+
+  return {
+    mapped: mappedCount,
+    total_units: targetUnits.length,
+    total_lots_available: targetLots.length,
+    unmapped: targetUnits.length - mappedCount,
+  };
+}

--- a/supabase/migrations/20260429120000_copro_overdue_actions.sql
+++ b/supabase/migrations/20260429120000_copro_overdue_actions.sql
@@ -1,0 +1,77 @@
+-- ============================================
+-- Module syndic — Historique des relances et mises en demeure
+-- ============================================
+-- Stocke chaque relance / mise en demeure envoyée à un copropriétaire
+-- en retard de paiement. Sert de journal légal et alimente les KPI
+-- du dashboard syndic.
+
+CREATE TABLE IF NOT EXISTS public.copro_overdue_notices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+  fund_call_id UUID REFERENCES public.copro_fund_calls(id) ON DELETE SET NULL,
+  fund_call_line_id UUID REFERENCES public.copro_fund_call_lines(id) ON DELETE SET NULL,
+  lot_id UUID REFERENCES public.copro_lots(id) ON DELETE SET NULL,
+
+  notice_type TEXT NOT NULL CHECK (notice_type IN ('reminder', 'formal_notice')),
+  channel TEXT NOT NULL DEFAULT 'email' CHECK (channel IN ('email', 'postal', 'sms', 'in_app')),
+
+  recipient_name TEXT,
+  recipient_email TEXT,
+
+  amount_due_cents INTEGER NOT NULL CHECK (amount_due_cents >= 0),
+  days_late INTEGER NOT NULL DEFAULT 0,
+
+  pdf_url TEXT,
+  message TEXT,
+
+  sent_by_user_id UUID REFERENCES auth.users(id),
+  sent_by_profile_id UUID REFERENCES public.profiles(id),
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_overdue_notices_site
+  ON public.copro_overdue_notices(site_id, sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_copro_overdue_notices_lot
+  ON public.copro_overdue_notices(lot_id, sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_copro_overdue_notices_call
+  ON public.copro_overdue_notices(fund_call_id);
+
+COMMENT ON TABLE public.copro_overdue_notices IS
+'Journal des relances et mises en demeure envoyées aux copropriétaires en retard. Trace légale.';
+
+-- ============================================
+-- RLS
+-- ============================================
+ALTER TABLE public.copro_overdue_notices ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "copro_overdue_notices_syndic_select" ON public.copro_overdue_notices;
+CREATE POLICY "copro_overdue_notices_syndic_select" ON public.copro_overdue_notices
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "copro_overdue_notices_syndic_insert" ON public.copro_overdue_notices;
+CREATE POLICY "copro_overdue_notices_syndic_insert" ON public.copro_overdue_notices
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );

--- a/supabase/migrations/20260429120100_copro_fonds_travaux_movements.sql
+++ b/supabase/migrations/20260429120100_copro_fonds_travaux_movements.sql
@@ -1,0 +1,98 @@
+-- ============================================
+-- Module syndic — Mouvements du fonds de travaux
+-- ============================================
+-- Trace tous les mouvements entrant et sortant du fonds de travaux
+-- (cotisations encaissées, dépenses de travaux, intérêts, etc.)
+-- pour produire l'historique requis par la loi ALUR.
+
+CREATE TABLE IF NOT EXISTS public.copro_fonds_travaux_movements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  fonds_id UUID NOT NULL REFERENCES public.copro_fonds_travaux(id) ON DELETE CASCADE,
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  movement_type TEXT NOT NULL CHECK (
+    movement_type IN ('cotisation', 'travaux', 'interets', 'remboursement', 'autre')
+  ),
+  direction TEXT NOT NULL CHECK (direction IN ('credit', 'debit')),
+
+  amount_cents INTEGER NOT NULL CHECK (amount_cents > 0),
+  movement_date DATE NOT NULL DEFAULT CURRENT_DATE,
+
+  description TEXT,
+  reference TEXT,
+  related_invoice_id UUID,
+  attachment_url TEXT,
+
+  created_by_profile_id UUID REFERENCES public.profiles(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_fonds_travaux_movements_fonds
+  ON public.copro_fonds_travaux_movements(fonds_id, movement_date DESC);
+CREATE INDEX IF NOT EXISTS idx_copro_fonds_travaux_movements_site
+  ON public.copro_fonds_travaux_movements(site_id, movement_date DESC);
+
+COMMENT ON TABLE public.copro_fonds_travaux_movements IS
+'Historique des mouvements du fonds de travaux ALUR (entrées et sorties).';
+
+-- Trigger pour mettre à jour le solde du fonds parent
+CREATE OR REPLACE FUNCTION public.update_fonds_travaux_balance()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  v_delta INTEGER;
+BEGIN
+  v_delta := CASE WHEN NEW.direction = 'credit' THEN NEW.amount_cents ELSE -NEW.amount_cents END;
+
+  UPDATE public.copro_fonds_travaux
+  SET
+    solde_actuel_cents = solde_actuel_cents + v_delta,
+    total_collected_cents = total_collected_cents + (CASE WHEN NEW.direction = 'credit' THEN NEW.amount_cents ELSE 0 END),
+    total_spent_cents = total_spent_cents + (CASE WHEN NEW.direction = 'debit' THEN NEW.amount_cents ELSE 0 END),
+    updated_at = NOW()
+  WHERE id = NEW.fonds_id;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_copro_fonds_travaux_movements_balance
+  ON public.copro_fonds_travaux_movements;
+CREATE TRIGGER trg_copro_fonds_travaux_movements_balance
+  AFTER INSERT ON public.copro_fonds_travaux_movements
+  FOR EACH ROW EXECUTE FUNCTION public.update_fonds_travaux_balance();
+
+-- ============================================
+-- RLS
+-- ============================================
+ALTER TABLE public.copro_fonds_travaux_movements ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "copro_fonds_travaux_movements_select" ON public.copro_fonds_travaux_movements;
+CREATE POLICY "copro_fonds_travaux_movements_select" ON public.copro_fonds_travaux_movements
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "copro_fonds_travaux_movements_insert" ON public.copro_fonds_travaux_movements;
+CREATE POLICY "copro_fonds_travaux_movements_insert" ON public.copro_fonds_travaux_movements
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );

--- a/supabase/migrations/20260429120200_copro_suppliers_contracts.sql
+++ b/supabase/migrations/20260429120200_copro_suppliers_contracts.sql
@@ -1,0 +1,198 @@
+-- ============================================
+-- Module syndic — Fournisseurs et contrats
+-- ============================================
+-- Permet au syndic de gérer son carnet de fournisseurs (entretien, ascenseur,
+-- chauffage, espaces verts, assurance immeuble, gardiennage, etc.) et le
+-- portefeuille de contrats associés à chaque copropriété.
+
+CREATE TABLE IF NOT EXISTS public.copro_suppliers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  syndic_profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+
+  name TEXT NOT NULL,
+  legal_form TEXT,
+  siret TEXT,
+  vat_number TEXT,
+
+  category TEXT NOT NULL DEFAULT 'autre' CHECK (
+    category IN (
+      'entretien', 'ascenseur', 'chauffage', 'plomberie', 'electricite',
+      'espaces_verts', 'nettoyage', 'gardiennage', 'securite',
+      'assurance', 'expert_comptable', 'avocat', 'architecte',
+      'travaux_batiment', 'autre'
+    )
+  ),
+
+  contact_name TEXT,
+  contact_email TEXT,
+  contact_phone TEXT,
+
+  address_line1 TEXT,
+  postal_code TEXT,
+  city TEXT,
+  country TEXT DEFAULT 'FR',
+
+  notes TEXT,
+  rating INTEGER CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5)),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_suppliers_syndic
+  ON public.copro_suppliers(syndic_profile_id, status);
+CREATE INDEX IF NOT EXISTS idx_copro_suppliers_category
+  ON public.copro_suppliers(category);
+CREATE INDEX IF NOT EXISTS idx_copro_suppliers_siret
+  ON public.copro_suppliers(siret) WHERE siret IS NOT NULL;
+
+COMMENT ON TABLE public.copro_suppliers IS
+'Carnet de fournisseurs partagé par le syndic (utilisable sur toutes ses copropriétés).';
+
+-- ============================================
+-- Contrats
+-- ============================================
+CREATE TABLE IF NOT EXISTS public.copro_supplier_contracts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplier_id UUID NOT NULL REFERENCES public.copro_suppliers(id) ON DELETE CASCADE,
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  contract_number TEXT,
+  title TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'entretien' CHECK (
+    category IN (
+      'entretien', 'ascenseur', 'chauffage', 'plomberie', 'electricite',
+      'espaces_verts', 'nettoyage', 'gardiennage', 'securite',
+      'assurance_immeuble', 'expert_comptable', 'avocat', 'autre'
+    )
+  ),
+
+  start_date DATE NOT NULL,
+  end_date DATE,
+  duration_months INTEGER,
+  tacit_renewal BOOLEAN NOT NULL DEFAULT FALSE,
+  notice_period_months INTEGER DEFAULT 3,
+
+  payment_frequency TEXT NOT NULL DEFAULT 'monthly' CHECK (
+    payment_frequency IN ('monthly', 'quarterly', 'annual', 'on_demand')
+  ),
+  amount_cents INTEGER CHECK (amount_cents IS NULL OR amount_cents >= 0),
+  vat_rate_pct DECIMAL(5, 2),
+  currency TEXT NOT NULL DEFAULT 'EUR',
+
+  contract_pdf_url TEXT,
+  voted_in_assembly_id UUID REFERENCES public.copro_assemblies(id),
+  voted_resolution_id UUID,
+
+  status TEXT NOT NULL DEFAULT 'active' CHECK (
+    status IN ('draft', 'active', 'suspended', 'expired', 'terminated')
+  ),
+  terminated_at TIMESTAMPTZ,
+  terminated_reason TEXT,
+
+  notes TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_copro_supplier_contracts_site
+  ON public.copro_supplier_contracts(site_id, status);
+CREATE INDEX IF NOT EXISTS idx_copro_supplier_contracts_supplier
+  ON public.copro_supplier_contracts(supplier_id);
+CREATE INDEX IF NOT EXISTS idx_copro_supplier_contracts_end_date
+  ON public.copro_supplier_contracts(end_date) WHERE status = 'active' AND end_date IS NOT NULL;
+
+COMMENT ON TABLE public.copro_supplier_contracts IS
+'Contrats fournisseurs rattachés à une copropriété (entretien, ascenseur, assurance, etc.).';
+
+-- ============================================
+-- RLS Suppliers
+-- ============================================
+ALTER TABLE public.copro_suppliers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "copro_suppliers_select_own" ON public.copro_suppliers;
+CREATE POLICY "copro_suppliers_select_own" ON public.copro_suppliers
+  FOR SELECT TO authenticated
+  USING (
+    syndic_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "copro_suppliers_insert_own" ON public.copro_suppliers;
+CREATE POLICY "copro_suppliers_insert_own" ON public.copro_suppliers
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    syndic_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "copro_suppliers_update_own" ON public.copro_suppliers;
+CREATE POLICY "copro_suppliers_update_own" ON public.copro_suppliers
+  FOR UPDATE TO authenticated
+  USING (
+    syndic_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "copro_suppliers_delete_own" ON public.copro_suppliers;
+CREATE POLICY "copro_suppliers_delete_own" ON public.copro_suppliers
+  FOR DELETE TO authenticated
+  USING (
+    syndic_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+-- ============================================
+-- RLS Contracts
+-- ============================================
+ALTER TABLE public.copro_supplier_contracts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "copro_supplier_contracts_select" ON public.copro_supplier_contracts;
+CREATE POLICY "copro_supplier_contracts_select" ON public.copro_supplier_contracts
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "copro_supplier_contracts_insert" ON public.copro_supplier_contracts;
+CREATE POLICY "copro_supplier_contracts_insert" ON public.copro_supplier_contracts
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "copro_supplier_contracts_update" ON public.copro_supplier_contracts;
+CREATE POLICY "copro_supplier_contracts_update" ON public.copro_supplier_contracts
+  FOR UPDATE TO authenticated
+  USING (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "copro_supplier_contracts_delete" ON public.copro_supplier_contracts;
+CREATE POLICY "copro_supplier_contracts_delete" ON public.copro_supplier_contracts
+  FOR DELETE TO authenticated
+  USING (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/20260429120300_owner_syndic_bridge.sql
+++ b/supabase/migrations/20260429120300_owner_syndic_bridge.sql
@@ -1,0 +1,222 @@
+-- ============================================
+-- Pont owner ↔ syndic : connecter un building (côté propriétaire)
+-- à un site (côté syndic) quand le syndic utilise aussi Talok.
+-- ============================================
+-- Cas d'usage :
+--   - Owner avec ownership_type='partial' réclame le rattachement à
+--     la copropriété gérée par un syndic Talok existant.
+--   - Owner avec ownership_type='full' bascule en mode "syndic-bénévole"
+--     pour structurer sa gestion (compta dédiée, contrats fournisseurs).
+--   - Le syndic invite directement ses copropriétaires (flow inverse,
+--     déjà existant via copro_invites — on ajoute juste le lien building).
+
+-- Champs sur buildings
+ALTER TABLE public.buildings
+  ADD COLUMN IF NOT EXISTS site_id UUID REFERENCES public.sites(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS site_link_status TEXT NOT NULL DEFAULT 'unlinked'
+    CHECK (site_link_status IN ('unlinked', 'pending', 'linked', 'rejected')),
+  ADD COLUMN IF NOT EXISTS site_linked_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS owner_syndic_mode TEXT NOT NULL DEFAULT 'none'
+    CHECK (owner_syndic_mode IN ('none', 'volunteer', 'managed_external'));
+
+CREATE INDEX IF NOT EXISTS idx_buildings_site_id
+  ON public.buildings(site_id) WHERE site_id IS NOT NULL;
+
+COMMENT ON COLUMN public.buildings.site_id IS
+'Si non null, immeuble lié à un site syndic Talok. Null sinon (mono-propriété, syndic externe, ou unlinked).';
+
+COMMENT ON COLUMN public.buildings.owner_syndic_mode IS
+'Indique comment le propriétaire gère la copropriété : none (pas de copro / N/A), volunteer (syndic-bénévole de son propre immeuble full), managed_external (syndic externe non-Talok ou sur Talok via site_id).';
+
+-- Table d'historique des demandes de rattachement
+CREATE TABLE IF NOT EXISTS public.building_site_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  building_id UUID NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  site_id UUID NOT NULL REFERENCES public.sites(id) ON DELETE CASCADE,
+
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled')),
+
+  claimed_by_profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  claim_message TEXT,
+
+  decided_by_profile_id UUID REFERENCES public.profiles(id),
+  decided_at TIMESTAMPTZ,
+  decision_reason TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Une seule demande pending à la fois pour un (building, site)
+  CONSTRAINT building_site_links_unique_pending
+    UNIQUE (building_id, site_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_building_site_links_building
+  ON public.building_site_links(building_id);
+CREATE INDEX IF NOT EXISTS idx_building_site_links_site_status
+  ON public.building_site_links(site_id, status);
+
+COMMENT ON TABLE public.building_site_links IS
+'Historique des demandes de rattachement entre buildings (côté owner) et sites (côté syndic). Un building peut avoir plusieurs entrées (rejet, nouvelle demande, etc.) mais une seule active.';
+
+-- ============================================
+-- RLS — building_site_links
+-- ============================================
+ALTER TABLE public.building_site_links ENABLE ROW LEVEL SECURITY;
+
+-- L'owner du building voit ses propres demandes
+DROP POLICY IF EXISTS "building_site_links_owner_select" ON public.building_site_links;
+CREATE POLICY "building_site_links_owner_select" ON public.building_site_links
+  FOR SELECT TO authenticated
+  USING (
+    claimed_by_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR building_id IN (
+      SELECT b.id FROM public.buildings b
+      JOIN public.profiles p ON p.id = b.owner_id
+      WHERE p.user_id = auth.uid()
+    )
+  );
+
+-- Le syndic du site voit les demandes adressées à ses sites
+DROP POLICY IF EXISTS "building_site_links_syndic_select" ON public.building_site_links;
+CREATE POLICY "building_site_links_syndic_select" ON public.building_site_links
+  FOR SELECT TO authenticated
+  USING (
+    site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );
+
+-- L'owner peut soumettre une demande
+DROP POLICY IF EXISTS "building_site_links_owner_insert" ON public.building_site_links;
+CREATE POLICY "building_site_links_owner_insert" ON public.building_site_links
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    claimed_by_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    AND building_id IN (
+      SELECT b.id FROM public.buildings b
+      JOIN public.profiles p ON p.id = b.owner_id
+      WHERE p.user_id = auth.uid()
+    )
+  );
+
+-- Owner ou syndic peut updater (cancel par owner / approve|reject par syndic)
+DROP POLICY IF EXISTS "building_site_links_update" ON public.building_site_links;
+CREATE POLICY "building_site_links_update" ON public.building_site_links
+  FOR UPDATE TO authenticated
+  USING (
+    claimed_by_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR site_id IN (
+      SELECT s.id FROM public.sites s
+      JOIN public.profiles p ON p.id = s.syndic_profile_id
+      WHERE p.user_id = auth.uid()
+    )
+  );
+
+-- ============================================
+-- Trigger : quand un link passe à 'approved', on met à jour le building
+-- et on crée le user_site_role coproprietaire_bailleur si absent.
+-- ============================================
+CREATE OR REPLACE FUNCTION public.apply_building_site_link()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  v_owner_profile_id UUID;
+  v_owner_user_id UUID;
+BEGIN
+  IF NEW.status = 'approved' AND (OLD.status IS DISTINCT FROM 'approved') THEN
+    -- Met à jour le building
+    UPDATE public.buildings
+    SET
+      site_id = NEW.site_id,
+      site_link_status = 'linked',
+      site_linked_at = NOW(),
+      owner_syndic_mode = 'managed_external',
+      updated_at = NOW()
+    WHERE id = NEW.building_id;
+
+    -- Crée le rôle copropriétaire si absent
+    SELECT b.owner_id INTO v_owner_profile_id
+    FROM public.buildings b WHERE b.id = NEW.building_id;
+
+    SELECT user_id INTO v_owner_user_id
+    FROM public.profiles WHERE id = v_owner_profile_id;
+
+    IF v_owner_user_id IS NOT NULL THEN
+      INSERT INTO public.user_site_roles (user_id, site_id, role_code)
+      VALUES (v_owner_user_id, NEW.site_id, 'coproprietaire_bailleur')
+      ON CONFLICT DO NOTHING;
+    END IF;
+
+  ELSIF NEW.status = 'rejected' AND (OLD.status IS DISTINCT FROM 'rejected') THEN
+    UPDATE public.buildings
+    SET
+      site_link_status = 'rejected',
+      updated_at = NOW()
+    WHERE id = NEW.building_id;
+
+  ELSIF NEW.status = 'cancelled' AND (OLD.status IS DISTINCT FROM 'cancelled') THEN
+    UPDATE public.buildings
+    SET
+      site_link_status = 'unlinked',
+      updated_at = NOW()
+    WHERE id = NEW.building_id AND site_link_status = 'pending';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_apply_building_site_link ON public.building_site_links;
+CREATE TRIGGER trg_apply_building_site_link
+  AFTER UPDATE ON public.building_site_links
+  FOR EACH ROW EXECUTE FUNCTION public.apply_building_site_link();
+
+-- Trigger INSERT : si le claim est immédiatement approved (cas owner=syndic), apply
+CREATE OR REPLACE FUNCTION public.apply_building_site_link_on_insert()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE
+  v_owner_profile_id UUID;
+  v_owner_user_id UUID;
+BEGIN
+  IF NEW.status = 'pending' THEN
+    UPDATE public.buildings
+    SET site_link_status = 'pending', updated_at = NOW()
+    WHERE id = NEW.building_id AND site_link_status IN ('unlinked', 'rejected');
+  ELSIF NEW.status = 'approved' THEN
+    UPDATE public.buildings
+    SET
+      site_id = NEW.site_id,
+      site_link_status = 'linked',
+      site_linked_at = NOW(),
+      owner_syndic_mode = 'managed_external',
+      updated_at = NOW()
+    WHERE id = NEW.building_id;
+
+    SELECT b.owner_id INTO v_owner_profile_id
+    FROM public.buildings b WHERE b.id = NEW.building_id;
+
+    SELECT user_id INTO v_owner_user_id
+    FROM public.profiles WHERE id = v_owner_profile_id;
+
+    IF v_owner_user_id IS NOT NULL THEN
+      INSERT INTO public.user_site_roles (user_id, site_id, role_code)
+      VALUES (v_owner_user_id, NEW.site_id, 'coproprietaire_bailleur')
+      ON CONFLICT DO NOTHING;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_apply_building_site_link_insert ON public.building_site_links;
+CREATE TRIGGER trg_apply_building_site_link_insert
+  AFTER INSERT ON public.building_site_links
+  FOR EACH ROW EXECUTE FUNCTION public.apply_building_site_link_on_insert();

--- a/supabase/migrations/20260429120400_building_units_copro_lot_mapping.sql
+++ b/supabase/migrations/20260429120400_building_units_copro_lot_mapping.sql
@@ -1,0 +1,17 @@
+-- ============================================
+-- Mapping fin building_units ↔ copro_lots
+-- ============================================
+-- Permet de relier précisément un lot physique côté owner (building_unit)
+-- au lot juridique côté syndic (copro_lot). Une fois mappés, on peut
+-- calculer le solde impayé EXACT par copropriétaire au lieu d'utiliser
+-- le total global du fund call.
+
+ALTER TABLE public.building_units
+  ADD COLUMN IF NOT EXISTS copro_lot_id UUID REFERENCES public.copro_lots(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_building_units_copro_lot
+  ON public.building_units(copro_lot_id)
+  WHERE copro_lot_id IS NOT NULL;
+
+COMMENT ON COLUMN public.building_units.copro_lot_id IS
+'FK vers copro_lots (côté syndic). Posé manuellement ou par auto-matching sur lot_number lors de l''approbation d''un building_site_link.';

--- a/supabase/migrations/20260429120500_syndic_invitations_public.sql
+++ b/supabase/migrations/20260429120500_syndic_invitations_public.sql
@@ -1,0 +1,85 @@
+-- ============================================
+-- Invitations publiques de syndics par les copropriétaires
+-- ============================================
+-- Quand un copropriétaire constate que son syndic n'est pas sur Talok,
+-- il peut générer un token d'invitation et l'envoyer (par email ou en
+-- partageant un lien). Le syndic clique → arrive sur une page d'inscription
+-- pré-remplie. Une fois inscrit, on lui présente la copropriété à créer
+-- et on auto-pré-rattache l'immeuble du copropriétaire qui l'a invité.
+
+CREATE TABLE IF NOT EXISTS public.syndic_invitations_public (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token TEXT NOT NULL UNIQUE,
+
+  building_id UUID NOT NULL REFERENCES public.buildings(id) ON DELETE CASCADE,
+  invited_by_profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+
+  -- Coordonnées suggérées (pré-remplissage)
+  suggested_syndic_name TEXT,
+  suggested_syndic_email TEXT,
+  suggested_syndic_phone TEXT,
+  suggested_copro_name TEXT,
+  message TEXT,
+
+  -- Suivi
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '60 days'),
+  redeemed_at TIMESTAMPTZ,
+  redeemed_by_user_id UUID REFERENCES auth.users(id),
+  resulting_site_id UUID REFERENCES public.sites(id),
+
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (
+    status IN ('pending', 'redeemed', 'expired', 'cancelled')
+  ),
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_syndic_invitations_public_token
+  ON public.syndic_invitations_public(token);
+CREATE INDEX IF NOT EXISTS idx_syndic_invitations_public_building
+  ON public.syndic_invitations_public(building_id);
+CREATE INDEX IF NOT EXISTS idx_syndic_invitations_public_status
+  ON public.syndic_invitations_public(status, expires_at);
+
+COMMENT ON TABLE public.syndic_invitations_public IS
+'Invitations publiques générées par un copropriétaire pour qu''un syndic externe rejoigne Talok et prenne en charge la copropriété de l''invitant.';
+
+-- ============================================
+-- RLS — l'owner du building voit ses invitations
+-- ============================================
+ALTER TABLE public.syndic_invitations_public ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "syndic_invitations_public_owner_select" ON public.syndic_invitations_public;
+CREATE POLICY "syndic_invitations_public_owner_select" ON public.syndic_invitations_public
+  FOR SELECT TO authenticated
+  USING (
+    invited_by_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role IN ('admin', 'platform_admin')
+    )
+  );
+
+DROP POLICY IF EXISTS "syndic_invitations_public_owner_insert" ON public.syndic_invitations_public;
+CREATE POLICY "syndic_invitations_public_owner_insert" ON public.syndic_invitations_public
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    invited_by_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    AND building_id IN (
+      SELECT b.id FROM public.buildings b
+      JOIN public.profiles p ON p.id = b.owner_id
+      WHERE p.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "syndic_invitations_public_owner_update" ON public.syndic_invitations_public;
+CREATE POLICY "syndic_invitations_public_owner_update" ON public.syndic_invitations_public
+  FOR UPDATE TO authenticated
+  USING (
+    invited_by_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+-- La route /auth/syndic-invite/[token] charge l'invitation via service_role
+-- (pas de policy public anonyme, le token suffit comme secret).


### PR DESCRIPTION
## Summary
This PR implements a comprehensive bridge between the owner (building) and syndic (site) modules, enabling owners to claim existing syndic-managed properties and syndics to invite external property managers. It includes supplier management, fund call operations, and formal overdue notice workflows.

## Key Changes

### Core Bridge Features
- **Building-Site Linking**: Added `site_id` and `site_link_status` fields to buildings table with states: `unlinked`, `pending`, `linked`, `rejected`
- **Site Claims**: Owners can submit claims to link their building to an existing syndic site; syndics can approve/reject with reasons
- **Syndic Invitations**: Owners can invite external syndics via public tokens that pre-fill registration forms
- **Volunteer Syndic Mode**: Full owners can activate "syndic-bénévole" mode to structure management without external syndic

### Supplier & Contract Management
- **Supplier Registry**: Syndics can manage supplier contacts (maintenance, heating, plumbing, insurance, etc.) with categories
- **Contract Tracking**: Link suppliers to sites with contract details, status, and frequency
- **Supplier Pages**: Dedicated UI for viewing/editing supplier info and associated contracts

### Fund Call & Overdue Operations
- **SEPA XML Export**: Generate Direct Debit files (pain.008.001.02) for unpaid fund call lines
- **Overdue Notices**: Send formal notices and reminders to delinquent copropriétaires
- **Overdue History**: Track all reminders and formal notices in `copro_overdue_notices` table
- **Bulk Reminders**: Mass reminder functionality for all overdue amounts on a site

### Fund Movements Tracking
- **Movement Records**: Log all fonds de travaux transactions (contributions, work expenses, interest, refunds)
- **Movement Types**: Support cotisation, travaux, intérêts, remboursement, autre
- **Audit Trail**: Maintain legal compliance with ALUR requirements

### UI Components & Pages
- **SyndicLinkBanner**: Interactive component for owners to search, claim, or invite syndics
- **SyndicSidePanel**: Read-only summary for linked buildings (next assembly, fund calls, documents)
- **Claims Management**: `/syndic/claims` page for syndics to review and decide on building claims
- **Suppliers Page**: `/syndic/suppliers` list and detail pages with contract management
- **Syndic Invite Flow**: `/auth/syndic-invite/[token]` public registration page with pre-filled data

### Database Migrations
- `copro_suppliers`: Supplier master data with contact info and categories
- `copro_supplier_contracts`: Contract details linked to suppliers and sites
- `copro_fonds_travaux_movements`: Transaction log for fund movements
- `copro_overdue_notices`: History of reminders and formal notices
- `syndic_invitations`: Public invitation tokens for external syndic onboarding
- `building_units_copro_lot_mapping`: Fine-grained mapping between owner units and syndic lots

### API Endpoints
- `POST /api/buildings/[id]/claim-site`: Submit building claim to syndic site
- `POST /api/buildings/[id]/invite-syndic`: Generate public syndic invitation
- `POST /api/buildings/[id]/activate-as-syndic`: Activate volunteer syndic mode
- `POST /api/buildings/[id]/unlink-site`: Cancel or break site link
- `GET /api/buildings/[id]/syndic-summary`: Read-only summary for linked buildings
- `GET /api/buildings/[id]/match-sites`: Search for syndic sites by location or name
- `POST /api/syndic/site-claims/[claimId]`: Approve/reject building claims
- `GET /api/copro/suppliers`: List syndic suppliers
- `POST /api/copro/suppliers`: Create supplier
- `POST /api/copro/fund-calls/[id]/sepa-xml`: Generate SEPA file
- `POST /api/copro/fund-calls/[id]/remind`: Send fund call reminder
- `POST /api/copro/overdue/formal-notice`: Send formal notice

https://claude.ai/code/session_01Pws8cCgifN6XqGVScTkPrW