### PR TITLE
P0/P1: chiffrement tokens OAuth Enedis/GRDF + idempotence cron

### DIFF
--- a/app/api/cron/meters-sync/route.ts
+++ b/app/api/cron/meters-sync/route.ts
@@ -10,8 +10,22 @@ import {
   fetchGRDFConsumption,
   refreshGRDFToken,
 } from '@/lib/services/meters';
+import { encrypt, decrypt, isEncrypted } from '@/lib/security/encryption.service';
 
 const CRON_SECRET = process.env.CRON_SECRET || '';
+
+// Délai minimum entre 2 sync d'un même compteur. Empêche un double-run
+// (Netlify timeout/retry) de re-synchroniser les mêmes lectures.
+const MIN_SYNC_INTERVAL_HOURS = 6;
+
+/**
+ * Renvoie le token en clair, qu'il soit déjà chiffré ou stocké en
+ * clair (legacy avant le fix de chiffrement OAuth).
+ */
+function readToken(stored: string | null | undefined): string | null {
+  if (!stored) return null;
+  return isEncrypted(stored) ? decrypt(stored) : stored;
+}
 
 /**
  * POST /api/cron/meters-sync
@@ -30,7 +44,9 @@ export async function POST(request: NextRequest) {
     const metersService = new PropertyMetersService(serviceClient);
     const meters = await metersService.getActiveConnectedMeters();
 
-    const results = { synced: 0, errors: 0, skipped: 0 };
+    const results = { synced: 0, errors: 0, skipped: 0, throttled: 0 };
+    const minIntervalMs = MIN_SYNC_INTERVAL_HOURS * 60 * 60 * 1000;
+    const now = Date.now();
 
     for (const meter of meters) {
       try {
@@ -39,32 +55,51 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        let accessToken = meter.oauth_token_encrypted;
+        // Idempotence : skip si on a sync ce compteur il y a moins de 6h.
+        // Évite qu'un double-run du cron (Netlify timeout/retry) ne
+        // re-synchronise les mêmes lectures.
+        const lastSync = (meter as any).last_sync_at;
+        if (lastSync && now - new Date(lastSync).getTime() < minIntervalMs) {
+          results.throttled++;
+          continue;
+        }
+
+        let accessToken = readToken(meter.oauth_token_encrypted);
+        const refreshTokenPlain = readToken(meter.oauth_refresh_token_encrypted);
+
+        if (!accessToken || !refreshTokenPlain) {
+          results.skipped++;
+          continue;
+        }
 
         // Check if token needs refresh
         if (meter.oauth_expires_at && new Date(meter.oauth_expires_at) < new Date()) {
           try {
             if (meter.provider === 'enedis') {
-              const refreshed = await refreshEnedisToken(meter.oauth_refresh_token_encrypted);
+              const refreshed = await refreshEnedisToken(refreshTokenPlain);
               accessToken = refreshed.access_token;
               const expiresAt = new Date(Date.now() + refreshed.expires_in * 1000).toISOString();
               await serviceClient
                 .from('property_meters')
                 .update({
-                  oauth_token_encrypted: refreshed.access_token,
-                  oauth_refresh_token_encrypted: refreshed.refresh_token,
+                  oauth_token_encrypted: encrypt(refreshed.access_token),
+                  oauth_refresh_token_encrypted: refreshed.refresh_token
+                    ? encrypt(refreshed.refresh_token)
+                    : null,
                   oauth_expires_at: expiresAt,
                 })
                 .eq('id', meter.id);
             } else if (meter.provider === 'grdf') {
-              const refreshed = await refreshGRDFToken(meter.oauth_refresh_token_encrypted);
+              const refreshed = await refreshGRDFToken(refreshTokenPlain);
               accessToken = refreshed.access_token;
               const expiresAt = new Date(Date.now() + refreshed.expires_in * 1000).toISOString();
               await serviceClient
                 .from('property_meters')
                 .update({
-                  oauth_token_encrypted: refreshed.access_token,
-                  oauth_refresh_token_encrypted: refreshed.refresh_token,
+                  oauth_token_encrypted: encrypt(refreshed.access_token),
+                  oauth_refresh_token_encrypted: refreshed.refresh_token
+                    ? encrypt(refreshed.refresh_token)
+                    : null,
                   oauth_expires_at: expiresAt,
                 })
                 .eq('id', meter.id);
@@ -74,6 +109,11 @@ export async function POST(request: NextRequest) {
             results.errors++;
             continue;
           }
+        }
+
+        if (!accessToken) {
+          results.skipped++;
+          continue;
         }
 
         // Fetch recent readings

--- a/app/api/oauth/enedis/callback/route.ts
+++ b/app/api/oauth/enedis/callback/route.ts
@@ -4,6 +4,7 @@ export const runtime = 'nodejs';
 import { getServiceClient } from '@/lib/supabase/service-client';
 import { NextRequest, NextResponse } from 'next/server';
 import { PropertyMetersService, exchangeEnedisCode, fetchEnedisDaily } from '@/lib/services/meters';
+import { encrypt } from '@/lib/security/encryption.service';
 
 /**
  * GET /api/oauth/enedis/callback?code=xxx&state=meterId:userId
@@ -48,11 +49,16 @@ export async function GET(request: NextRequest) {
       .eq('user_id', userId)
       .maybeSingle();
 
-    // Store encrypted tokens and mark as connected
+    // Chiffrement AES-256-GCM avant stockage. Les colonnes sont
+    // *_encrypted ; jusqu'ici elles contenaient le token brut (TODO oublié).
+    // Si un attaquant accédait à la DB, les tokens OAuth Enedis lui
+    // donnaient accès aux relevés du compteur du locataire.
     const expiresAt = new Date(Date.now() + tokenResponse.expires_in * 1000).toISOString();
     await metersService.markConnected(meterId, {
-      oauth_token_encrypted: tokenResponse.access_token, // TODO: encrypt with vault
-      oauth_refresh_token_encrypted: tokenResponse.refresh_token,
+      oauth_token_encrypted: encrypt(tokenResponse.access_token),
+      oauth_refresh_token_encrypted: tokenResponse.refresh_token
+        ? encrypt(tokenResponse.refresh_token)
+        : null,
       oauth_expires_at: expiresAt,
       connection_consent_by: profile?.id || userId,
     });

--- a/app/api/oauth/grdf/callback/route.ts
+++ b/app/api/oauth/grdf/callback/route.ts
@@ -4,6 +4,7 @@ export const runtime = 'nodejs';
 import { getServiceClient } from '@/lib/supabase/service-client';
 import { NextRequest, NextResponse } from 'next/server';
 import { PropertyMetersService, exchangeGRDFCode, fetchGRDFConsumption } from '@/lib/services/meters';
+import { encrypt } from '@/lib/security/encryption.service';
 
 /**
  * GET /api/oauth/grdf/callback?code=xxx&state=meterId:userId
@@ -46,10 +47,14 @@ export async function GET(request: NextRequest) {
       .eq('user_id', userId)
       .maybeSingle();
 
+    // Chiffrement AES-256-GCM avant stockage. Cf. fix Enedis (les
+    // colonnes *_encrypted contenaient le token brut).
     const expiresAt = new Date(Date.now() + tokenResponse.expires_in * 1000).toISOString();
     await metersService.markConnected(meterId, {
-      oauth_token_encrypted: tokenResponse.access_token,
-      oauth_refresh_token_encrypted: tokenResponse.refresh_token,
+      oauth_token_encrypted: encrypt(tokenResponse.access_token),
+      oauth_refresh_token_encrypted: tokenResponse.refresh_token
+        ? encrypt(tokenResponse.refresh_token)
+        : null,
       oauth_expires_at: expiresAt,
       connection_consent_by: profile?.id || userId,
     });


### PR DESCRIPTION
## Audit OAuth meters — 3 bugs sécurité

### P0 — Tokens OAuth en clair dans `property_meters`
Les colonnes `oauth_token_encrypted` et `oauth_refresh_token_encrypted` contenaient le **token brut** (TODO oublié dans le callback). Un dump DB exposait les tokens Enedis/GRDF de tous les locataires connectés → lecture non autorisée des compteurs.

`lib/security/encryption.service.ts` (AES-256-GCM) existait déjà — branché dans :
- `app/api/oauth/enedis/callback/route.ts`
- `app/api/oauth/grdf/callback/route.ts`

### P1 — Refresh tokens re-stockés en clair
Le cron `/api/cron/meters-sync` refreshait les tokens et stockait le résultat **en clair**. Même chiffrement appliqué côté UPDATE.

### P1 — Cron sans idempotence (double-run)
Un timeout Netlify + retry pouvait re-synchroniser les mêmes lectures et fausser les courbes. Ajoute un throttle : skip si `last_sync_at < 6h`. Nouveau compteur `throttled` dans la réponse JSON.

## Stratégie de migration

Backward compat sans migration SQL : `readToken()` utilise `isEncrypted()` pour détecter le format. Les tokens legacy en clair seront remplacés au prochain refresh OAuth (cycle ~24h). Aucun downtime.

## Test plan

- [ ] Variable `ENCRYPTION_KEY` présente en prod (sinon `encrypt()` throw)
- [ ] Connecter un nouveau compteur Enedis → row property_meters montre token chiffré (préfixe `enc:` ou format hex >= 64 chars)
- [ ] Forcer un refresh token → la nouvelle valeur est chiffrée
- [ ] Lancer le cron 2x consécutivement → 2ème run a `throttled > 0`
- [ ] Compteurs legacy (token en clair) continuent de fonctionner jusqu'au refresh

## Non corrigé

- **P2 photos OCR upload doublon** : nécessite ajout colonne `external_id` sur meter_readings, scope plus large.

https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL7AcrE2biXaG4VLEuKyRu)_