### PR TITLE
Add authentication-aware navigation for header components

### DIFF
--- a/components/marketing/header/CTAButtons.tsx
+++ b/components/marketing/header/CTAButtons.tsx
@@ -1,15 +1,38 @@
+"use client";
+
 import Link from "next/link";
-import { Home } from "lucide-react";
+import { Home, LogIn } from "lucide-react";
+import { useAuth } from "@/lib/hooks/use-auth";
 
 export function CTAButtons() {
+  const { isAuthenticated, initialized } = useAuth();
+
+  if (!initialized) {
+    return <div className="flex items-center gap-3" aria-hidden />;
+  }
+
+  if (isAuthenticated) {
+    return (
+      <div className="flex items-center gap-3">
+        <Link
+          href="/dashboard"
+          className="hidden items-center gap-2 rounded-lg border border-[#2563EB]/30 px-4 py-2 text-sm font-medium text-[#2563EB] transition-colors hover:bg-[#2563EB]/5 md:inline-flex"
+        >
+          <Home className="h-4 w-4" />
+          Mon espace
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-3">
       <Link
         href="/auth/signin"
         className="hidden items-center gap-2 rounded-lg border border-[#2563EB]/30 px-4 py-2 text-sm font-medium text-[#2563EB] transition-colors hover:bg-[#2563EB]/5 md:inline-flex"
       >
-        <Home className="h-4 w-4" />
-        Mon espace
+        <LogIn className="h-4 w-4" />
+        Connexion
       </Link>
 
       <Link

--- a/components/marketing/header/MobileNav.tsx
+++ b/components/marketing/header/MobileNav.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Menu, Home } from "lucide-react";
+import { Menu, Home, LogIn } from "lucide-react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import {
   Accordion,
@@ -11,9 +11,11 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { PRODUCT_ITEMS, SOLUTIONS_ITEMS } from "./nav-items";
+import { useAuth } from "@/lib/hooks/use-auth";
 
 export function MobileNav({ className = "" }: { className?: string }) {
   const [open, setOpen] = useState(false);
+  const { isAuthenticated, initialized } = useAuth();
 
   const close = () => setOpen(false);
 
@@ -89,23 +91,38 @@ export function MobileNav({ className = "" }: { className?: string }) {
             Tarifs
           </Link>
 
-          <div className="mt-6 flex flex-col gap-3">
-            <Link
-              href="/auth/signin"
-              onClick={close}
-              className="flex items-center justify-center gap-2 rounded-lg border border-[#2563EB]/30 py-2.5 text-sm font-medium text-[#2563EB]"
-            >
-              <Home className="h-4 w-4" />
-              Mon espace
-            </Link>
-            <Link
-              href="/essai-gratuit"
-              onClick={close}
-              className="rounded-lg bg-[#2563EB] py-2.5 text-center text-sm font-medium text-white"
-            >
-              Essai gratuit
-            </Link>
-          </div>
+          {initialized && (
+            <div className="mt-6 flex flex-col gap-3">
+              {isAuthenticated ? (
+                <Link
+                  href="/dashboard"
+                  onClick={close}
+                  className="flex items-center justify-center gap-2 rounded-lg border border-[#2563EB]/30 py-2.5 text-sm font-medium text-[#2563EB]"
+                >
+                  <Home className="h-4 w-4" />
+                  Mon espace
+                </Link>
+              ) : (
+                <>
+                  <Link
+                    href="/auth/signin"
+                    onClick={close}
+                    className="flex items-center justify-center gap-2 rounded-lg border border-[#2563EB]/30 py-2.5 text-sm font-medium text-[#2563EB]"
+                  >
+                    <LogIn className="h-4 w-4" />
+                    Connexion
+                  </Link>
+                  <Link
+                    href="/essai-gratuit"
+                    onClick={close}
+                    className="rounded-lg bg-[#2563EB] py-2.5 text-center text-sm font-medium text-white"
+                  >
+                    Essai gratuit
+                  </Link>
+                </>
+              )}
+            </div>
+          )}
         </nav>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Summary
Updated the mobile navigation and CTA buttons components to display different content based on user authentication status. Authenticated users now see a dashboard link, while unauthenticated users see sign-in and free trial options.

## Key Changes
- **MobileNav.tsx**: 
  - Integrated `useAuth` hook to check authentication status
  - Conditionally render navigation buttons based on `isAuthenticated` state
  - Changed "Mon espace" link destination from `/auth/signin` to `/dashboard` for authenticated users
  - Updated sign-in button icon from `Home` to `LogIn` and label from "Mon espace" to "Connexion"
  - Wrapped button section with `initialized` check to prevent layout shift during auth state loading

- **CTAButtons.tsx**:
  - Converted to client component with `"use client"` directive
  - Integrated `useAuth` hook for authentication state management
  - Implemented three render states: loading (empty), authenticated (dashboard link only), and unauthenticated (sign-in + free trial)
  - Updated sign-in button icon from `Home` to `LogIn` and label to "Connexion"
  - Added proper loading state handling to prevent hydration mismatches

## Implementation Details
- Both components now use the `useAuth` hook to access `isAuthenticated` and `initialized` states
- The `initialized` flag ensures UI stability during authentication state resolution
- Unauthenticated users see both sign-in and free trial CTA options
- Authenticated users see a direct link to their dashboard instead of sign-in options
- Icon changes improve semantic clarity (LogIn icon for sign-in action, Home icon for dashboard)

https://claude.ai/code/session_01JVD2woqtTtVqaWYqCY2FGm