### PR TITLE
fix(entities): débloquer la création d'entité particulier pour tous l…

### DIFF
--- a/app/owner/entities/EntitiesPageClient.tsx
+++ b/app/owner/entities/EntitiesPageClient.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { bulkDeleteEntities, findDuplicateEntities, deduplicateEntities } from "./actions";
 import { useAuth } from "@/lib/hooks/use-auth";
-import { useSubscription, UpgradeModal } from "@/components/subscription";
 import type { LegalEntity } from "@/lib/types/legal-entity";
 
 interface EntitiesPageClientProps {
@@ -47,9 +46,6 @@ export function EntitiesPageClient({ entities: serverEntities }: EntitiesPageCli
   const { entities: storeEntities, activeEntityId, lastFetchedAt, fetchEntities, removeEntity } = useEntityStore();
   const { profile } = useAuth();
   const { toast } = useToast();
-  const { hasFeature } = useSubscription();
-  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
-  const canCreateNonParticulier = hasFeature("multi_mandants");
   const [search, setSearch] = useState("");
   const [activeFilter, setActiveFilter] = useState("all");
 
@@ -374,20 +370,8 @@ export function EntitiesPageClient({ entities: serverEntities }: EntitiesPageCli
             onToggle={toggleSelection}
           />
         ))}
-        {!selectionMode && (
-          canCreateNonParticulier ? (
-            <AddEntityCard />
-          ) : (
-            <div
-              onClick={() => setShowUpgradeModal(true)}
-              className="cursor-pointer"
-            >
-              <AddEntityCard />
-            </div>
-          )
-        )}
+        {!selectionMode && <AddEntityCard />}
       </div>
