### PR TITLE
P0/P1: conformité FEC DGFIP + RLS régularisation + clôture exercice

### DIFF
--- a/app/api/accounting/exercises/[exerciseId]/close/route.ts
+++ b/app/api/accounting/exercises/[exerciseId]/close/route.ts
@@ -110,14 +110,22 @@ export async function POST(
       });
 
       if (balanceSheetAccounts.length > 0) {
+        // Bug fixé : un compte peut avoir des mouvements en débit ET en
+        // crédit dans l'exercice (ex: 512100 banque). On doit reporter
+        // le SOLDE NET (D - C), pas les deux côtés. Sinon le bilan
+        // d'a-nouveau est artificiellement gonflé et déséquilibré.
         const lines = balanceSheetAccounts
-          .filter((b) => b.soldeDebitCents > 0 || b.soldeCreditCents > 0)
-          .map((b) => ({
-            accountNumber: b.accountNumber,
-            label: `A-nouveau ${b.label}`,
-            debitCents: b.soldeDebitCents,
-            creditCents: b.soldeCreditCents,
-          }));
+          .map((b) => {
+            const soldeNet = b.soldeDebitCents - b.soldeCreditCents;
+            if (soldeNet === 0) return null;
+            return {
+              accountNumber: b.accountNumber,
+              label: `A-nouveau ${b.label}`,
+              debitCents: soldeNet > 0 ? soldeNet : 0,
+              creditCents: soldeNet < 0 ? -soldeNet : 0,
+            };
+          })
+          .filter((l): l is NonNullable<typeof l> => l !== null);
 
         if (lines.length >= 2) {
           // Ensure balance: add balancing line if needed

--- a/app/api/accounting/regularization/route.ts
+++ b/app/api/accounting/regularization/route.ts
@@ -53,6 +53,24 @@ export async function GET(request: Request) {
       throw new ApiError(400, "entityId est requis");
     }
 
+    // Validation cross-entity : vérifier que l'utilisateur possède bien
+    // l'entité demandée. Sans ce check, un owner pouvait passer n'importe
+    // quel entityId UUID dans la query string et lire les régularisations
+    // d'une autre SCI (cf. pattern dans accounting/entries/route.ts).
+    const isAdmin =
+      profile.role === "admin" || profile.role === "platform_admin";
+    if (!isAdmin) {
+      const { data: entity } = await supabase
+        .from("legal_entities")
+        .select("id")
+        .eq("id", entityId)
+        .eq("owner_profile_id", profile.id)
+        .maybeSingle();
+      if (!entity) {
+        throw new ApiError(403, "Accès refusé à cette entité");
+      }
+    }
+
     let query = supabase
       .from("charge_regularizations")
       .select("*")
@@ -135,6 +153,22 @@ export async function POST(request: Request) {
 
     if (!entityId || !propertyId || !exerciseYear) {
       throw new ApiError(400, "entityId, propertyId et exerciseYear sont requis");
+    }
+
+    // Validation cross-entity (cf. GET) — un owner ne doit pas pouvoir
+    // créer une régularisation sur une SCI qu'il ne possède pas.
+    const isAdmin =
+      profile.role === "admin" || profile.role === "platform_admin";
+    if (!isAdmin) {
+      const { data: entity } = await supabase
+        .from("legal_entities")
+        .select("id")
+        .eq("id", entityId)
+        .eq("owner_profile_id", profile.id)
+        .maybeSingle();
+      if (!entity) {
+        throw new ApiError(403, "Accès refusé à cette entité");
+      }
     }
 
     if (

--- a/lib/accounting/engine.ts
+++ b/lib/accounting/engine.ts
@@ -368,6 +368,21 @@ export async function reverseEntry(
     throw new Error('Can only reverse validated entries');
   }
 
+  // Refuse de contre-passer dans un exercice fermé : la contre-passation
+  // créerait une nouvelle entry validée dans un exercice qui doit rester
+  // figé pour la conformité (pas de modification post-clôture).
+  const { data: exercise } = await supabase
+    .from('accounting_exercises')
+    .select('status')
+    .eq('id', original.exercise_id)
+    .maybeSingle();
+  if ((exercise as { status?: string } | null)?.status === 'closed') {
+    throw new Error(
+      "Impossible de contre-passer : l'exercice de l'écriture est clôturé. " +
+        "Créez l'opération de correction dans l'exercice ouvert courant.",
+    );
+  }
+
   const lines: EntryLine[] = original.accounting_entry_lines.map(
     (line: { account_number: string; label: string | null; debit_cents: number; credit_cents: number; piece_ref: string | null }) => ({
       accountNumber: line.account_number,

--- a/lib/accounting/fec.ts
+++ b/lib/accounting/fec.ts
@@ -210,6 +210,16 @@ export async function generateFEC(
       continue;
     }
 
+    // FEC requirement (DGFIP) : ValidDate ne peut pas être vide. Une
+    // entry validée doit avoir validated_at non-NULL ; sinon la requête
+    // a un bug en amont et le FEC sera rejeté à l'import.
+    if (!entry.validated_at) {
+      errors.push(
+        `Ecriture ${entry.entry_number} marquée validée sans validated_at — FEC rejeté`,
+      );
+      continue;
+    }
+
     // Validate balance
     const totalD = lines.reduce((s, l) => s + l.debit_cents, 0);
     const totalC = lines.reduce((s, l) => s + l.credit_cents, 0);
@@ -221,6 +231,17 @@ export async function generateFEC(
     }
 
     for (const line of lines) {
+      // FEC requirement (DGFIP) : CompteLib doit être le libellé officiel
+      // du compte au plan comptable. Si le compte a été supprimé entre
+      // la création de l'écriture et l'export, le label retombait
+      // silencieusement sur le numéro brut → FEC accepté mais incohérent.
+      // On le détecte explicitement pour que le user puisse réparer.
+      if (!accountLabels.has(line.account_number)) {
+        errors.push(
+          `Ecriture ${entry.entry_number} : compte ${line.account_number} introuvable dans chart_of_accounts`,
+        );
+        continue;
+      }
       fecLines.push({
         JournalCode: entry.journal_code,
         JournalLib: journalLabels.get(entry.journal_code) ?? entry.journal_code,

--- a/lib/accounting/reconciliation.ts
+++ b/lib/accounting/reconciliation.ts
@@ -287,7 +287,10 @@ export async function reconcileTransactions(
     .eq('entity_id', entityId)
     .eq('exercise_id', exerciseId)
     .eq('is_validated', true)
-    .in('journal_code', ['BQ', 'OD']);
+    // Inclure 'AN' pour les agences avec compte mandant qui passent par
+    // un journal a-nouveau dédié au lieu de BQ ; sinon les transactions
+    // banque mandant restent éternellement orphelines.
+    .in('journal_code', ['BQ', 'OD', 'AN']);
 
   if (entryError) throw new Error(`Failed to fetch entries: ${entryError.message}`);
 


### PR DESCRIPTION
## Audit comptabilité — 6 bugs corrigés (2 P0, 4 P1)

### P0 — Conformité FEC (rejet DGFIP imminent)
- **ValidDate manquant** : `lib/accounting/fec.ts` n'incluait pas de check `validated_at IS NOT NULL`. Une entry marquée `is_validated=true` mais sans timestamp produisait un FEC rejetable à l'import.
- **Compte manquant en chart_of_accounts** : si un compte est supprimé après création d'une écriture, l'export FEC retombait silencieusement sur `account_number` brut comme libellé. Désormais erreur explicite.

### P0 — RLS bypass régularisation cross-entité
`/api/accounting/regularization` (GET + POST) ne vérifiait pas que `legal_entities.owner_profile_id = profile.id`. Un owner pouvait passer un `entityId` UUID arbitraire et lire/créer des régul sur la SCI d'un autre owner. Ajoute la même validation que `/api/accounting/entries`.

### P1 — Clôture exercice : a-nouveaux déséquilibrés
Les a-nouveaux reportaient `(soldeDebit, soldeCredit)` séparément, ce qui gonflait le bilan pour tout compte ayant des mouvements dans les deux sens (ex. 512100 banque). Désormais on reporte le **solde net** (D - C).

### P1 — Réconciliation ignore journal AN
Les agences avec compte mandant utilisent le journal `AN` (a-nouveau). La réconciliation ne scannait que `BQ` et `OD`. Toutes leurs transactions banque mandant restaient orphelines.

### P1 — reverseEntry sans check exercice fermé
`reverseEntry()` ne vérifiait pas si l'exercice de l'entry à contre-passer était `closed`. Une contre-passation pouvait créer une nouvelle entry validée dans un exercice qui doit rester figé pour conformité.

## Non corrigé dans cette PR

- **P1 #11 réconciliation TOCTOU** : nécessite ajout colonne `matched_at` + UPDATE atomique sur `accounting_entries`. Scope plus large.
- **P2 #21 OCR TVA écart > 2ct** : changement de comportement (warning → erreur bloquante) qui mérite décision produit.

## Faux positif écarté

- **Bug #15 "feature gate 'charges' inexistant"** : vérification a montré que `'charges'` est bien défini dans `ACCOUNTING_FEATURE_MAP` (mappé à `bank_reconciliation`). Pas de fix.

## Test plan

- [ ] Export FEC d'un exercice avec entry sans `validated_at` → erreur explicite (pas FEC corrompu)
- [ ] Export FEC avec compte supprimé → erreur explicite
- [ ] Owner A appelle `GET /api/accounting/regularization?entityId=<SCI_de_owner_B>` → 403
- [ ] Clôture exercice avec compte 512100 ayant mouvements D et C → solde net reporté
- [ ] Réconciliation entité avec compte mandant `AN` → transactions matchent
- [ ] `reverseEntry` sur entry d'exercice clôturé → erreur explicite

https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL7AcrE2biXaG4VLEuKyRu)_