### PR TITLE
fix(providers): cache 0-result poisoning + auto-zoom carte + UX refresh

### DIFF
--- a/app/api/providers/nearby/route.ts
+++ b/app/api/providers/nearby/route.ts
@@ -132,7 +132,14 @@ const CATEGORY_TO_OSM_FILTERS: Record<string, string[]> = {
 // Cache Redis (Upstash) — partagé entre toutes les lambdas Vercel.
 // En dev sans Redis configuré, getRedis() retourne null et le code dégrade
 // proprement (pas de cache, mais fonctionnel).
-const CACHE_TTL_SEC = 24 * 60 * 60; // 24 heures
+//
+// TTL différencié pour éviter le "0-result poisoning" : si Google a un
+// hoquet transient (REQUEST_DENIED, OVER_QUERY_LIMIT, ZERO_RESULTS sur
+// une requête trop spécifique) ou si OSM Overpass est down, on cachait
+// avant 24 h une liste vide → l'utilisateur restait bloqué une journée
+// entière. On garde 24 h pour les résultats utiles, 5 min pour les vides.
+const CACHE_TTL_OK_SEC = 24 * 60 * 60;     // 24 heures pour ≥ 1 résultat
+const CACHE_TTL_EMPTY_SEC = 5 * 60;        // 5 minutes pour 0 résultat
 const CACHE_PREFIX = "providers:nearby:v1";
 
 export async function GET(request: NextRequest) {
@@ -200,6 +207,10 @@ export async function GET(request: NextRequest) {
     const lng = parseFloat(searchParams.get("lng") || "0");
     const radius = parseInt(searchParams.get("radius") || "10000"); // 10km par défaut
     const address = searchParams.get("address") || "";
+    // `?fresh=1` permet à l'utilisateur (bouton "Actualiser") de bypasser
+    // le cache Redis. Indispensable quand Google a corrigé un downtime ou
+    // qu'un nouvel artisan vient d'apparaître — on ne veut pas l'attendre 24 h.
+    const skipCache = searchParams.get("fresh") === "1";
 
     // Vérifier la clé API Google
     const googleApiKey = process.env.GOOGLE_PLACES_API_KEY;
@@ -209,7 +220,7 @@ export async function GET(request: NextRequest) {
     const cacheKey = `${CACHE_PREFIX}:${category}:${lat.toFixed(2)}:${lng.toFixed(2)}:${radius}`;
     const redis = getRedis();
 
-    if (redis) {
+    if (redis && !skipCache) {
       try {
         const cached = await redis.get<NearbyProvider[]>(cacheKey);
         if (cached && Array.isArray(cached)) {
@@ -447,6 +458,24 @@ export async function GET(request: NextRequest) {
       // un point qui apparaîtrait hors du cercle bleu sur la carte.
       .filter((p: NearbyProvider) => (p.distance_km ?? 0) <= radius / 1000);
 
+    // Si Google retourne 0 résultat (zone mal couverte par sa taxonomie,
+    // typique en DROM-COM), on retombe sur OSM Overpass plutôt que de
+    // renvoyer une liste vide. Pour "Tout métier", l'union des 17 tags
+    // OSM remonte presque toujours quelque chose.
+    if (providers.length === 0) {
+      const osmFallback = await searchOSMProviders(category, latitude, longitude, radius);
+      if (osmFallback.length > 0) {
+        await writeCache(redis, cacheKey, osmFallback);
+        return NextResponse.json({
+          providers: osmFallback,
+          source: "osm",
+          total: osmFallback.length,
+          search_location: { lat: latitude, lng: longitude },
+          fallback_reason: "google_zero_results",
+        });
+      }
+    }
+
     await writeCache(redis, cacheKey, providers);
 
     void logGooglePlacesUsage({
@@ -475,14 +504,19 @@ export async function GET(request: NextRequest) {
 }
 
 // Écriture cache Redis tolérante aux pannes (fail-open).
+// TTL différencié : 24 h si on a des résultats utilisables, 5 min sinon —
+// les zéro-résultats sont souvent transients (rate-limit Google, Overpass
+// timeout, key invalide pendant 30 s) et on ne veut pas bloquer
+// l'utilisateur 24 h à cause d'un hoquet de l'API tierce.
 async function writeCache(
   redis: ReturnType<typeof getRedis>,
   key: string,
   data: NearbyProvider[],
 ): Promise<void> {
   if (!redis) return;
+  const ttl = data.length > 0 ? CACHE_TTL_OK_SEC : CACHE_TTL_EMPTY_SEC;
   try {
-    await redis.set(key, data, { ex: CACHE_TTL_SEC });
+    await redis.set(key, data, { ex: ttl });
   } catch (err) {
     console.warn("[providers/nearby] Redis write échoué:", err);
   }

--- a/app/owner/providers/page.tsx
+++ b/app/owner/providers/page.tsx
@@ -54,6 +54,7 @@ import { SERVICE_TYPE_LABELS, type ServiceType } from '@/lib/data/service-pricin
 import { PLANS, getRequiredPlanForFeature } from '@/lib/subscriptions/plans';
 import { formatPropertyAddress } from '@/lib/properties/address';
 import { geocodeAddress } from '@/lib/services/geocoding.service';
+import { useToast } from '@/components/ui/use-toast';
 
 interface PropertyOption {
   id: string;
@@ -90,6 +91,7 @@ export default function ProvidersMarketplacePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { hasFeature } = useSubscription();
+  const { toast } = useToast();
   
   const [providers, setProviders] = useState<ProviderCardData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -220,14 +222,24 @@ export default function ProvidersMarketplacePage() {
       }
       
       const response = await fetch(`/api/providers/search?${params.toString()}`);
-      
+
       if (response.ok) {
         const data = await response.json();
         setProviders(data.providers || []);
         setTotalCount(data.total || 0);
+      } else if (response.status === 429) {
+        // Rate-limit Google Places atteint (par-user-h, par-user-day, ou
+        // par-IP-h). Avant on échouait silencieusement → l'utilisateur
+        // pensait qu'aucun artisan n'existait.
+        toast({
+          title: "Trop de recherches",
+          description: "Vous avez atteint la limite. Réessayez dans environ une heure.",
+          variant: "destructive",
+        });
+        setProviders([]);
+        setTotalCount(0);
       } else {
-        // Aucun prestataire disponible - API non accessible
-        console.warn("[providers] API non disponible, aucun prestataire chargé");
+        console.warn("[providers] API non disponible, status =", response.status);
         setProviders([]);
         setTotalCount(0);
       }
@@ -626,14 +638,20 @@ export default function ProvidersMarketplacePage() {
               <CardContent className="py-8 text-center">
                 <Search className="h-10 w-10 mx-auto text-muted-foreground mb-3" />
                 <h3 className="text-lg font-medium">
-                  Aucun prestataire Talok ne correspond à vos critères
+                  {activeFiltersCount > 0
+                    ? "Aucun prestataire Talok ne correspond à vos filtres"
+                    : "Aucun prestataire Talok inscrit dans votre zone pour le moment"}
                 </h3>
                 <p className="text-muted-foreground mt-1 text-sm">
-                  Pas d'inquiétude — la carte ci-dessous liste les artisans réels autour de votre bien.
+                  {activeFiltersCount > 0
+                    ? "Essayez de relâcher quelques filtres ou consultez la carte ci-dessous pour les artisans réels autour de votre bien."
+                    : "La marketplace Talok grandit chaque semaine — en attendant, la carte ci-dessous liste les artisans et entreprises autour de votre bien."}
                 </p>
-                <Button variant="outline" className="mt-4" onClick={clearFilters}>
-                  Réinitialiser les filtres
-                </Button>
+                {activeFiltersCount > 0 && (
+                  <Button variant="outline" className="mt-4" onClick={clearFilters}>
+                    Réinitialiser les filtres
+                  </Button>
+                )}
               </CardContent>
             </Card>
           ) : (

--- a/components/provider/map-autofit.tsx
+++ b/components/provider/map-autofit.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+// =====================================================
+// MapAutoFit — composant Leaflet "headless" qui ajuste le zoom de la
+// carte pour que le cercle de rayon soit entièrement visible avec une
+// petite marge. Doit être rendu à l'intérieur d'un <MapContainer>.
+// =====================================================
+
+import { useEffect } from "react";
+import { useMap } from "react-leaflet";
+import L from "leaflet";
+
+interface MapAutoFitProps {
+  /** Centre de la zone (bien sélectionné). */
+  center: { lat: number; lng: number };
+  /** Rayon de recherche en mètres. */
+  radiusMeters: number;
+}
+
+export function MapAutoFit({ center, radiusMeters }: MapAutoFitProps) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+    // L.latLng(...).toBounds(diameterMeters) crée un carré centré sur
+    // le point de rayon ~diameterMeters/2 dans chaque direction. On passe
+    // 2 × radius pour englober le cercle complet.
+    const bounds = L.latLng(center.lat, center.lng).toBounds(radiusMeters * 2);
+    // padding [20, 20] = 20 px de marge visuelle pour que le cercle ne
+    // touche pas les bords de la carte.
+    map.fitBounds(bounds, { padding: [20, 20], animate: true });
+  }, [map, center.lat, center.lng, radiusMeters]);
+
+  return null;
+}

--- a/components/provider/nearby-providers-search.tsx
+++ b/components/provider/nearby-providers-search.tsx
@@ -28,6 +28,7 @@ import {
   StickyNote,
   Save,
   Globe,
+  RefreshCw,
 } from "lucide-react";
 import "leaflet/dist/leaflet.css";
 
@@ -83,6 +84,18 @@ const Popup = dynamic(
 const Circle = dynamic(
   () => import("react-leaflet").then((m) => m.Circle),
   { ssr: false }
+);
+
+// Composant interne qui fait fitBounds sur le cercle de rayon à chaque
+// changement de centre / rayon. Sans ça, MapContainer reste figé sur
+// `zoom={13}` (zoom de l'init) — quand l'utilisateur élargit à 100 km
+// la carte ne dézoome pas et le cercle déborde de la zone visible.
+//
+// Dynamique pour garder useMap dans le bundle client uniquement (Leaflet
+// ne supporte pas le SSR).
+const MapAutoFit = dynamic(
+  () => import("./map-autofit").then((m) => m.MapAutoFit),
+  { ssr: false },
 );
 
 interface PropertyOption {
@@ -720,6 +733,10 @@ export function NearbyProvidersSearch({
     };
   }, [isControlled, selectedProperty]);
 
+  // Compteur d'actualisations manuelles : incrémenté par le bouton "Actualiser",
+  // sert de dépendance au useEffect pour re-déclencher une recherche bypass cache.
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
   // Lancer la recherche dès qu'on a un centre, une catégorie et un rayon
   useEffect(() => {
     if (!center || !selectedProperty) return;
@@ -736,11 +753,27 @@ export function NearbyProvidersSearch({
           radius: String(radius),
           address: selectedProperty.address,
         });
+        // Le 1er appel utilise le cache (rapide). Toute pression sur "Actualiser"
+        // ajoute ?fresh=1 pour bypass le cache Redis 24 h et refaire un vrai
+        // call Google/OSM — utile quand Marie-Line a changé la zone ou quand
+        // on suspecte un cache 0-result poisoning.
+        if (refreshNonce > 0) params.set("fresh", "1");
         const res = await fetch(`/api/providers/nearby?${params.toString()}`);
         const data = await res.json();
         if (cancelled) return;
         if (res.status === 403 && data?.error === "premium_required") {
           setPremiumRequired(true);
+          setProviders([]);
+          setDataSource(null);
+        } else if (res.status === 429) {
+          // Rate-limit explicite — on utilise le toast plutôt que le banner
+          // rouge "erreur" pour signaler que c'est temporaire et lié à la
+          // fréquence d'usage (pas à un bug Talok).
+          toast({
+            title: "Trop de recherches",
+            description: "Limite quotidienne Google atteinte. Réessayez dans environ une heure.",
+            variant: "destructive",
+          });
           setProviders([]);
           setDataSource(null);
         } else if (!res.ok) {
@@ -763,7 +796,7 @@ export function NearbyProvidersSearch({
     return () => {
       cancelled = true;
     };
-  }, [center, category, radius, selectedProperty]);
+  }, [center, category, radius, selectedProperty, refreshNonce]);
 
   if (!isControlled && propertiesLoading) {
     return (
@@ -951,31 +984,43 @@ export function NearbyProvidersSearch({
                 Aucun prestataire trouvé pour cette catégorie dans un rayon de {Math.round(radius / 1000)} km.
               </span>
             </div>
-            {/* Bouton "élargir auto" — disponible si on n'est pas déjà au max
-                de la liste (50 km en mode contrôlé via parent, 50 km en
-                standalone via RADIUS_OPTIONS). */}
-            {(() => {
-              const currentKm = Math.round(radius / 1000);
-              const nextKm = currentKm < 20 ? 50 : currentKm < 50 ? 100 : null;
-              if (!nextKm) return null;
-              const handleExpand = () => {
-                if (isControlled && onRequestRadiusKm) {
-                  onRequestRadiusKm(nextKm);
-                } else {
-                  setRadius(nextKm * 1000);
-                }
-              };
-              return (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleExpand}
-                  className="self-start sm:self-auto"
-                >
-                  Élargir à {nextKm} km
-                </Button>
-              );
-            })()}
+            <div className="flex flex-wrap gap-2 self-start sm:self-auto">
+              {/* Refresh manuel : bypass cache 24 h. Utile quand le résultat
+                  est cached à 0 par accident (Google transient down,
+                  Overpass timeout) et que l'utilisateur sait qu'il devrait y
+                  avoir des artisans dans la zone. */}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setRefreshNonce((n) => n + 1)}
+                disabled={loading}
+              >
+                <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${loading ? "animate-spin" : ""}`} />
+                Actualiser
+              </Button>
+              {/* Bouton "élargir auto" : 5/10/20 → 50, 30/50 → 100. */}
+              {(() => {
+                const currentKm = Math.round(radius / 1000);
+                const nextKm = currentKm < 20 ? 50 : currentKm < 50 ? 100 : null;
+                if (!nextKm) return null;
+                const handleExpand = () => {
+                  if (isControlled && onRequestRadiusKm) {
+                    onRequestRadiusKm(nextKm);
+                  } else {
+                    setRadius(nextKm * 1000);
+                  }
+                };
+                return (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleExpand}
+                  >
+                    Élargir à {nextKm} km
+                  </Button>
+                );
+              })()}
+            </div>
           </div>
         )}
 
@@ -994,10 +1039,13 @@ export function NearbyProvidersSearch({
                 <MapContainer
                   key={`${center.lat}-${center.lng}-${radius}`}
                   center={[center.lat, center.lng]}
-                  zoom={13}
+                  // Zoom initial très large — MapAutoFit ajuste précisément
+                  // au cercle après mount.
+                  zoom={11}
                   scrollWheelZoom
                   style={{ height: "100%", width: "100%" }}
                 >
+                  <MapAutoFit center={center} radiusMeters={radius} />
                   <TileLayer
                     attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"


### PR DESCRIPTION
## Contexte

Audit après PR #594 : Marie-Line à La Caravelle (Trinité, Martinique) voyait toujours 0 résultat sur "Électricité 30 km" alors que `GOOGLE_PLACES_API_KEY` est configurée sur Vercel. Diagnostic : **cache 0-result poisoning** sur Redis (TTL 24 h appliqué aux listes vides).

## Fixes (5)

### 🔴 Cache TTL différencié — résout le bug actuel
`writeCache()` cachait les `[]` pendant 24 h. Une 1re requête malchanceuse (Google transient down, Overpass timeout, key invalide pendant 30 s) bloquait la zone une journée entière.
→ **24 h si ≥ 1 résultat, 5 min si vide.**

### 🟠 Fallback OSM si Google ZERO_RESULTS
Si Nearby + Text Search Google sortent à 0 (DROM-COM mal couverte par la taxonomie Google), on tente Overpass avant de cacher l'échec.

### 🟠 Param `?fresh=1` + bouton "Actualiser"
Bypass cache 24 h depuis l'UI. Indispensable quand l'utilisateur sait qu'il devrait y avoir des artisans (et pour purger un cache poisoning sans CLI Redis).

### 🟠 Auto-zoom Leaflet (`MapAutoFit`)
Avant : `zoom={13}` hardcodé → cercle de 30/100 km invisible. Maintenant `fitBounds` recalcule à chaque changement de centre/rayon, avec padding 20 px.

### 🟠 Toast 429 + texte adaptatif
- 429 → toast "Trop de recherches, réessayez dans environ 1 h" (au lieu de silent fail)
- "Aucun prestataire Talok ne correspond à vos critères" devient "Aucun prestataire Talok inscrit dans votre zone pour le moment" si aucun filtre actif (= base vide pour la région, pas un problème de filtres)

## Test plan

- [ ] Marie-Line clique "Actualiser" sur Caravelle → nouveau call Google direct, pas de cache hit
- [ ] Si Google retourne ≥ 1 résultat → cache 24 h
- [ ] Si Google retourne 0 → fallback OSM tenté, puis si vide cache 5 min seulement
- [ ] Élargir rayon de 30 → 100 km : la carte dézoome automatiquement et le cercle reste visible
- [ ] Spammer la recherche → toast 429 apparaît au bout de 30 calls/h
- [ ] Owner sans aucun Talok dans sa zone : voit "Aucun inscrit pour le moment" sans bouton "Réinitialiser"
- [ ] Owner avec filtres actifs et 0 match : voit "ne correspond à vos filtres" + bouton reset

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb5hqHKToxLH9cGkHN16uL)_