### PR TITLE
P0/P1: refunds loyers + race condition payments + date SEPA

### DIFF
--- a/app/api/payments/setup-sepa/route.ts
+++ b/app/api/payments/setup-sepa/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
     const { data: lease } = await supabase
       .from("leases")
       .select(`
-        id, loyer, charges_forfaitaires, depot_de_garantie,
+        id, loyer, charges_forfaitaires, depot_de_garantie, statut,
         property:properties(
           id, adresse_complete,
           owner:profiles!properties_owner_id_fkey(
@@ -89,6 +89,22 @@ export async function POST(request: NextRequest) {
 
     if (!lease) {
       return NextResponse.json({ error: "Bail non trouvé" }, { status: 404 });
+    }
+
+    // Refuser de créer un mandat SEPA tant que le bail n'est pas
+    // entièrement signé. Sans cette garde, le locataire pouvait être
+    // engagé dans des prélèvements automatiques avant que le bail soit
+    // juridiquement actif (donc sans accord ferme côté propriétaire).
+    const allowedStatuses = ["fully_signed", "active"];
+    if (!allowedStatuses.includes((lease as any).statut)) {
+      return NextResponse.json(
+        {
+          error:
+            "Le mandat SEPA ne peut être créé qu'une fois le bail intégralement signé.",
+          lease_status: (lease as any).statut,
+        },
+        { status: 409 }
+      );
     }
 
     const owner = (lease.property as any)?.owner;
@@ -256,15 +272,36 @@ export async function POST(request: NextRequest) {
 }
 
 /**
+ * Renvoie le dernier jour calendaire d'un mois donné (1-indexed).
+ * Ex : lastDayOfMonth(2026, 2) = 28 (ou 29 année bissextile).
+ */
+function lastDayOfMonth(year: number, monthOneBased: number): number {
+  // Date(year, month, 0) renvoie le dernier jour du mois précédent.
+  return new Date(year, monthOneBased, 0).getDate();
+}
+
+/**
+ * Construit une Date au jour `day` du mois (year, monthZeroBased), en
+ * cappant au dernier jour réel du mois si `day > lastDayOfMonth`.
+ *
+ * Bug fixé : `new Date(2026, 1, 29)` retournait silencieusement le
+ * 1er mars (overflow), prélevant les locataires à une mauvaise date.
+ */
+function safeDateInMonth(year: number, monthZeroBased: number, day: number): Date {
+  const last = lastDayOfMonth(year, monthZeroBased + 1);
+  return new Date(year, monthZeroBased, Math.min(day, last));
+}
+
+/**
  * Calculer la prochaine date de prélèvement
  */
 function getNextCollectionDate(day: number): string {
   const now = new Date();
-  let nextDate = new Date(now.getFullYear(), now.getMonth(), day);
+  let nextDate = safeDateInMonth(now.getFullYear(), now.getMonth(), day);
 
   // Si le jour est déjà passé ce mois, prendre le mois suivant
   if (nextDate <= now) {
-    nextDate = new Date(now.getFullYear(), now.getMonth() + 1, day);
+    nextDate = safeDateInMonth(now.getFullYear(), now.getMonth() + 1, day);
   }
 
   // Ajouter 5 jours de délai minimum pour SEPA
@@ -272,7 +309,7 @@ function getNextCollectionDate(day: number): string {
   minDate.setDate(minDate.getDate() + 5);
 
   if (nextDate < minDate) {
-    nextDate = new Date(now.getFullYear(), now.getMonth() + 1, day);
+    nextDate = safeDateInMonth(now.getFullYear(), now.getMonth() + 1, day);
   }
 
   return nextDate.toISOString().split("T")[0];

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -343,13 +343,17 @@ async function upsertPaymentAttempt(
     paidAt?: string | null;
   }
 ) {
+  // Lit le statut actuel pour calculer newlySucceeded/newlyFailed.
+  // La race condition ne porte plus sur l'INSERT (UNIQUE provider_ref +
+  // upsert ON CONFLICT) ; ce SELECT sert uniquement à savoir si on
+  // déclenche les side-effects post-paiement (compta, quittance, email).
   const { data: existingPayment } = await supabase
     .from("payments")
-    .select("id, statut")
+    .select("statut")
     .eq("provider_ref", params.providerRef)
     .maybeSingle();
 
-  const existing = existingPayment as { id?: string | null; statut?: string | null } | null;
+  const existing = existingPayment as { statut?: string | null } | null;
   // `payments.date_paiement` est de type DATE — les callers passent souvent
   // `new Date().toISOString()` (timestamp ISO). On normalise vers YYYY-MM-DD
   // pour éviter la coercition silencieuse côté Postgres.
@@ -365,31 +369,22 @@ async function upsertPaymentAttempt(
     statut: params.status,
   };
 
-  if (existing?.id) {
-    const { data: updatedPayment } = await supabase
-      .from("payments")
-      .update(payload)
-      .eq("id", existing.id)
-      .select("id")
-      .single();
-
-    return {
-      paymentId: (updatedPayment as { id?: string } | null)?.id || existing.id,
-      newlySucceeded: existing.statut !== "succeeded" && params.status === "succeeded",
-      newlyFailed: existing.statut !== "failed" && params.status === "failed",
-    };
-  }
-
-  const { data: createdPayment } = await supabase
+  // Upsert atomique sur la contrainte UNIQUE (provider_ref) installée par
+  // migration 20260504100000. Élimine la fenêtre TOCTOU entre SELECT et
+  // INSERT qui permettait deux webhooks Stripe simultanés de créer deux
+  // rows payments pour le même payment_intent.
+  const { data: upsertedPayment } = await supabase
     .from("payments")
-    .insert(payload)
+    .upsert(payload, { onConflict: "provider_ref" })
     .select("id")
     .single();
 
   return {
-    paymentId: (createdPayment as { id?: string } | null)?.id || null,
-    newlySucceeded: params.status === "succeeded",
-    newlyFailed: params.status === "failed",
+    paymentId: (upsertedPayment as { id?: string } | null)?.id ?? null,
+    newlySucceeded:
+      (existing?.statut ?? null) !== "succeeded" && params.status === "succeeded",
+    newlyFailed:
+      (existing?.statut ?? null) !== "failed" && params.status === "failed",
   };
 }
 
@@ -2087,6 +2082,53 @@ export async function POST(request: NextRequest) {
               .from("work_orders")
               .update({ statut: "cancelled" })
               .eq("id", wp.work_order_id);
+          }
+        }
+
+        // Cas normal : paiement de loyer (table payments). Le payment_intent
+        // d'origine est référencé par charge.payment_intent.
+        // Bug pré-existant : ce cas n'était PAS traité, la facture restait
+        // "paid" après remboursement et la compta divergeait.
+        const paymentIntentId =
+          typeof charge.payment_intent === "string"
+            ? charge.payment_intent
+            : charge.payment_intent?.id ?? null;
+
+        if (paymentIntentId) {
+          const { data: rentPayment } = await supabase
+            .from("payments")
+            .select("id, invoice_id, statut, montant")
+            .eq("provider_ref", paymentIntentId)
+            .maybeSingle();
+
+          if (rentPayment) {
+            const rp = rentPayment as {
+              id: string;
+              invoice_id: string | null;
+              statut: string | null;
+              montant: number | string | null;
+            };
+
+            const refundedCents = charge.amount_refunded ?? 0;
+            const grossCents = Math.round(Number(rp.montant ?? 0) * 100);
+            const isFullRefund = grossCents > 0 && refundedCents >= grossCents;
+
+            await supabase
+              .from("payments")
+              .update({
+                statut: isFullRefund ? "refunded" : rp.statut ?? "succeeded",
+              })
+              .eq("id", rp.id);
+
+            if (rp.invoice_id) {
+              // Recalcule le statut de la facture à partir des paiements
+              // restants (paid → refunded ou partially_paid selon le solde).
+              await syncInvoiceStatusFromPayments(
+                supabase as any,
+                rp.invoice_id,
+                null
+              );
+            }
           }
         }
         break;

--- a/supabase/migrations/20260504100000_payments_provider_ref_unique.sql
+++ b/supabase/migrations/20260504100000_payments_provider_ref_unique.sql
@@ -1,0 +1,47 @@
+-- ============================================
+-- Race condition fix : UNIQUE constraint sur payments.provider_ref
+-- ============================================
+-- Bug audit (2026-05-03) : upsertPaymentAttempt() faisait SELECT puis
+-- INSERT/UPDATE sans verrou ni ON CONFLICT. Deux webhooks Stripe
+-- simultanés pour le même payment_intent pouvaient créer deux rows
+-- payments → double-encaissement comptable.
+--
+-- Fix en deux temps :
+--   1. Dédoublonner les rows existantes (garde la plus ancienne, supprime
+--      les autres). Critère : même provider_ref non-NULL.
+--   2. Ajouter UNIQUE (provider_ref) WHERE provider_ref IS NOT NULL.
+--      Le code TS bascule en upsert(..., { onConflict: 'provider_ref' })
+--      pour éliminer la fenêtre TOCTOU.
+--
+-- Idempotent : DROP IF EXISTS + CREATE OR REPLACE.
+-- ============================================
+
+BEGIN;
+
+-- 1. Cleanup des doublons existants (best-effort, garde le plus ancien)
+WITH ranked AS (
+  SELECT
+    id,
+    provider_ref,
+    ROW_NUMBER() OVER (
+      PARTITION BY provider_ref
+      ORDER BY created_at ASC, id ASC
+    ) AS rn
+  FROM public.payments
+  WHERE provider_ref IS NOT NULL
+)
+DELETE FROM public.payments
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- 2. UNIQUE partial index — autorise plusieurs paiements sans provider_ref
+--    (cash, virements manuels), interdit les doublons par provider_ref.
+DROP INDEX IF EXISTS idx_payments_provider_ref_unique;
+CREATE UNIQUE INDEX idx_payments_provider_ref_unique
+  ON public.payments (provider_ref)
+  WHERE provider_ref IS NOT NULL;
+
+COMMENT ON INDEX public.idx_payments_provider_ref_unique IS
+  'Anti race-condition sur les webhooks Stripe : un même payment_intent_id '
+  '(ou setup_intent_id) ne peut produire qu''un seul enregistrement payments.';
+
+COMMIT;


### PR DESCRIPTION
## Audit Stripe webhooks & SEPA — 4 bugs corrigés

### P0 — Refunds loyers ignorés
`charge.refunded` ne traitait que `work_order_payments`. Pour un loyer remboursé manuellement sur Stripe, la facture restait `statut='paid'` et la compta divergeait. Le handler résout désormais aussi les paiements de loyer via `charge.payment_intent` et appelle `syncInvoiceStatusFromPayments()`.

### P1 — Race condition `upsertPaymentAttempt`
SELECT puis INSERT sans verrou → 2 webhooks simultanés créaient 2 rows. Migration ajoute UNIQUE partial sur `payments.provider_ref` (avec dédup historique). Code bascule en `upsert(..., { onConflict: 'provider_ref' })` pour l'atomicité.

### P1 — Date SEPA fausse pour mois courts
`new Date(2026, 1, 29)` → 1er mars (overflow silencieux). `safeDateInMonth()` clipe au dernier jour réel du mois.

### P2 — Mandat SEPA créable sur bail non signé
Refuse désormais si `leases.statut NOT IN ('fully_signed','active')`. Évite d'engager le locataire dans des prélèvements avant accord ferme.

## Non corrigé dans cette PR

- **P1 idempotence webhook** : la solution propre est d'ajouter idempotency à chaque side-effect (fait pour `payments` ici). Court-circuiter sur tout `event_id` casserait les retries Stripe pour les vraies failures transitoires.
- **P2 token signature HMAC sans nonce** : crypto out of scope, à scoper séparément.

## Test plan

- [ ] Migration `20260504100000` applique sans erreur (DEDUP doit être no-op si pas de doublon)
- [ ] Refund manuel sur Stripe → facture passe à `refunded`, paiement passe à `refunded`
- [ ] 2 webhooks simultanés → 1 seul row dans payments
- [ ] Setup SEPA jour=29 en janvier → date prélèvement = 28 février (pas 1er mars)
- [ ] Setup SEPA sur bail draft → 409 explicite

https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL7AcrE2biXaG4VLEuKyRu)_