### PR TITLE
Fix Next.js control flow exceptions and header propagation in layouts

### DIFF
--- a/app/syndic/layout.tsx
+++ b/app/syndic/layout.tsx
@@ -52,28 +52,48 @@ const navigation = [
  * Vérifie l'authentification et le rôle syndic côté serveur
  * SOTA 2026: Protection serveur obligatoire
  */
+// Detecte les exceptions de contrôle de flux Next.js (redirect / notFound) pour
+// les laisser remonter au routeur — sinon on les avale et le layout boucle.
+function isNextControlFlow(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const digest = (err as { digest?: string }).digest;
+  return typeof digest === "string" && digest.startsWith("NEXT_");
+}
+
 export default async function SyndicLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = await createClient();
+  // Lire le pathname d'abord (avant tout `await`) pour éviter les warnings
+  // dynamic-API et garantir un fallback propre si le header est absent.
+  const pathname = headers().get("x-pathname") || "/syndic";
 
-  // 1. Vérifier l'authentification
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
+  let profile: { id: string; role: string; prenom: string | null; nom: string | null; identity_status: string | null } | null = null;
 
-  if (authError || !user) {
-    redirect("/auth/signin?redirect=/syndic/dashboard");
+  try {
+    const supabase = await createClient();
+
+    // 1. Vérifier l'authentification
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      redirect("/auth/signin?redirect=/syndic/dashboard");
+    }
+
+    // 2. Récupérer le profil (avec fallback service role en cas de récursion RLS)
+    const { profile: fetched } = await getServerProfile<{ id: string; role: string; prenom: string | null; nom: string | null; identity_status: string | null }>(
+      user.id,
+      "id, role, prenom, nom, identity_status"
+    );
+    profile = fetched;
+  } catch (err) {
+    // Laisser passer redirect()/notFound()
+    if (isNextControlFlow(err)) throw err;
+    // Toute autre erreur (DB indisponible, env vars manquantes, etc.) :
+    // on évite la page 500 en redirigeant proprement vers signin avec un retour.
+    console.error("[SyndicLayout] auth/profile resolution failed:", err);
+    redirect("/auth/signin?redirect=/syndic/dashboard&error=auth_unavailable");
   }
-
-  // 2. Récupérer le profil (avec fallback service role en cas de récursion RLS)
-  const { profile } = await getServerProfile<{ id: string; role: string; prenom: string | null; nom: string | null; identity_status: string | null }>(
-    user.id,
-    "id, role, prenom, nom, identity_status"
-  );
 
   if (!profile) {
     redirect("/auth/signin");
@@ -86,7 +106,6 @@ export default async function SyndicLayout({
   }
 
   // 3.bis Identity Gate — redirige vers l'onboarding si le niveau requis n'est pas atteint
-  const pathname = headers().get("x-pathname") || "/syndic";
   checkIdentityGate(pathname, profile.role, profile.identity_status);
 
   // 4. Rendre le layout - SOTA 2026: Thème light unifié + breakpoint lg

--- a/middleware.ts
+++ b/middleware.ts
@@ -192,14 +192,26 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  // 7. Propager le pathname et les rôles autorisés pour les layouts serveur (identity gate)
-  const response = NextResponse.next();
-  response.headers.set("x-pathname", pathname);
+  // 7. Propager le pathname et les rôles autorisés pour les layouts serveur (identity gate).
+  // En Next.js 14, les Server Components lisent les headers via `headers()` qui
+  // retourne les REQUEST headers — pas ceux de la response. Pour qu'un layout
+  // puisse lire `x-pathname`, il faut donc cloner et muter les request headers
+  // via `NextResponse.next({ request: { headers } })`. On garde aussi la pose
+  // sur la response pour debug/observabilité côté client.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", pathname);
 
-  // Trouver les rôles autorisés pour cette route et les propager au layout serveur
   const matchedRoute = Object.keys(ROUTE_ROLES).find(
     (route) => pathname === route || pathname.startsWith(`${route}/`)
   );
+  if (matchedRoute) {
+    requestHeaders.set("x-allowed-roles", ROUTE_ROLES[matchedRoute].join(","));
+  }
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.headers.set("x-pathname", pathname);
   if (matchedRoute) {
     response.headers.set("x-allowed-roles", ROUTE_ROLES[matchedRoute].join(","));
   }


### PR DESCRIPTION
## Summary
This PR fixes critical issues with exception handling in the syndic layout and improves header propagation from middleware to server components in Next.js 14.

## Key Changes

- **Exception Handling in SyndicLayout**: Wrapped authentication and profile fetching in a try-catch block that properly detects and re-throws Next.js control flow exceptions (`redirect()` and `notFound()`). Other errors now gracefully redirect to signin with an error parameter instead of causing 500 errors or infinite loops.

- **Header Propagation Fix**: Updated middleware to properly propagate `x-pathname` and `x-allowed-roles` headers to server components by mutating request headers via `NextResponse.next({ request: { headers } })`. In Next.js 14, server components read REQUEST headers (not response headers), so this change ensures layouts can access these values via `headers()`.

- **Pathname Reading Order**: Moved pathname header reading to the beginning of SyndicLayout before any async operations to avoid dynamic API warnings and ensure consistent fallback behavior.

## Implementation Details

- Added `isNextControlFlow()` helper to detect Next.js exceptions by checking for the `NEXT_` digest prefix
- Maintains backward compatibility by keeping response header assignments for observability
- Improved error logging for debugging authentication/profile resolution failures
- Ensures identity gate checks work correctly with proper header access

https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