-      <UpgradeModal open={showUpgradeModal} onClose={() => setShowUpgradeModal(false)} feature="multi_mandants" />
 
       {/* No results */}
       {filteredEntities.length === 0 && allEntities.length > 0 && (

--- a/app/owner/entities/new/page.tsx
+++ b/app/owner/entities/new/page.tsx
@@ -13,14 +13,23 @@ import { useEntityStore } from "@/stores/useEntityStore";
 import { createEntity } from "@/app/owner/entities/actions";
 import { EntityFormWizard } from "@/components/entities/create/EntityFormWizard";
 import type { EntityFormData } from "@/lib/entities/entity-form-utils";
-import { PlanGate } from "@/components/subscription";
+import { useSubscription, UpgradeModal } from "@/components/subscription";
+import { useState } from "react";
 
 export default function NewEntityPage() {
   const router = useRouter();
   const { toast } = useToast();
   const { addEntity } = useEntityStore();
+  const { hasFeature } = useSubscription();
+  const canCreateNonParticulier = hasFeature("multi_mandants");
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
   const handleSubmit = async (formData: EntityFormData) => {
+    if (formData.entityType !== "particulier" && !canCreateNonParticulier) {
+      setShowUpgradeModal(true);
+      return;
+    }
+
     try {
       const result = await createEntity({
         entity_type: formData.entityType as Parameters<
@@ -113,7 +122,7 @@ export default function NewEntityPage() {
   };
 
   return (
-    <PlanGate feature="multi_mandants" mode="block">
+    <>
       <EntityFormWizard
         mode="create"
         onSubmit={handleSubmit}
@@ -126,7 +135,14 @@ export default function NewEntityPage() {
         }}
         submitLabel="Créer l&apos;entité"
         submitLoadingLabel="Création..."
+        gateNonParticulier={!canCreateNonParticulier}
+        onGatedTypeAttempt={() => setShowUpgradeModal(true)}
       />
-    </PlanGate>
+      <UpgradeModal
+        open={showUpgradeModal}
+        onClose={() => setShowUpgradeModal(false)}
+        feature="multi_mandants"
+      />
+    </>
   );
 }

--- a/components/entities/EntityCard.tsx
+++ b/components/entities/EntityCard.tsx
@@ -206,21 +206,36 @@ export function EntityCardSkeleton() {
 
 /**
  * AddEntityCard — Carte "Ajouter une entité"
+ *
+ * Si onClick est fourni, la carte agit comme un bouton (pas de Link interne).
+ * Sinon, elle navigue vers /owner/entities/new.
  */
-export function AddEntityCard() {
-  return (
-    <Link href="/owner/entities/new">
-      <Card className="border-dashed hover:border-primary/50 hover:bg-muted/30 transition-all cursor-pointer h-full">
-        <CardContent className="p-5 flex flex-col items-center justify-center text-center h-full min-h-[240px]">
-          <div className="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center mb-3">
-            <Building2 className="h-6 w-6 text-primary" />
-          </div>
-          <p className="font-medium text-sm">Ajouter une entité</p>
-          <p className="text-xs text-muted-foreground mt-1">
-            SCI, SARL, SAS, indivision...
-          </p>
-        </CardContent>
-      </Card>
-    </Link>
+export function AddEntityCard({ onClick }: { onClick?: () => void } = {}) {
+  const inner = (
+    <Card className="border-dashed hover:border-primary/50 hover:bg-muted/30 transition-all cursor-pointer h-full">
+      <CardContent className="p-5 flex flex-col items-center justify-center text-center h-full min-h-[240px]">
+        <div className="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center mb-3">
+          <Building2 className="h-6 w-6 text-primary" />
+        </div>
+        <p className="font-medium text-sm">Ajouter une entité</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          SCI, SARL, SAS, indivision...
+        </p>
+      </CardContent>
+    </Card>
   );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="text-left w-full h-full"
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return <Link href="/owner/entities/new">{inner}</Link>;
 }

--- a/components/entities/EntitySelector.tsx
+++ b/components/entities/EntitySelector.tsx
@@ -10,7 +10,7 @@
  * P1-8: Peut filtrer les entités par bien sélectionné (propertyEntityId)
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useEntityStore } from "@/stores/useEntityStore";
 import { Building2, User, AlertCircle, Star } from "lucide-react";
 import {
@@ -57,6 +57,23 @@ export function EntitySelector({
   className,
 }: EntitySelectorProps) {
   const { entities, isLoading } = useEntityStore();
+
+  // If a "particulier" entity already exists, hide the legacy "Profil personnel"
+  // option (which maps to legal_entity_id = null). Otherwise the user sees two
+  // indistinguishable choices and can create orphan records.
+  const particulierEntity = useMemo(
+    () => entities.find((e) => e.entityType === "particulier"),
+    [entities]
+  );
+  const hasParticulierEntity = !!particulierEntity;
+
+  // Auto-coerce legacy null value (= "Profil personnel") onto the existing
+  // particulier entity to prevent orphan records.
+  useEffect(() => {
+    if (value === null && particulierEntity) {
+      onChange(particulierEntity.id);
+    }
+  }, [value, particulierEntity, onChange]);
 
   // P1-8: Sort entities — property owner entity first, then alphabetical
   const sortedEntities = useMemo(() => {
@@ -120,13 +137,17 @@ export function EntitySelector({
           <SelectValue placeholder="Sélectionner une entité" />
         </SelectTrigger>
         <SelectContent>
-          {/* Personal profile option */}
-          <SelectItem value="__personal__">
-            <div className="flex items-center gap-2">
-              <User className="h-4 w-4 text-muted-foreground" />
-              <span>Profil personnel</span>
-            </div>
-          </SelectItem>
+          {/* Personal profile option — hidden if a "particulier" entity exists
+              to avoid the orphan-record trap (legal_entity_id NULL bypasses
+              the accounting module). */}
+          {!hasParticulierEntity && (
+            <SelectItem value="__personal__">
+              <div className="flex items-center gap-2">
+                <User className="h-4 w-4 text-muted-foreground" />
+                <span>Profil personnel</span>
+              </div>
+            </SelectItem>
+          )}
 
           {/* Entity options — P1-8: property owner entity shown first */}
           {sortedEntities.map((entity) => {

--- a/components/entities/create/EntityFormWizard.tsx
+++ b/components/entities/create/EntityFormWizard.tsx
@@ -107,6 +107,10 @@ export interface EntityFormWizardProps {
   submitLabel: string;
   /** Submit loading label */
   submitLoadingLabel: string;
+  /** Display a "Plan Enterprise requis" badge on non-particulier types */
+  gateNonParticulier?: boolean;
+  /** Called when user clicks a gated (non-particulier) type without access */
+  onGatedTypeAttempt?: () => void;
 }
 
 // ============================================
@@ -121,6 +125,8 @@ export function EntityFormWizard({
   header,
   submitLabel,
   submitLoadingLabel,
+  gateNonParticulier = false,
+  onGatedTypeAttempt,
 }: EntityFormWizardProps) {
   const router = useRouter();
 
@@ -427,6 +433,8 @@ export function EntityFormWizard({
           <StepEntityType
             value={formData.entityType}
             onChange={(v) => updateFormData({ entityType: v })}
+            gateNonParticulier={gateNonParticulier}
+            onGatedTypeAttempt={onGatedTypeAttempt}
           />
         )}
         {step === 2 && (

--- a/components/entities/create/StepEntityType.tsx
+++ b/components/entities/create/StepEntityType.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { Building2, User, Users, ArrowUpDown } from "lucide-react";
+import { Building2, User, Users, ArrowUpDown, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface StepEntityTypeProps {
   value: string;
   onChange: (type: string) => void;
+  /** When true, non-particulier types are visually locked and onChange is intercepted */
+  gateNonParticulier?: boolean;
+  /** Called when a locked type is clicked */
+  onGatedTypeAttempt?: () => void;
 }
 
 const ENTITY_TYPES = [
@@ -120,7 +124,20 @@ const ENTITY_TYPES = [
   },
 ];
 
-export function StepEntityType({ value, onChange }: StepEntityTypeProps) {
+export function StepEntityType({
+  value,
+  onChange,
+  gateNonParticulier = false,
+  onGatedTypeAttempt,
+}: StepEntityTypeProps) {
+  const handleClick = (typeId: string) => {
+    if (gateNonParticulier && typeId !== "particulier") {
+      onGatedTypeAttempt?.();
+      return;
+    }
+    onChange(typeId);
+  };
+
   return (
     <div className="space-y-4">
       <div>
@@ -133,15 +150,18 @@ export function StepEntityType({ value, onChange }: StepEntityTypeProps) {
       <div className="grid gap-3 sm:grid-cols-2">
         {ENTITY_TYPES.map((type) => {
           const isSelected = value === type.id;
+          const isLocked = gateNonParticulier && type.id !== "particulier";
           return (
             <button
               key={type.id}
-              onClick={() => onChange(type.id)}
+              type="button"
+              onClick={() => handleClick(type.id)}
               className={cn(
-                "flex items-start gap-3 p-4 rounded-lg border text-left transition-all",
+                "relative flex items-start gap-3 p-4 rounded-lg border text-left transition-all",
                 isSelected
                   ? "border-primary bg-primary/5 ring-2 ring-primary/20"
-                  : "border-border hover:border-primary/30 hover:bg-muted/30"
+                  : "border-border hover:border-primary/30 hover:bg-muted/30",
+                isLocked && "opacity-70"
               )}
             >
               <div
@@ -157,15 +177,23 @@ export function StepEntityType({ value, onChange }: StepEntityTypeProps) {
                   )}
                 />
               </div>
-              <div>
-                <p
-                  className={cn(
-                    "font-medium text-sm",
-                    isSelected && "text-primary"
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <p
+                    className={cn(
+                      "font-medium text-sm",
+                      isSelected && "text-primary"
+                    )}
+                  >
+                    {type.label}
+                  </p>
+                  {isLocked && (
+                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-bold bg-amber-500/20 text-amber-600 rounded border border-amber-500/30 uppercase">
+                      <Lock className="h-2.5 w-2.5" />
+                      Enterprise
+                    </span>
                   )}
-                >
-                  {type.label}
-                </p>
+                </div>
                 <p className="text-xs text-muted-foreground mt-0.5">
                   {type.description}
                 </p>

--- a/providers/EntityProvider.tsx
+++ b/providers/EntityProvider.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useRef, type ReactNode } from "react";
 import { useEntityStore } from "@/stores/useEntityStore";
 import { useAuth } from "@/lib/hooks/use-auth";
+import { useToast } from "@/components/ui/use-toast";
 
 interface EntityProviderProps {
   children: ReactNode;
@@ -24,6 +25,7 @@ let ensureDefaultPromise: Promise<void> | null = null;
 
 export function EntityProvider({ children }: EntityProviderProps) {
   const { profile } = useAuth();
+  const { toast } = useToast();
   const fetchEntities = useEntityStore((s) => s.fetchEntities);
   const setActiveEntity = useEntityStore((s) => s.setActiveEntity);
   const autoSelectDoneRef = useRef(false);
@@ -65,6 +67,13 @@ export function EntityProvider({ children }: EntityProviderProps) {
                   if (!currentId && newEntities.length > 0) {
                     useEntityStore.getState().setActiveEntity(newEntities[0].id);
                   }
+                } else {
+                  toast({
+                    title: "Configuration incomplète",
+                    description:
+                      "Impossible de créer votre entité par défaut. Créez-en une manuellement depuis Mes entités.",
+                    variant: "destructive",
+                  });
                 }
               } finally {
                 ensureDefaultPromise = null;
@@ -102,11 +111,17 @@ export function EntityProvider({ children }: EntityProviderProps) {
         }
       } catch (err) {
         console.error("[EntityProvider] Error loading entities:", err);
+        toast({
+          title: "Erreur de chargement",
+          description:
+            "Impossible de charger vos entités juridiques. Rafraîchissez la page.",
+          variant: "destructive",
+        });
       }
     };
 
     loadEntities();
-  }, [profile?.id, fetchEntities, setActiveEntity]);
+  }, [profile?.id, fetchEntities, setActiveEntity, toast]);
 
   // Reactive guard: if entities arrive after initial render and activeEntityId is still null
   const entities = useEntityStore((s) => s.entities);


### PR DESCRIPTION
…es plans

Le PlanGate global sur /owner/entities/new bloquait toute création (y compris particulier) pour les plans non-Enterprise, alors que le serveur autorise explicitement la création de "particulier" sans multi_mandants. Conséquence : le bouton "Ajouter" / "AddEntityCard" cliquait sur un écran verrouillé.

- Retire <PlanGate mode="block"> de /owner/entities/new
- Ajoute un gating granulaire dans StepEntityType (badge Enterprise sur les types non-particulier ; clic = ouverture UpgradeModal)
- Corrige la race condition Link/onClick dans EntitiesPageClient en rendant AddEntityCard agnostique (Link par défaut OU onClick si fourni)
- Masque "Profil personnel" dans EntitySelector si une entité particulier existe déjà, et auto-coerce value=null vers cette entité (évite les biens orphelins legal_entity_id NULL invisibles en compta)
- Toast d'erreur visible si ensureDefaultEntity() ou fetchEntities() échoue dans EntityProvider (au lieu d'un console.error silencieux)

https://claude.ai/code/session_01XuQitEmXKXJkC3tNVkaypN