### PR TITLE
Fix critical passkey security and UX issues

### DIFF
--- a/app/api/auth/passkeys/[id]/route.ts
+++ b/app/api/auth/passkeys/[id]/route.ts
@@ -1,0 +1,70 @@
+/**
+ * API Route: Supprime une passkey
+ * DELETE /api/auth/passkeys/[id]
+ *
+ * Le parametre [id] correspond au UUID interne de passkey_credentials.id
+ * (et non au credential_id WebAuthn). C'est ce que renvoie /api/auth/2fa/status
+ * et ce que la UI passe au bouton supprimer.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "Identifiant de passkey manquant" },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Non authentifié" },
+        { status: 401 }
+      );
+    }
+
+    // RLS garantit que l'utilisateur ne peut supprimer que ses propres passkeys
+    const { error: deleteError, count } = await supabase
+      .from("passkey_credentials")
+      .delete({ count: "exact" })
+      .eq("id", id)
+      .eq("user_id", user.id);
+
+    if (deleteError) {
+      console.error("[Passkeys] Erreur suppression:", deleteError);
+      return NextResponse.json(
+        { error: "Erreur lors de la suppression" },
+        { status: 500 }
+      );
+    }
+
+    if (!count) {
+      return NextResponse.json(
+        { error: "Passkey introuvable" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    console.error("[Passkeys] Erreur suppression:", error);
+    return NextResponse.json(
+      { error: "Erreur lors de la suppression" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/passkeys/authenticate/options/route.ts
+++ b/app/api/auth/passkeys/authenticate/options/route.ts
@@ -14,41 +14,42 @@ const RP_ID = rawAppUrl ? new URL(normalizedAppUrl).hostname : "localhost";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { email } = body;
+    const body = await request.json().catch(() => ({}));
+    const email: string | undefined = typeof body?.email === "string"
+      ? body.email.trim().toLowerCase()
+      : undefined;
 
     const serviceClient = getServiceClient();
 
-    let allowCredentials: { id: string; type: "public-key" }[] = [];
+    let allowCredentials: {
+      id: string;
+      type: "public-key";
+      transports?: string[];
+    }[] = [];
 
-    // Si email fourni, récupérer les passkeys de l'utilisateur
+    // Si email fourni, restreindre les credentials autorises a ceux de l'utilisateur.
+    // Lookup direct par email via la table profiles (pas de listUsers paginee).
     if (email) {
-      const { data: userData } = await serviceClient
+      const { data: profile } = await serviceClient
         .from("profiles")
         .select("user_id")
-        .eq("user_id", (serviceClient.auth.admin
-          ? undefined
-          : undefined) as any)
-        .single();
+        .eq("email", email)
+        .maybeSingle();
 
-      // Rechercher l'utilisateur par email via auth.users
-      const { data: authUser } = await serviceClient.auth.admin.listUsers();
-      const user = authUser?.users?.find(
-        (u) => u.email?.toLowerCase() === email.toLowerCase()
-      );
-
-      if (user) {
+      if (profile?.user_id) {
         const { data: credentials } = await serviceClient
           .from("passkey_credentials")
           .select("credential_id, transports")
-          .eq("user_id", user.id);
+          .eq("user_id", profile.user_id);
 
-        allowCredentials = (credentials || []).map((cred: any) => ({
+        allowCredentials = (credentials || []).map((cred) => ({
           id: cred.credential_id as string,
           type: "public-key" as const,
-          transports: cred.transports,
-        })) as { id: string; type: "public-key" }[];
+          transports: (cred.transports as string[] | null) || undefined,
+        }));
       }
+      // Si pas trouve : on ne revele rien et on genere quand meme des options
+      // (le navigateur affichera les passkeys disponibles via discoverable cred).
     }
 
     const options = await generateAuthenticationOptions({
@@ -58,19 +59,29 @@ export async function POST(request: NextRequest) {
       timeout: 60000,
     });
 
-    // Stocker le challenge (sans user_id si pas connecté)
+    // Stocker le challenge (sans user_id, identifie par UUID retourne au client)
     const challengeId = crypto.randomUUID();
-    await serviceClient.from("passkey_challenges").insert({
-      id: challengeId,
-      user_id: null, // Sera vérifié après
-      challenge: options.challenge,
-      type: "authentication",
-      expires_at: new Date(Date.now() + 60000).toISOString(),
-    });
+    const { error: challengeError } = await serviceClient
+      .from("passkey_challenges")
+      .insert({
+        id: challengeId,
+        user_id: null,
+        challenge: options.challenge,
+        type: "authentication",
+        expires_at: new Date(Date.now() + 60000).toISOString(),
+      });
+
+    if (challengeError) {
+      console.error("[Passkeys] Erreur stockage challenge auth:", challengeError);
+      return NextResponse.json(
+        { error: "Erreur lors de la préparation de la connexion" },
+        { status: 500 }
+      );
+    }
 
     return NextResponse.json({
       ...options,
-      challengeId, // Renvoyer l'ID pour la vérification
+      challengeId,
     });
   } catch (error: unknown) {
     console.error("[Passkeys] Erreur génération options auth:", error);

--- a/app/api/auth/passkeys/authenticate/verify/route.ts
+++ b/app/api/auth/passkeys/authenticate/verify/route.ts
@@ -63,6 +63,8 @@ export async function POST(request: NextRequest) {
     const publicKey = Buffer.from(storedCredential.public_key as string, "base64");
 
     // Vérifier la réponse d'authentification
+    // requireUserVerification: false — on accepte les cles sans biometrie
+    // (la UV est tentee si l'authenticateur la supporte cote client).
     const verification = await verifyAuthenticationResponse({
       response: credential,
       expectedChallenge: challengeData.challenge as string,
@@ -74,7 +76,7 @@ export async function POST(request: NextRequest) {
         counter: storedCredential.counter as number,
         transports: storedCredential.transports as any,
       },
-      requireUserVerification: true,
+      requireUserVerification: false,
     });
 
     if (!verification.verified) {
@@ -111,14 +113,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Générer un magic link pour créer la session
+    // Generer un magic link et recuperer le hashed_token. Le client utilisera
+    // ensuite supabase.auth.verifyOtp({ token_hash, type: 'magiclink' }) pour
+    // etablir la session (generateLink ne renvoie PAS access_token directement).
     const { data: magicLinkData, error: magicLinkError } =
       await serviceClient.auth.admin.generateLink({
         type: "magiclink",
         email: authUser.user.email!,
       });
 
-    if (magicLinkError) {
+    const tokenHash = (magicLinkData?.properties as any)?.hashed_token as
+      | string
+      | undefined;
+
+    if (magicLinkError || !tokenHash) {
+      console.error("[Passkeys] Erreur generation magic link:", magicLinkError);
       return NextResponse.json(
         { error: "Erreur création session" },
         { status: 500 }
@@ -127,9 +136,10 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      // Renvoyer les tokens pour établir la session côté client
-      access_token: (magicLinkData.properties as any)?.access_token,
-      refresh_token: (magicLinkData.properties as any)?.refresh_token,
+      // Le client appelle verifyOtp({ token_hash, type: 'magiclink' })
+      // pour echanger ce hash contre une session (cookies).
+      token_hash: tokenHash,
+      email: authUser.user.email,
       user: {
         id: authUser.user.id,
         email: authUser.user.email,

--- a/app/api/auth/passkeys/register/options/route.ts
+++ b/app/api/auth/passkeys/register/options/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generateRegistrationOptions } from "@simplewebauthn/server";
 import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase/service-client";
 
 const RP_NAME = "Talok";
 // Normaliser l'URL avec protocole pour éviter "Invalid URL" avec new URL()
@@ -13,7 +14,7 @@ const rawAppUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
 const normalizedAppUrl = rawAppUrl.startsWith("http") ? rawAppUrl : `https://${rawAppUrl}`;
 const RP_ID = rawAppUrl ? new URL(normalizedAppUrl).hostname : "localhost";
 
-export async function POST(request: NextRequest) {
+export async function POST(_request: NextRequest) {
   try {
     const supabase = await createClient();
     const {
@@ -35,15 +36,16 @@ export async function POST(request: NextRequest) {
       .eq("user_id", user.id)
       .single();
 
-    // Récupérer les passkeys existantes de l'utilisateur
+    // Récupérer les passkeys existantes de l'utilisateur (pour exclusion)
     const { data: existingCredentials } = await supabase
       .from("passkey_credentials")
-      .select("credential_id")
+      .select("credential_id, transports")
       .eq("user_id", user.id);
 
     const excludeCredentials = (existingCredentials || []).map((cred) => ({
-      id: cred.credential_id,
+      id: cred.credential_id as string,
       type: "public-key" as const,
+      transports: (cred.transports as string[] | null) || undefined,
     }));
 
     const options = await generateRegistrationOptions({
@@ -59,18 +61,36 @@ export async function POST(request: NextRequest) {
       authenticatorSelection: {
         residentKey: "preferred",
         userVerification: "preferred",
-        authenticatorAttachment: "platform", // Préférer Face ID / Touch ID
+        // Pas de authenticatorAttachment : on autorise platform (Touch ID,
+        // Face ID, Windows Hello) ET cross-platform (YubiKey, clés FIDO2)
       },
       timeout: 60000,
     });
 
-    // Stocker le challenge temporairement
-    await supabase.from("passkey_challenges").upsert({
-      user_id: user.id,
-      challenge: options.challenge,
-      type: "registration",
-      expires_at: new Date(Date.now() + 60000).toISOString(),
-    });
+    // Stocker le challenge via le service client (RLS reservee au service_role).
+    // onConflict: "user_id,type" garantit qu'un seul challenge actif existe
+    // par (user, type) — l'index unique partiel est cree par la migration
+    // 20260504120000_passkeys_hardening.sql.
+    const serviceClient = getServiceClient();
+    const { error: challengeError } = await serviceClient
+      .from("passkey_challenges")
+      .upsert(
+        {
+          user_id: user.id,
+          challenge: options.challenge,
+          type: "registration",
+          expires_at: new Date(Date.now() + 60000).toISOString(),
+        },
+        { onConflict: "user_id,type" }
+      );
+
+    if (challengeError) {
+      console.error("[Passkeys] Erreur stockage challenge:", challengeError);
+      return NextResponse.json(
+        { error: "Erreur lors de la préparation de l'enregistrement" },
+        { status: 500 }
+      );
+    }
 
     return NextResponse.json(options);
   } catch (error: unknown) {

--- a/app/api/auth/passkeys/register/verify/route.ts
+++ b/app/api/auth/passkeys/register/verify/route.ts
@@ -58,15 +58,25 @@ export async function POST(request: NextRequest) {
     }
 
     // Vérifier la réponse d'enregistrement
+    // requireUserVerification: false car on demande "preferred" cote client.
+    // Si l'authenticateur fait quand meme la UV (Touch ID/Face ID), elle sera
+    // verifiee par WebAuthn ; sinon on accepte (cle de securite sans biometrie).
     const verification = await verifyRegistrationResponse({
       response: credential,
       expectedChallenge: challengeData.challenge as string,
       expectedOrigin: ORIGIN,
       expectedRPID: RP_ID,
-      requireUserVerification: true,
+      requireUserVerification: false,
     });
 
     if (!verification.verified || !verification.registrationInfo) {
+      // Toujours nettoyer le challenge meme en cas d'echec
+      await serviceClient
+        .from("passkey_challenges")
+        .delete()
+        .eq("user_id", user.id)
+        .eq("type", "registration");
+
       return NextResponse.json(
         { error: "Vérification échouée" },
         { status: 400 }
@@ -79,6 +89,24 @@ export async function POST(request: NextRequest) {
     const credentialIdBase64 = Buffer.from(registrationInfo.credential.id).toString("base64url");
     const publicKeyBase64 = Buffer.from(registrationInfo.credential.publicKey).toString("base64");
 
+    // Calculer un friendly_name unique pour cet utilisateur
+    // (l'index unique (user_id, friendly_name) interdit les doublons)
+    const baseName = (friendlyName as string)?.trim() || "Ma passkey";
+    const { data: existingNames } = await serviceClient
+      .from("passkey_credentials")
+      .select("friendly_name")
+      .eq("user_id", user.id);
+
+    const usedNames = new Set(
+      (existingNames || []).map((c) => c.friendly_name as string)
+    );
+    let finalName = baseName;
+    let suffix = 2;
+    while (usedNames.has(finalName)) {
+      finalName = `${baseName} (${suffix})`;
+      suffix += 1;
+    }
+
     // Enregistrer la passkey dans la base de données
     const { error: insertError } = await serviceClient
       .from("passkey_credentials")
@@ -90,7 +118,7 @@ export async function POST(request: NextRequest) {
         device_type: registrationInfo.credentialDeviceType,
         backed_up: registrationInfo.credentialBackedUp,
         transports: credential.response.transports || [],
-        friendly_name: friendlyName || "Ma passkey",
+        friendly_name: finalName,
       });
 
     if (insertError) {

--- a/features/auth/components/sign-in-form.tsx
+++ b/features/auth/components/sign-in-form.tsx
@@ -10,11 +10,13 @@ import { PasswordInput } from "@/components/ui/password-input";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/components/ui/use-toast";
 import { Separator } from "@/components/ui/separator";
-import { authService } from "../services/auth.service";
+import { authService, signInWithPasskey } from "../services/auth.service";
 import type { SignInData } from "../services/auth.service";
 import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
 import { TalokLogo } from "@/components/marketing/TalokLogo";
 import { getRoleDashboardUrl } from "@/lib/helpers/role-redirects";
+import { isWebAuthnSupported } from "@/lib/auth/passkeys";
+import { Fingerprint } from "lucide-react";
 
 // Icône SVG pour Google OAuth
 const GoogleIcon = () => (
@@ -63,11 +65,17 @@ export function SignInForm() {
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [appleLoading, setAppleLoading] = useState(false);
+  const [passkeyLoading, setPasskeyLoading] = useState(false);
+  const [passkeySupported, setPasskeySupported] = useState(false);
   const [formData, setFormData] = useState<SignInData>({
     email: "",
     password: "",
   });
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPasskeySupported(isWebAuthnSupported());
+  }, []);
 
   const redirectTo = getSafeRedirectUrl(searchParams.get("redirect"));
 
@@ -103,6 +111,40 @@ export function SignInForm() {
         variant: "destructive",
       });
       setGoogleLoading(false);
+    }
+  };
+
+  const handlePasskeySignIn = async () => {
+    setPasskeyLoading(true);
+    try {
+      const result = await signInWithPasskey(formData.email || undefined);
+
+      if (!result.success) {
+        toast({
+          title: "Connexion par passkey impossible",
+          description: result.error || "Aucune passkey n'a pu être validée.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      // Session etablie via verifyOtp dans signInWithPasskey
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const profile = await authService.getProfile();
+      const profileData = profile as any;
+      const targetRoute = redirectTo || getRoleDashboardUrl(profileData?.role);
+      router.push(targetRoute);
+      router.refresh();
+    } catch (error: unknown) {
+      console.error("[SignIn] Erreur passkey:", error);
+      const errorMessage = error instanceof Error ? error.message : "Erreur de connexion par passkey";
+      toast({
+        title: "Erreur de connexion",
+        description: errorMessage,
+        variant: "destructive",
+      });
+    } finally {
+      setPasskeyLoading(false);
     }
   };
 
@@ -246,6 +288,23 @@ export function SignInForm() {
             )}
             <span className="ml-2">Continuer avec Apple</span>
           </Button>
+
+          {passkeySupported && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handlePasskeySignIn}
+              disabled={loading || googleLoading || appleLoading || passkeyLoading}
+              className="w-full"
+            >
+              {passkeyLoading ? (
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+              ) : (
+                <Fingerprint className="h-5 w-5" />
+              )}
+              <span className="ml-2">Se connecter avec une passkey</span>
+            </Button>
+          )}
         </div>
 
         <div className="relative">

--- a/features/auth/services/auth.service.ts
+++ b/features/auth/services/auth.service.ts
@@ -418,6 +418,21 @@ export async function signInWithPasskey(email?: string): Promise<{
       return { success: false, error: verifyData.error };
     }
 
+    // 4. Echanger le token_hash contre une session Supabase (cookies)
+    if (!verifyData.token_hash) {
+      return { success: false, error: "Réponse de session invalide" };
+    }
+
+    const supabase = createClient();
+    const { error: otpError } = await supabase.auth.verifyOtp({
+      type: "magiclink",
+      token_hash: verifyData.token_hash,
+    });
+
+    if (otpError) {
+      return { success: false, error: otpError.message };
+    }
+
     return {
       success: true,
       user: verifyData.user,

--- a/supabase/migrations/20260504120000_passkeys_hardening.sql
+++ b/supabase/migrations/20260504120000_passkeys_hardening.sql
@@ -1,0 +1,89 @@
+-- Migration: Passkeys hardening (correction des bugs critiques)
+-- Date: 2026-05-04
+-- Description:
+--   - Restreint les RLS de passkey_challenges au service_role (corrige une fuite)
+--   - Ajoute une contrainte unique (user_id, type) sur les challenges pour
+--     que l'upsert lors de l'enregistrement remplace l'ancien challenge
+--     plutot que de creer des doublons (cause de "Challenge expire ou invalide")
+--   - Ajoute un index unique (user_id, friendly_name) tronque pour eviter les noms
+--     de passkey en doublon
+--   - Planifie le cleanup automatique des challenges expires via pg_cron
+
+-- =============================================================================
+-- 1) Nettoyer les challenges expires accumules avant d'ajouter la contrainte
+-- =============================================================================
+DELETE FROM passkey_challenges WHERE expires_at < NOW();
+
+-- Si plusieurs challenges actifs existent encore pour un meme (user_id, type),
+-- ne garder que le plus recent (defensif, table normalement vide post-reset)
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY user_id, type
+           ORDER BY created_at DESC
+         ) AS rn
+  FROM passkey_challenges
+  WHERE user_id IS NOT NULL
+)
+DELETE FROM passkey_challenges
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- =============================================================================
+-- 2) Contrainte unique partielle (user_id, type) sur les challenges actifs
+-- Permet d'utiliser .upsert({ onConflict: 'user_id,type' }) sans doublons
+-- =============================================================================
+CREATE UNIQUE INDEX IF NOT EXISTS idx_passkey_challenges_user_type_unique
+  ON passkey_challenges(user_id, type)
+  WHERE user_id IS NOT NULL;
+
+-- =============================================================================
+-- 3) RLS strict sur passkey_challenges : seulement service_role
+-- L'ancienne policy "FOR ALL USING (true)" sans clause TO permettait a
+-- n'importe quel utilisateur authentifie de lire/modifier les challenges
+-- des autres. On restreint au service_role exclusivement.
+-- =============================================================================
+DROP POLICY IF EXISTS "Service role full access to challenges" ON passkey_challenges;
+
+CREATE POLICY "service_role can manage challenges"
+  ON passkey_challenges
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Pas de policy pour authenticated/anon : ils n'ont aucun acces direct.
+-- Toutes les operations sur passkey_challenges doivent passer par les
+-- routes API utilisant getServiceClient().
+
+-- =============================================================================
+-- 4) Index unique (user_id, friendly_name) pour eviter les "Ma passkey" en doublon
+-- =============================================================================
+CREATE UNIQUE INDEX IF NOT EXISTS idx_passkey_credentials_user_friendly_unique
+  ON passkey_credentials(user_id, friendly_name);
+
+-- =============================================================================
+-- 5) Cleanup automatique des challenges expires (pg_cron, toutes les 10 min)
+-- =============================================================================
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Supprime un eventuel ancien job de meme nom avant de le recreer
+DO $$
+BEGIN
+  PERFORM cron.unschedule('cleanup-passkey-challenges');
+EXCEPTION
+  WHEN OTHERS THEN NULL;
+END $$;
+
+SELECT cron.schedule(
+  'cleanup-passkey-challenges',
+  '*/10 * * * *',
+  $$SELECT cleanup_expired_passkey_challenges();$$
+);
+
+-- =============================================================================
+-- 6) Commentaires
+-- =============================================================================
+COMMENT ON INDEX idx_passkey_challenges_user_type_unique IS
+  'Garantit un seul challenge actif par (user_id, type). Utilise par upsert onConflict.';
+COMMENT ON INDEX idx_passkey_credentials_user_friendly_unique IS
+  'Evite les noms de passkey en doublon pour un meme utilisateur.';


