### PR TITLE
Fix admin/platform_admin redirect to skip signup flow

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -117,6 +117,14 @@ export async function GET(request: Request) {
 
       const profileData = profile as ProfilePartial | null;
 
+      // Roles privilegies (admin, platform_admin) : pas de flux d'inscription
+      // public — on les envoie direct sur leur dashboard. Sans ce shortcut
+      // isValidRole() rejette "admin" (pas dans PUBLIC_ROLES) et le user
+      // termine sur /signup/role meme s'il a un compte complet.
+      if (profileData?.role === "admin" || profileData?.role === "platform_admin") {
+        return NextResponse.redirect(new URL(getRoleDashboardUrl(profileData.role), origin));
+      }
+
       const metadataRole = data.user.user_metadata?.role as string | undefined;
       const role = isValidRole(profileData?.role)
         ? (profileData!.role as PublicRole)
@@ -211,6 +219,17 @@ export async function GET(request: Request) {
         .maybeSingle();
 
       const profileData = profile as ProfilePartial | null;
+
+      // Roles privilegies (admin, platform_admin) : pas de flux d'inscription
+      // public — on les envoie direct sur leur dashboard. Sans ce shortcut
+      // isValidRole() rejette "admin" (pas dans PUBLIC_ROLES) et le user
+      // termine sur /signup/role meme s'il a un compte complet.
+      if (profileData?.role === "admin" || profileData?.role === "platform_admin") {
+        const dashUrl = isSafeRelativePath(redirectParam)
+          ? redirectParam
+          : getRoleDashboardUrl(profileData.role);
+        return NextResponse.redirect(new URL(dashUrl, origin));
+      }
 
       // Rôle : priorité au profil DB, fallback sur user_metadata.role (posé au
       // signUp). Si rien, on envoie choisir un rôle.


### PR DESCRIPTION
## Summary
Added early redirect logic for privileged roles (admin, platform_admin) to bypass the public signup flow and send users directly to their role-specific dashboard.

## Key Changes
- Added role-based redirect checks in two callback handlers that skip the standard signup flow for admin and platform_admin roles
- First handler: Redirects directly to role dashboard without any additional validation
- Second handler: Respects safe redirect parameters when available, otherwise uses role dashboard URL
- Prevents users with privileged roles from being incorrectly routed to `/signup/role` despite having complete accounts

## Implementation Details
- The checks are placed early in the callback flow, before `isValidRole()` validation which would reject these privileged roles (not in PUBLIC_ROLES)
- Uses `getRoleDashboardUrl()` to determine the appropriate dashboard destination
- Second implementation includes `isSafeRelativePath()` check to safely honor redirect parameters when provided
- Includes French comments explaining the rationale for this special handling

https://claude.ai/code/session_0125DQ9Sj16tSGjkZuq9LsT9