### PR TITLE
Add missing bio column to provider_profiles table

### DIFF
--- a/supabase/migrations/20260504190000_provider_profiles_bio.sql
+++ b/supabase/migrations/20260504190000_provider_profiles_bio.sql
@@ -1,0 +1,13 @@
+-- Migration: provider_profiles — ajout colonne bio
+-- Bug fix: la sauvegarde du profil prestataire échouait avec
+-- "Could not find the 'bio' column of 'provider_profiles' in the schema cache"
+-- car la colonne était utilisée par /api/me/provider-profile (PUT) et la page
+-- /provider/settings, mais n'avait jamais été créée en base.
+
+ALTER TABLE provider_profiles
+  ADD COLUMN IF NOT EXISTS bio TEXT;
+
+COMMENT ON COLUMN provider_profiles.bio IS
+  'Description / présentation du prestataire affichée aux propriétaires (max 2000 caractères, contrôlé côté API).';
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
This migration adds the missing `bio` column to the `provider_profiles` table, fixing a schema mismatch that was causing provider profile updates to fail.

## Changes
- Added `bio` TEXT column to `provider_profiles` table
- Added column documentation indicating it stores provider descriptions (max 2000 characters, validated at API level)
- Reloaded PostgREST schema cache to reflect the new column

## Details
The `bio` column was being referenced by the provider profile API endpoint (`PUT /api/me/provider-profile`) and the provider settings page (`/provider/settings`), but the column was never created in the database schema. This caused profile save operations to fail with a "Could not find the 'bio' column" error. This migration resolves the schema inconsistency.

https://claude.ai/code/session_01BbqPvjgDJsKNrFzNLXKqBC