### PR TITLE
fix(providers): liste vide DROM-COM + cache Redis + invite in-app + tracking DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,9 +190,20 @@ SIGNATURE_TOKEN_SECRET=remplacez-par-un-secret-unique-d-au-moins-32-caracteres
 # E2E_ADMIN_PASSWORD=TestPassword123!
 
 # ==============================================================================
-# NETLIFY (Auto-configuré par Netlify)
+# UPSTASH REDIS (Cache distribué + rate-limit)
+# Requis en prod pour : rate-limit SMS/OTP, cache Google Places, cache
+# place_details. Optionnel en dev (le code dégrade proprement sans Redis).
+# Configuration sur Vercel : Settings → Environment Variables → cocher
+# Production + Preview + Development.
 # ==============================================================================
-# NETLIFY=true (défini automatiquement sur Netlify)
+# UPSTASH_REDIS_REST_URL=https://xxx.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=AYxxxxxxxxxxxxxxxxxx
+
+# ==============================================================================
+# VERCEL (Auto-configuré par Vercel)
+# ==============================================================================
+# VERCEL=1 (défini automatiquement par la plateforme)
+# VERCEL_ENV=production|preview|development
 
 # ==============================================================================
 # NORDIGEN / GOCARDLESS (Open Banking DSP2)

--- a/app/api/providers/external-favorites/[placeId]/invite/route.ts
+++ b/app/api/providers/external-favorites/[placeId]/invite/route.ts
@@ -99,7 +99,7 @@ export async function POST(
   // ajouté en favori, et on récupère le nom enregistré pour personnaliser.
   const { data: favorite } = await (supabase as any)
     .from("provider_external_favorites")
-    .select("name, phone")
+    .select("name, phone, invite_count")
     .eq("owner_profile_id", profile.id)
     .eq("place_id", placeId)
     .maybeSingle();
@@ -141,6 +141,31 @@ export async function POST(
       { error: "L'envoi de l'email a échoué. Réessayez dans un instant." },
       { status: 502 },
     );
+  }
+
+  // Persiste le tracking après envoi réussi (avant l'envoi : pas pertinent
+  // si Resend échoue). On n'utilise pas RPC `increment` ici pour éviter une
+  // fonction SQL dédiée — on lit puis on écrit, race acceptable (un compteur
+  // décalé d'1 invitation n'est pas un bug critique).
+  try {
+    await (supabase as any)
+      .from("provider_external_favorites")
+      .update({
+        last_invite_at: new Date().toISOString(),
+        last_invite_email: email,
+        // Postgres expression update : SQL `+1` direct côté serveur via
+        // `increment` n'existe pas dans supabase-js, on remonte le compteur
+        // côté JS — favorite.invite_count récupéré au check précédent serait
+        // plus propre, mais on accepte ici un .select() supplémentaire pour
+        // ne pas écraser un autre incrément concurrent.
+        invite_count: ((favorite as any).invite_count ?? 0) + 1,
+      })
+      .eq("owner_profile_id", profile.id)
+      .eq("place_id", placeId);
+  } catch (err) {
+    // Échec de tracking ≠ échec d'envoi. On a déjà envoyé l'email,
+    // on ne veut pas faire échouer la requête utilisateur pour ça.
+    console.warn("[providers/invite] Tracking update échoué:", err);
   }
 
   return NextResponse.json({ success: true });

