### PR TITLE
fix(providers): website link, Nearby Search + DROM-COM geocoding

### DIFF
--- a/app/api/geocode/route.ts
+++ b/app/api/geocode/route.ts
@@ -8,6 +8,10 @@ export const dynamic = "force-dynamic";
 // =====================================================
 
 import { NextRequest, NextResponse } from "next/server";
+import {
+  extractPostalCode,
+  postalCodeToCountryCodes,
+} from "@/lib/properties/address";
 
 interface GeocodeResult {
   latitude: number;
@@ -47,10 +51,19 @@ async function geocodeWithNominatim(
   address: string,
   countryCode: string,
 ): Promise<GeocodeResult | null> {
+  // Si l'adresse contient un code postal DROM-COM (97xxx), on élargit
+  // les pays autorisés — sinon Nominatim filtre sur la France métropole
+  // et géocode l'adresse à 4500 km du vrai bien.
+  const postal = extractPostalCode(address);
+  const countries =
+    postal && postal.startsWith("97")
+      ? postalCodeToCountryCodes(postal)
+      : countryCode;
+
   const params = new URLSearchParams({
     format: "json",
     q: address,
-    countrycodes: countryCode,
+    countrycodes: countries,
     limit: "1",
   });
   const res = await fetch(

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -11,6 +11,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 import { logGooglePlacesUsage } from "@/lib/services/google-places-usage";
 import { getPlanLevel, type PlanSlug } from "@/lib/subscriptions/plans";
+import {
+  extractPostalCode,
+  postalCodeToCountryCodes,
+} from "@/lib/properties/address";
 
 // Mapping des catégories vers les types Google Places
 const CATEGORY_TO_GOOGLE_TYPE: Record<string, string[]> = {
@@ -200,8 +204,15 @@ export async function GET(request: NextRequest) {
           resultsCount: geocodeOk ? 1 : 0,
         });
       } else {
-        // Fallback Nominatim
-        const nominatimUrl = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(address)}&countrycodes=fr&limit=1`;
+        // Fallback Nominatim — élargir aux codes pays DROM-COM si l'adresse
+        // contient un code postal 97xxx, sinon Nominatim filtre l'adresse à
+        // la métropole et géocode à 4500 km du vrai bien.
+        const fallbackPostal = extractPostalCode(address);
+        const countries =
+          fallbackPostal && fallbackPostal.startsWith("97")
+            ? postalCodeToCountryCodes(fallbackPostal)
+            : "fr";
+        const nominatimUrl = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(address)}&countrycodes=${countries}&limit=1`;
         const nominatimRes = await fetch(nominatimUrl, {
           headers: {
             "User-Agent": "Talok/1.0 (contact@talok.fr)",

--- a/lib/properties/address.ts
+++ b/lib/properties/address.ts
@@ -158,6 +158,43 @@ export function extractDepartment(postalCode: string): string {
 }
 
 /**
+ * Mappe un code postal vers les codes pays ISO 3166-1 alpha-2 utilisés
+ * par Nominatim/OSM. Critique pour les DROM-COM : `countrycodes=fr` seul
+ * exclut les territoires d'outre-mer chez Nominatim — une adresse
+ * martiniquaise géocode alors en métropole (~4500 km de décalage).
+ *
+ * On renvoie une liste séparée par virgules ("mq,fr") pour rester
+ * tolérant : si OSM rattache l'adresse à FR plutôt qu'à MQ, ça matche
+ * quand même.
+ */
+export function postalCodeToCountryCodes(
+  postalCode: string | null | undefined,
+): string {
+  if (!postalCode) return 'fr';
+  const prefix = postalCode.substring(0, 3);
+  switch (prefix) {
+    case '971': return 'gp,fr'; // Guadeloupe
+    case '972': return 'mq,fr'; // Martinique
+    case '973': return 'gf,fr'; // Guyane
+    case '974': return 're,fr'; // La Réunion
+    case '975': return 'pm,fr'; // Saint-Pierre-et-Miquelon
+    case '976': return 'yt,fr'; // Mayotte
+    case '977': return 'bl,fr'; // Saint-Barthélemy
+    case '978': return 'mf,fr'; // Saint-Martin
+    default: return 'fr';
+  }
+}
+
+/**
+ * Extrait le code postal (5 chiffres) d'une chaîne d'adresse libre.
+ * Ex: "12 rue Victor Hugo, 97200 Fort-de-France" → "97200".
+ */
+export function extractPostalCode(address: string): string | null {
+  const match = address.match(/\b(\d{5})\b/);
+  return match ? match[1] : null;
+}
+
+/**
  * Formate une adresse complete a partir de ses composants.
  */
 export function formatFullAddress(

--- a/lib/services/geocoding.service.ts
+++ b/lib/services/geocoding.service.ts
@@ -4,6 +4,11 @@
  * Garde un fallback direct Nominatim côté serveur (SSR/scripts).
  */
 
+import {
+  extractPostalCode,
+  postalCodeToCountryCodes,
+} from "@/lib/properties/address";
+
 export interface GeocodingResult {
   latitude: number;
   longitude: number;
@@ -39,8 +44,15 @@ async function geocodeViaNominatimDirect(
   countryCode: string,
   limit: number,
 ): Promise<GeocodingResult | null> {
+  // Élargir aux codes pays DROM-COM si le code postal est 97xxx, sinon
+  // Nominatim filtre l'adresse à la métropole.
+  const postal = extractPostalCode(address);
+  const countries =
+    postal && postal.startsWith("97")
+      ? postalCodeToCountryCodes(postal)
+      : countryCode;
   const encodedAddress = encodeURIComponent(address);
-  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodedAddress}&countrycodes=${countryCode}&limit=${limit}`;
+  const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodedAddress}&countrycodes=${countries}&limit=${limit}`;
   const response = await fetch(url, {
     headers: {
       "User-Agent": "Talok/1.0 (contact@talok.fr)",


### PR DESCRIPTION
## Summary

- **Lien site web** dans la fiche détail prestataire (`/owner/providers`) — Place Details API en lazy-fetch, cache 24h, persisté en favori (nouvelle colonne `provider_external_favorites.website` + migration `20260502090000`).
- **Bandeau Mode démonstration** + correction du mislabel `source: "google"` sur les fixtures démo, qui faisait passer les données fictives pour de la vraie Google Places dans la fiche détail.
- **Switch Text Search → Nearby Search** : Google traite désormais `location + radius` comme une contrainte stricte (proximity-optimisé) et plus comme un simple bias keyword — les coordonnées `geometry.location` rooftop sont la meilleure précision possible côté API.
- **Fix DROM-COM Nominatim** : `countrycodes=fr` exclut les territoires d'outre-mer chez OSM. Une adresse martiniquaise géocodait à ~4500 km du vrai bien quand le fallback Nominatim était utilisé. Nouveau helper `postalCodeToCountryCodes()` (971→`gp,fr`, 972→`mq,fr`, 973→`gf,fr`, 974→`re,fr`, 976→`yt,fr`...) appliqué dans les 3 chemins de fallback (`/api/geocode`, `/api/providers/nearby`, `lib/services/geocoding.service.ts`).

## Test plan

- [ ] Sur un bien Martinique (97200), ouvrir `/owner/providers` — la carte se centre sur le bien, pas en métropole
- [ ] Cliquer un prestataire — la fiche détail charge le site web et l'adresse
- [ ] Vérifier que **Source: Google Places** n'apparaît que pour de la vraie donnée Google (sinon "Démonstration")
- [ ] Si la clé `GOOGLE_PLACES_API_KEY` n'est pas lue, le bandeau ambre indique la cause
- [ ] La nouvelle migration `20260502090000_provider_external_favorites_add_website.sql` doit être appliquée (ajoute la colonne `website` à `provider_external_favorites`)

https://claude.ai/code/session_01PmKaPsmFFxhN4LwLBEG14M


---
_Generated by [Claude Code](https://claude.ai/code/session_01PmKaPsmFFxhN4LwLBEG14M)_