### PR DESCRIPTION
## Summary
This PR addresses critical security vulnerabilities and UX bugs in the passkey authentication system, including RLS policy bypass, challenge duplication, and missing session establishment.

## Key Changes

### Security Fixes
- **RLS Policy Hardening**: Restrict `passkey_challenges` table access to `service_role` only, preventing authenticated users from reading/modifying other users' challenges
- **Challenge Deduplication**: Add unique partial index on `(user_id, type)` for active challenges to prevent duplicate challenges via upsert
- **Friendly Name Uniqueness**: Add unique index on `(user_id, friendly_name)` to prevent duplicate passkey names per user

### Database Migration
- Add migration `20260504120000_passkeys_hardening.sql` that:
  - Cleans up expired challenges before adding constraints
  - Creates unique partial indexes for challenge and credential deduplication
  - Replaces overly permissive RLS policy with service_role-only access
  - Schedules automatic cleanup of expired challenges via pg_cron (every 10 minutes)

### API Improvements
- **Authentication Options** (`authenticate/options`): 
  - Sanitize email input (trim, lowercase)
  - Use direct email lookup via profiles table instead of paginated `listUsers()`
  - Include transports in allowCredentials for better device compatibility
  - Add error handling for challenge storage
  
- **Registration Options** (`register/options`):
  - Use service client for challenge storage (respects RLS)
  - Remove `authenticatorAttachment: "platform"` to allow both platform and cross-platform authenticators
  - Use upsert with `onConflict: "user_id,type"` to prevent duplicates
  
