### PR TITLE
Clean up duplicate passkey_challenges RLS policy

### DIFF
--- a/supabase/migrations/20260504120000_passkeys_hardening.sql
+++ b/supabase/migrations/20260504120000_passkeys_hardening.sql
@@ -43,6 +43,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_passkey_challenges_user_type_unique
 -- des autres. On restreint au service_role exclusivement.
 -- =============================================================================
 DROP POLICY IF EXISTS "Service role full access to challenges" ON passkey_challenges;
+DROP POLICY IF EXISTS "service_role can manage challenges" ON passkey_challenges;
 
 CREATE POLICY "service_role can manage challenges"
   ON passkey_challenges


### PR DESCRIPTION
## Summary
This change removes a duplicate RLS (Row Level Security) policy definition on the `passkey_challenges` table to prevent policy conflicts and ensure clean policy management.

## Key Changes
- Dropped the old "Service role full access to challenges" policy before creating the new "service_role can manage challenges" policy
- Added explicit cleanup of any existing "service_role can manage challenges" policy to ensure idempotent migrations

## Implementation Details
The migration now safely handles policy recreation by:
1. Dropping the legacy policy with the old naming convention
2. Dropping any existing instance of the new policy name (for idempotency)
3. Creating the new "service_role can manage challenges" policy

This prevents "policy already exists" errors when running migrations multiple times and ensures a single, well-defined policy governs service role access to passkey challenges.

https://claude.ai/code/session_0125DQ9Sj16tSGjkZuq9LsT9