### PR TITLE
UI: labels cohérents pour multi-rôles dans /copro et /syndic

### DIFF
--- a/app/copro/layout.tsx
+++ b/app/copro/layout.tsx
@@ -92,7 +92,50 @@ export default async function CoproLayout({
     redirect(getRoleDashboardUrl(profile.role));
   }
 
-  // 4. Rendre le layout avec la sidebar
+  // 4. Déterminer le libellé du rôle effectif sur la copro pour adapter
+  //    l'UI (sidebar, footer). Un locataire_copro ne doit pas voir
+  //    "Copropriétaire" écrit partout — sinon le label ment et trahit
+  //    l'incohérence du parcours.
+  const ROLE_LABELS: Record<string, string> = {
+    syndic: "Syndic",
+    tresorier: "Trésorier",
+    conseil_syndical: "Conseil syndical",
+    coproprietaire: "Copropriétaire",
+    coproprietaire_bailleur: "Copropriétaire bailleur",
+    coproprietaire_occupant: "Copropriétaire occupant",
+    coproprietaire_nu: "Copropriétaire (nue-propriété)",
+    usufruitier: "Usufruitier",
+    locataire_copro: "Locataire en copropriété",
+  };
+  // Priorité au rôle primaire si déjà copro, sinon le rôle granulaire le
+  // plus élevé dans user_site_roles (syndic > tresorier > conseil > copro > locataire).
+  let effectiveCoproLabel: string =
+    ROLE_LABELS[profile.role] ?? "Copropriétaire";
+  if (!ROLE_LABELS[profile.role]) {
+    const { data: userRoles } = await supabase
+      .from("user_site_roles")
+      .select("role_code")
+      .eq("user_id", user.id)
+      .in("role_code", Object.keys(ROLE_LABELS));
+    const codes = ((userRoles ?? []) as Array<{ role_code: string }>).map(
+      (r) => r.role_code
+    );
+    const priority = [
+      "syndic",
+      "tresorier",
+      "conseil_syndical",
+      "coproprietaire_bailleur",
+      "coproprietaire",
+      "coproprietaire_occupant",
+      "coproprietaire_nu",
+      "usufruitier",
+      "locataire_copro",
+    ];
+    const top = priority.find((p) => codes.includes(p));
+    if (top) effectiveCoproLabel = ROLE_LABELS[top];
+  }
+
+  // 5. Rendre le layout avec la sidebar
   return (
     <ErrorBoundary>
       <CsrfTokenInjector />
@@ -121,7 +164,7 @@ export default async function CoproLayout({
                       Mon Espace
                     </h1>
                     <p className="text-xs text-muted-foreground">
-                      Copropriétaire
+                      {effectiveCoproLabel}
                     </p>
                   </div>
                 </div>
@@ -145,8 +188,11 @@ export default async function CoproLayout({
                 ))}
               </nav>
 
-              {/* Lien vers espace bailleur si applicable */}
-              {profile.role === "coproprietaire_bailleur" && (
+              {/* Lien vers espace bailleur — affiché si le user est
+                  bailleur soit par profile.role (cas legacy), soit par
+                  user_site_roles (cas standard owner avec rôle granulaire). */}
+              {(profile.role === "coproprietaire_bailleur" ||
+                effectiveCoproLabel === "Copropriétaire bailleur") && (
                 <div className="px-3 pb-4">
                   <div className="p-3 rounded-xl bg-violet-500/10 border border-violet-500/30">
                     <p className="text-xs text-violet-400 mb-2">
@@ -178,7 +224,7 @@ export default async function CoproLayout({
                       {profile.prenom} {profile.nom}
                     </p>
                     <p className="text-xs text-muted-foreground truncate">
-                      Copropriétaire
+                      {effectiveCoproLabel}
                     </p>
                   </div>
                 </div>

--- a/app/syndic/layout.tsx
+++ b/app/syndic/layout.tsx
@@ -179,7 +179,7 @@ export default async function SyndicLayout({
                     Espace Syndic
                   </h1>
                   <p className="text-xs text-muted-foreground">
-                    Talok Pro
+                    {isOwnerInSyndicSpace ? "Mode bénévole" : "Talok Pro"}
                   </p>
                 </div>
               </div>
@@ -218,8 +218,8 @@ export default async function SyndicLayout({
                   <p className="text-sm font-medium text-foreground truncate">
                     {profile.prenom} {profile.nom}
                   </p>
-                  <p className="text-xs text-muted-foreground truncate capitalize">
-                    {profile.role}
+                  <p className="text-xs text-muted-foreground truncate">
+                    {isOwnerInSyndicSpace ? "Syndic bénévole" : "Syndic"}
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Contexte

Les PRs #574 et #575 ont ouvert l'accès aux espaces `/copro` et `/syndic` à des utilisateurs dont `profile.role` n'est pas le rôle "natif" du namespace (locataire en copro, owner-bénévole syndic). Mais plusieurs labels UI restaient hardcodés et **mentaient** sur le rôle effectif.

## Changements

### `/copro`
- **Sidebar header & footer** : remplaçaient "Copropriétaire" en dur → maintenant un label dérivé du rôle réel via `user_site_roles` (priorité syndic > tresorier > conseil > coproprietaire_bailleur > coproprietaire > coproprietaire_occupant > coproprietaire_nu > usufruitier > locataire_copro). Un locataire en copro voit "Locataire en copropriété", pas "Copropriétaire".
- **Bandeau "Gérer les charges récupérables"** : ne s'affichait que si `profile.role === 'coproprietaire_bailleur'` (jamais le cas après les fixes). Couvre maintenant aussi `user_site_roles.role_code === 'coproprietaire_bailleur'`.

### `/syndic`
- **Sous-titre header** : affichait "Talok Pro" pour tous, y compris les owner-bénévoles. Maintenant "Mode bénévole" pour eux, "Talok Pro" pour les vrais syndics professionnels.
- **Footer rôle** : affichait `profile.role` capitalisé (donc "Owner" littéralement pour un bénévole). Maintenant "Syndic bénévole" ou "Syndic".

## Test plan

- [ ] Tenant invité comme `locataire_copro` → header `/copro` affiche "Locataire en copropriété"
- [ ] Owner avec `coproprietaire_bailleur` user_site_roles → bandeau charges récupérables visible
- [ ] Owner-bénévole sur `/syndic` → "Mode bénévole" en sous-titre, "Syndic bénévole" en footer
- [ ] Vrai syndic → "Talok Pro" en sous-titre, "Syndic" en footer (inchangé)

## Commit

- `1152b30` fix(ui): labels cohérents avec le rôle effectif dans /copro et /syndic

https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL7AcrE2biXaG4VLEuKyRu)_