- **Registration Verification** (`register/verify`):
  - Set `requireUserVerification: false` to support security keys without biometrics
  - Add friendly name deduplication logic with suffix numbering
  - Clean up challenge on verification failure
  
- **Authentication Verification** (`authenticate/verify`):
  - Set `requireUserVerification: false` for broader device support
  - Return `token_hash` instead of direct tokens for proper magic link flow
  - Include email in response for session establishment
  
- **New Endpoint**: Add `DELETE /api/auth/passkeys/[id]` to allow users to remove passkeys

### Frontend Updates
- **Sign-In Form**: 
  - Add passkey sign-in button with WebAuthn support detection
  - Implement `handlePasskeySignIn` with proper error handling and redirect flow
  - Add loading state and conditional rendering based on browser support
  
- **Auth Service**:
  - Update `signInWithPasskey()` to properly exchange `token_hash` for session via `verifyOtp()`
  - Establish authenticated session before returning success

## Notable Implementation Details
- All passkey challenge operations now use `getServiceClient()` to bypass RLS and ensure only backend can manage challenges
- Magic link flow properly uses `verifyOtp({ type: 'magiclink', token_hash })` to establish session cookies
- Friendly name collision handling uses suffix numbering (e.g., "Ma passkey (2)") for user-friendly deduplication
- Email lookup optimized to avoid expensive paginated admin API calls

https://claude.ai/code/session_01Ubpo6d4N8CnTfsSDJsnCqc