### PR TITLE
Audit talok.fr — fixes SEO/légal, couverture des 7 rôles, page /solutions

### DIFF
--- a/app/fonctionnalites/etats-des-lieux/page.tsx
+++ b/app/fonctionnalites/etats-des-lieux/page.tsx
@@ -311,7 +311,7 @@ export default function EtatDesLieuxPage() {
               Réalisez votre premier EDL numérique
             </h2>
             <p className="text-slate-300 mb-8">
-              Essayez gratuitement pendant 14 jours. Aucune carte bancaire requise.
+              1er mois offert. Aucune carte bancaire requise.
             </p>
             <Link href="/auth/signup">
               <Button size="lg" className="bg-white text-slate-900 hover:bg-slate-100">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -93,20 +93,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }));
 
   const solutionPages: MetadataRoute.Sitemap = [
-    "administrateurs-biens",
-    "outre-mer",
-    "investisseurs",
-    "proprietaires-particuliers",
-    "sci-familiales",
-    "syndics",
-    "locataires",
-    "prestataires",
-    "garants",
-  ].map((slug) => ({
-    url: `${BASE_URL}/solutions/${slug}`,
+    { slug: "", priority: 0.85 },
+    { slug: "administrateurs-biens", priority: 0.8 },
+    { slug: "outre-mer", priority: 0.8 },
+    { slug: "investisseurs", priority: 0.8 },
+    { slug: "proprietaires-particuliers", priority: 0.8 },
+    { slug: "sci-familiales", priority: 0.8 },
+    { slug: "syndics", priority: 0.8 },
+    { slug: "locataires", priority: 0.8 },
+    { slug: "prestataires", priority: 0.8 },
+    { slug: "garants", priority: 0.8 },
+  ].map(({ slug, priority }) => ({
+    url: slug ? `${BASE_URL}/solutions/${slug}` : `${BASE_URL}/solutions`,
     lastModified: now,
     changeFrequency: "monthly" as const,
-    priority: 0.8,
+    priority,
   }));
 
   const toolPages: MetadataRoute.Sitemap = [

--- a/app/solutions/outre-mer/page.tsx
+++ b/app/solutions/outre-mer/page.tsx
@@ -369,7 +369,7 @@ export default function OutreMerPage() {
             </h2>
             <p className="text-slate-300 mb-8">
               Né en Martinique. Pensé pour vos réalités.
-              Essayez gratuitement pendant 14 jours.
+              1er mois offert sur tous les plans payants.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link href="/essai-gratuit">

--- a/app/solutions/page.tsx
+++ b/app/solutions/page.tsx
@@ -1,0 +1,204 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  User,
+  Briefcase,
+  Building,
+  Building2,
+  Landmark,
+  Users,
+  Wrench,
+  ShieldCheck,
+  Palmtree,
+  ArrowRight,
+  Sparkles,
+} from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Solutions Talok — Une plateforme pour 7 rôles",
+  description:
+    "Propriétaires, investisseurs, agences, syndics, locataires, prestataires, garants : Talok adapte ses outils à chaque profil. Découvrez la solution qui vous correspond.",
+  alternates: { canonical: "https://talok.fr/solutions" },
+  openGraph: {
+    title: "Solutions Talok — Une plateforme pour 7 rôles",
+    description:
+      "Une plateforme de gestion locative qui parle la langue de chacun : bailleur, locataire, syndic, artisan, garant.",
+    type: "website",
+    url: "https://talok.fr/solutions",
+  },
+};
+
+const SOLUTIONS = [
+  {
+    icon: User,
+    title: "Propriétaires particuliers",
+    desc: "1 à 10 logements. Gérez sans agence, sans erreur juridique. À partir de 0 €.",
+    href: "/solutions/proprietaires-particuliers",
+    color: "from-indigo-500 to-violet-500",
+    badge: "Le plus choisi",
+  },
+  {
+    icon: Briefcase,
+    title: "Investisseurs & SCI",
+    desc: "Multi-biens, multi-entités. Comptabilité, fiscalité, vision patrimoniale.",
+    href: "/solutions/investisseurs",
+    color: "from-violet-500 to-purple-500",
+    badge: "",
+  },
+  {
+    icon: Building2,
+    title: "SCI familiales",
+    desc: "Comptes d’associés, quote-parts, déclaration 2072, AG. Tout pour l’expert-comptable.",
+    href: "/solutions/sci-familiales",
+    color: "from-purple-500 to-fuchsia-500",
+    badge: "",
+  },
+  {
+    icon: Building,
+    title: "Administrateurs de biens",
+    desc: "Multi-propriétaires, équipes, CRG mandant, white-label, API complète.",
+    href: "/solutions/administrateurs-biens",
+    color: "from-blue-500 to-cyan-500",
+    badge: "Enterprise",
+  },
+  {
+    icon: Landmark,
+    title: "Syndics de copropriété",
+    desc: "Bénévole ou pro. AG en ligne, appels de fonds, comptabilité copro, extranet.",
+    href: "/solutions/syndics",
+    color: "from-cyan-500 to-teal-500",
+    badge: "",
+  },
+  {
+    icon: Users,
+    title: "Locataires & colocataires",
+    desc: "Payer, signer, suivre ses droits. Gratuit pour le locataire, garants invités gratuitement.",
+    href: "/solutions/locataires",
+    color: "from-emerald-500 to-cyan-500",
+    badge: "Gratuit",
+  },
+  {
+    icon: Wrench,
+    title: "Prestataires & artisans",
+    desc: "Recevez des missions, devis & factures, planning, encaissement. Sans commission.",
+    href: "/solutions/prestataires",
+    color: "from-orange-500 to-amber-500",
+    badge: "Gratuit",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Garants",
+    desc: "Acte de cautionnement clair, suivi temps réel des paiements, alertes intelligentes.",
+    href: "/solutions/garants",
+    color: "from-sky-500 to-blue-500",
+    badge: "Gratuit",
+  },
+  {
+    icon: Palmtree,
+    title: "France d’outre-mer",
+    desc: "Né en Martinique. TVA DROM, Pinel OM, Girardin, normes cycloniques natifs.",
+    href: "/solutions/outre-mer",
+    color: "from-pink-500 to-rose-500",
+    badge: "DROM-COM",
+  },
+];
+
+export default function SolutionsIndexPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
+      {/* Hero */}
+      <section className="relative pt-24 pb-12 overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-indigo-900/20 via-transparent to-transparent" />
+
+        <div className="container mx-auto px-4 relative">
+          <div className="max-w-3xl mx-auto text-center">
+            <span className="inline-flex items-center gap-2 rounded-full bg-indigo-500/15 border border-indigo-500/30 px-3 py-1 text-xs font-semibold text-indigo-300 mb-6">
+              <Sparkles className="w-3 h-3" />
+              7 rôles · 1 plateforme
+            </span>
+            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-tight">
+              La solution Talok adaptée à{" "}
+              <span className="bg-gradient-to-r from-indigo-400 via-violet-400 to-cyan-400 bg-clip-text text-transparent">
+                votre rôle
+              </span>
+            </h1>
+            <p className="text-lg md:text-xl text-slate-400 leading-relaxed">
+              Bailleur, locataire, agence, syndic, artisan, garant : chacun a
+              ses outils, ses raccourcis, son tableau de bord. Mais tout le
+              monde travaille sur la même plateforme.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Solutions grid */}
+      <section className="pb-20">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 max-w-6xl mx-auto">
+            {SOLUTIONS.map((s) => (
+              <Link
+                key={s.href}
+                href={s.href}
+                className="group relative overflow-hidden rounded-2xl border border-slate-700/50 bg-slate-800/30 p-6 transition-all hover:border-slate-600 hover:bg-slate-800/50 hover:-translate-y-0.5"
+              >
+                {s.badge && (
+                  <span className="absolute top-4 right-4 rounded-full bg-slate-900/80 border border-slate-700 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-300">
+                    {s.badge}
+                  </span>
+                )}
+                <div
+                  className={`mb-5 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br ${s.color} shadow-lg`}
+                >
+                  <s.icon className="h-6 w-6 text-white" />
+                </div>
+                <h2 className="text-lg font-semibold text-white mb-2">
+                  {s.title}
+                </h2>
+                <p className="text-sm text-slate-400 leading-relaxed mb-4">
+                  {s.desc}
+                </p>
+                <span className="inline-flex items-center gap-1 text-sm font-medium text-indigo-300 group-hover:text-indigo-200 transition-colors">
+                  Découvrir
+                  <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" />
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="pb-24">
+        <div className="container mx-auto px-4">
+          <div className="max-w-3xl mx-auto text-center bg-gradient-to-br from-indigo-900/40 to-violet-900/40 rounded-3xl p-10 md:p-14 border border-indigo-500/30">
+            <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">
+              Pas sûr du rôle qui vous correspond ?
+            </h2>
+            <p className="text-slate-300 mb-7">
+              Créez votre compte, choisissez votre profil, et Talok vous
+              guide. Vous pouvez changer plus tard si votre situation évolue.
+            </p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <Link
+                href="/auth/signup"
+                className="inline-flex items-center gap-2 rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-slate-900 hover:bg-slate-100 transition-colors"
+              >
+                Créer mon compte gratuit
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/contact"
+                className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-5 py-2.5 text-sm font-semibold text-slate-200 hover:bg-slate-800 transition-colors"
+              >
+                Parler à l’équipe
+              </Link>
+            </div>
+            <p className="mt-4 text-xs text-slate-400">
+              1er mois offert sur les plans payants · Aucune carte bancaire requise
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/solutions/proprietaires-particuliers/page.tsx
+++ b/app/solutions/proprietaires-particuliers/page.tsx
@@ -127,7 +127,7 @@ export default function ProprietairesParticuliersPage() {
             <div className="flex flex-wrap justify-center gap-6 text-sm text-slate-400">
               <div className="flex items-center gap-2">
                 <Check className="w-4 h-4 text-emerald-400" />
-                14 jours d'essai gratuit
+                1er mois offert
               </div>
               <div className="flex items-center gap-2">
                 <Check className="w-4 h-4 text-emerald-400" />
@@ -320,7 +320,7 @@ export default function ProprietairesParticuliersPage() {
               </Button>
             </Link>
             <p className="mt-4 text-sm text-slate-400">
-              14 jours gratuits · Sans engagement · Support inclus
+              1er mois offert · Sans engagement · Support inclus
             </p>
           </motion.div>
         </div>

--- a/app/temoignages/page.tsx
+++ b/app/temoignages/page.tsx
@@ -267,7 +267,7 @@ export default function TemoignagesPage() {
               Rejoignez +10 000 propriétaires satisfaits
             </h2>
             <p className="text-slate-300 mb-6">
-              Essayez gratuitement pendant 14 jours. Sans carte bancaire.
+              1er mois offert sur les plans payants. Sans carte bancaire.
             </p>
             <Link href="/auth/signup">
               <Button size="lg" className="bg-white text-slate-900 hover:bg-slate-100">


### PR DESCRIPTION
Audit complet de **talok.fr** suivi des correctifs (4 commits, ~30 fichiers, ~1 950 lignes).

## 🚨 Bugs critiques corrigés

| # | Bug | Fix |
|---|---|---|
| 1 | `/og-image.png` 404 (partages sociaux cassés) | `app/opengraph-image.tsx` via `next/og` (1200×630, gradient `#1D4ED8 → #60A5FA`) |
| 2 | `/apple-touch-icon.png` 404 | `app/apple-icon.tsx` (180×180) |
| 3 | Téléphones placeholders `01 XX XX XX XX` / `0696 XX XX XX` affichés en prod sur `/contact` | Carte téléphone remplacée par mention email/formulaire + délai 2h ouvrables |
| 4 | `/securite` 404 alors que référencée dans 2 footers | Page créée (6 piliers sécurité, signalement faille, canonical/OG) |
| 5 | URL `/guides/investissement-dom-tom` (terminologie interdite par `talok-context`) | Slug renommé `investissement-outre-mer` + redirect 301 |
| 6 | `/guides/[slug]` retournait HTTP 200 sur slugs inexistants | `notFound()` → vrai 404 |

## 🔄 Cohérence prix/produit (essai 30 j)

`lib/subscriptions/plans.ts` est la source de vérité (`trial_days: 30`). Toutes les pages désynchronisées « 7 jours » ou « 14 jours » alignées sur **« 1er mois offert (30 jours) »** :

- `app/faq/page.tsx` Q3
- `app/legal/cgv/page.tsx` §6
- `app/solutions/proprietaires-particuliers/page.tsx` (×2)
- `app/solutions/outre-mer/page.tsx`
- `app/temoignages/page.tsx`
- `app/fonctionnalites/etats-des-lieux/page.tsx`

> ⚠️ Les `14 jours` de `/legal/cgv` §7 et `settings/billing` sont conservés — ils correspondent au **droit de rétractation L. 221-18 Code conso** (légal, ≠ période d'essai).

## 👥 Couverture des 7 rôles

La home et le menu Solutions ne couvraient que **3 rôles sur 7**. La section `<PourQui>` existait mais n'était même pas montée.

### Page d'accueil
- `LandingPageClient.tsx` : monte enfin `<PourQui />` entre `<PropertyTypes />` et `<Pricing />`
- `PourQui.tsx` : 3 → **6 personas** (Propriétaire · Investisseur ⭐ · Agence · Syndic · Locataire & colocataire · Prestataire / Artisan), grille responsive 1/2/3, CTA « Voir la solution » par carte

### 3 nouvelles pages dédiées (~330 / 370 / 330 lignes)

| Route | Persona | Palette | CTA primaire |
|---|---|---|---|
| `/solutions/locataires` | Léa, Saint-Denis (974), T2 | emerald → cyan | `/auth/signup` |
| `/solutions/prestataires` | Karl, Le Lamentin (972), plombier | orange → amber | `/auth/signup?role=provider` |
| `/solutions/garants` | Patricia, Pointe-à-Pitre (971), garante d'étudiant | sky → blue | `/invite` |

Architecture identique à `/solutions/proprietaires-particuliers` :
1. Hero (badge + h1 dégradé + 2 CTA + 3 micro-bénéfices)
2. Pain Points (3 cards icône rouge → ampoule verte)
3. Features (4–6 cards grid 2 cols)
4. Section spéciale par persona (Mes droits / Comment ça marche / Vos droits légaux)
5. Témoignage + Final CTA `rounded-3xl`

### Page hub `/solutions` (était 404)
Grille 3×3 listant les **9 solutions**, gradient unique par rôle, badges contextuels (`Le plus choisi`, `Gratuit`, `Enterprise`, `DROM-COM`).

## 🔌 Wiring complet

- `lib/seo/metadata.ts` : +3 entrées `PAGE_METADATA` (locataires, prestataires, garants) avec keywords ciblés
- `nav-items.ts` `SOLUTIONS_ITEMS` : 5 → **8 entrées** (consommé automatiquement par `SolutionsDropdown` desktop + `MobileNav`)
- `Footer.tsx` colonne Solutions : 5 → 8 liens, intitulés alignés
- `sitemap.ts` : +`/solutions` + 3 sous-pages (priorités 0.85 / 0.8) → 47 URLs

## 🧹 Autres correctifs SEO

- `/legal/mentions` : `<CardTitle>` (= h3) → vrai `<h1>`
- Footer marketing : retire « Nouveautés » doublon, retire « Blog » (en stub), supprime « App mobile » qui pointait vers `/fonctionnalites` générique → remplacés par « Modèles » + « Sécurité »
- Sitemap complété : `/modeles`, `/modeles/etat-des-lieux`, `/modeles/quittance-loyer`, `/securite` (pages publiques qui manquaient)
- Terminologie : `Fiscalité Outre-Mer` → `Fiscalité outre-mer` ; `Déclaration 2044 spécial Outre-Mer` → `spéciale outre-mer` (skill `talok-context` exige minuscule m)

## 🚧 Reporté à la demande de l'utilisateur (P0 légal)

Champs encore en placeholder `[À CONFIRMER PAR THOMAS]` — données métier à fournir, non touchées :

- `/legal/mentions` : raison sociale, forme juridique, capital, siège, SIRET, RCS, TVA intra, téléphone (8 champs)
- `/legal/privacy` : raison sociale, adresse responsable de traitement (2 champs)
- Clause médiateur consommation (Art. L. 612-1 Code conso)

## 📊 Commits

| SHA | Sujet |
|---|---|
| `73e7fe5` | OG image, /securite, FAQ, slug DOM-TOM, h1 mentions, footer |
| `9a24ff5` | CGV 30 j, terminologie outre-mer, vraie 404 guides |
| `9755e98` | Couverture 7 rôles : PourQui x6, +3 pages /solutions, wiring complet |
| `089f9ef` | Page index /solutions + 5 alignements 14 j → 30 j résiduels |

## ✅ Test plan

- [ ] `/og-image.png` (auto-généré par Next/og) renvoie une image de partage gradient
- [ ] `/apple-icon.png` renvoie une icône T sur fond bleu
- [ ] `/securite` répond 200 avec les 6 piliers
- [ ] Partage sur Slack / LinkedIn / WhatsApp affiche bien la nouvelle image OG
- [ ] `/guides/investissement-dom-tom` redirige 301 vers `/guides/investissement-outre-mer`
- [ ] `/guides/slug-bidon` renvoie un vrai HTTP 404
- [ ] Home : section « Pour qui ? » visible avec 6 cartes
- [ ] `/solutions` (index) répond 200 avec les 9 cartes
- [ ] `/solutions/locataires` `/solutions/prestataires` `/solutions/garants` répondent 200
- [ ] Menu Solutions desktop + mobile : 8 entrées
- [ ] Footer : Solutions = 8 liens, Produit = Fonctionnalités/Tarifs/Modèles/Sécurité
- [ ] FAQ Q3 : « 1er mois offert (30 jours) … 1 bien »
- [ ] CGV §6 : « 1er mois offert (30 jours) »
- [ ] `/contact` : carte téléphone sans `XX`
- [ ] `/legal/mentions` : un seul `<h1>` (« Mentions Légales »)
- [ ] `sitemap.xml` contient `/solutions`, `/securite`, `/modeles*`

https://claude.ai/code/session_01R3cG8qa6dbqaki8LAxTYd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3cG8qa6dbqaki8LAxTYd1)_