### PR TITLE
HOTFIX: markConnected accepte refresh_token null (build Vercel cassé)

### DIFF
--- a/lib/services/meters/meters.service.ts
+++ b/lib/services/meters/meters.service.ts
@@ -133,7 +133,7 @@ export class PropertyMetersService {
     meterId: string,
     tokenData: {
       oauth_token_encrypted: string;
-      oauth_refresh_token_encrypted: string;
+      oauth_refresh_token_encrypted: string | null;
       oauth_expires_at: string;
       connection_consent_by: string;
     }


### PR DESCRIPTION
## Hotfix — build Vercel cassé après PR #579

PR #579 (chiffrement OAuth) a introduit une régression de type :

```
app/api/oauth/enedis/callback/route.ts(59,7):
  Type 'string | null' is not assignable to type 'string'.
```

Les callbacks Enedis/GRDF passent désormais `null` quand `tokenResponse.refresh_token` est absent (le chiffrement conditionnel ajouté pour la sécurité préserve le `null`), mais le type de `markConnected()` exigeait toujours `string`.

## Fix

Élargit `oauth_refresh_token_encrypted` en `string | null` dans la signature de `markConnected()`. La colonne DB l'autorise déjà (voir `disconnect()` qui la met explicitement à `null`).

Diff : 1 ligne.

## À merger immédiatement pour rétablir la prod.

https://claude.ai/code/session_018Jwpyhu6efXToEm7SSswhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL7AcrE2biXaG4VLEuKyRu)_