### PR TITLE
fix(auth): 2FA setup 500, passkey introuvable, Google re-consent

### DIFF
--- a/app/api/auth/passkeys/register/verify/route.ts
+++ b/app/api/auth/passkeys/register/verify/route.ts
@@ -85,8 +85,11 @@ export async function POST(request: NextRequest) {
 
     const { registrationInfo } = verification;
 
-    // Encoder le credential ID et la clé publique en base64
-    const credentialIdBase64 = Buffer.from(registrationInfo.credential.id).toString("base64url");
+    // @simplewebauthn/server v13 : registrationInfo.credential.id est deja une
+    // Base64URLString (string), on la stocke telle quelle. Re-encoder via
+    // Buffer.from(str).toString('base64url') donnerait la base64-de-l'ASCII et
+    // casserait le lookup au login. La publicKey reste un Uint8Array.
+    const credentialIdBase64 = registrationInfo.credential.id;
     const publicKeyBase64 = Buffer.from(registrationInfo.credential.publicKey).toString("base64");
 
     // Calculer un friendly_name unique pour cet utilisateur

--- a/features/auth/services/auth.service.ts
+++ b/features/auth/services/auth.service.ts
@@ -286,14 +286,17 @@ export class AuthService {
    */
   async signInWithGoogle() {
     const redirectUrl = getAuthCallbackUrl();
-    
+
+    // Pas de access_type=offline ni prompt=consent : l'app ne consomme aucun
+    // refresh_token Google cote serveur, les forcer reaffichait l'ecran de
+    // consentement a chaque connexion. select_account laisse choisir le compte
+    // Google sans re-confirmer les permissions.
     const { data, error } = await this.supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
         redirectTo: redirectUrl,
         queryParams: {
-          access_type: "offline",
-          prompt: "consent",
+          prompt: "select_account",
         },
       },
     });


### PR DESCRIPTION
## Summary

Trois bugs d'auth corrigés dans la même branche.

### 1. `POST /api/auth/2fa/setup` → 500
- `hash_2fa_recovery_codes()` et `verify_2fa_recovery_code()` (migration `20260504130000`) étaient déclarées avec `SET search_path = public`. Or `pgcrypto` est installé dans le schéma `extensions` chez Supabase, donc `crypt()` et `gen_salt()` étaient introuvables → erreur `function gen_salt(unknown, integer) does not exist` qui remontait en toast « Erreur lors de la génération des codes de récupération ».
- Fix : nouvelle migration `20260504190000_fix_2fa_recovery_pgcrypto_schema.sql` qui qualifie les appels (`extensions.crypt`, `extensions.gen_salt`) et étend `search_path` à `public, extensions`. Migration déjà appliquée en prod (project IMMO) et vérifiée.

### 2. Passkey « non trouvée » alors qu'elle existe
- `@simplewebauthn/server@13` retourne `registrationInfo.credential.id` en `Base64URLString` (string), plus en `Uint8Array`. `Buffer.from(stringValue).toString("base64url")` ré-encodait l'ASCII de la chaîne au lieu de la garder, donc la DB stockait un id différent de celui que le navigateur envoyait au login → `eq("credential_id", …)` ne matchait jamais.
- Fix : on stocke `registrationInfo.credential.id` tel quel.
- Repair : la ligne existante en prod (id `f60a46cd-…`) a été décodée en place pour que la passkey déjà enregistrée fonctionne sans re-création.

### 3. Google OAuth redemande le consentement à chaque login
- `signInWithGoogle` forçait `access_type=offline` + `prompt=consent`. L'app ne consomme aucun refresh_token Google côté serveur (Maps utilise une API key séparée), ces flags ne servaient qu'à réafficher la consent screen à chaque connexion.
- Fix : remplacé par `prompt=select_account` — permet de changer de compte sans re-valider les permissions.

## Test plan

- [ ] `/admin/security` → bouton « Configurer 2FA » : la modale s'ouvre avec QR code et codes de récupération (pas de toast d'erreur).
- [ ] Une fois la 2FA activée, vérifier qu'un code TOTP fonctionne et qu'un recovery code à usage unique fonctionne aussi.
- [ ] Login avec passkey existante (compte Thomas Admin) → connexion directe sans erreur « Passkey non trouvée ».
- [ ] Création d'une nouvelle passkey puis login avec → OK.
- [ ] « Continuer avec Google » : à la 2ᵉ connexion, plus d'écran de consentement (juste le sélecteur de compte si plusieurs comptes Google).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxHxRKPSoCG2fztv53sehh)_