### PR TITLE
fix(seo): partages sociaux cassés — pointer og:image vers /opengraph-image

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -190,7 +190,7 @@ export const metadata: Metadata = {
       "Gérez vos locations comme un pro. Baux ALUR, e-signatures, scoring IA, Open Banking. Rejoignez +10 000 propriétaires. 1er mois offert.",
     images: [
       {
-        url: "/og-image.png",
+        url: "/opengraph-image",
         width: 1200,
         height: 630,
         alt: "Talok - Logiciel de gestion locative",
@@ -205,7 +205,7 @@ export const metadata: Metadata = {
     title: "Talok | Logiciel de Gestion Locative n°1",
     description:
       "Baux ALUR, e-signatures, scoring IA, Open Banking. +10 000 propriétaires en France. 1er mois offert.",
-    images: ["/og-image.png"],
+    images: ["/opengraph-image"],
   },
   appleWebApp: {
     capable: true,

--- a/components/seo/JsonLd.tsx
+++ b/components/seo/JsonLd.tsx
@@ -355,7 +355,7 @@ export function ArticleSchema({
     "@type": "Article",
     headline,
     description,
-    image: image || "https://talok.fr/og-image.png",
+    image: image || "https://talok.fr/opengraph-image",
     datePublished,
     dateModified: dateModified || datePublished,
     author: {

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -62,7 +62,7 @@ export function generatePageMetadata({
   title,
   description,
   keywords = [],
-  image = "/og-image.png",
+  image = "/opengraph-image",
   noIndex = false,
   canonical,
 }: PageMetadataOptions): Metadata {


### PR DESCRIPTION
Fix critique post-déploiement : audit live de talok.fr a montré que tous les partages sociaux étaient cassés.

## 🐛 Problème détecté en prod

```
$ curl https://talok.fr/og-image.png    → 404
$ curl https://talok.fr/opengraph-image → 200, image/png, 1200×630 ✅
$ curl https://talok.fr/ | grep og:image → vide ou pointe sur /og-image.png (404)
```

`app/opengraph-image.tsx` (introduit dans #572) est correctement servi par Next.js à `/opengraph-image` — pas à `/og-image.png`. Mais 4 emplacements continuaient de référencer l'ancienne URL hardcodée.

## ✅ Fix

| Fichier | Changement |
|---|---|
| `app/layout.tsx:193` | `openGraph.images.url` : `/og-image.png` → `/opengraph-image` |
| `app/layout.tsx:208` | `twitter.images` : `/og-image.png` → `/opengraph-image` |
| `components/seo/JsonLd.tsx:358` | Fallback Article schema → `/opengraph-image` |
| `lib/seo/metadata.ts:65` | Default `image` du helper `generatePageMetadata` → `/opengraph-image` |

Le 4ᵉ point fait basculer **toutes les pages** consommant `PAGE_METADATA.*` (fonctionnalités, solutions, outils, légal) sur la nouvelle URL d'un coup.

## 📊 Diff

- 3 fichiers, +4 / -4 lignes
- Aucune nouvelle dépendance
- Aucune migration

## ✅ Test plan

- [ ] `curl -sI https://talok.fr/opengraph-image` → 200, `Content-Type: image/png`
- [ ] `curl -s https://talok.fr/ | grep og:image` → contient `https://talok.fr/opengraph-image`
- [ ] Tester partage WhatsApp / Slack / LinkedIn de https://talok.fr → image gradient bleu visible
- [ ] Facebook Sharing Debugger sur https://talok.fr → og:image valide
- [ ] LinkedIn Post Inspector sur https://talok.fr → image visible

https://claude.ai/code/session_01R3cG8qa6dbqaki8LAxTYd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3cG8qa6dbqaki8LAxTYd1)_