### PR TITLE
Add website field to provider details and implement Place Details API

### DIFF
--- a/app/api/providers/external-favorites/route.ts
+++ b/app/api/providers/external-favorites/route.ts
@@ -16,6 +16,7 @@ interface ExternalFavoritePayload {
   category?: string | null;
   address?: string | null;
   phone?: string | null;
+  website?: string | null;
   latitude?: number | null;
   longitude?: number | null;
   rating?: number | null;
@@ -105,6 +106,7 @@ export async function POST(request: NextRequest) {
         category: body.category ?? null,
         address: body.address ?? null,
         phone: body.phone ?? null,
+        website: body.website ?? null,
         latitude: body.latitude ?? null,
         longitude: body.longitude ?? null,
         rating: body.rating ?? null,

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -52,6 +52,7 @@ interface GooglePlaceResult {
   user_ratings_total?: number;
   formatted_phone_number?: string;
   international_phone_number?: string;
+  website?: string;
   opening_hours?: {
     open_now?: boolean;
   };
@@ -71,6 +72,7 @@ interface NearbyProvider {
   rating?: number;
   reviews_count?: number;
   phone?: string;
+  website?: string;
   is_open?: boolean;
   photo_url?: string;
   google_maps_url: string;
@@ -287,6 +289,7 @@ export async function GET(request: NextRequest) {
           rating: place.rating,
           reviews_count: place.user_ratings_total,
           phone: place.formatted_phone_number || place.international_phone_number,
+          website: place.website,
           is_open: place.opening_hours?.open_now,
           photo_url: place.photos?.[0]?.photo_reference
             ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=100&photo_reference=${place.photos[0].photo_reference}&key=${googleApiKey}`
@@ -378,6 +381,7 @@ function getDemoProviders(
     phone: string;
     is_open: boolean;
     mapsTerm: string;
+    website?: string;
   };
 
   const build = (seeds: Seed[]): NearbyProvider[] =>
@@ -393,6 +397,7 @@ function getDemoProviders(
         rating: s.rating,
         reviews_count: s.reviews_count,
         phone: s.phone,
+        website: s.website,
         is_open: s.is_open,
         google_maps_url: mapsLink(s.mapsTerm),
         source: "google" as const,

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -41,7 +41,11 @@ const CATEGORY_TO_SEARCH_TERM: Record<string, string> = {
 interface GooglePlaceResult {
   place_id: string;
   name: string;
+  // formatted_address est renvoyé par Text Search ; Nearby Search renvoie
+  // `vicinity` (rue + commune) à la place. On lit les deux pour rester
+  // compatible avec les deux endpoints.
   formatted_address?: string;
+  vicinity?: string;
   geometry: {
     location: {
       lat: number;
@@ -238,17 +242,50 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Rechercher via Google Places API (Text Search)
+    // -------------------------------------------------------------------
+    // Stratégie : Nearby Search d'abord (proximity-optimisé, respecte
+    // strictement location + radius), puis fallback Text Search si zéro
+    // résultat (Nearby Search filtre sur le `type` Google et peut rater
+    // une boutique mal catégorisée).
+    //
+    // Les coordonnées renvoyées par Google (`geometry.location.lat/lng`)
+    // sont les coordonnées rooftop officielles du commerce — c'est la
+    // meilleure précision possible côté API.
+    // -------------------------------------------------------------------
     const searchTerm = CATEGORY_TO_SEARCH_TERM[category] || "artisan dépannage";
-    const textSearchUrl = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(searchTerm)}&location=${latitude},${longitude}&radius=${radius}&language=fr&key=${googleApiKey}`;
+    const googleTypes = CATEGORY_TO_GOOGLE_TYPE[category] || [];
+    const primaryType = googleTypes[0]; // Nearby Search n'accepte qu'un seul type
 
-    const placesRes = await fetch(textSearchUrl);
-    const placesData = await placesRes.json();
+    const buildNearbyUrl = () => {
+      const params = new URLSearchParams({
+        location: `${latitude},${longitude}`,
+        radius: String(radius),
+        keyword: searchTerm,
+        language: "fr",
+        key: googleApiKey,
+      });
+      if (primaryType) params.set("type", primaryType);
+      return `https://maps.googleapis.com/maps/api/place/nearbysearch/json?${params.toString()}`;
+    };
+
+    const buildTextSearchUrl = () =>
+      `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(searchTerm)}&location=${latitude},${longitude}&radius=${radius}&language=fr&key=${googleApiKey}`;
+
+    type GoogleSearchEndpoint = "nearby_search" | "text_search";
+    let placesData: { status: string; results?: GooglePlaceResult[]; error_message?: string };
+    let usedEndpoint: GoogleSearchEndpoint = "nearby_search";
+
+    const nearbyRes = await fetch(buildNearbyUrl());
+    placesData = await nearbyRes.json();
 
     if (placesData.status !== "OK" && placesData.status !== "ZERO_RESULTS") {
-      console.error("Google Places API error:", placesData.status, placesData.error_message);
+      console.error(
+        "Google Places (nearby) error:",
+        placesData.status,
+        placesData.error_message,
+      );
       void logGooglePlacesUsage({
-        endpoint: "text_search",
+        endpoint: "nearby_search",
         source: "google",
         status: "error",
         category,
@@ -263,26 +300,52 @@ export async function GET(request: NextRequest) {
         providers: demo,
         source: "demo",
         search_location: { lat: latitude, lng: longitude },
-        error: "Erreur API Google, données de démonstration affichées",
+        error: `Erreur API Google (${placesData.status}), données de démonstration affichées`,
       });
     }
 
-    // Transformer les résultats
+    // Fallback Text Search si Nearby Search ne renvoie rien (le `type`
+    // exact peut manquer pour des artisans indépendants).
+    if (!placesData.results?.length) {
+      const textRes = await fetch(buildTextSearchUrl());
+      const textData = await textRes.json();
+
+      if (textData.status === "OK") {
+        placesData = textData;
+        usedEndpoint = "text_search";
+      } else if (
+        textData.status !== "ZERO_RESULTS" &&
+        textData.status !== "OK"
+      ) {
+        void logGooglePlacesUsage({
+          endpoint: "text_search",
+          source: "google",
+          status: "error",
+          category,
+          userId: user.id,
+          metadata: {
+            google_status: textData.status,
+            google_error: textData.error_message,
+          },
+        });
+      }
+    }
+
+    // Transformer les résultats — coordonnées issues du rooftop Google.
     const providers: NearbyProvider[] = (placesData.results || [])
-      .slice(0, 10) // Limiter à 10 résultats
+      .slice(0, 10)
       .map((place: GooglePlaceResult) => {
-        // Calculer la distance approximative
         const distance = calculateDistance(
           latitude,
           longitude,
           place.geometry.location.lat,
-          place.geometry.location.lng
+          place.geometry.location.lng,
         );
 
         return {
           id: place.place_id,
           name: place.name,
-          address: place.formatted_address || "",
+          address: place.formatted_address || place.vicinity || "",
           latitude: place.geometry.location.lat,
           longitude: place.geometry.location.lng,
           distance_km: Math.round(distance * 10) / 10,
@@ -298,13 +361,15 @@ export async function GET(request: NextRequest) {
           source: "google" as const,
         };
       })
-      .filter((p: NearbyProvider) => (p.distance_km ?? 0) <= radius / 1000); // Filtrer par distance
+      // Garde-fou : Nearby Search peut occasionnellement renvoyer un
+      // résultat juste hors rayon ; on filtre côté serveur pour éviter
+      // un point qui apparaîtrait hors du cercle bleu sur la carte.
+      .filter((p: NearbyProvider) => (p.distance_km ?? 0) <= radius / 1000);
 
-    // Mettre en cache
     cache.set(cacheKey, { data: providers, timestamp: Date.now() });
 
     void logGooglePlacesUsage({
-      endpoint: "text_search",
+      endpoint: usedEndpoint,
       source: "google",
       status: providers.length === 0 ? "zero_results" : "ok",
       category,
@@ -317,6 +382,7 @@ export async function GET(request: NextRequest) {
       source: "google",
       total: providers.length,
       search_location: { lat: latitude, lng: longitude },
+      endpoint: usedEndpoint,
     });
   } catch (error) {
     console.error("Erreur API providers/nearby:", error);

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -76,7 +76,7 @@ interface NearbyProvider {
   is_open?: boolean;
   photo_url?: string;
   google_maps_url: string;
-  source: "google";
+  source: "google" | "demo";
 }
 
 // Cache simple en mémoire (en production, utiliser Redis)
@@ -400,7 +400,7 @@ function getDemoProviders(
         website: s.website,
         is_open: s.is_open,
         google_maps_url: mapsLink(s.mapsTerm),
-        source: "google" as const,
+        source: "demo" as const,
       };
     });
 

--- a/app/api/providers/place-details/[placeId]/route.ts
+++ b/app/api/providers/place-details/[placeId]/route.ts
@@ -1,0 +1,147 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// =====================================================
+// API: Détails d'un prestataire Google Places
+// GET /api/providers/place-details/[placeId]
+//
+// Le Text Search ne renvoie pas le site web ni le téléphone : on récupère
+// ces champs via Place Details au moment où l'utilisateur ouvre la fiche
+// détail d'un prestataire. Cache 24h en mémoire (mêmes contraintes que
+// /api/providers/nearby) pour limiter le coût (17 $ / 1000 appels).
+// =====================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
+import { logGooglePlacesUsage } from "@/lib/services/google-places-usage";
+import { getPlanLevel, type PlanSlug } from "@/lib/subscriptions/plans";
+
+interface PlaceDetailsResult {
+  website?: string;
+  phone?: string;
+  google_maps_url?: string;
+}
+
+const cache = new Map<string, { data: PlaceDetailsResult; timestamp: number }>();
+const CACHE_DURATION = 24 * 60 * 60 * 1000;
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ placeId: string }> },
+) {
+  const { placeId } = await params;
+  if (!placeId) {
+    return NextResponse.json({ error: "placeId manquant" }, { status: 400 });
+  }
+
+  // Les ID démo (préfixe "demo-") n'existent pas chez Google : court-circuit
+  if (placeId.startsWith("demo-")) {
+    return NextResponse.json({ details: {} as PlaceDetailsResult });
+  }
+
+  try {
+    const supabase = await createRouteHandlerClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("id")
+      .eq("user_id", user.id)
+      .single();
+    if (!profile) {
+      return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+    }
+
+    // Même feature gate que /nearby (Confort+)
+    const { data: subscription } = await supabase
+      .from("subscriptions")
+      .select("plan_slug, status")
+      .eq("owner_id", profile.id)
+      .in("status", ["active", "trialing"])
+      .maybeSingle();
+
+    const planSlug: PlanSlug = (subscription?.plan_slug as PlanSlug) || "gratuit";
+    if (getPlanLevel(planSlug) < getPlanLevel("confort")) {
+      return NextResponse.json(
+        {
+          error: "premium_required",
+          message: "Cette fonctionnalité nécessite un plan Confort ou supérieur",
+          upgrade_url: "/owner/money?tab=forfait",
+        },
+        { status: 403 },
+      );
+    }
+
+    // Cache hit
+    const cached = cache.get(placeId);
+    if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+      void logGooglePlacesUsage({
+        endpoint: "place_details",
+        source: "cache",
+        status: "ok",
+        userId: user.id,
+        cacheHit: true,
+      });
+      return NextResponse.json({ details: cached.data, cached: true });
+    }
+
+    const googleApiKey = process.env.GOOGLE_PLACES_API_KEY;
+    if (!googleApiKey) {
+      return NextResponse.json({ details: {} as PlaceDetailsResult });
+    }
+
+    // Champs limités pour minimiser le coût (Place Details est facturé
+    // par "field" au-delà du Basic data ; website + phone sont en Contact data).
+    const fields = [
+      "website",
+      "formatted_phone_number",
+      "international_phone_number",
+      "url",
+    ].join(",");
+    const url = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${encodeURIComponent(placeId)}&fields=${fields}&language=fr&key=${googleApiKey}`;
+
+    const res = await fetch(url);
+    const data = await res.json();
+
+    if (data.status !== "OK") {
+      void logGooglePlacesUsage({
+        endpoint: "place_details",
+        source: "google",
+        status: "error",
+        userId: user.id,
+        metadata: { google_status: data.status, google_error: data.error_message },
+      });
+      return NextResponse.json({ details: {} as PlaceDetailsResult });
+    }
+
+    const result: PlaceDetailsResult = {
+      website: data.result?.website,
+      phone:
+        data.result?.formatted_phone_number ||
+        data.result?.international_phone_number,
+      google_maps_url: data.result?.url,
+    };
+
+    cache.set(placeId, { data: result, timestamp: Date.now() });
+
+    void logGooglePlacesUsage({
+      endpoint: "place_details",
+      source: "google",
+      status: "ok",
+      userId: user.id,
+      resultsCount: 1,
+    });
+
+    return NextResponse.json({ details: result });
+  } catch (error) {
+    console.error("Erreur API providers/place-details:", error);
+    return NextResponse.json({ error: "Erreur serveur" }, { status: 500 });
+  }
+}

--- a/components/provider/external-favorites-section.tsx
+++ b/components/provider/external-favorites-section.tsx
@@ -20,6 +20,7 @@ import {
   StickyNote,
   Save,
   X,
+  Globe,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -34,6 +35,7 @@ interface ExternalFavorite {
   category: string | null;
   address: string | null;
   phone: string | null;
+  website: string | null;
   rating: number | null;
   reviews_count: number | null;
   google_maps_url: string | null;
@@ -216,6 +218,17 @@ export function ExternalFavoritesSection() {
                   >
                     <Phone className="h-3 w-3" />
                     {f.phone}
+                  </a>
+                )}
+                {f.website && (
+                  <a
+                    href={f.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                  >
+                    <Globe className="h-3 w-3" />
+                    Site web
                   </a>
                 )}
                 {f.google_maps_url && (

--- a/components/provider/nearby-providers-search.tsx
+++ b/components/provider/nearby-providers-search.tsx
@@ -186,6 +186,8 @@ export function NearbyProvidersSearch({
   const [providers, setProviders] = useState<NearbyProvider[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [dataSource, setDataSource] = useState<"google" | "cache" | "demo" | null>(null);
+  const [demoReason, setDemoReason] = useState<string | null>(null);
   const [premiumRequired, setPremiumRequired] = useState(false);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const [detailProvider, setDetailProvider] = useState<NearbyProvider | null>(null);
@@ -591,11 +593,24 @@ export function NearbyProvidersSearch({
         if (res.status === 403 && data?.error === "premium_required") {
           setPremiumRequired(true);
           setProviders([]);
+          setDataSource(null);
+          setDemoReason(null);
         } else if (!res.ok) {
           setError(data?.error || "Erreur lors de la recherche");
           setProviders([]);
+          setDataSource(null);
+          setDemoReason(null);
         } else {
           setProviders(data.providers || []);
+          setDataSource((data?.source as "google" | "cache" | "demo") ?? null);
+          // L'API renvoie `error` ou `message` quand elle bascule en démo
+          // (clé manquante, erreur Google) — on le surface pour qu'on puisse
+          // diagnostiquer côté ops sans aller fouiller les logs.
+          setDemoReason(
+            data?.source === "demo"
+              ? (data?.error as string) || (data?.message as string) || null
+              : null,
+          );
         }
       } catch (err) {
         if (!cancelled) {
@@ -735,6 +750,24 @@ export function NearbyProvidersSearch({
           <div className="rounded-lg border border-emerald-200 bg-emerald-50/40 p-3 text-xs text-emerald-900 dark:bg-emerald-950/20 dark:border-emerald-900 dark:text-emerald-200">
             <BookmarkCheck className="inline h-3.5 w-3.5 mr-1 -mt-0.5" />
             {savedIds.size} prestataire{savedIds.size > 1 ? "s" : ""} enregistré{savedIds.size > 1 ? "s" : ""} dans vos favoris (synchronisés sur tous vos appareils).
+          </div>
+        )}
+
+        {dataSource === "demo" && !premiumRequired && (
+          <div className="rounded-lg border border-amber-300 bg-amber-50/60 p-3 text-xs text-amber-900 dark:bg-amber-950/20 dark:border-amber-900 dark:text-amber-200 flex gap-2">
+            <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+            <div>
+              <strong>Mode démonstration.</strong> Les prestataires affichés sont fictifs : leurs adresses ne correspondent pas à leur position sur la carte.
+              {demoReason && (
+                <>
+                  {" "}
+                  <span className="opacity-80">Cause : {demoReason}</span>
+                </>
+              )}
+              <span className="block mt-1 opacity-80">
+                Pour des résultats réels, vérifiez que la variable <code className="font-mono">GOOGLE_PLACES_API_KEY</code> est bien définie pour l'environnement de production et que le déploiement a été relancé après son ajout.
+              </span>
+            </div>
           </div>
         )}
 

--- a/components/provider/nearby-providers-search.tsx
+++ b/components/provider/nearby-providers-search.tsx
@@ -27,6 +27,7 @@ import {
   MessageSquare,
   StickyNote,
   Save,
+  Globe,
 } from "lucide-react";
 import "leaflet/dist/leaflet.css";
 
@@ -93,6 +94,7 @@ interface NearbyProvider {
   rating?: number;
   reviews_count?: number;
   phone?: string;
+  website?: string;
   is_open?: boolean;
   photo_url?: string;
   google_maps_url: string;
@@ -226,20 +228,60 @@ export function NearbyProvidersSearch({
     setDetailNotes("");
     setDetailNotesLoaded("");
 
-    // Si déjà en favori, charger les notes existantes
+    // Si déjà en favori, charger les notes existantes + champs persistés
+    // (website, phone) qui ne sont pas dans le résultat Text Search.
     if (savedIds.has(provider.id)) {
       try {
         const res = await fetch("/api/providers/external-favorites");
-        if (!res.ok) return;
-        const data = await res.json();
-        const found = (data?.favorites ?? []).find(
-          (f: any) => f.place_id === provider.id,
-        );
-        const notes = (found?.notes as string) ?? "";
-        setDetailNotes(notes);
-        setDetailNotesLoaded(notes);
+        if (res.ok) {
+          const data = await res.json();
+          const found = (data?.favorites ?? []).find(
+            (f: any) => f.place_id === provider.id,
+          );
+          const notes = (found?.notes as string) ?? "";
+          setDetailNotes(notes);
+          setDetailNotesLoaded(notes);
+          if (found?.website || found?.phone) {
+            setDetailProvider((prev) =>
+              prev && prev.id === provider.id
+                ? {
+                    ...prev,
+                    website: prev.website ?? found.website ?? undefined,
+                    phone: prev.phone ?? found.phone ?? undefined,
+                  }
+                : prev,
+            );
+          }
+        }
       } catch (err) {
         console.warn("[NearbyProvidersSearch] Lecture notes échouée:", err);
+      }
+    }
+
+    // Le Text Search Google ne renvoie ni site web ni téléphone : on
+    // enrichit la fiche via Place Details (cache 24h côté serveur).
+    if (provider.source === "google" && (!provider.website || !provider.phone)) {
+      try {
+        const res = await fetch(
+          `/api/providers/place-details/${encodeURIComponent(provider.id)}`,
+        );
+        if (res.ok) {
+          const data = await res.json();
+          const details = data?.details ?? {};
+          if (details.website || details.phone) {
+            setDetailProvider((prev) =>
+              prev && prev.id === provider.id
+                ? {
+                    ...prev,
+                    website: prev.website ?? details.website ?? undefined,
+                    phone: prev.phone ?? details.phone ?? undefined,
+                  }
+                : prev,
+            );
+          }
+        }
+      } catch (err) {
+        console.warn("[NearbyProvidersSearch] Lecture détails échouée:", err);
       }
     }
   };
@@ -330,6 +372,7 @@ export function NearbyProvidersSearch({
             category,
             address: provider.address ?? null,
             phone: provider.phone ?? null,
+            website: provider.website ?? null,
             latitude: provider.latitude,
             longitude: provider.longitude,
             rating: provider.rating ?? null,
@@ -971,6 +1014,18 @@ export function NearbyProvidersSearch({
                       <a href={`tel:${detailProvider.phone.replace(/\s/g, "")}`}>
                         <Phone className="h-4 w-4 mr-2" />
                         Appeler {detailProvider.phone}
+                      </a>
+                    </Button>
+                  )}
+                  {detailProvider.website && (
+                    <Button asChild variant="outline" className="w-full justify-start">
+                      <a
+                        href={detailProvider.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Globe className="h-4 w-4 mr-2" />
+                        Visiter le site web
                       </a>
                     </Button>
                   )}

--- a/supabase/migrations/20260502090000_provider_external_favorites_add_website.sql
+++ b/supabase/migrations/20260502090000_provider_external_favorites_add_website.sql
@@ -1,0 +1,13 @@
+-- =====================================================
+-- Migration: provider_external_favorites — ajout website
+-- =====================================================
+-- Le Text Search Google Places ne renvoie pas le site web : il faut un
+-- appel Place Details supplémentaire. Pour éviter de re-payer cet appel
+-- à chaque ouverture de la fiche favorite, on persiste l'URL aux côtés
+-- du téléphone.
+-- =====================================================
+
+ALTER TABLE provider_external_favorites
+  ADD COLUMN IF NOT EXISTS website TEXT;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
This PR enriches provider details by adding website information and implementing a new Place Details API endpoint. Google Places Text Search doesn't return website or phone data, so we now fetch these fields via a dedicated Place Details endpoint with 24-hour server-side caching to minimize API costs.

## Key Changes

- **New API Endpoint** (`/api/providers/place-details/[placeId]`):
  - Fetches website, phone, and Google Maps URL from Google Places Details API
  - Implements 24-hour in-memory cache to reduce costs ($17 per 1000 calls)
  - Requires "Confort" plan or higher (same feature gate as nearby search)
  - Handles demo place IDs (prefixed with "demo-") gracefully

- **Improved Nearby Search** (`/api/providers/nearby`):
  - Implements two-tier search strategy: Nearby Search first (proximity-optimized), then Text Search fallback
  - Adds website field to provider results
  - Better address handling (uses `vicinity` from Nearby Search when `formatted_address` unavailable)
  - Improved error logging and demo mode messaging
  - Tracks which endpoint was used for analytics

- **Enhanced Provider Details UI**:
  - Fetches Place Details when opening provider detail card
  - Displays website link with Globe icon in provider detail modal
  - Persists website and phone data from favorites for quick access
  - Shows demo mode warning with diagnostic information when API key is missing

- **Database Migration**:
  - Adds `website` column to `provider_external_favorites` table
  - Allows persisting website URLs alongside phone numbers to avoid repeated API calls

- **External Favorites Section**:
  - Displays website link in favorites list
  - Stores and retrieves website data from database

## Implementation Details

- Website field is optional and only fetched when needed (lazy loading on detail view)
- Demo providers now properly marked with `source: "demo"` instead of `source: "google"`
- Cache strategy balances cost reduction with data freshness (24-hour TTL)
- Graceful degradation: missing website/phone doesn't break the UI
- Comprehensive error handling with user-friendly messaging for premium requirements

https://claude.ai/code/session_01PmKaPsmFFxhN4LwLBEG14M