### PR TITLE
Enhance EntityCard with keyboard navigation and edit action

### DIFF
--- a/components/entities/EntityCard.tsx
+++ b/components/entities/EntityCard.tsx
@@ -4,8 +4,10 @@
  * EntityCard — Carte résumé d'une entité juridique
  */
 
+import type { KeyboardEvent, MouseEvent } from "react";
 import Link from "next/link";
-import { Building2, Check, AlertCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Building2, Check, AlertCircle, Pencil } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -25,19 +27,44 @@ interface EntityCardProps {
 }
 
 export function EntityCard({ entity, isActive, compact, selectable, selected, onToggle }: EntityCardProps) {
+  const router = useRouter();
   const Icon = getEntityIcon(entity.entityType);
   const typeLabel = ENTITY_TYPE_LABELS[entity.entityType] || entity.entityType;
   const hasWarnings = !entity.hasIban || !entity.siret;
 
+  const handleCardClick = () => {
+    if (selectable && onToggle) {
+      onToggle(entity.id);
+      return;
+    }
+    if (!compact) {
+      router.push(`/owner/entities/${entity.id}`);
+    }
+  };
+
+  const isCardClickable = selectable || !compact;
+
   return (
     <Card
+      role={isCardClickable ? "button" : undefined}
+      tabIndex={isCardClickable ? 0 : undefined}
+      onKeyDown={
+        isCardClickable
+          ? (e: KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleCardClick();
+              }
+            }
+          : undefined
+      }
       className={cn(
         "relative transition-all hover:shadow-md",
+        isCardClickable && "cursor-pointer",
         isActive && "ring-2 ring-primary",
-        selectable && "cursor-pointer",
         selected && "ring-2 ring-destructive bg-destructive/5"
       )}
-      onClick={selectable && onToggle ? () => onToggle(entity.id) : undefined}
+      onClick={isCardClickable ? handleCardClick : undefined}
     >
       <CardContent className={cn("p-5", compact && "p-4")}>
         {selectable && (
@@ -134,9 +161,18 @@ export function EntityCard({ entity, isActive, compact, selectable, selected, on
             </div>
 
             {/* Actions */}
-            <div className="flex gap-2">
+            <div
+              className="flex gap-2"
+              onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
+            >
               <Button variant="outline" size="sm" className="flex-1" asChild>
                 <Link href={`/owner/entities/${entity.id}`}>Gérer</Link>
+              </Button>
+              <Button variant="default" size="sm" className="flex-1" asChild>
+                <Link href={`/owner/entities/${entity.id}/edit`}>
+                  <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                  Modifier
+                </Link>
               </Button>
             </div>
           </>


### PR DESCRIPTION
## Summary
Enhanced the EntityCard component to improve accessibility and user interaction by adding keyboard navigation support and a new edit action button.

## Key Changes
- **Keyboard Navigation**: Added keyboard event handling to make cards keyboard-accessible when clickable (Enter and Space keys trigger the card action)
- **Accessibility Improvements**: 
  - Added `role="button"` and `tabIndex` attributes to make clickable cards semantically correct
  - Cards are now properly focusable and navigable via keyboard
- **Enhanced Click Handling**: Refactored click logic into a `handleCardClick` function that:
  - Toggles selection when in selectable mode
  - Navigates to entity details when not in compact mode
- **New Edit Button**: Added a secondary "Modifier" (Edit) button with pencil icon in the actions section
- **Event Propagation**: Added `stopPropagation()` to the actions container to prevent card click when interacting with buttons
- **Improved Styling**: Updated cursor styling to apply to all clickable cards (not just selectable ones)

## Implementation Details
- Imported `KeyboardEvent` and `MouseEvent` types from React for proper type safety
- Added `useRouter` hook from `next/navigation` for client-side navigation
- Introduced `isCardClickable` computed variable to determine if card should be interactive
- Actions buttons now properly prevent event bubbling to the card's click handler

https://claude.ai/code/session_01TjgfhbqiDd4JDKd9qCKwm8