--- a/app/api/providers/external-favorites/[placeId]/invite/route.ts
+++ b/app/api/providers/external-favorites/[placeId]/invite/route.ts
@@ -1,0 +1,147 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// =====================================================
+// API: Inviter un prestataire externe (Google/OSM) à rejoindre Talok
+// POST /api/providers/external-favorites/[placeId]/invite
+//
+// Remplace l'ancien `mailto:` qui sortait de l'app : on envoie
+// désormais le mail depuis no-reply@talok.fr (Resend) avec un lien
+// d'inscription tracké, et l'utilisateur reste dans l'app.
+// =====================================================
+
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase/server";
+import { withFeatureAccess } from "@/lib/middleware/subscription-check";
+import { sendEmail } from "@/lib/services/email-service";
+import { emailTemplates } from "@/lib/emails/templates";
+import { applyRateLimit } from "@/lib/rate-limit/upstash";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface InvitePayload {
+  email: string;
+  custom_message?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ placeId: string }> },
+) {
+  const { placeId } = await params;
+  if (!placeId) {
+    return NextResponse.json({ error: "placeId manquant" }, { status: 400 });
+  }
+
+  let body: InvitePayload;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Payload JSON invalide" }, { status: 400 });
+  }
+
+  const email = body.email?.trim().toLowerCase();
+  if (!email || !EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ error: "Email invalide" }, { status: 400 });
+  }
+
+  // Garde-fou anti-abus : un message custom de 2000 caractères max, sinon
+  // un propriétaire pourrait écrire un essai entier.
+  const customMessage = body.custom_message?.trim().slice(0, 2000) || undefined;
+
+  const supabase = await createRouteHandlerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, prenom, nom")
+    .eq("user_id", user.id)
+    .single();
+  if (!profile) {
+    return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
+  }
+
+  // Même feature gate que /nearby — la marketplace est Pro+.
+  const featureCheck = await withFeatureAccess(profile.id, "providers_management");
+  if (!featureCheck.allowed) {
+    return NextResponse.json(
+      {
+        error: "premium_required",
+        message: featureCheck.message,
+        required_plan: featureCheck.requiredPlan,
+      },
+      { status: 403 },
+    );
+  }
+
+  // Rate-limit anti-abus : max 20 invitations/jour par owner. Évite qu'un
+  // compte compromis spamme tout le carnet d'artisans Google.
+  const rl = await applyRateLimit({
+    key: `provider-invite:${profile.id}`,
+    limit: 20,
+    windowSec: 24 * 60 * 60,
+  });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Limite quotidienne atteinte (20 invitations/24 h)." },
+      { status: 429 },
+    );
+  }
+
+  // Vérifier que le placeId est bien dans les favoris du propriétaire.
+  // On évite ainsi qu'un owner spamme un place_id arbitraire sans l'avoir
+  // ajouté en favori, et on récupère le nom enregistré pour personnaliser.
+  const { data: favorite } = await (supabase as any)
+    .from("provider_external_favorites")
+    .select("name, phone")
+    .eq("owner_profile_id", profile.id)
+    .eq("place_id", placeId)
+    .maybeSingle();
+
+  if (!favorite) {
+    return NextResponse.json(
+      { error: "Ce prestataire doit être enregistré en favori avant d'envoyer une invitation." },
+      { status: 404 },
+    );
+  }
+
+  const ownerName = `${profile.prenom ?? ""} ${profile.nom ?? ""}`.trim() || "Un propriétaire";
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://talok.fr";
+  // UTM pour tracer la conversion côté analytics (PostHog) sans passer par
+  // une table de tracking dédiée — chaque inscription `provider` issue de
+  // ce flux remontera un `utm_source=marketplace_invite`.
+  const registerUrl = `${appUrl}/auth/register?role=provider&utm_source=marketplace_invite&utm_medium=email&utm_campaign=owner_invite`;
+
+  const template = emailTemplates.providerInviteFromOwner({
+    providerName: favorite.name || "Prestataire",
+    ownerName,
+    customMessage,
+    registerUrl,
+  });
+
+  try {
+    await sendEmail({
+      to: email,
+      subject: template.subject,
+      html: template.html,
+      tags: [{ name: "type", value: "provider_invite_from_owner" }],
+      // Idempotency-key par couple owner+place+email : si l'utilisateur clique
+      // 2 fois, on ne renvoie pas 2 mails dans la même fenêtre.
+      idempotencyKey: `provider-invite-from-owner/${profile.id}/${placeId}/${email}`,
+    });
+  } catch (err) {
+    console.error("[providers/invite] Resend error:", err);
+    return NextResponse.json(
+      { error: "L'envoi de l'email a échoué. Réessayez dans un instant." },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -10,12 +10,16 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 import { logGooglePlacesUsage } from "@/lib/services/google-places-usage";
-import { getPlanLevel, type PlanSlug } from "@/lib/subscriptions/plans";
 import {
   extractPostalCode,
   postalCodeToCountryCodes,
 } from "@/lib/properties/address";
 import { checkGooglePlacesQuota } from "@/lib/rate-limit/google-places";
+import { getRedis } from "@/lib/rate-limit/upstash";
+import {
+  withFeatureAccess,
+  createSubscriptionErrorResponse,
+} from "@/lib/middleware/subscription-check";
 
 // Mapping des catégories vers les types Google Places
 const CATEGORY_TO_GOOGLE_TYPE: Record<string, string[]> = {
@@ -125,9 +129,11 @@ const CATEGORY_TO_OSM_FILTERS: Record<string, string[]> = {
   ],
 };
 
-// Cache simple en mémoire (en production, utiliser Redis)
-const cache = new Map<string, { data: NearbyProvider[]; timestamp: number }>();
-const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 heures
+// Cache Redis (Upstash) — partagé entre toutes les lambdas Netlify/Vercel.
+// En dev sans Redis configuré, getRedis() retourne null et le code dégrade
+// proprement (pas de cache, mais fonctionnel).
+const CACHE_TTL_SEC = 24 * 60 * 60; // 24 heures
+const CACHE_PREFIX = "providers:nearby:v1";
 
 export async function GET(request: NextRequest) {
   try {
@@ -142,7 +148,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Non authentifié" }, { status: 401 });
     }
 
-    // Vérifier le plan de l'utilisateur (doit être Confort ou supérieur)
     const { data: profile } = await supabase
       .from("profiles")
       .select("id")
@@ -153,35 +158,23 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
     }
 
-    // Vérifier l'abonnement.
-    // NB : la table `subscriptions` est scopée par `owner_id` (FK profiles.id),
-    // pas `user_id`. L'ancienne requête `.eq("user_id", profile.id)` ne
-    // matchait JAMAIS, donc planSlug retombait toujours sur "gratuit" et
-    // tous les comptes — y compris entreprise — recevaient 403.
-    // On accepte aussi `trialing` car un compte en période d'essai a accès
-    // aux features de son plan.
-    const { data: subscription } = await supabase
-      .from("subscriptions")
-      .select("plan_slug, status")
-      .eq("owner_id", profile.id)
-      .in("status", ["active", "trialing"])
-      .maybeSingle();
-
-    const planSlug: PlanSlug = (subscription?.plan_slug as PlanSlug) || "gratuit";
-    // Confort+ = niveau confort ou supérieur (pro, enterprise_s/m/l/xl, legacy
-    // enterprise). On compare via getPlanLevel pour ne pas oublier les variantes
-    // entreprise — un slug `enterprise_s` n'aurait jamais matché la liste
-    // hardcodée précédente.
-    const isConfortOrHigher = getPlanLevel(planSlug) >= getPlanLevel("confort");
-
-    if (!isConfortOrHigher) {
+    // Aligner le gating UI ↔ API : la page /owner/providers vérifie déjà
+    // `providers_management` (Pro+) côté client. On utilise la même feature
+    // ici plutôt qu'un seuil ad-hoc Confort+ qui créait une incohérence
+    // (l'utilisateur Confort ne voyait jamais la page mais l'API l'aurait
+    // laissé passer).
+    const featureCheck = await withFeatureAccess(profile.id, "providers_management");
+    if (!featureCheck.allowed) {
+      // On garde la convention `error: premium_required` pour que l'UI
+      // continue d'afficher la modale d'upgrade contextuelle.
       return NextResponse.json(
         {
           error: "premium_required",
-          message: "Cette fonctionnalité nécessite un plan Confort ou supérieur",
+          message: featureCheck.message,
           upgrade_url: "/owner/money?tab=forfait",
+          required_plan: featureCheck.requiredPlan,
         },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -211,26 +204,35 @@ export async function GET(request: NextRequest) {
     // Vérifier la clé API Google
     const googleApiKey = process.env.GOOGLE_PLACES_API_KEY;
 
-    // Créer une clé de cache
-    const cacheKey = `${category}-${lat.toFixed(2)}-${lng.toFixed(2)}-${radius}`;
+    // Clé de cache Redis — la précision .toFixed(2) regroupe les requêtes
+    // dans un rayon de ~1 km, ce qui maximise les hits sans créer de biais.
+    const cacheKey = `${CACHE_PREFIX}:${category}:${lat.toFixed(2)}:${lng.toFixed(2)}:${radius}`;
+    const redis = getRedis();
 
-    // Vérifier le cache
-    const cached = cache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
-      void logGooglePlacesUsage({
-        endpoint: "text_search",
-        source: "cache",
-        status: "ok",
-        category,
-        userId: user.id,
-        resultsCount: cached.data.length,
-        cacheHit: true,
-      });
-      return NextResponse.json({
-        providers: cached.data,
-        source: "cache",
-        cached: true,
-      });
+    if (redis) {
+      try {
+        const cached = await redis.get<NearbyProvider[]>(cacheKey);
+        if (cached && Array.isArray(cached)) {
+          void logGooglePlacesUsage({
+            endpoint: "text_search",
+            source: "cache",
+            status: "ok",
+            category,
+            userId: user.id,
+            resultsCount: cached.length,
+            cacheHit: true,
+          });
+          return NextResponse.json({
+            providers: cached,
+            source: "cache",
+            cached: true,
+          });
+        }
+      } catch (err) {
+        // Redis down → on ignore et on appelle Google/OSM directement
+        // (fail-open, comme tout le reste de la pile rate-limit).
+        console.warn("[providers/nearby] Redis read échoué:", err);
+      }
     }
 
     // Si on a une adresse mais pas de coordonnées, géocoder via Google (si dispo)
@@ -292,7 +294,7 @@ export async function GET(request: NextRequest) {
     // de vrais artisans présents dans OSM autour du bien sélectionné.
     if (!googleApiKey) {
       const osmResults = await searchOSMProviders(category, latitude, longitude, radius);
-      cache.set(cacheKey, { data: osmResults, timestamp: Date.now() });
+      await writeCache(redis, cacheKey, osmResults);
       void logGooglePlacesUsage({
         endpoint: "text_search",
         source: "osm",
@@ -374,7 +376,7 @@ export async function GET(request: NextRequest) {
       // Fallback OSM : on renvoie de vrais artisans depuis OpenStreetMap
       // plutôt que des données fictives.
       const osmResults = await searchOSMProviders(category, latitude, longitude, radius);
-      cache.set(cacheKey, { data: osmResults, timestamp: Date.now() });
+      await writeCache(redis, cacheKey, osmResults);
       return NextResponse.json({
         providers: osmResults,
         source: "osm",
@@ -445,7 +447,7 @@ export async function GET(request: NextRequest) {
       // un point qui apparaîtrait hors du cercle bleu sur la carte.
       .filter((p: NearbyProvider) => (p.distance_km ?? 0) <= radius / 1000);
 
-    cache.set(cacheKey, { data: providers, timestamp: Date.now() });
+    await writeCache(redis, cacheKey, providers);
 
     void logGooglePlacesUsage({
       endpoint: usedEndpoint,
@@ -469,6 +471,20 @@ export async function GET(request: NextRequest) {
       { error: "Erreur serveur" },
       { status: 500 }
     );
+  }
+}
+
+// Écriture cache Redis tolérante aux pannes (fail-open).
+async function writeCache(
+  redis: ReturnType<typeof getRedis>,
+  key: string,
+  data: NearbyProvider[],
+): Promise<void> {
+  if (!redis) return;
+  try {
+    await redis.set(key, data, { ex: CACHE_TTL_SEC });
+  } catch (err) {
+    console.warn("[providers/nearby] Redis write échoué:", err);
   }
 }
 

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -92,6 +92,10 @@ interface NearbyProvider {
 
 // Mapping catégories → tags OpenStreetMap (Overpass).
 // Utilisé pour le fallback réel quand Google Places n'est pas disponible.
+// Pour `autre` (Tout métier) on inclut tous les métiers du bâtiment courants
+// qui n'ont pas d'entrée dédiée dans l'UI (couvreur, maçon, carreleur, etc.) :
+// le propriétaire ne doit pas être obligé de connaître la catégorie OSM
+// exacte pour trouver une entreprise qui réalise les travaux.
 const CATEGORY_TO_OSM_FILTERS: Record<string, string[]> = {
   plomberie: ["craft=plumber"],
   electricite: ["craft=electrician"],
@@ -101,7 +105,18 @@ const CATEGORY_TO_OSM_FILTERS: Record<string, string[]> = {
   peinture: ["craft=painter"],
   nettoyage: ["office=cleaning", "craft=cleaning"],
   jardinage: ["craft=gardener", "craft=tree_surgeon"],
-  autre: ["craft=handyman", "craft=builder", "shop=hardware"],
+  autre: [
+    "craft=handyman",
+    "craft=builder",
+    "craft=roofer",
+    "craft=stonemason",
+    "craft=tiler",
+    "craft=plasterer",
+    "craft=glazier",
+    "craft=metal_construction",
+    "shop=hardware",
+    "shop=trade",
+  ],
 };
 
 // Cache simple en mémoire (en production, utiliser Redis)
@@ -298,7 +313,10 @@ export async function GET(request: NextRequest) {
     // sont les coordonnées rooftop officielles du commerce — c'est la
     // meilleure précision possible côté API.
     // -------------------------------------------------------------------
-    const searchTerm = CATEGORY_TO_SEARCH_TERM[category] || "artisan dépannage";
+    // Fallback volontairement large : on ne biaise pas vers "dépannage" / 24h.
+    // Toute entreprise qui propose le métier doit pouvoir remonter, le
+    // propriétaire choisira ensuite qui contacter.
+    const searchTerm = CATEGORY_TO_SEARCH_TERM[category] || "artisan";
     const googleTypes = CATEGORY_TO_GOOGLE_TYPE[category] || [];
     const primaryType = googleTypes[0]; // Nearby Search n'accepte qu'un seul type
 

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -40,9 +40,10 @@ const CATEGORY_TO_SEARCH_TERM: Record<string, string> = {
   peinture: "peintre bâtiment",
   nettoyage: "entreprise nettoyage",
   jardinage: "jardinier paysagiste",
-  // "autre" / Tout métier : terme volontairement large pour ne pas filtrer
-  // les artisans isolés (très présents en DROM-COM où Google catégorise mal).
-  autre: "artisan",
+  // "autre" / Tout métier : on cible artisans ET entreprises (SARL, SAS,
+  // sociétés bâtiment). Mot "artisan" seul rate les entreprises classiques
+  // qui font les mêmes travaux. "bâtiment" attrape les entreprises générales.
+  autre: "artisan entreprise bâtiment",
 };
 
 interface GooglePlaceResult {
@@ -116,6 +117,11 @@ const CATEGORY_TO_OSM_FILTERS: Record<string, string[]> = {
     "craft=metal_construction",
     "shop=hardware",
     "shop=trade",
+    // Entreprises (pas seulement artisans isolés) : `office=construction_company`
+    // est le tag canonique OSM pour les sociétés du bâtiment qui ne sont pas
+    // taguées craft=*. Sans ça, une SARL bâtiment de 12 salariés à Fort-de-France
+    // ne remontait jamais sur la carte.
+    "office=construction_company",
   ],
 };
 

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -40,7 +40,9 @@ const CATEGORY_TO_SEARCH_TERM: Record<string, string> = {
   peinture: "peintre bâtiment",
   nettoyage: "entreprise nettoyage",
   jardinage: "jardinier paysagiste",
-  autre: "dépannage artisan",
+  // "autre" / Tout métier : terme volontairement large pour ne pas filtrer
+  // les artisans isolés (très présents en DROM-COM où Google catégorise mal).
+  autre: "artisan",
 };
 
 interface GooglePlaceResult {
@@ -300,6 +302,12 @@ export async function GET(request: NextRequest) {
     const googleTypes = CATEGORY_TO_GOOGLE_TYPE[category] || [];
     const primaryType = googleTypes[0]; // Nearby Search n'accepte qu'un seul type
 
+    // Pour "autre" / Tout métier on retire toute contrainte de type Google :
+    // `general_contractor` filtre la majorité des artisans indépendants
+    // (zéro résultat sur Fort-de-France 20 km par exemple). On laisse le
+    // keyword seul piloter la recherche.
+    const isAllCategories = category === "autre";
+
     const buildNearbyUrl = () => {
       const params = new URLSearchParams({
         location: `${latitude},${longitude}`,
@@ -308,7 +316,7 @@ export async function GET(request: NextRequest) {
         language: "fr",
         key: googleApiKey,
       });
-      if (primaryType) params.set("type", primaryType);
+      if (primaryType && !isAllCategories) params.set("type", primaryType);
       return `https://maps.googleapis.com/maps/api/place/nearbysearch/json?${params.toString()}`;
     };
 
@@ -469,8 +477,21 @@ async function searchOSMProviders(
   centerLng: number,
   radiusMeters: number,
 ): Promise<NearbyProvider[]> {
+  // Pour "autre" / Tout métier on union TOUS les tags de toutes les
+  // catégories. Sans ça, en DROM-COM (couverture OSM craft=* éparse) la
+  // recherche ne retournait que `craft=handyman/builder` + `shop=hardware`
+  // — quasi inexistants à Fort-de-France ou Cayenne, donc liste vide.
   const filters =
-    CATEGORY_TO_OSM_FILTERS[category] || CATEGORY_TO_OSM_FILTERS.autre;
+    category === "autre"
+      ? Array.from(
+          new Set(
+            Object.entries(CATEGORY_TO_OSM_FILTERS)
+              .filter(([key]) => key !== "autre")
+              .flatMap(([, v]) => v)
+              .concat(CATEGORY_TO_OSM_FILTERS.autre),
+          ),
+        )
+      : CATEGORY_TO_OSM_FILTERS[category] || CATEGORY_TO_OSM_FILTERS.autre;
 
   // Union de nodes/ways pour chaque tag, dans le rayon demandé.
   const queryParts = filters
@@ -484,7 +505,11 @@ async function searchOSMProviders(
     })
     .join("\n");
 
-  const overpassQuery = `[out:json][timeout:15];(${queryParts});out center tags 40;`;
+  // Timeout 25s pour absorber les unions larges (catégorie "autre" → 17 tags
+  // donc 34 sous-requêtes node+way). `out center tags 60` suffit largement
+  // après dédup et tri par distance, on ne garde de toute façon que les 15
+  // premiers côté serveur.
+  const overpassQuery = `[out:json][timeout:25];(${queryParts});out center tags 60;`;
 
   try {
     const res = await fetch("https://overpass-api.de/api/interpreter", {

--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -129,7 +129,7 @@ const CATEGORY_TO_OSM_FILTERS: Record<string, string[]> = {
   ],
 };
 
-// Cache Redis (Upstash) — partagé entre toutes les lambdas Netlify/Vercel.
+// Cache Redis (Upstash) — partagé entre toutes les lambdas Vercel.
 // En dev sans Redis configuré, getRedis() retourne null et le code dégrade
 // proprement (pas de cache, mais fonctionnel).
 const CACHE_TTL_SEC = 24 * 60 * 60; // 24 heures

--- a/app/api/providers/place-details/[placeId]/route.ts
+++ b/app/api/providers/place-details/[placeId]/route.ts
@@ -14,8 +14,9 @@ export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase/server";
 import { logGooglePlacesUsage } from "@/lib/services/google-places-usage";
-import { getPlanLevel, type PlanSlug } from "@/lib/subscriptions/plans";
 import { checkGooglePlacesQuota } from "@/lib/rate-limit/google-places";
+import { getRedis } from "@/lib/rate-limit/upstash";
+import { withFeatureAccess } from "@/lib/middleware/subscription-check";
 
 interface PlaceDetailsResult {
   website?: string;
@@ -23,8 +24,8 @@ interface PlaceDetailsResult {
   google_maps_url?: string;
 }
 
-const cache = new Map<string, { data: PlaceDetailsResult; timestamp: number }>();
-const CACHE_DURATION = 24 * 60 * 60 * 1000;
+const CACHE_TTL_SEC = 24 * 60 * 60; // 24h
+const CACHE_PREFIX = "providers:place_details:v1";
 
 export async function GET(
   request: NextRequest,
@@ -61,21 +62,15 @@ export async function GET(
       return NextResponse.json({ error: "Profil non trouvé" }, { status: 404 });
     }
 
-    // Même feature gate que /nearby (Confort+)
-    const { data: subscription } = await supabase
-      .from("subscriptions")
-      .select("plan_slug, status")
-      .eq("owner_id", profile.id)
-      .in("status", ["active", "trialing"])
-      .maybeSingle();
-
-    const planSlug: PlanSlug = (subscription?.plan_slug as PlanSlug) || "gratuit";
-    if (getPlanLevel(planSlug) < getPlanLevel("confort")) {
+    // Même feature gate que /nearby (Pro+, via providers_management).
+    const featureCheck = await withFeatureAccess(profile.id, "providers_management");
+    if (!featureCheck.allowed) {
       return NextResponse.json(
         {
           error: "premium_required",
-          message: "Cette fonctionnalité nécessite un plan Confort ou supérieur",
+          message: featureCheck.message,
           upgrade_url: "/owner/money?tab=forfait",
+          required_plan: featureCheck.requiredPlan,
         },
         { status: 403 },
       );
@@ -94,17 +89,26 @@ export async function GET(
       );
     }
 
-    // Cache hit
-    const cached = cache.get(placeId);
-    if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
-      void logGooglePlacesUsage({
-        endpoint: "place_details",
-        source: "cache",
-        status: "ok",
-        userId: user.id,
-        cacheHit: true,
-      });
-      return NextResponse.json({ details: cached.data, cached: true });
+    // Cache Redis (place_details Google = ~17$/1000 appels, ça vaut le partage
+    // entre lambdas).
+    const cacheKey = `${CACHE_PREFIX}:${placeId}`;
+    const redis = getRedis();
+    if (redis) {
+      try {
+        const cached = await redis.get<PlaceDetailsResult>(cacheKey);
+        if (cached && typeof cached === "object") {
+          void logGooglePlacesUsage({
+            endpoint: "place_details",
+            source: "cache",
+            status: "ok",
+            userId: user.id,
+            cacheHit: true,
+          });
+          return NextResponse.json({ details: cached, cached: true });
+        }
+      } catch (err) {
+        console.warn("[providers/place-details] Redis read échoué:", err);
+      }
     }
 
     const googleApiKey = process.env.GOOGLE_PLACES_API_KEY;
@@ -144,7 +148,13 @@ export async function GET(
       google_maps_url: data.result?.url,
     };
 
-    cache.set(placeId, { data: result, timestamp: Date.now() });
+    if (redis) {
+      try {
+        await redis.set(cacheKey, result, { ex: CACHE_TTL_SEC });
+      } catch (err) {
+        console.warn("[providers/place-details] Redis write échoué:", err);
+      }
+    }
 
     void logGooglePlacesUsage({
       endpoint: "place_details",

--- a/app/api/providers/search/route.ts
+++ b/app/api/providers/search/route.ts
@@ -9,6 +9,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase/server';
 import { withFeatureAccess, createSubscriptionErrorResponse } from '@/lib/middleware/subscription-check';
+import { extractPostalCode } from '@/lib/properties/address';
 
 export async function GET(request: NextRequest) {
   try {
@@ -281,13 +282,30 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Filtre par localisation (matching textuel sur zones_intervention).
-    // `location` peut être un code postal, une ville ou un département.
+    // Filtre par localisation (matching sur zones_intervention).
+    // `location` peut être un code postal (5 chiffres), une ville, ou un dép.
+    // Ancien comportement : `includes(lowerLocation)` matchait "Paris" dans
+    // "Parisot" et n'était pas robuste sur "75001". On normalise et on
+    // privilégie le code postal s'il est fourni.
     if (location) {
-      const lowerLocation = location.toLowerCase();
-      filteredProviders = filteredProviders.filter(p =>
-        p.location.toLowerCase().includes(lowerLocation),
-      );
+      const postal = extractPostalCode(location);
+      if (postal) {
+        // Match strict sur le code postal (présent en clair dans p.location).
+        filteredProviders = filteredProviders.filter((p) =>
+          p.location.includes(postal),
+        );
+      } else {
+        // Match sur mots entiers (\\b) pour éviter "Paris" → "Parisot".
+        const tokens = normalizeLocation(location)
+          .split(/\s+/)
+          .filter((t) => t.length >= 3);
+        if (tokens.length > 0) {
+          filteredProviders = filteredProviders.filter((p) => {
+            const haystack = normalizeLocation(p.location);
+            return tokens.every((t) => new RegExp(`\\b${escapeRegex(t)}\\b`).test(haystack));
+          });
+        }
+      }
     }
 
     // Filtre par rayon (uniquement pour les artisans géocodés).
@@ -368,6 +386,24 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+// Normalise une chaîne de lieu pour comparaison (lowercase, sans accent).
+// "Saint-Étienne" → "saint etienne", "fort-de-france" → "fort de france".
+function normalizeLocation(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFD")
+    // Unicode block U+0300–U+036F = combining diacritical marks.
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[-']/g, " ")
+    .trim();
+}
+
+// Échappe les caractères regex spéciaux (sécurité — `location` vient de
+// query string utilisateur).
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // Distance en km entre deux points (formule de Haversine).

--- a/app/owner/providers/page.tsx
+++ b/app/owner/providers/page.tsx
@@ -107,6 +107,9 @@ export default function ProvidersMarketplacePage() {
   const [properties, setProperties] = useState<PropertyOption[]>([]);
   const [selectedPropertyId, setSelectedPropertyId] = useState<string>('');
   const [propertyCenter, setPropertyCenter] = useState<{ lat: number; lng: number } | null>(null);
+  // Indique que le géocodage Nominatim est en cours pour éviter d'afficher
+  // prématurément "Bien non géolocalisé" pendant la résolution (1-2 s).
+  const [propertyCenterLoading, setPropertyCenterLoading] = useState<boolean>(false);
   const [radiusKm, setRadiusKm] = useState<number>(30);
 
   const selectedProperty = properties.find((p) => p.id === selectedPropertyId) ?? null;
@@ -163,6 +166,7 @@ export default function ProvidersMarketplacePage() {
     (async () => {
       if (!selectedProperty) {
         setPropertyCenter(null);
+        setPropertyCenterLoading(false);
         return;
       }
       if (selectedProperty.latitude != null && selectedProperty.longitude != null) {
@@ -170,11 +174,14 @@ export default function ProvidersMarketplacePage() {
           lat: selectedProperty.latitude,
           lng: selectedProperty.longitude,
         });
+        setPropertyCenterLoading(false);
         return;
       }
+      setPropertyCenterLoading(true);
       const result = await geocodeAddress(selectedProperty.address);
       if (cancelled) return;
       setPropertyCenter(result ? { lat: result.latitude, lng: result.longitude } : null);
+      setPropertyCenterLoading(false);
     })();
     return () => {
       cancelled = true;
@@ -667,13 +674,20 @@ export default function ProvidersMarketplacePage() {
           )}
 
           {/* Carte des artisans à proximité — toujours visible pour compléter
-              les artisans Talok inscrits avec les commerces Google/OSM. */}
+              les artisans Talok inscrits avec les commerces Google/OSM.
+              Le parent pilote bien + rayon (mode contrôlé) pour éviter les
+              sélecteurs en doublon avec ceux du Card ci-dessus. */}
           <div className="mt-6">
             <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
               Autres artisans à proximité (carte)
             </h2>
             <NearbyProvidersSearch
               initialCategory={filters.services[0] ?? 'autre'}
+              controlledProperty={selectedProperty}
+              controlledCenter={propertyCenter}
+              controlledCenterLoading={propertyCenterLoading}
+              controlledRadiusKm={radiusKm}
+              hasTalokProviders={providers.length > 0}
             />
           </div>
         </>

--- a/app/owner/providers/page.tsx
+++ b/app/owner/providers/page.tsx
@@ -687,6 +687,7 @@ export default function ProvidersMarketplacePage() {
               controlledCenter={propertyCenter}
               controlledCenterLoading={propertyCenterLoading}
               controlledRadiusKm={radiusKm}
+              onRequestRadiusKm={setRadiusKm}
               hasTalokProviders={providers.length > 0}
             />
           </div>

--- a/components/provider/nearby-providers-search.tsx
+++ b/components/provider/nearby-providers-search.tsx
@@ -142,6 +142,18 @@ const RADIUS_OPTIONS = [
 interface NearbyProvidersSearchProps {
   initialCategory?: string;
   className?: string;
+  // Pilotage externe (parent = source de vérité). Quand fournis, le composant
+  // n'affiche plus son propre sélecteur de bien ni de rayon, et n'appelle plus
+  // /api/properties ni geocodeAddress (déjà fait par le parent).
+  controlledProperty?: PropertyOption | null;
+  controlledCenter?: { lat: number; lng: number } | null;
+  // Permet de différencier "géocoding en cours" (skeleton) de
+  // "géocoding échoué" (message d'erreur).
+  controlledCenterLoading?: boolean;
+  controlledRadiusKm?: number;
+  // Pour adapter le titre : "Aucun prestataire référencé" vs "Compléter les
+  // prestataires Talok par les artisans à proximité".
+  hasTalokProviders?: boolean;
 }
 
 const SAVED_PROVIDERS_STORAGE_KEY = "talok:nearby-providers:saved";
@@ -173,16 +185,28 @@ function writeSavedIds(ids: Set<string>) {
 export function NearbyProvidersSearch({
   initialCategory = "autre",
   className,
+  controlledProperty,
+  controlledCenter,
+  controlledCenterLoading = false,
+  controlledRadiusKm,
+  hasTalokProviders = false,
 }: NearbyProvidersSearchProps) {
   const router = useRouter();
   const { toast } = useToast();
+  const isControlled = controlledProperty !== undefined;
   const [properties, setProperties] = useState<PropertyOption[]>([]);
-  const [propertiesLoading, setPropertiesLoading] = useState(true);
+  const [propertiesLoading, setPropertiesLoading] = useState(!isControlled);
   const [selectedPropertyId, setSelectedPropertyId] = useState<string>("");
   const [category, setCategory] = useState<string>(normalizeCategory(initialCategory));
-  const [radius, setRadius] = useState<number>(10000);
+  // Rayon en mètres (Google Places + Overpass attendent des mètres).
+  // Quand le parent pilote, on dérive ce rayon depuis controlledRadiusKm.
+  const [radius, setRadius] = useState<number>(
+    controlledRadiusKm ? controlledRadiusKm * 1000 : 10000,
+  );
 
-  const [center, setCenter] = useState<{ lat: number; lng: number } | null>(null);
+  const [center, setCenter] = useState<{ lat: number; lng: number } | null>(
+    controlledCenter ?? null,
+  );
   const [providers, setProviders] = useState<NearbyProvider[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -453,16 +477,31 @@ export function NearbyProvidersSearch({
   };
 
   const selectedProperty = useMemo(
-    () => properties.find((p) => p.id === selectedPropertyId) ?? null,
-    [properties, selectedPropertyId]
+    () =>
+      isControlled
+        ? controlledProperty ?? null
+        : properties.find((p) => p.id === selectedPropertyId) ?? null,
+    [isControlled, controlledProperty, properties, selectedPropertyId],
   );
 
   useEffect(() => {
     setIsClient(true);
   }, []);
 
-  // Charger les biens du propriétaire
+  // Sync rayon contrôlé (km → m).
   useEffect(() => {
+    if (controlledRadiusKm != null) setRadius(controlledRadiusKm * 1000);
+  }, [controlledRadiusKm]);
+
+  // Sync centre contrôlé.
+  useEffect(() => {
+    if (controlledCenter !== undefined) setCenter(controlledCenter);
+  }, [controlledCenter]);
+
+  // Charger les biens du propriétaire — sauté en mode contrôlé (le parent a
+  // déjà chargé /api/properties + géocodé, on évite ainsi le double appel).
+  useEffect(() => {
+    if (isControlled) return;
     let cancelled = false;
     (async () => {
       setPropertiesLoading(true);
@@ -496,7 +535,7 @@ export function NearbyProvidersSearch({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isControlled]);
 
   // Préparer les icônes Leaflet (uniquement côté client)
   useEffect(() => {
@@ -539,8 +578,10 @@ export function NearbyProvidersSearch({
     });
   }, []);
 
-  // Géocoder l'adresse du bien sélectionné si pas déjà fait
+  // Géocoder l'adresse du bien sélectionné si pas déjà fait — sauté en mode
+  // contrôlé (le parent fournit déjà `controlledCenter`).
   useEffect(() => {
+    if (isControlled) return;
     let cancelled = false;
     (async () => {
       if (!selectedProperty) {
@@ -568,7 +609,7 @@ export function NearbyProvidersSearch({
     return () => {
       cancelled = true;
     };
-  }, [selectedProperty]);
+  }, [isControlled, selectedProperty]);
 
   // Lancer la recherche dès qu'on a un centre, une catégorie et un rayon
   useEffect(() => {
@@ -615,7 +656,7 @@ export function NearbyProvidersSearch({
     };
   }, [center, category, radius, selectedProperty]);
 
-  if (propertiesLoading) {
+  if (!isControlled && propertiesLoading) {
     return (
       <Card className={className}>
         <CardContent className="py-8 space-y-3">
@@ -626,7 +667,7 @@ export function NearbyProvidersSearch({
     );
   }
 
-  if (properties.length === 0) {
+  if (!isControlled && properties.length === 0) {
     return (
       <Card className={className}>
         <CardContent className="py-12 text-center space-y-3">
@@ -634,6 +675,41 @@ export function NearbyProvidersSearch({
           <h3 className="font-medium">Aucun bien à géolocaliser</h3>
           <p className="text-sm text-muted-foreground">
             Ajoutez un bien avec son adresse pour voir les prestataires autour.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // En mode contrôlé, le parent gère le cas "pas de bien sélectionné" — on
+  // affiche un placeholder léger plutôt qu'un Card vide qui désaligne le layout.
+  if (isControlled && !selectedProperty) {
+    return null;
+  }
+
+  // Si le parent a fourni un bien mais que le géocodage a échoué (rare en
+  // DROM-COM avec une adresse mal formée), on aide l'utilisateur à corriger
+  // au lieu de boucler sur un loader silencieux (BUG audit #5).
+  // controlledCenterLoading distingue "Nominatim en cours" (skeleton) de
+  // "Nominatim a renvoyé null" (vrai échec).
+  if (isControlled && selectedProperty && controlledCenter === null) {
+    if (controlledCenterLoading) {
+      return (
+        <Card className={className}>
+          <CardContent className="py-8 space-y-3">
+            <Skeleton className="h-6 w-1/3" />
+            <Skeleton className="h-64 w-full" />
+          </CardContent>
+        </Card>
+      );
+    }
+    return (
+      <Card className={className}>
+        <CardContent className="py-8 text-center space-y-2">
+          <MapPin className="h-10 w-10 mx-auto text-muted-foreground" />
+          <h3 className="font-medium">Bien non géolocalisé</h3>
+          <p className="text-sm text-muted-foreground">
+            L'adresse <strong>{selectedProperty.address}</strong> n'a pas pu être trouvée. Vérifiez l'orthographe sur la fiche du bien (Mes biens → Modifier).
           </p>
         </CardContent>
       </Card>
@@ -649,32 +725,37 @@ export function NearbyProvidersSearch({
             Prestataires autour de votre logement
           </h3>
           <p className="text-sm text-muted-foreground">
-            Aucun prestataire référencé pour le moment — voici les artisans à proximité du bien sélectionné.
+            {hasTalokProviders
+              ? "Complétez les prestataires Talok ci-dessus avec les artisans et entreprises à proximité du bien sélectionné."
+              : "Aucun prestataire Talok inscrit dans la zone — voici les artisans et entreprises à proximité du bien sélectionné."}
           </p>
         </div>
 
-        {/* Filtres */}
-        <div className="grid gap-3 md:grid-cols-3">
-          <div className="space-y-1">
-            <label className="text-xs font-medium text-muted-foreground">
-              Bien
-            </label>
-            <Select
-              value={selectedPropertyId}
-              onValueChange={setSelectedPropertyId}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Choisir un bien" />
-              </SelectTrigger>
-              <SelectContent>
-                {properties.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
-                    {p.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+        {/* Filtres — sélecteur Métier uniquement en mode contrôlé (le parent
+            pilote le bien et le rayon pour éviter les doublons). */}
+        <div className={isControlled ? "max-w-sm" : "grid gap-3 md:grid-cols-3"}>
+          {!isControlled && (
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">
+                Bien
+              </label>
+              <Select
+                value={selectedPropertyId}
+                onValueChange={setSelectedPropertyId}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Choisir un bien" />
+                </SelectTrigger>
+                <SelectContent>
+                  {properties.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
           <div className="space-y-1">
             <label className="text-xs font-medium text-muted-foreground">
               Métier
@@ -692,26 +773,28 @@ export function NearbyProvidersSearch({
               </SelectContent>
             </Select>
           </div>
-          <div className="space-y-1">
-            <label className="text-xs font-medium text-muted-foreground">
-              Rayon de recherche
-            </label>
-            <Select
-              value={String(radius)}
-              onValueChange={(v) => setRadius(Number(v))}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {RADIUS_OPTIONS.map((r) => (
-                  <SelectItem key={r.value} value={String(r.value)}>
-                    {r.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          {!isControlled && (
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">
+                Rayon de recherche
+              </label>
+              <Select
+                value={String(radius)}
+                onValueChange={(v) => setRadius(Number(v))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {RADIUS_OPTIONS.map((r) => (
+                    <SelectItem key={r.value} value={String(r.value)}>
+                      {r.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
         </div>
 
         {premiumRequired && (

--- a/components/provider/nearby-providers-search.tsx
+++ b/components/provider/nearby-providers-search.tsx
@@ -49,6 +49,15 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { geocodeAddress } from "@/lib/services/geocoding.service";
@@ -151,6 +160,9 @@ interface NearbyProvidersSearchProps {
   // "géocoding échoué" (message d'erreur).
   controlledCenterLoading?: boolean;
   controlledRadiusKm?: number;
+  // Permet au composant de demander au parent d'augmenter le rayon
+  // (ex. bouton "Élargir à 50 km" affiché quand 0 résultat).
+  onRequestRadiusKm?: (radiusKm: number) => void;
   // Pour adapter le titre : "Aucun prestataire référencé" vs "Compléter les
   // prestataires Talok par les artisans à proximité".
   hasTalokProviders?: boolean;
@@ -189,6 +201,7 @@ export function NearbyProvidersSearch({
   controlledCenter,
   controlledCenterLoading = false,
   controlledRadiusKm,
+  onRequestRadiusKm,
   hasTalokProviders = false,
 }: NearbyProvidersSearchProps) {
   const router = useRouter();
@@ -221,6 +234,13 @@ export function NearbyProvidersSearch({
   const [propertyIcon, setPropertyIcon] = useState<any>(null);
   const [providerIcon, setProviderIcon] = useState<any>(null);
   const [isClient, setIsClient] = useState(false);
+
+  // Dialog d'invitation in-app (remplace l'ancien mailto: qui sortait
+  // l'utilisateur vers son client mail). Le mail part de no-reply@talok.fr.
+  const [inviteProvider, setInviteProvider] = useState<NearbyProvider | null>(null);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteMessage, setInviteMessage] = useState("");
+  const [inviteSending, setInviteSending] = useState(false);
 
   // Hydratation immédiate depuis localStorage (UI réactive sans flash),
   // puis réconciliation avec le serveur (source de vérité multi-appareils).
@@ -340,21 +360,58 @@ export function NearbyProvidersSearch({
     }
   };
 
-  const inviteByEmail = (provider: NearbyProvider) => {
-    const subject = "Rejoignez-moi sur Talok pour gérer nos interventions";
-    const body = [
-      `Bonjour ${provider.name},`,
-      "",
-      "Je gère mes biens immobiliers avec Talok (talok.fr) et j'aimerais vous y inscrire pour pouvoir échanger nos devis, factures et photos d'intervention au même endroit.",
-      "",
-      "Créez votre compte prestataire gratuit ici :",
-      "https://talok.fr/auth/register?role=provider",
-      "",
-      "Talok est un logiciel français (né en Martinique) de gestion locative — votre profil est gratuit côté artisan.",
-      "",
-      "Merci !",
-    ].join("\n");
-    window.location.href = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  const openInviteDialog = (provider: NearbyProvider) => {
+    // Pré-condition : le prestataire doit être en favori (la route serveur
+    // l'exige pour éviter le spam). On s'en assure proactivement ici plutôt
+    // que d'attendre l'erreur 404.
+    if (!savedIds.has(provider.id)) {
+      toast({
+        title: "Enregistrez d'abord ce prestataire",
+        description: "Cliquez sur ‟Enregistrer” avant de l'inviter sur Talok.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setInviteProvider(provider);
+    setInviteEmail("");
+    setInviteMessage("");
+  };
+
+  const submitInvite = async () => {
+    if (!inviteProvider) return;
+    setInviteSending(true);
+    try {
+      const res = await fetch(
+        `/api/providers/external-favorites/${encodeURIComponent(inviteProvider.id)}/invite`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: inviteEmail.trim(),
+            custom_message: inviteMessage.trim() || undefined,
+          }),
+        },
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error || "HTTP " + res.status);
+      }
+      toast({
+        title: "Invitation envoyée",
+        description: `Un email a été envoyé à ${inviteEmail}.`,
+      });
+      setInviteProvider(null);
+    } catch (err) {
+      console.error("[NearbyProvidersSearch] Invitation échouée:", err);
+      toast({
+        title: "Envoi impossible",
+        description:
+          err instanceof Error ? err.message : "Réessayez dans un instant.",
+        variant: "destructive",
+      });
+    } finally {
+      setInviteSending(false);
+    }
   };
 
   const inviteBySms = (provider: NearbyProvider) => {
@@ -835,11 +892,38 @@ export function NearbyProvidersSearch({
         )}
 
         {dataSource && providers.length === 0 && !loading && !premiumRequired && !error && (
-          <div className="rounded-lg border bg-muted/40 p-4 text-sm text-muted-foreground flex gap-2">
-            <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
-            <span>
-              Aucun prestataire trouvé pour cette catégorie dans un rayon de {Math.round(radius / 1000)} km. Essayez d'élargir le rayon ou de changer de métier.
-            </span>
+          <div className="rounded-lg border bg-muted/40 p-4 text-sm text-muted-foreground flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex gap-2">
+              <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
+              <span>
+                Aucun prestataire trouvé pour cette catégorie dans un rayon de {Math.round(radius / 1000)} km.
+              </span>
+            </div>
+            {/* Bouton "élargir auto" — disponible si on n'est pas déjà au max
+                de la liste (50 km en mode contrôlé via parent, 50 km en
+                standalone via RADIUS_OPTIONS). */}
+            {(() => {
+              const currentKm = Math.round(radius / 1000);
+              const nextKm = currentKm < 20 ? 50 : currentKm < 50 ? 100 : null;
+              if (!nextKm) return null;
+              const handleExpand = () => {
+                if (isControlled && onRequestRadiusKm) {
+                  onRequestRadiusKm(nextKm);
+                } else {
+                  setRadius(nextKm * 1000);
+                }
+              };
+              return (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleExpand}
+                  className="self-start sm:self-auto"
+                >
+                  Élargir à {nextKm} km
+                </Button>
+              );
+            })()}
           </div>
         )}
 
@@ -1222,7 +1306,7 @@ export function NearbyProvidersSearch({
                   <div className="grid grid-cols-2 gap-2">
                     <Button
                       variant="outline"
-                      onClick={() => inviteByEmail(detailProvider)}
+                      onClick={() => openInviteDialog(detailProvider)}
                     >
                       <Mail className="h-4 w-4 mr-2" />
                       Email
@@ -1249,6 +1333,82 @@ export function NearbyProvidersSearch({
           )}
         </SheetContent>
       </Sheet>
+
+      {/* Dialog d'invitation in-app — remplace l'ancien mailto: pour que le
+          mail parte de no-reply@talok.fr (deliverability + tracking UTM). */}
+      <Dialog
+        open={!!inviteProvider}
+        onOpenChange={(open) => {
+          if (!open) setInviteProvider(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Inviter sur Talok</DialogTitle>
+            <DialogDescription>
+              {inviteProvider
+                ? `${inviteProvider.name} recevra un email d'invitation depuis Talok avec un lien pour créer sa fiche prestataire gratuite.`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-xs font-medium" htmlFor="invite-email">
+                Email du prestataire *
+              </label>
+              <Input
+                id="invite-email"
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="contact@artisan.fr"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium" htmlFor="invite-message">
+                Message personnalisé (optionnel)
+              </label>
+              <Textarea
+                id="invite-message"
+                value={inviteMessage}
+                onChange={(e) => setInviteMessage(e.target.value)}
+                placeholder="Ex. : Bonjour, j'ai 3 biens en location à Fort-de-France et j'aimerais vous y associer pour les interventions futures."
+                rows={3}
+                maxLength={2000}
+              />
+              <div className="text-right text-xs text-muted-foreground">
+                {inviteMessage.length}/2000
+              </div>
+            </div>
+          </div>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setInviteProvider(null)}
+              disabled={inviteSending}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={submitInvite}
+              disabled={inviteSending || !inviteEmail.trim()}
+            >
+              {inviteSending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Envoi…
+                </>
+              ) : (
+                <>
+                  <Mail className="h-4 w-4 mr-2" />
+                  Envoyer l'invitation
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/components/provider/nearby-providers-search.tsx
+++ b/components/provider/nearby-providers-search.tsx
@@ -108,6 +108,10 @@ interface NearbyProvider {
   photo_url?: string;
   google_maps_url: string;
   source: "google" | "osm";
+  // Tracking d'invitation (persisté côté DB via /invite). Optionnel : seuls
+  // les favoris en ont, et seulement après un envoi réussi.
+  last_invite_at?: string | null;
+  invite_count?: number | null;
 }
 
 // Mapping ServiceType (filtres marketplace) -> catégorie API /api/providers/nearby
@@ -180,6 +184,18 @@ function readSavedIds(): Set<string> {
   } catch {
     return new Set();
   }
+}
+
+// Format compact d'une date d'invitation pour le badge — au-delà de 30 jours
+// on affiche la date courte, sinon "il y a X jours" pour rester lisible.
+function formatInviteDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const days = Math.floor((Date.now() - d.getTime()) / 86400000);
+  if (days <= 0) return "aujourd'hui";
+  if (days === 1) return "hier";
+  if (days < 30) return `il y a ${days} j`;
+  return `le ${d.toLocaleDateString("fr-FR", { day: "numeric", month: "short" })}`;
 }
 
 function writeSavedIds(ids: Set<string>) {
@@ -286,13 +302,15 @@ export function NearbyProvidersSearch({
           const notes = (found?.notes as string) ?? "";
           setDetailNotes(notes);
           setDetailNotesLoaded(notes);
-          if (found?.website || found?.phone) {
+          if (found) {
             setDetailProvider((prev) =>
               prev && prev.id === provider.id
                 ? {
                     ...prev,
                     website: prev.website ?? found.website ?? undefined,
                     phone: prev.phone ?? found.phone ?? undefined,
+                    last_invite_at: found.last_invite_at ?? null,
+                    invite_count: found.invite_count ?? 0,
                   }
                 : prev,
             );
@@ -540,6 +558,40 @@ export function NearbyProvidersSearch({
         : properties.find((p) => p.id === selectedPropertyId) ?? null,
     [isControlled, controlledProperty, properties, selectedPropertyId],
   );
+
+  // Décale légèrement les markers superposés (mêmes coords ou très proches).
+  // Sans ça, 3 artisans dans le même immeuble ne donnent qu'un seul pin
+  // cliquable. On regroupe par lat/lng arrondis à 4 décimales (~11 m), puis
+  // on dispose en cercle de ~13 m autour du point d'origine. Les coords
+  // réelles utilisées pour la distance restent celles de `providers`.
+  const displayedProviders = useMemo<NearbyProvider[]>(() => {
+    const groups = new Map<string, NearbyProvider[]>();
+    for (const p of providers) {
+      const key = `${p.latitude.toFixed(4)},${p.longitude.toFixed(4)}`;
+      const arr = groups.get(key);
+      if (arr) arr.push(p);
+      else groups.set(key, [p]);
+    }
+
+    const result: NearbyProvider[] = [];
+    for (const group of groups.values()) {
+      if (group.length === 1) {
+        result.push(group[0]);
+        continue;
+      }
+      // ~13 m de rayon. 0.00012° de latitude ≈ 13.3 m partout.
+      const radiusDeg = 0.00012;
+      for (let i = 0; i < group.length; i++) {
+        const angle = (2 * Math.PI * i) / group.length;
+        result.push({
+          ...group[i],
+          latitude: group[i].latitude + radiusDeg * Math.cos(angle),
+          longitude: group[i].longitude + radiusDeg * Math.sin(angle),
+        });
+      }
+    }
+    return result;
+  }, [providers]);
 
   useEffect(() => {
     setIsClient(true);
@@ -976,7 +1028,7 @@ export function NearbyProvidersSearch({
                     </Marker>
                   )}
                   {providerIcon &&
-                    providers.map((p) => (
+                    displayedProviders.map((p) => (
                       <Marker
                         key={p.id}
                         position={[p.latitude, p.longitude]}
@@ -1129,12 +1181,21 @@ export function NearbyProvidersSearch({
           {detailProvider && (
             <>
               <SheetHeader className="text-left">
-                <SheetTitle className="flex items-start gap-2 pr-6">
+                <SheetTitle className="flex flex-wrap items-start gap-2 pr-6">
                   <span className="flex-1">{detailProvider.name}</span>
                   {savedIds.has(detailProvider.id) && (
                     <Badge variant="secondary" className="bg-emerald-100 text-emerald-700 hover:bg-emerald-100 flex-shrink-0">
                       <BookmarkCheck className="h-3 w-3 mr-1" />
                       Enregistré
+                    </Badge>
+                  )}
+                  {detailProvider.last_invite_at && (
+                    <Badge variant="secondary" className="bg-blue-100 text-blue-700 hover:bg-blue-100 flex-shrink-0">
+                      <Mail className="h-3 w-3 mr-1" />
+                      Invité {formatInviteDate(detailProvider.last_invite_at)}
+                      {detailProvider.invite_count && detailProvider.invite_count > 1
+                        ? ` (×${detailProvider.invite_count})`
+                        : ""}
                     </Badge>
                   )}
                 </SheetTitle>

--- a/lib/emails/templates.ts
+++ b/lib/emails/templates.ts
@@ -2140,6 +2140,47 @@ export const emailTemplates = {
     };
   },
 
+  // Invitation envoyée par un propriétaire à un artisan repéré sur la
+  // marketplace (Google Places / OSM). Pas de compte créé côté Talok à ce
+  // stade — c'est juste un teaser pour pousser l'artisan à s'inscrire.
+  providerInviteFromOwner: (data: {
+    providerName: string;
+    ownerName: string;
+    customMessage?: string;
+    registerUrl: string;
+  }) => ({
+    subject: `${data.ownerName} vous invite sur Talok`,
+    html: baseLayout(`
+      <div class="content">
+        <h1>Bonjour ${escapeHtml(data.providerName)},</h1>
+        <p>
+          <strong>${escapeHtml(data.ownerName)}</strong> gère ses biens sur Talok et souhaite vous y retrouver pour échanger devis, factures et photos d'intervention au même endroit.
+        </p>
+
+        ${
+          data.customMessage
+            ? `<div class="highlight-box">
+                <p style="color: ${COLORS.gray[500]}; font-size: 14px; margin-bottom: 8px;">Message de ${escapeHtml(data.ownerName)} :</p>
+                <p style="margin: 4px 0; white-space: pre-line;">${escapeHtml(data.customMessage)}</p>
+              </div>`
+            : ""
+        }
+
+        <p>
+          Talok est un logiciel français de gestion locative (né en Martinique). La création de votre fiche prestataire est gratuite — vous touchez plus de propriétaires sans changer vos outils.
+        </p>
+
+        <div style="text-align: center;">
+          <a href="${data.registerUrl}" class="button">Créer ma fiche prestataire</a>
+        </div>
+
+        <p style="font-size: 13px; color: ${COLORS.gray[500]}; margin-top: 24px;">
+          Vous recevez ce message parce que ${escapeHtml(data.ownerName)} vous a recommandé manuellement depuis la marketplace Talok. Vous ne recevrez pas d'autres emails de notre part sans inscription.
+        </p>
+      </div>
+    `, `${data.ownerName} vous invite sur Talok`),
+  }),
+
   providerInvite: (data: {
     providerName: string;
     email: string;

--- a/lib/rate-limit/upstash.ts
+++ b/lib/rate-limit/upstash.ts
@@ -6,7 +6,7 @@
  * sliding window), largement suffisant pour de l'anti-abus SMS.
  *
  * À utiliser pour les flux SMS / OTP qui doivent survivre en
- * environnement serverless multi-instances (Netlify).
+ * environnement serverless multi-instances (Vercel).
  * Ne remplace pas lib/security/rate-limit.ts (route-level legacy).
  */
 

--- a/supabase/migrations/20260505100000_provider_external_favorites_invite_tracking.sql
+++ b/supabase/migrations/20260505100000_provider_external_favorites_invite_tracking.sql
@@ -1,0 +1,27 @@
+-- =====================================================
+-- Tracking des invitations envoyées depuis la marketplace
+-- =====================================================
+-- POST /api/providers/external-favorites/[placeId]/invite envoie un mail
+-- Talok-side à un artisan repéré sur la carte. On persiste ici les
+-- métadonnées de tracking (qui a invité qui, quand, combien de fois)
+-- pour : (a) éviter les doublons si le propriétaire reclique, (b) afficher
+-- un badge "Invité le 5/5/2026" dans le sheet détail, (c) servir de base
+-- à un funnel de conversion plus tard (PostHog).
+
+ALTER TABLE public.provider_external_favorites
+  ADD COLUMN IF NOT EXISTS last_invite_at TIMESTAMPTZ NULL,
+  ADD COLUMN IF NOT EXISTS last_invite_email TEXT NULL,
+  ADD COLUMN IF NOT EXISTS invite_count INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.provider_external_favorites.last_invite_at IS
+  'Horodatage du dernier envoi d''invitation Talok-side via /invite. NULL = jamais invité.';
+COMMENT ON COLUMN public.provider_external_favorites.last_invite_email IS
+  'Email cible de la dernière invitation (pour audit + dédup côté UI).';
+COMMENT ON COLUMN public.provider_external_favorites.invite_count IS
+  'Nombre total d''invitations envoyées pour ce favori (toutes adresses confondues).';
+
+-- Index partiel : la liste "favoris déjà invités" reste petite, on peut
+-- afficher un badge sans scan de table.
+CREATE INDEX IF NOT EXISTS idx_provider_external_favorites_last_invite
+  ON public.provider_external_favorites (owner_profile_id, last_invite_at DESC NULLS LAST)
+  WHERE last_invite_at IS NOT NULL;


### PR DESCRIPTION
## Contexte

Bug rapporté par Marie-Line (Fort-de-France) : sur `/owner/providers`, la carte "Tout métier" remontait 0 prestataire alors que la zone compte des dizaines d'artisans réels — donc tout le module providers semblait déconnecté.

Audit puis 6 commits couvrant 13 bugs / améliorations identifiés.

## Bugs fonctionnels corrigés

1. **`Tout métier` vide en DROM-COM**
   - Google Places : retrait de `type=general_contractor` qui filtrait les indépendants. Keyword élargi à `artisan entreprise bâtiment`.
   - OSM Overpass : union de tous les tags `craft=*` des 8 métiers + couvreur, maçon, carreleur, plâtrier, vitrier, métallier + `office=construction_company` pour les SARL/SAS du bâtiment.

2. **Biais "dépannage"** (sortie 24 h) supprimé : keyword `artisan dépannage` → `artisan`. Toute entreprise qui propose les travaux remonte.

3. **Double sélecteur de bien et de rayon** entre la page parent et `NearbyProvidersSearch` → mode contrôlé (parent = source de vérité), géocoding centralisé.

4. **Texte statique "Aucun prestataire référencé"** → conditionnel via `hasTalokProviders`.

5. **Géocoding silencieux en échec** → message clair pointant vers Mes biens → Modifier.

6. **Filtre `location` naïf** dans `/api/providers/search` (`Paris` matchait `Parisot`) → détection code postal en priorité, sinon tokens normalisés (NFD + word-boundary).

## Architecture / production

7. **Cache mémoire `Map()`** inutile en serverless → migration sur Upstash Redis (24 h TTL, fail-open). Variables `UPSTASH_REDIS_REST_*` déjà configurées sur Vercel Production + Preview.

8. **Gating Pro+ aligné** UI ↔ API. Les 3 routes (`/nearby`, `/place-details`, `/search`) utilisent désormais `withFeatureAccess('providers_management')` au lieu d'un seuil ad-hoc Confort+ qui créait une incohérence.

## UX nouvelles

9. **Bouton "Élargir le rayon"** quand 0 résultat (5/10/20 km → propose 50 km ; 30/50 km → 100 km).

10. **Invitation in-app** (remplace `mailto:`) :
    - `POST /api/providers/external-favorites/[placeId]/invite` envoie via Resend depuis `no-reply@talok.fr`
    - Lien d'inscription tracké (`utm_source=marketplace_invite`)
    - Garde-fous : favori requis, rate-limit 20/24 h par owner, idempotency-key
    - Nouveau template `providerInviteFromOwner`
    - Dialog UI (capture email + message custom 2000 char max)

11. **Tracking DB des invitations** (migration `20260505100000`) : colonnes `last_invite_at`, `last_invite_email`, `invite_count` + index partiel. Badge UI "Invité hier / il y a 5 j (×3)".

12. **Markers superposés** (3+ artisans dans le même immeuble) → cercle de ~13 m, tous cliquables. Sans nouvelle dépendance.

## Cleanup Vercel

13. Commentaires `Netlify` → `Vercel` dans `nearby/route.ts` et `rate-limit/upstash.ts`. Section `.env.example` `UPSTASH_REDIS_*` documentée + section `VERCEL` remplaçant `NETLIFY`.

## Migration SQL

`supabase/migrations/20260505100000_provider_external_favorites_invite_tracking.sql` — déjà appliquée par l'utilisateur via Supabase SQL editor.

## Test plan

- [ ] `/owner/providers` côté Marie-Line (Fort-de-France) avec "Tout métier" → liste non vide
- [ ] Filtre Plomberie / Électricité → toujours strict (pas de régression)
- [ ] Inviter un prestataire en favori → email reçu depuis `no-reply@talok.fr`
- [ ] Re-cliquer "Inviter" sur le même → idempotency tient (1 seul mail)
- [ ] Badge "Invité aujourd'hui" apparaît dans le sheet détail
- [ ] Bouton "Élargir à 50 km" fonctionne quand 0 résultat
- [ ] Cache Redis : 2e requête `/nearby` → réponse `source: "cache"` instantanée
- [ ] Métropole (e.g. Lyon) → pas de timeout Overpass sur l'union élargie

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb5hqHKToxLH9cGkHN16uL)_