### PR TITLE
fix: 500 sur /api/providers + 403 nearby (plans entreprise & owner_id)

### DIFF
--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -105,13 +105,19 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
     }
 
-    // Vérifier l'abonnement
+    // Vérifier l'abonnement.
+    // NB : la table `subscriptions` est scopée par `owner_id` (FK profiles.id),
+    // pas `user_id`. L'ancienne requête `.eq("user_id", profile.id)` ne
+    // matchait JAMAIS, donc planSlug retombait toujours sur "gratuit" et
+    // tous les comptes — y compris entreprise — recevaient 403.
+    // On accepte aussi `trialing` car un compte en période d'essai a accès
+    // aux features de son plan.
     const { data: subscription } = await supabase
       .from("subscriptions")
       .select("plan_slug, status")
-      .eq("user_id", profile.id)
-      .eq("status", "active")
-      .single();
+      .eq("owner_id", profile.id)
+      .in("status", ["active", "trialing"])
+      .maybeSingle();
 
     const planSlug: PlanSlug = (subscription?.plan_slug as PlanSlug) || "gratuit";
     // Confort+ = niveau confort ou supérieur (pro, enterprise_s/m/l/xl, legacy

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -10,6 +10,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 import { logGooglePlacesUsage } from "@/lib/services/google-places-usage";
+import { getPlanLevel, type PlanSlug } from "@/lib/subscriptions/plans";
 
 // Mapping des catégories vers les types Google Places
 const CATEGORY_TO_GOOGLE_TYPE: Record<string, string[]> = {
@@ -112,10 +113,14 @@ export async function GET(request: NextRequest) {
       .eq("status", "active")
       .single();
 
-    const planSlug = subscription?.plan_slug || "gratuit";
-    const premiumPlans = ["confort", "pro", "enterprise"];
+    const planSlug: PlanSlug = (subscription?.plan_slug as PlanSlug) || "gratuit";
+    // Confort+ = niveau confort ou supérieur (pro, enterprise_s/m/l/xl, legacy
+    // enterprise). On compare via getPlanLevel pour ne pas oublier les variantes
+    // entreprise — un slug `enterprise_s` n'aurait jamais matché la liste
+    // hardcodée précédente.
+    const isConfortOrHigher = getPlanLevel(planSlug) >= getPlanLevel("confort");
 
-    if (!premiumPlans.includes(planSlug)) {
+    if (!isConfortOrHigher) {
       return NextResponse.json(
         {
           error: "premium_required",

--- a/app/api/providers/route.ts
+++ b/app/api/providers/route.ts
@@ -46,16 +46,15 @@ export async function GET(request: Request) {
     const limit = parseInt(searchParams.get("limit") || "50");
     const offset = parseInt(searchParams.get("offset") || "0");
 
-    // Construire la requête
+    // Construire la requête.
+    // NB : on ne tente PAS d'embed `work_orders` ici — `work_orders.provider_id`
+    // référence `profiles(id)`, pas `providers(id)`, donc PostgREST ne trouve
+    // pas de relation et renvoie une 500. Le compteur d'interventions vit
+    // déjà dans `providers.total_interventions` (maintenu par le trigger
+    // `update_provider_intervention_count`, cf. migration providers SOTA).
     let query = supabase
       .from("providers")
-      .select(
-        `
-        *,
-        work_orders:work_orders(count)
-      `,
-        { count: "exact" }
-      );
+      .select("*", { count: "exact" });
 
     // Filtrer par catégorie
     if (category) {

--- a/lib/subscriptions/ai/plan-recommender.graph.ts
+++ b/lib/subscriptions/ai/plan-recommender.graph.ts
@@ -9,7 +9,7 @@
 import { StateGraph, END, START, Annotation } from "@langchain/langgraph";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { createFastModel } from "@/lib/ai/config";
-import { PLANS, type PlanSlug, formatPrice } from "../plans";
+import { PLANS, type PlanSlug, formatPrice, getPlanLevel } from "../plans";
 
 // ============================================
 // STATE DEFINITION
@@ -151,7 +151,8 @@ async function determineRecommendation(state: PlanRecommenderStateType): Promise
       reasoning = "Vous approchez des limites du plan Confort. Le plan Pro vous offre plus de capacité et des fonctionnalités avancées.";
       confidence = 85;
     } else if (currentPlan === "pro" && projectedProperties > 100) {
-      recommendedPlan = "enterprise";
+      // `enterprise` est legacy ; le ticket d'entrée actuel est enterprise_s.
+      recommendedPlan = "enterprise_s";
       reasoning = "Votre parc immobilier dépasse bientôt les 100 biens. L'offre Enterprise vous garantit une scalabilité sans limite.";
       confidence = 75;
     }
@@ -177,14 +178,18 @@ async function determineRecommendation(state: PlanRecommenderStateType): Promise
     confidence = 70;
   }
   
-  // Cas 4: Croissance anticipée forte
-  else if (growthPotential === "high" && currentPlan !== "enterprise") {
+  // Cas 4: Croissance anticipée forte. On exclut le sommet de la grille
+  // (enterprise_xl) plutôt que le slug legacy `enterprise` — un compte
+  // `enterprise_s` était précédemment toujours considéré comme non-top
+  // par `currentPlan !== "enterprise"`, ce qui est correct, mais on
+  // bascule sur la comparaison de niveau pour être explicite.
+  else if (growthPotential === "high" && getPlanLevel(currentPlan) < getPlanLevel("enterprise_xl")) {
     const nextPlan: Partial<Record<PlanSlug, PlanSlug>> = {
       gratuit: "starter",
       starter: "confort",
       confort: "pro",
-      pro: "enterprise",
-      enterprise: "enterprise",
+      pro: "enterprise_s",
+      enterprise: "enterprise_m", // legacy alias = niveau enterprise_s
       enterprise_s: "enterprise_m",
       enterprise_m: "enterprise_l",
       enterprise_l: "enterprise_xl",
@@ -379,8 +384,11 @@ export async function getRecommendedPlan(input: {
     confidence: 0,
   });
 
-  const currentLevel = ["starter", "confort", "pro", "enterprise"].indexOf(input.currentPlan);
-  const recommendedLevel = ["starter", "confort", "pro", "enterprise"].indexOf(result.recommendedPlan);
+  // On utilise getPlanLevel comme source de vérité pour couvrir TOUS les
+  // slugs (enterprise_s/m/l/xl + legacy `enterprise`). L'ancienne liste
+  // hardcodée renvoyait -1 pour ces variantes et faussait isUpgrade.
+  const currentLevel = getPlanLevel(input.currentPlan);
+  const recommendedLevel = getPlanLevel(result.recommendedPlan);
 
   return {
     recommendedPlan: result.recommendedPlan,


### PR DESCRIPTION
## Summary

Quatre correctifs liés à la page `/owner/providers` et au gating des plans, faisant suite au merge de #563.

## Bugs corrigés

### 1. `c0f861a` — `/api/providers` renvoyait 500
La GET `/api/providers` faisait un embed PostgREST `work_orders:work_orders(count)`, mais `work_orders.provider_id` référence `profiles(id)`, pas `providers(id)`. PostgREST ne trouvait aucune relation et renvoyait une erreur, mappée ensuite en 500 par `handleApiError`.

**Fix** : embed retiré. Le compteur d'interventions vit déjà dans `providers.total_interventions`, maintenu par le trigger `update_provider_intervention_count` (cf. migration `20260408120000_providers_module_sota.sql`).

### 2. `7f5d7ec` — `/api/providers/nearby` 403 sur les variantes entreprise
La route gardait l'accès via une liste hardcodée :
```ts
const premiumPlans = ["confort", "pro", "enterprise"];
```
Or, depuis la refonte des plans (`lib/subscriptions/plans.ts`), les plans entreprise réels portent les slugs `enterprise_s/m/l/xl`. Le slug `enterprise` n'est plus qu'un alias legacy. Conséquence : un compte sur forfait entreprise (cas signalé sur talok.fr) recevait un 403 alors qu'il a payé pour la recherche géolocalisée.

**Fix** : remplacement par `getPlanLevel(planSlug) >= getPlanLevel("confort")` (helper exporté par `plans.ts`, source de vérité).

### 3. `4694f01` — plan-recommender utilisait toujours le slug legacy `enterprise`
`lib/subscriptions/ai/plan-recommender.graph.ts` recommandait `"enterprise"` à plusieurs endroits :
- Recommandation upgrade `pro → "enterprise"` au lieu de `enterprise_s`
- Filtre "non au sommet" : `currentPlan !== "enterprise"`
- Calcul `isUpgrade` via `["starter","confort","pro","enterprise"].indexOf(...)` qui renvoyait `-1` pour les variantes

**Fix** : alignement sur `getPlanLevel()`, recommandation legacy remplacée par `enterprise_s`, mappe `nextPlan` cohérente (pro → enterprise_s → m → l → xl).

### 4. `f9bfd2b` — vraie cause du 403 sur `/api/providers/nearby`
Au-delà de la liste hardcodée du fix #2, la requête de gating elle-même était cassée :
```ts
.eq("user_id", profile.id)   // ❌ la colonne n'existe pas
```
La table `subscriptions` (migration `20241129000001`) est scopée par `owner_id` (FK `profiles.id`). La requête ne matchait JAMAIS, donc `subscription` était systématiquement null et `planSlug` retombait sur `"gratuit"` → 403 garanti pour 100 % des comptes, peu importe le forfait réel.

**Fix** :
- `user_id` → `owner_id` (le vrai bug)
- `status = "active"` → `status IN ("active","trialing")` (les comptes en essai gardent l'accès)
- `.single()` → `.maybeSingle()` (ne plus traiter "0 ligne" comme une erreur)

Pattern aligné avec les autres routes qui interrogent correctement `subscriptions` (api-keys, webhooks, billing).

## Audit complémentaire

Vérifié dans toute la codebase qu'aucun autre callsite ne gate une feature avec `=== "enterprise"` ou `["...", "enterprise"]`. Tous les autres tests (admin/subscriptions, api-keys, webhooks, smart-paywall, owner-subscription-card) utilisent `startsWith("enterprise")` qui couvre déjà les variantes.

## Test plan

- [ ] `GET /api/providers?limit=100` retourne 200 avec la liste des providers (plus de 500)
- [ ] `GET /api/providers/nearby?...` retourne 200 pour un owner sur forfait entreprise (plus de 403)
- [ ] Un owner sur plan gratuit/starter reçoit toujours 403 sur `/nearby`
- [ ] Un owner en `trialing` Confort+ a accès à `/nearby`
- [ ] Le moteur de recommandation IA propose `enterprise_s` (et plus `enterprise`) à un user pro qui dépasse 100 biens

https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ)_